### PR TITLE
reskusic_190213_194055.401

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.EntityFrameworkCore.SqlServer.yaml
+++ b/curations/nuget/nuget/-/Microsoft.EntityFrameworkCore.SqlServer.yaml
@@ -15,3 +15,14 @@ revisions:
   2.1.2:
     licensed:
       declared: Apache-2.0
+  2.1.3:
+    described:
+      sourceLocation:
+        name: entityframeworkcore
+        namespace: aspnet
+        provider: github
+        revision: 166e6014791e59c9f0937b05498c82f12cd559b2
+        type: git
+        url: 'https://github.com/aspnet/entityframeworkcore/commit/166e6014791e59c9f0937b05498c82f12cd559b2'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Added information for Microsoft.EntityFrameworkCore.SqlServer 2.1.3

**Details:**
The source repository was incorrect for this component.
The license information was missing for this component.

**Resolution:**
The package repository information is from the nuget package page, here: https://www.nuget.org/packages/Microsoft.EntityFrameworkCore.SqlServer
License information is from the component GitHub repo here: https://github.com/aspnet/EntityFrameworkCore/blob/2.1.3/LICENSE.txt


**Affected definitions**:
- Microsoft.EntityFrameworkCore.SqlServer 2.1.3