### PR TITLE
cruzerika_190108_235535.686

### DIFF
--- a/curations/git/github/moagrius/copycss.yaml
+++ b/curations/git/github/moagrius/copycss.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: copycss
+  namespace: moagrius
+  provider: github
+  type: git
+revisions:
+  827cc865ebe484e19fe6d4b372ed7149f5bb13a9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
License declared should be MIT

**Details:**
There is no license declared.

**Resolution:**
See:
- github repo package management file (bower.json): https://github.com/moagrius/copycss/blob/827cc865ebe484e19fe6d4b372ed7149f5bb13a9/bower.json
- github repo copyright file header: https://github.com/moagrius/copycss/blob/827cc865ebe484e19fe6d4b372ed7149f5bb13a9/jquery.copycss.js

**Affected definitions**:
- copycss 827cc865ebe484e19fe6d4b372ed7149f5bb13a9