### PR TITLE
bduranc_181207_184056.686

### DIFF
--- a/curations/maven/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
+++ b/curations/maven/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jackson-databind
+  namespace: com.fasterxml.jackson.core
+  provider: mavencentral
+  type: maven
+revisions:
+  2.8.9:
+    licensed:
+      declared: Apache-2.0

--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: jackson-databind
+  namespace: com.fasterxml.jackson.core
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.8.9:
+    described:
+      sourceLocation:
+        name: jackson-databind
+        namespace: fasterxml
+        provider: github
+        revision: c45ed8c4cbf6c29317bf4cf562558884fa698eec
+        type: git
+        url: 'https://github.com/fasterxml/jackson-databind/commit/c45ed8c4cbf6c29317bf4cf562558884fa698eec'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updated source location and declared license

**Details:**
-No source location on one definition
-No declared license on both definitions

**Resolution:**
Source location is: https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.8.9
README.MD says Apache 2.0 is the applicable license

**Affected definitions**:
- jackson-databind 2.8.9,- jackson-databind 2.8.9