### PR TITLE
Add WTFPL license

### DIFF
--- a/curations/pypi/pypi/-/pyaml.yaml
+++ b/curations/pypi/pypi/-/pyaml.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pyaml
+  provider: pypi
+  type: pypi
+revisions:
+  17.8.0:
+    licensed:
+      declared: WTFPL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add WTFPL license

**Details:**
Missing license is WTFPL

**Resolution:**
Per https://github.com/mk-fg/pretty-yaml/blob/master/COPYING I believe this component's license is WTFPL

**Affected definitions**:
- pyaml 17.8.0