### PR TITLE
bduranc_181205_214904.797

### DIFF
--- a/curations/maven/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
+++ b/curations/maven/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
@@ -7,3 +7,6 @@ revisions:
   2.5.2:
     licensed:
       declared: Apache-2.0
+  2.8.9:
+    licensed:
+      declared: Apache-2.0

--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-core.yaml
@@ -15,3 +15,14 @@ revisions:
         url: 'https://github.com/FasterXML/jackson-core/tree/jackson-core-2.5.2'
     licensed:
       declared: Apache-2.0
+  2.8.9:
+    described:
+      sourceLocation:
+        name: jackson-core
+        namespace: fasterxml
+        provider: github
+        revision: 4d1c109708f39d031c09b2eecdd21de2e1c80570
+        type: git
+        url: 'https://github.com/fasterxml/jackson-core/commit/4d1c109708f39d031c09b2eecdd21de2e1c80570'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update source location and declared license

**Details:**
Declared license is Apache-2.0

**Resolution:**
Source location is: https://github.com/FasterXML/jackson-core/tree/jackson-core-2.8.9
Body of README.MD reads "This package is the base on which Jackson data-binding package builds on. It is licensed under Apache License 2.0. "

**Affected definitions**:
- jackson-core 2.8.9,- jackson-core 2.8.9