### PR TITLE
AE49_181207_190917.791

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Buffers.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Buffers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetty.Buffers
+  provider: nuget
+  type: nuget
+revisions:
+  0.4.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License 

**Details:**
Add MIT

**Resolution:**
https://github.com/Azure/DotNetty/blob/v0.4.0/LICENSE.txt

**Affected definitions**:
- DotNetty.Buffers 0.4.8