### PR TITLE
bduranc_181110_015410.024

### DIFF
--- a/curations/git/github/fasterxml/aalto-xml.yaml
+++ b/curations/git/github/fasterxml/aalto-xml.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: aalto-xml
+  namespace: fasterxml
+  provider: github
+  type: git
+revisions:
+  90a1408a8fbfb37e53b714495ff97b8baa7313e1:
+    files:
+      - license: Apache-2.0
+        path: lib/stax-api-1.0.1.jar
+      - license: CPL-1.0
+        path: lib/test/junit-3.8.1.jar
+      - license: BSD-3-Clause
+        path: lib/stax2-api-3.1.1.jar


### PR DESCRIPTION

**Type:** Missing

**Summary:**
File license declarations

**Details:**
Identified the applicable licenses for 3 JAR files in this project

**Resolution:**
in <root>/lib/
1. test/junit-3.8.1.jar - CPL-1.0 - license inside jar
2. stax-api-1.0.1.jar - ASL-2.0 - https://web.archive.org/web/20060429065804/http://stax.codehaus.org:80/Home (CRC match to binary under "Downloads" section of this site)
3. stax2-api-3.1.1.jar - BSD 3-Clause - license inside jar

**Affected definitions**:
- aalto-xml 90a1408a8fbfb37e53b714495ff97b8baa7313e1