### PR TITLE
bduranc_181217_211706.163

### DIFF
--- a/curations/git/github/nodejs/node.yaml
+++ b/curations/git/github/nodejs/node.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: node
+  namespace: nodejs
+  provider: github
+  type: git
+revisions:
+  d4982f6f5e4a9a703127489a553b8d782997ea43:
+    files:
+      - attributions:
+          - 'Copyright (c) 2007, 2008 gnombat@users.sourceforge.net'
+        license: GPL-3.0
+        path: doc/sh_main.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
declaring license for file covered under GPLv3

**Details:**
File under /doc/api_assets/sh_main.js has no declared license but is confirmed to be GPLv3.

**Resolution:**
Inside this file, the header comments mention this license: http://shjs.sourceforge.net/doc/gplv3.html

**Affected definitions**:
- node d4982f6f5e4a9a703127489a553b8d782997ea43