### PR TITLE
ariel11_181026_194736.657

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerBI.Api.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerBI.Api.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerBI.Api
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing License

**Details:**
https://www.nuget.org/packages/Microsoft.PowerBI.Api/3.0.0 has no “License” or “Project” and is unlisted. 

**Resolution:**
The closest version is “MIT” - https://www.nuget.org/packages/Microsoft.PowerBI.Api/2.0.14. Declaring "MIT" but maybe we should leave blank?

**Affected definitions**:
- Microsoft.PowerBI.Api 3.0.0