### PR TITLE
Declaring License

### DIFF
--- a/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
+++ b/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
@@ -15,3 +15,6 @@ revisions:
   6.7.40:
     licensed:
       declared: MIT
+  6.7.46:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring License

**Details:**
Missing License

**Resolution:**
Declaring license based on Source URL for a notice file

**Affected definitions**:
- vscode-chrome-debug-core 6.7.46