### PR TITLE
AE49_181106_211608.827

### DIFF
--- a/curations/nuget/nuget/-/MvvmLightLibsStd10.yaml
+++ b/curations/nuget/nuget/-/MvvmLightLibsStd10.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MvvmLightLibsStd10
+  provider: nuget
+  type: nuget
+revisions:
+  5.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
No separate license file for this version, other versions posted in repo are licensed under https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- MvvmLightLibsStd10 5.4.1