### PR TITLE
bduranc_181207_232642.604

### DIFF
--- a/curations/maven/mavencentral/org.hibernate/hibernate-validator.yaml
+++ b/curations/maven/mavencentral/org.hibernate/hibernate-validator.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: hibernate-validator
+  namespace: org.hibernate
+  provider: mavencentral
+  type: maven
+revisions:
+  6.0.7.Final:
+    described:
+      sourceLocation:
+        name: hibernate-validator
+        namespace: hibernate
+        provider: github
+        revision: 1553e9fc48b1ad33151f8c46971a313d055932a7
+        type: git
+        url: 'https://github.com/hibernate/hibernate-validator/commit/1553e9fc48b1ad33151f8c46971a313d055932a7'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare license and source location

**Details:**
-No license declared
-No source location

**Resolution:**
Declared license should be: Apache 2.0

See Maven Repository: http://central.maven.org/maven2/org/hibernate/validator/hibernate-validator/6.0.7.Final/hibernate-validator-6.0.7.Final.pom

**Affected definitions**:
- hibernate-validator 6.0.7.Final