### PR TITLE
bduranc_190214_042637.939

### DIFF
--- a/curations/git/github/ionic-team/ionic.yaml
+++ b/curations/git/github/ionic-team/ionic.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ionic
+  namespace: ionic-team
+  provider: github
+  type: git
+revisions:
+  c463b065c79481939de958ec6eb9c7827c62ec2f:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license

**Details:**
Declared license is MIT

**Resolution:**
MIT license as noted on LICENSE markdown file in project's repository: https://github.com/ionic-team/ionic/blob/v3.9.2/LICENSE

**Affected definitions**:
- ionic c463b065c79481939de958ec6eb9c7827c62ec2f