### PR TITLE
bduranc_181219_055606.649

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.core/jackson-databind.yaml
@@ -15,6 +15,17 @@ revisions:
         url: 'https://github.com/fasterxml/jackson-databind/commit/c45ed8c4cbf6c29317bf4cf562558884fa698eec'
     licensed:
       declared: Apache-2.0
+  2.9.0:
+    described:
+      sourceLocation:
+        name: jackson-databind
+        namespace: fasterxml
+        provider: github
+        revision: e969f0a31b781f5dfb74e16ddd5ee4b4fa36e8d8
+        type: git
+        url: 'https://github.com/fasterxml/jackson-databind/commit/e969f0a31b781f5dfb74e16ddd5ee4b4fa36e8d8'
+    licensed:
+      declared: Apache-2.0
   2.9.3:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Specified source location and declared license

**Details:**
No license was declared for this component
And no source location was specified for this component

**Resolution:**
Applicable license for this component is Apache-2.0.
Source location in GitHub is: https://github.com/FasterXML/jackson-databind/tree/jackson-databind-2.9.0/

License information is available under README.MD

**Affected definitions**:
- jackson-databind 2.9.0