### PR TITLE
Declaring License

### DIFF
--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring License

**Details:**
Per source link

**Resolution:**
https://github.com/dotnet/core-setup/blob/caa7b7e2bad98e56a687fb5cbaf60825500800f7/LICENSE.TXT

**Affected definitions**:
- runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy 2.1.0