### PR TITLE
Add JSON to license of twitter4j-core

### DIFF
--- a/curations/maven/mavencentral/org.twitter4j/twitter4j-core.yaml
+++ b/curations/maven/mavencentral/org.twitter4j/twitter4j-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: twitter4j-core
+  namespace: org.twitter4j
+  provider: mavencentral
+  type: maven
+revisions:
+  4.0.6:
+    licensed:
+      declared: Apache-2.0 AND JSON


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Add JSON to license of twitter4j-core

**Details:**
twitter4j-core includes some code under the JSON License. This is acknowledged in the LICENSE.txt file, for example; the full text of the license appears in a few source files. It is relevant that the JSON is widely considered to be a non-open-source license (and thus for example not somehow subsumable into the Apache License 2.0 for purposes of making a reasonably useful license description).

**Resolution:**
Correct the Declared license to "Apache-2.0 AND JSON"


**Affected definitions**:
- twitter4j-core 4.0.6