### PR TITLE
AE49_181107_211942.551

### DIFF
--- a/curations/nuget/nuget/-/System.Numerics.Vectors.yaml
+++ b/curations/nuget/nuget/-/System.Numerics.Vectors.yaml
@@ -6,3 +6,6 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
This component is part of .NET Core, which is under MIT. No separate version specific repo - https://github.com/dotnet/corefx/blob/master/LICENSE.TXT.

**Affected definitions**:
- System.Numerics.Vectors 4.5.0