### PR TITLE
AE49_181106_212228.881

### DIFF
--- a/curations/nuget/nuget/-/System.Buffers.yaml
+++ b/curations/nuget/nuget/-/System.Buffers.yaml
@@ -6,3 +6,6 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
System Buffers is part of .NET Core which is licensed under MIT - https://github.com/dotnet/corefx/blob/master/LICENSE.TXT.

**Affected definitions**:
- System.Buffers 4.5.0