### PR TITLE
cruzerika_190108_235035.996

### DIFF
--- a/curations/git/github/mikemcl/big.js.yaml
+++ b/curations/git/github/mikemcl/big.js.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: big.js
+  namespace: mikemcl
+  provider: github
+  type: git
+revisions:
+  86268e96b3dbf6db8ce319489f410277d9d4ea1b:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license should be MIT

**Details:**
There is no license declared.

**Resolution:**
See:
-github repo: https://github.com/MikeMcl/big.js/blob/86268e96b3dbf6db8ce319489f410277d9d4ea1b/LICENCE

**Affected definitions**:
- big.js 86268e96b3dbf6db8ce319489f410277d9d4ea1b