### PR TITLE
reskusic_190219_232034.474

### DIFF
--- a/curations/git/github/openssl/openssl.yaml
+++ b/curations/git/github/openssl/openssl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: openssl
+  namespace: openssl
+  provider: github
+  type: git
+revisions:
+  3ce7bc40a3c48da1c96c2d04c10045bd797c6aa3:
+    licensed:
+      declared: OpenSSL


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Added information for for OpenSSL 1.0.2o

**Details:**
The license information was missing for this component.

**Resolution:**
The license information is here, from the git repository: https://github.com/openssl/openssl/blob/3ce7bc40a3c48da1c96c2d04c10045bd797c6aa3/LICENSE

NOTE: The second license (the "Original SSLeay License") does not appear to be in the ClearlyDefined license catalog. 

**Affected definitions**:
- openssl 3ce7bc40a3c48da1c96c2d04c10045bd797c6aa3