### PR TITLE
Updating Openni to be Apache2.0

### DIFF
--- a/curations/git/github/openni/openni.yaml
+++ b/curations/git/github/openni/openni.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   d50d0e3fb0a5913185ea03c5fd5268cb4472a2a4:
     licensed:
-      declared: Apache-2.0
+      declared: GPL-3.0 AND LGPL-3.0

--- a/curations/git/github/openni/openni.yaml
+++ b/curations/git/github/openni/openni.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: openni
+  namespace: openni
+  provider: github
+  type: git
+revisions:
+  d50d0e3fb0a5913185ea03c5fd5268cb4472a2a4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updating Openni to be Apache2.0

**Details:**
Looked at the repo on Github and saw that the declared License is Apache2.0, but CDL doesn't have an associated license.

**Resolution:**
https://github.com/OpenNI/OpenNI/blob/master/LICENSE

**Affected definitions**:
- openni d50d0e3fb0a5913185ea03c5fd5268cb4472a2a4