### PR TITLE
bduranc_181011_175751.127

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: jackson-core
+  namespace: com.fasterxml.jackson.core
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.5.2:
+    described:
+      sourceLocation:
+        name: jackson-core
+        namespace: FasterXML
+        provider: github
+        revision: jackson-core-2.5.2
+        type: git
+        url: 'https://github.com/FasterXML/jackson-core/tree/jackson-core-2.5.2'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
-Updated source location to Jackson GH repo
-Updated declared license to ASL 2.0 (see GH README.md)