### PR TITLE
Added release date

### DIFF
--- a/curations/gem/rubygems/-/one_gadget.yaml
+++ b/curations/gem/rubygems/-/one_gadget.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: one_gadget
+  provider: rubygems
+  type: gem
+revisions:
+  1.6.2:
+    described:
+      releaseDate: '2018-10-25'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added release date

**Details:**
Adding release date per https://rubygems.org/gems/one_gadget/versions/1.6.2

**Resolution:**
Also found this in the commit history for the source: https://github.com/david942j/one_gadget/commit/8b3f71be0b55683abf54ff737d9814bd2fd97b2b

**Affected definitions**:
- one_gadget 1.6.2