### PR TITLE
AE49_181111_200836.523

### DIFF
--- a/curations/nuget/nuget/-/Libuv.yaml
+++ b/curations/nuget/nuget/-/Libuv.yaml
@@ -6,3 +6,6 @@ revisions:
   1.10.0:
     licensed:
       declared: MIT
+  1.9.1:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Markdig.Signed.yaml
+++ b/curations/nuget/nuget/-/Markdig.Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Markdig.Signed
+  provider: nuget
+  type: nuget
+revisions:
+  0.15.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add BSD-2-Clause

**Resolution:**
https://github.com/lunet-io/markdig/blob/v0.15.1/license.txt

**Affected definitions**:
- Libuv 1.9.1,- Markdig.Signed 0.15.1