### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.ResourceManager.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.ResourceManager.yaml
@@ -9,6 +9,9 @@ revisions:
   1.5.0-preview:
     licensed:
       declared: MIT
+  1.6.0-preview:
+    licensed:
+      declared: MIT
   1.9.0-preview:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet published 5/2/2017

**Resolution:**
This commit from 5/2/2017 - https://github.com/Azure/azure-sdk-for-net/commit/194e1123854148004c00f4169cd1b7704f5545f1 - shows the license is MIT

**Affected definitions**:
- Microsoft.Azure.Management.ResourceManager 1.6.0-preview