### PR TITLE
Project license is BSD 2-Clause

### DIFF
--- a/curations/maven/mavencentral/com.github.bumptech.glide/glide.yaml
+++ b/curations/maven/mavencentral/com.github.bumptech.glide/glide.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: glide
+  namespace: com.github.bumptech.glide
+  provider: mavencentral
+  type: maven
+revisions:
+  4.8.0:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/sourcearchive/mavencentral/com.github.bumptech.glide/glide.yaml
+++ b/curations/sourcearchive/mavencentral/com.github.bumptech.glide/glide.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: glide
+  namespace: com.github.bumptech.glide
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  4.8.0:
+    described:
+      sourceLocation:
+        name: glide
+        namespace: bumptech
+        provider: github
+        revision: 914996cac11108ec1a02c21a10af53ebc4980d7f
+        type: git
+        url: 'https://github.com/bumptech/glide/commit/914996cac11108ec1a02c21a10af53ebc4980d7f'
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Project license is BSD 2-Clause

**Details:**
Update declared license and source URL

**Resolution:**
The license for this project is BSD-2-Clause.

See here for detail: https://github.com/bumptech/glide/blob/v4.8.0/LICENSE

**Affected definitions**:
- glide 4.8.0,- glide 4.8.0