### PR TITLE
Adding MIT

### DIFF
--- a/curations/nuget/nuget/-/NuGetValidator.yaml
+++ b/curations/nuget/nuget/-/NuGetValidator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGetValidator
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding MIT

**Details:**
Adding MIT license per https://github.com/mishra14/NuGetBuildValidwators/blob/master/license.txt

**Resolution:**
Couldn't find a tag for this version, but adding MIT license per https://github.com/mishra14/NuGetBuildValidwators/blob/master/license.txt

**Affected definitions**:
- NuGetValidator 1.3.7