### PR TITLE
Declaring License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.EventHub.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.EventHub.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.0.1-preview:
+    licensed:
+      declared: MIT
   2.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring License

**Details:**
NuGet was published 9-13-2016 - https://www.nuget.org/packages/Microsoft.Azure.Management.EventHub/0.0.1-preview

**Resolution:**
9-13-2016 commit the license is MIT - https://github.com/Azure/azure-sdk-for-net/commit/5764856d77d065ab52175a08b6143b84af608b85

**Affected definitions**:
- Microsoft.Azure.Management.EventHub 0.0.1-preview