### PR TITLE
Adding GPL 3 license

### DIFF
--- a/curations/nuget/nuget/-/opencl-nug.yaml
+++ b/curations/nuget/nuget/-/opencl-nug.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: opencl-nug
+  provider: nuget
+  type: nuget
+revisions:
+  0.777.12:
+    licensed:
+      declared: GPL-3.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding GPL 3 license

**Details:**
Missing GPL 3 license for opencl-nug

**Resolution:**
Per https://github.com/mancoast/opencl-nug/blob/master/COPYING I believe this project's license is GPL 3

**Affected definitions**:
- opencl-nug 0.777.12