### PR TITLE
StephenWeatherford_190131_014141.293

### DIFF
--- a/curations/npm/npmjs/-/semaphore.yaml
+++ b/curations/npm/npmjs/-/semaphore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: semaphore
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add license

**Details:**
Set to MIT license

**Resolution:**
There is no actual license in the sources, and it's not declared in the package.json (https://github.com/abrkn/semaphore.js/blob/v1.0.5/package.json).  However, the README.md mentions that the license is MIT at the bottom (https://github.com/abrkn/semaphore.js/tree/v1.0.5#license).

**Affected definitions**:
- semaphore 1.0.5