### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
@@ -30,3 +30,6 @@ revisions:
   9.3.1:
     licensed:
       declared: Apache-2.0
+  9.3.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Not a tagged version.  NuGet published on Nov 27 2018

**Resolution:**
Commit from same date shows Apache v2 - https://github.com/Azure/azure-storage-net/commit/7275d982228918eab4459d3b239fd635a757a16e

**Affected definitions**:
- WindowsAzure.Storage 9.3.3