### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.Runtime.yaml
+++ b/curations/nuget/nuget/-/System.Composition.Runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Composition.Runtime
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet posted on May 29 2018

**Resolution:**
Commit from same date shows MIT - https://github.com/dotnet/corefx/commit/dff80dc05a5d4f67fcef065aa9e625860ad71cd2

**Affected definitions**:
- System.Composition.Runtime 1.2.0