### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.JsonWebTokens.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.JsonWebTokens.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.IdentityModel.JsonWebTokens
+  provider: nuget
+  type: nuget
+revisions:
+  5.2.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Per commit bumping version to 5.2.4

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/commit/22f20251337767dec2b03562688595373ebb0056

**Affected definitions**:
- Microsoft.IdentityModel.JsonWebTokens 5.2.4