### PR TITLE
bduranc_181109_183609.307

### DIFF
--- a/curations/nuget/nuget/-/ZXing.Net.yaml
+++ b/curations/nuget/nuget/-/ZXing.Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ZXing.Net
+  provider: nuget
+  type: nuget
+revisions:
+  0.14.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is Apache-2.0

**Details:**
No license dec;ared.

**Resolution:**
See: https://www.nuget.org/packages/ZXing.Net/0.14.0.1
License is Apache-2.0

**Affected definitions**:
- ZXing.Net 0.14.0.1