### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudioEng.MicroBuild.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudioEng.MicroBuild.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudioEng.MicroBuild.Core
+  provider: nuget
+  type: nuget
+revisions:
+  0.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Per license link on NuGet download page

**Resolution:**
https://microsoft.mit-license.org/

**Affected definitions**:
- Microsoft.VisualStudioEng.MicroBuild.Core 0.4.1