### PR TITLE
AE49_181101_205939.630

### DIFF
--- a/curations/nuget/nuget/-/JSNLog.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/JSNLog.AspNetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: JSNLog.AspNetCore
+  provider: nuget
+  type: nuget
+revisions:
+  99.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
No license file associates with this version. All other version are licensed under MIT - https://github.com/mperdeck/jsnlog/blob/2.28.0/LICENSE.md.

**Affected definitions**:
- JSNLog.AspNetCore 99.0.0