### PR TITLE
dabutvin_181217_222834.225

### DIFF
--- a/curations/npm/npmjs/-/base-64.yaml
+++ b/curations/npm/npmjs/-/base-64.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: base-64
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Marking base-64.js as MIT

**Details:**
They are using the old package.json format of `licenses` array instead of `license` string

**Resolution:**
Curate as MIT

**Affected definitions**:
- base-64 0.1.0