### PR TITLE
AE49_190110_195713.522

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions.yaml
@@ -6,7 +6,13 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.1:
+    licensed:
+      declared: Apache-2.0
   2.0.2:
+    licensed:
+      declared: Apache-2.0
+  2.1.2:
     licensed:
       declared: Apache-2.0
   2.1.3:

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv.yaml
@@ -6,6 +6,12 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.0.1:
+    licensed:
+      declared: Apache-2.0
   2.0.2:
+    licensed:
+      declared: Apache-2.0
+  2.1.0:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets.yaml
@@ -3,6 +3,15 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: Apache-2.0
+  2.1.1:
+    licensed:
+      declared: Apache-2.0
+  2.1.2:
+    licensed:
+      declared: Apache-2.0
   2.1.3:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Session.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Session.yaml
@@ -3,6 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.1:
+    licensed:
+      declared: Apache-2.0
+  2.1.0:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.SignalR.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.SignalR.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-2.0
   1.0.3:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License

**Details:**
Bulk contribution

**Resolution:**
n/a

**Affected definitions**:
- Microsoft.AspNetCore.Server.Kestrel.Transport.Abstractions 2.1.2,- Microsoft.AspNetCore.Server.Kestrel.Transport.Libuv 2.0.1,- Microsoft.AspNetCore.Server.Kestrel.Transport.Sockets 2.1.0,- Microsoft.AspNetCore.Session 2.1.0,- Microsoft.AspNetCore.SignalR 1.0.1