### PR TITLE
AE49_181106_214549.078

### DIFF
--- a/curations/npm/npmjs/-/scriptjs.yaml
+++ b/curations/npm/npmjs/-/scriptjs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: scriptjs
+  provider: npmjs
+  type: npm
+revisions:
+  2.5.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
MIT noted on NPM page https://www.npmjs.com/package/scriptjs/v/2.5.8, and project license - https://github.com/ded/script.js/blob/master/LICENSE.

**Affected definitions**:
- scriptjs 2.5.8