### PR TITLE
ariel11_181112_200432.548

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.Abstractions.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.0:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Localization.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Localization.Abstractions.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Localization.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Localization.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Logging.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Logging.Abstractions.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Logging.Console.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Logging.Console.yaml
@@ -9,6 +9,9 @@ revisions:
   2.0.1:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Logging.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Options.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Options.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   2.1.0-preview1-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing License

**Details:**
Declaring License

**Resolution:**
Declaring License for v. 2.0.2 components that point to https://github.com/aspnet/Home/commit/c4c6e1b0e9667662646939139205e12bf57e865c. 

**Affected definitions**:
- Microsoft.Extensions.Configuration.Abstractions 2.0.2,- Microsoft.Extensions.Hosting.Abstractions 2.0.2,- Microsoft.Extensions.Localization 2.0.2,- Microsoft.Extensions.Localization.Abstractions 2.0.2,- Microsoft.Extensions.Logging 2.0.2,- Microsoft.Extensions.Logging.Abstractions 2.0.2,- Microsoft.Extensions.Logging.Console 2.0.2,- Microsoft.Extensions.Options 2.0.2