### PR TITLE
adding github/php/php-src license information

### DIFF
--- a/curations/git/github/php/php-src/php-src.yml
+++ b/curations/git/github/php/php-src/php-src.yml
@@ -1,0 +1,9 @@
+coordinates:
+  name: php-src
+  namespace: php
+  provider: github
+  type: git
+revisions:
+  c16ea99f5de90081f25034c19b5c89896fb38bd4:
+    licensed:
+      declared: PHP-3.01


### PR DESCRIPTION
I had a look at the repo itself the license file is available in the repo root