### PR TITLE
Curated gem to BSD-3-Clause

### DIFF
--- a/curations/gem/rubygems/-/a2km.yaml
+++ b/curations/gem/rubygems/-/a2km.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: a2km
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Curated gem to BSD-3-Clause

**Details:**
Found the license here: https://github.com/minrk/a2km/blob/0.0.0/LICENSE

**Resolution:**
Sets the license according to the source, the package simply declared "BSD" without being specific to which variant.

**Affected definitions**:
- a2km 0.0.0