### PR TITLE
Updating License for this commit of Zlib to the Zlib license

### DIFF
--- a/curations/git/github/madler/zlib.yaml
+++ b/curations/git/github/madler/zlib.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  9712272c78b9d9c93746d9c8e156a3728c65ca72:
+    licensed:
+      declared: Zlib
   cacf7f1d4e3d44d871b605da3b647f07d718623f:
     licensed:
       declared: Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updating License for this commit of Zlib to the Zlib license

**Details:**
The Zlib repo has a zlib license.

**Resolution:**
License is on the main page of the repo as well as on https://www.zlib.net/zlib_license.html

**Affected definitions**:
- zlib 9712272c78b9d9c93746d9c8e156a3728c65ca72