### PR TITLE
cruzerika_181217_225554.782

### DIFF
--- a/curations/git/github/asynchttpclient/async-http-client.yaml
+++ b/curations/git/github/asynchttpclient/async-http-client.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: async-http-client
+  namespace: asynchttpclient
+  provider: github
+  type: git
+revisions:
+  cee7964fdbd1878f08c82dd0c12196b9297e21de:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license should be Apache License 2.0

**Details:**
No license is declared

**Resolution:**
See:
- girthub repo: https://github.com/AsyncHttpClient/async-http-client/blob/cee7964fdbd1878f08c82dd0c12196b9297e21de/LICENSE-2.0.txt

**Affected definitions**:
- async-http-client cee7964fdbd1878f08c82dd0c12196b9297e21de