### PR TITLE
There is no license declared.

### DIFF
--- a/curations/git/github/acdlite/recompose.yaml
+++ b/curations/git/github/acdlite/recompose.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: recompose
+  namespace: acdlite
+  provider: github
+  type: git
+revisions:
+  88e89d49b8de648c6315a3b3d0bdd06816997581:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
There is no license declared.

**Details:**
Declared license should be MIT.

**Resolution:**
See basePackage.json on github:
https://github.com/acdlite/recompose/blob/88e89d49b8de648c6315a3b3d0bdd06816997581/src/basePackage.json

**Affected definitions**:
- recompose 88e89d49b8de648c6315a3b3d0bdd06816997581