### PR TITLE
cruzerika_181207_002742.983

### DIFF
--- a/curations/git/github/fasterxml/jackson-jaxrs-providers.yaml
+++ b/curations/git/github/fasterxml/jackson-jaxrs-providers.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jackson-jaxrs-providers
+  namespace: fasterxml
+  provider: github
+  type: git
+revisions:
+  c7e21d98338e33bdcc026cafc2334da27819fa8a:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
Declared license should be Apache License 2.0

**Details:**
No license declared.

**Resolution:**
See:
github repo: https://github.com/FasterXML/jackson-jaxrs-providers/blob/c7e21d98338e33bdcc026cafc2334da27819fa8a/base/src/main/resources/META-INF/LICENSE

**Affected definitions**:
- jackson-jaxrs-providers c7e21d98338e33bdcc026cafc2334da27819fa8a