### PR TITLE
bduranc_181217_202215.301

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
@@ -15,3 +15,14 @@ revisions:
         url: 'https://github.com/fasterxml/jackson-databind/commit/c45ed8c4cbf6c29317bf4cf562558884fa698eec'
     licensed:
       declared: Apache-2.0
+  2.9.3:
+    described:
+      sourceLocation:
+        name: jackson-databind
+        namespace: fasterxml
+        provider: github
+        revision: d4f5fc1b1e53774b85188da1b4ebd5ed09ff6aa5
+        type: git
+        url: 'https://github.com/fasterxml/jackson-databind/commit/d4f5fc1b1e53774b85188da1b4ebd5ed09ff6aa5'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update source location and declared license

**Details:**
No source location or declared license are present

**Resolution:**
Source location: https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.9.3
Declared license: Apache-2.0
(See: README.md of source location above)

**Affected definitions**:
- jackson-databind 2.9.3