### PR TITLE
AE49_181107_211827.720

### DIFF
--- a/curations/nuget/nuget/-/System.Net.WebSockets.WebSocketProtocol.yaml
+++ b/curations/nuget/nuget/-/System.Net.WebSockets.WebSocketProtocol.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Net.WebSockets.WebSocketProtocol
+  provider: nuget
+  type: nuget
+revisions:
+  4.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
This component is part of .NET Core which is under MIT, no separate repo for 4.5.1 - https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- System.Net.WebSockets.WebSocketProtocol 4.5.1