### PR TITLE
reskusic_190219_230754.461

### DIFF
--- a/curations/git/github/boostorg/boost.yaml
+++ b/curations/git/github/boostorg/boost.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: boost
+  namespace: boostorg
+  provider: github
+  type: git
+revisions:
+  1a9dda41fbfb0dfbec17ab6afeba8138265395f7:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Added information for for boost 1.67.0

**Details:**
The license information was missing for this component.

**Resolution:**
The license information is here, from the git repository: https://github.com/boostorg/boost/blob/boost-1.67.0/LICENSE_1_0.txt

**Affected definitions**:
- boost 1a9dda41fbfb0dfbec17ab6afeba8138265395f7