### PR TITLE
reskusic_190213_191308.355

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.App.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.App.yaml
@@ -8,7 +8,10 @@ revisions:
       declared: Apache-2.0
   2.1.2:
     licensed:
-      declared: Apache-2.0      
+      declared: Apache-2.0
   2.1.3:
+    licensed:
+      declared: Apache-2.0
+  2.1.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added information for Microsoft.AspNetCore.App 2.1.4

**Details:**
The license information was missing for this component.

**Resolution:**
License information is from the component GitHub repo here: https://github.com/aspnet/AspNetCore/blob/6dd5a7bcf815886f1e62ba06c289a4696b90f0aa/LICENSE.txt

**Affected definitions**:
- Microsoft.AspNetCore.App 2.1.4