### PR TITLE
License incorrectly declared as MIT

### DIFF
--- a/curations/npm/npmjs/-/react-native-appboy-sdk.yaml
+++ b/curations/npm/npmjs/-/react-native-appboy-sdk.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: react-native-appboy-sdk
+  provider: npmjs
+  type: npm
+revisions:
+  1.10.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License incorrectly declared as MIT

**Details:**
While the package.json declares the license as MIT the LICENSE.md is not the MIT license: https://github.com/Appboy/appboy-react-sdk/blob/fdfa85f2ded37fcff9fcc85b41ded0c598d4156b/LICENSE.md

**Resolution:**
As this license isn't a SPDX-listed license this PR updates the declared license to NOASSERTION.

**Affected definitions**:
- react-native-appboy-sdk 1.10.0