### PR TITLE
Declared license should be BSD-3-Clause

### DIFF
--- a/curations/pypi/pypi/-/Flask.yaml
+++ b/curations/pypi/pypi/-/Flask.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Flask
+  provider: pypi
+  type: pypi
+revisions:
+  0.10.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license should be BSD-3-Clause

**Details:**
Text of root directory license closely matches SPDX BSD-3-Clause (but possibly not a match in an SPDX-conformance sense because of an overly strict SPDX definition); in any case it is not BSD-2-Clause. docs/license.rst also says it is licensed under "a 3-clause BSD license"

**Resolution:**
Correct declared license to BSD-3-Clause

**Affected definitions**:
- Flask 0.10.1