### PR TITLE
StephenWeatherford_190131_014856.782

### DIFF
--- a/curations/npm/npmjs/-/xmlhttprequest-ssl.yaml
+++ b/curations/npm/npmjs/-/xmlhttprequest-ssl.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: xmlhttprequest-ssl
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.3:
+    described:
+      sourceLocation:
+        name: node-xmlhttprequest
+        namespace: mjwwit
+        provider: github
+        revision: b0fa1e0ddb900e28cf6cfbf8f6ade2babc4a12f9
+        type: git
+        url: 'https://github.com/mjwwit/node-xmlhttprequest/commit/b0fa1e0ddb900e28cf6cfbf8f6ade2babc4a12f9'
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/xmlhttprequest-ssl.yaml
+++ b/curations/npm/npmjs/-/xmlhttprequest-ssl.yaml
@@ -9,8 +9,8 @@ revisions:
         name: node-xmlhttprequest
         namespace: mjwwit
         provider: github
-        revision: b0fa1e0ddb900e28cf6cfbf8f6ade2babc4a12f9
+        revision: d35e16183e162f3c67b29191ab20e4c81db68742
         type: git
-        url: 'https://github.com/mjwwit/node-xmlhttprequest/commit/b0fa1e0ddb900e28cf6cfbf8f6ade2babc4a12f9'
+        url: 'https://github.com/mjwwit/node-XMLHttpRequest/commit/d35e16183e162f3c67b29191ab20e4c81db68742'
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add license

**Details:**
Add MIT license

**Resolution:**
There is no release tag for 1.5.3, so I pointed the source at 1.5.4 (license is https://github.com/mjwwit/node-XMLHttpRequest/blob/1.5.4/LICENSE). The license has not changed at any point before then.

**Affected definitions**:
- xmlhttprequest-ssl 1.5.3