### PR TITLE
TravisEz13_190115_013356.183

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -6,3 +6,6 @@ revisions:
   9.12.2:
     licensed:
       declared: MIT
+  9.13.13:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the license for NJsonSchema

**Details:**
Update the license for NJsonSchema
Got the license from the nuget package page, license info link

**Resolution:**
Update the license for NJsonSchema
Got the license from the nuget package page, license info link

**Affected definitions**:
- NJsonSchema 9.13.13