### PR TITLE
ariel11_190204_160849.944

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Swift4.CoreFoundation.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Swift4.CoreFoundation.yaml
@@ -4,5 +4,10 @@ coordinates:
   type: nuget
 revisions:
   4.0.1:
+    files:
+      - attributions:
+          - 'Copyright 2017 Lucas Teixeira '
+        license: ''
+        path: Xamarin.Swift4.CoreFoundation.nuspec
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing copyright

**Details:**
Adding copyright

**Resolution:**
Doing 1 as a test.  The NuGet download page just says "Copyright 2017."  But the repo (https://github.com/Flash3001/Xamarin.SwiftSupport) has "Copyright 2017 Lucas Teixeira" at the bottom of the readme.

**Affected definitions**:
- Xamarin.Swift4.CoreFoundation 4.0.1