### PR TITLE
AE49_181119_132400.320

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.7.1:
+    licensed:
+      declared: MIT
   2.7.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
This is an Application Insights dotnet component under MIT - https://github.com/Microsoft/ApplicationInsights-dotnet/blob/2.7.1/LICENSE

**Affected definitions**:
- Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel 2.7.1