### PR TITLE
AE49_181101_142055.053

### DIFF
--- a/curations/nuget/nuget/-/Edge.js.yaml
+++ b/curations/nuget/nuget/-/Edge.js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Edge.js
+  provider: nuget
+  type: nuget
+revisions:
+  5.9.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add Apache 2.0

**Resolution:**
Closest license file found is v5.0 https://github.com/tjanczuk/edge/blob/v5.0.0/LICENSE.txt

**Affected definitions**:
- Edge.js 5.9.1