### PR TITLE
update amdetective for older version

### DIFF
--- a/curations/npm/npmjs/-/amdetective.yaml
+++ b/curations/npm/npmjs/-/amdetective.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.2:
+    licensed:
+      declared: BSD-3-Clause
   0.2.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
update amdetective for older version

**Details:**
Used to list "BSD" as the license. See the change here: https://github.com/mixu/amdetective/commit/482e77fb79c87e37f6e61733ffa4a1677724ab2e

**Resolution:**
"BSD" is not SPDX, so it was not detected

**Affected definitions**:
- amdetective 0.0.2