### PR TITLE
Declaring License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.EventHub.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.EventHub.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring License

**Details:**
NuGet published on Oct 29 2018 - https://www.nuget.org/packages/Microsoft.Azure.Management.EventHub/2.3.0

**Resolution:**
Commits from same date (44c46ea and 044dbe9) show MIT as the license.

**Affected definitions**:
- Microsoft.Azure.Management.EventHub 2.3.0