### PR TITLE
TravisEz13_190110_231905.689

### DIFF
--- a/curations/nuget/nuget/-/Markdig.Signed.yaml
+++ b/curations/nuget/nuget/-/Markdig.Signed.yaml
@@ -12,3 +12,6 @@ revisions:
   0.15.4:
     licensed:
       declared: BSD-2-Clause
+  0.15.6:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.5:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetAppHost.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetAppHost.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.5:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.5:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.5:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.NETCore.Platforms.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.Platforms.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.1:
     licensed:
       declared: MIT
+  2.1.2:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Net.Http.WinHttpHandler.yaml
+++ b/curations/nuget/nuget/-/System.Net.Http.WinHttpHandler.yaml
@@ -6,3 +6,6 @@ revisions:
   4.5.1:
     licensed:
       declared: MIT
+  4.5.2:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Security.Cryptography.Pkcs.yaml
+++ b/curations/nuget/nuget/-/System.Security.Cryptography.Pkcs.yaml
@@ -9,3 +9,6 @@ revisions:
   4.5.1:
     licensed:
       declared: MIT
+  4.5.2:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Text.Encoding.CodePages.yaml
+++ b/curations/nuget/nuget/-/System.Text.Encoding.CodePages.yaml
@@ -9,3 +9,6 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Set Licenses for packages

**Details:**
Set Licenses for packages
Got license from the nuget page license info link

**Resolution:**
Set Licenses for packages

**Affected definitions**:
- Markdig.Signed 0.15.6,- Microsoft.NETCore.App 2.1.5,- Microsoft.NETCore.DotNetAppHost 2.1.5,- Microsoft.NETCore.DotNetHostPolicy 2.1.5,- Microsoft.NETCore.DotNetHostResolver 2.1.5,- Microsoft.NETCore.Platforms 2.1.2,- System.Net.Http.WinHttpHandler 4.5.2,- System.Security.Cryptography.Pkcs 4.5.2,- System.Text.Encoding.CodePages 4.5.1