### PR TITLE
reskusic_190213_191616.205

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -12,3 +12,6 @@ revisions:
   2.0.0:
     licensed:
       declared: MIT
+  2.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added information for Microsoft.DotNet.PlatformAbstractions 2.1.0

**Details:**
The license information was missing for this component.

**Resolution:**
License information is from the component GitHub repo here: https://github.com/dotnet/core-setup/blob/caa7b7e2bad98e56a687fb5cbaf60825500800f7/LICENSE.TXT

**Affected definitions**:
- Microsoft.DotNet.PlatformAbstractions 2.1.0