### PR TITLE
Declared license should be Apache 2.0

### DIFF
--- a/curations/git/github/ytti/oxidized-web.yaml
+++ b/curations/git/github/ytti/oxidized-web.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: oxidized-web
+  namespace: ytti
+  provider: github
+  type: git
+revisions:
+  5add416a32a2ac34ff8dc23c0e1587a82813b339:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license should be Apache 2.0

**Details:**
There is no declared license

**Resolution:**
The license is found on the readme file in github repo: 
https://github.com/ytti/oxidized-web/blob/master/README.md

**Affected definitions**:
- oxidized-web 5add416a32a2ac34ff8dc23c0e1587a82813b339