### PR TITLE
StephenWeatherford_190131_012102.398

### DIFF
--- a/curations/npm/npmjs/-/sax.yaml
+++ b/curations/npm/npmjs/-/sax.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.5.8:
     licensed:
-      declared: 'BSD-2-Clause, W3C'
+      declared: 'BSD-2-Clause'

--- a/curations/npm/npmjs/-/sax.yaml
+++ b/curations/npm/npmjs/-/sax.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sax
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.8:
+    licensed:
+      declared: 'BSD-2-Clause, W3C'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add licenses

**Details:**
Add licenses

**Resolution:**
https://github.com/isaacs/sax-js/blob/v0.5.8/LICENSE
https://github.com/isaacs/sax-js/blob/v0.5.8/LICENSE-W3C.html

Note that the second license appears to be just for one of the example files distributed along with the source (see comment for https://github.com/isaacs/sax-js/commit/cfc087f30f29ff3)

**Affected definitions**:
- sax 0.5.8