### PR TITLE
ariel11_181204_192311.656

### DIFF
--- a/curations/nuget/nuget/-/Rx-PlatformServices.yaml
+++ b/curations/nuget/nuget/-/Rx-PlatformServices.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Rx-PlatformServices
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License as Apache v2, however, this one is unclear.  

**Details:**
The fwlink on NuGet page says "MS-EULA License" https://www.nuget.org/packages/Rx-PlatformServices/2.2.4, which indicates to me it may have been a EULA at that time.  However, the fwlink now takes you to the master branch license, which is Apache v2, "Copyright (c) .NET Foundation..." (more below)

**Resolution:**
However, if you dig for v2.2.4, it says Apache v2, "Copyright (c) Microsoft Open Technologies, Inc." https://github.com/dotnet/reactive/blob/4be75495a11ab799b6b7ad7a3889a15d7d5df7d5/Ix.NET/Source/license.txt.  So, declaring as Apache v2.

**Affected definitions**:
- Rx-PlatformServices 2.2.4