### PR TITLE
ariel11_181220_211653.859

### DIFF
--- a/curations/npm/npmjs/-/xmldom.yaml
+++ b/curations/npm/npmjs/-/xmldom.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xmldom
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.27:
+    licensed:
+      declared: LGPL-2.0 OR MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing License

**Details:**
Declaring License

**Resolution:**
The commit near the date of this package just links to https://www.gnu.org/licenses/lgpl.html, which shows LGPL v3.  However, the current release package.json specifies v2, so I think this is the intended license.

**Affected definitions**:
- xmldom 0.1.27