### PR TITLE
Adding MIT License

### DIFF
--- a/curations/npm/npmjs/-/path-to-regexp.yaml
+++ b/curations/npm/npmjs/-/path-to-regexp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: path-to-regexp
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding MIT License

**Details:**
Adding MIT license based on what I can tell from the commit history

**Resolution:**
There's no license at tag 0.1.2 but the closest I could find was MIT at 1.0 https://github.com/pillarjs/path-to-regexp/blob/v1.0.0/LICENSE

**Affected definitions**:
- path-to-regexp 0.1.2