### PR TITLE
Licensed under Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Client.yaml
+++ b/curations/nuget/nuget/-/NuGet.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Client
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Licensed under Apache-2.0

**Details:**
NuGet is licensed under Apache-2.0

**Resolution:**
Sets the license correctly based on https://github.com/NuGet/NuGet.Client/commits/dev/LICENSE.txt

**Affected definitions**:
- NuGet.Client 4.0.0