### PR TITLE
bduranc_181024_234728.510

### DIFF
--- a/curations/git/github/tonytomov/jqgrid.yaml
+++ b/curations/git/github/tonytomov/jqgrid.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: jqgrid
+  namespace: tonytomov
+  provider: github
+  type: git
+revisions:
+  361af3db2d25368c8a3b25224cad6a702e10e5fd:
+    files:
+      - attributions:
+          - 'Copyright (c) 2008, Tony Tomov, tony@trirand.com'
+          - 'Copyright (c) 2007,2008 Brice Burgess <bhb@iceburg.net>'
+        license: ''
+        path: js/minified/jqModal.js
+      - attributions:
+          - 'Copyright (c) 2008, Tony Tomov, tony@trirand.com'
+          - 'Copyright (c) 2007 Brice Burgess <bhb@iceburg.net>, http://www.iceburg.net'
+        license: ''
+        path: js/minified/jqDnR.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add additional copyright holder to two minified JS depedencies

**Details:**
The two minified JS files located at:

a) "<root>/js/minified/jqDnR.js"
b) "<root>/js/minified/jqModal.js"

only declare the copyright of the author of jqGrid. Quick diff against the original uncompressed versions of files located under <root>/js/ show two are very similar.


**Resolution:**
Added one additional copyright holder to each of the below file:

a) "<root>/js/minified/jqDnR.js" ( (C) from <root>/js/jqDnR.js)
b) "<root>/js/minified/jqModal.js" ( (C) from <root>/js/jqModal.js)

**Affected definitions**:
- jqgrid 361af3db2d25368c8a3b25224cad6a702e10e5fd