### PR TITLE
reskusic_190219_232339.720

### DIFF
--- a/curations/git/github/madler/zlib.yaml
+++ b/curations/git/github/madler/zlib.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: zlib
+  namespace: madler
+  provider: github
+  type: git
+revisions:
+  cacf7f1d4e3d44d871b605da3b647f07d718623f:
+    licensed:
+      declared: Zlib


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Added information for for zlib 1.2.11

**Details:**
The license information was missing for this component.

**Resolution:**
The license information is here, from the git repository: https://github.com/madler/zlib/blob/cacf7f1d4e3d44d871b605da3b647f07d718623f/README

**Affected definitions**:
- zlib cacf7f1d4e3d44d871b605da3b647f07d718623f