### PR TITLE
AE49_181106_213055.724

### DIFF
--- a/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
+++ b/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
@@ -1,6 +1,5 @@
 coordinates:
   name: System.IdentityModel.Tokens.Jwt
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
@@ -8,5 +7,8 @@ revisions:
     licensed:
       declared: Apache-2.0
   5.1.4:
+    licensed:
+      declared: MIT
+  5.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
Repo and last version 5.3.0 is licensed under MIT - https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/5.3.0/LICENSE.txt

**Affected definitions**:
- System.IdentityModel.Tokens.Jwt 5.2.0