### PR TITLE
bduranc_181205_191249.095

### DIFF
--- a/curations/maven/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
+++ b/curations/maven/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jackson-core
+  namespace: com.fasterxml.jackson.core
+  provider: mavencentral
+  type: maven
+revisions:
+  2.5.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license is Apache-2.0

**Details:**
https://github.com/FasterXML/jackson-core/tree/jackson-core-2.5.2
Body of README.MD reads "This package is the base on which Jackson data-binding package builds on. It is licensed under Apache License 2.0. "

**Resolution:**
Clarifies the declared license for component Jackson-core 2.5.2

**Affected definitions**:
- jackson-core 2.5.2