### PR TITLE
cruzerika_181207_004628.514

### DIFF
--- a/curations/git/github/cthackers/adm-zip.yaml
+++ b/curations/git/github/cthackers/adm-zip.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: adm-zip
+  namespace: cthackers
+  provider: github
+  type: git
+revisions:
+  d8ed9063262309b700d0cfa1979d948aa3ac515c:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license should be MIT.

**Details:**
No license is declared.

**Resolution:**
See:
- github repo: https://github.com/cthackers/adm-zip/blob/d8ed9063262309b700d0cfa1979d948aa3ac515c/MIT-LICENSE.txt

**Affected definitions**:
- adm-zip d8ed9063262309b700d0cfa1979d948aa3ac515c