### PR TITLE
Adding MIT license to components

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
@@ -15,6 +15,9 @@ revisions:
   2.3.0:
     licensed:
       declared: MIT
+  2.3.2:
+    licensed:
+      declared: MIT
   2.3.5:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Client.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.17.1:
+    licensed:
+      declared: MIT
   1.5.1:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -5,7 +5,10 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: MIT  
+      declared: MIT
+  1.15.1:
+    licensed:
+      declared: MIT
   1.3.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -12,3 +12,6 @@ revisions:
   2.1.5:
     licensed:
       declared: MIT
+  2.1.7:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Configuration.ConfigurationManager.yaml
+++ b/curations/nuget/nuget/-/System.Configuration.ConfigurationManager.yaml
@@ -6,6 +6,9 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.4.1:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
+++ b/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
@@ -18,6 +18,9 @@ revisions:
   5.2.1:
     licensed:
       declared: MIT
+  5.2.2:
+    licensed:
+      declared: MIT
   5.2.4:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.App.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.App.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.7:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetAppHost.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetAppHost.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.7:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.7:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostResolver.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostResolver.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding MIT license to components

**Details:**
Adding MIT license to components

**Resolution:**
Adding MIT license to components

**Affected definitions**:
- Microsoft.Azure.Devices.Shared 1.15.1,- System.IdentityModel.Tokens.Jwt 5.2.2,- System.Configuration.ConfigurationManager 4.4.1,- Microsoft.Azure.Amqp 2.3.2,- runtime.win-x64.Microsoft.NETCore.DotNetAppHost 2.1.7,- runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy 2.1.7,- Microsoft.NETCore.DotNetHostPolicy 2.1.7,- runtime.win-x64.Microsoft.NETCore.DotNetHostResolver 2.1.7,- runtime.win-x64.Microsoft.NETCore.App 2.1.7,- Microsoft.Azure.Devices.Client 1.17.1