### PR TITLE
Adding jquery MIT license

### DIFF
--- a/curations/git/github/jquery/jquery.yaml
+++ b/curations/git/github/jquery/jquery.yaml
@@ -15,3 +15,6 @@ revisions:
   16b079b164d62bd807c612806842a13bf9b04d17:
     licensed:
       declared: MIT
+  8f2a9d9272d6ed7f32d3a484740ab342c02541e0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding jquery MIT license

**Details:**
Missing MIT license 

**Resolution:**
Curation per https://github.com/jquery/jquery/blob/8f2a9d9272d6ed7f32d3a484740ab342c02541e0/MIT-LICENSE.txt

**Affected definitions**:
- jquery 8f2a9d9272d6ed7f32d3a484740ab342c02541e0