### PR TITLE
bduranc_181205_202035.078

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-annotations.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-annotations.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: jackson-annotations
+  namespace: com.fasterxml.jackson.core
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.6.6:
+    described:
+      sourceLocation:
+        name: jackson-annotations
+        namespace: fasterxml
+        provider: github
+        revision: 81ef33c7f89dcf17081f10de66a0269363b6f0e2
+        type: git
+        url: 'https://github.com/fasterxml/jackson-annotations/commit/81ef33c7f89dcf17081f10de66a0269363b6f0e2'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update source location and declared license

**Details:**
Declared license is Apache-2.0

**Resolution:**
Source location is: https://github.com/FasterXML/jackson-annotations/blob/jackson-annotations-2.6.6/
You can see README.MD in source location reads: "Project is licensed under Apache License 2.0."

**Affected definitions**:
- jackson-annotations 2.6.6