### PR TITLE
Updating PSReadLine Declared License to BSD-2-Clause

### DIFF
--- a/curations/git/github/lzybkr/psreadline.yaml
+++ b/curations/git/github/lzybkr/psreadline.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   38eb016b0a942dde0ab0b2f71f51944b56b05af4:
     licensed:
-      declared: 'BSD-2-Clause '
+      declared: 'BSD-2-Clause'

--- a/curations/git/github/lzybkr/psreadline.yaml
+++ b/curations/git/github/lzybkr/psreadline.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: psreadline
+  namespace: lzybkr
+  provider: github
+  type: git
+revisions:
+  38eb016b0a942dde0ab0b2f71f51944b56b05af4:
+    licensed:
+      declared: 'BSD-2-Clause '


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Updating PSReadLine Declared License to BSD-2-Clause

**Details:**
https://github.com/lzybkr/PSReadLine/blob/master/PSReadLine/License.txt is the license text found which seems to have been put in place before this particular version PSReadLine.

**Resolution:**
Updated Declared License of PSReadLine

**Affected definitions**:
- psreadline 38eb016b0a942dde0ab0b2f71f51944b56b05af4