### PR TITLE
EricJizbaMSFT_190204_184246.354

### DIFF
--- a/curations/npm/npmjs/-/domutils.yaml
+++ b/curations/npm/npmjs/-/domutils.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: domutils
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Correct domutils license

**Details:**
License should be BSD-2-Clause

**Resolution:**
No tag for 1.5.1, but surrounding releases have it and no commits affecting LICENSE between
https://github.com/fb55/domutils/blob/v1.5.0/LICENSE
https://github.com/fb55/domutils/blob/v1.6.0/LICENSE

**Affected definitions**:
- domutils 1.5.1