### PR TITLE
MIssing CDDL Licenses and MIT

### DIFF
--- a/curations/maven/mavencentral/javax.activation/activation.yaml
+++ b/curations/maven/mavencentral/javax.activation/activation.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: activation
+  namespace: javax.activation
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: CDDL-1.0
+  1.1.1:
+    licensed:
+      declared: CDDL-1.0

--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
@@ -12,3 +12,6 @@ revisions:
   2.1.5:
     licensed:
       declared: MIT
+  2.1.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIssing CDDL Licenses and MIT

**Details:**
MIssing CDDL Licenses and MIT

**Resolution:**
MIssing CDDL Licenses and MIT

**Affected definitions**:
- Microsoft.NETCore.DotNetHostResolver 2.1.7,- activation 1.1.1