### PR TITLE
MIT AND Apache-2.0? No, It should be 'OR'

### DIFF
--- a/curations/git/github/yoshuawuyts/github_auth.yaml
+++ b/curations/git/github/yoshuawuyts/github_auth.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: github_auth
+  namespace: yoshuawuyts
+  provider: github
+  type: git
+revisions:
+  cc676daad2bb473e88005091033258121b133e6d:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
MIT AND Apache-2.0? No, It should be 'OR'

**Details:**
MIT AND Apache-2.0? No, It should be MIT OR Apache-2.0

**Resolution:**
https://github.com/yoshuawuyts/github_auth/blob/master/README.md

**Affected definitions**:
- github_auth cc676daad2bb473e88005091033258121b133e6d