### PR TITLE
add license : MIT

### DIFF
--- a/curations/git/github/component/component.yaml
+++ b/curations/git/github/component/component.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: component
+  namespace: component
+  provider: github
+  type: git
+revisions:
+  03823566dd2ed26bd04daf82a9b6458b0ec7affa:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
add license : MIT

**Details:**
I found that the component is under MIT : https://github.com/componentjs/component/blob/master/LICENSE

**Resolution:**
https://github.com/componentjs/component/blob/master/LICENSE

**Affected definitions**:
- component 03823566dd2ed26bd04daf82a9b6458b0ec7affa