### PR TITLE
cruzerika_181217_225339.146

### DIFF
--- a/curations/git/github/rails/arel.yaml
+++ b/curations/git/github/rails/arel.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: arel
+  namespace: rails
+  provider: github
+  type: git
+revisions:
+  5a75bcaf67613b4241a3223b734ed4dc8526df6c:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license should be MIT

**Details:**
No license is declared

**Resolution:**
See:
- github repo: https://github.com/rails/arel/blob/5a75bcaf67613b4241a3223b734ed4dc8526df6c/MIT-LICENSE.txt

**Affected definitions**:
- arel 5a75bcaf67613b4241a3223b734ed4dc8526df6c