### PR TITLE
cruzerika_181207_004223.743

### DIFF
--- a/curations/git/github/activiti/activiti.yaml
+++ b/curations/git/github/activiti/activiti.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: activiti
+  namespace: activiti
+  provider: github
+  type: git
+revisions:
+  2bd372bbaac918962694dc58b7c4e3feaedfdfa7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license should be Apache License 2.0

**Details:**
No license is declared.

**Resolution:**
See:
github repo: https://github.com/Activiti/Activiti/blob/c8666252c669d89f2c6d7063e4a89aadf6b73175/LICENSE.txt

**Affected definitions**:
- activiti 2bd372bbaac918962694dc58b7c4e3feaedfdfa7