### PR TITLE
More MIT Licenses

### DIFF
--- a/curations/nuget/nuget/-/Libuv.yaml
+++ b/curations/nuget/nuget/-/Libuv.yaml
@@ -6,9 +6,12 @@ revisions:
   1.10.0:
     licensed:
       declared: MIT
+  1.9.0:
+    licensed:
+      declared: MIT
   1.9.1:
     licensed:
-      declared: MIT      
+      declared: MIT
   1.9.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.481:
     licensed:
       declared: MIT
+  2.0.519:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
+++ b/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
@@ -21,3 +21,6 @@ revisions:
   5.2.4:
     licensed:
       declared: MIT
+  5.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
More MIT Licenses

**Details:**
More MIT Licenses

**Resolution:**
More MIT Licenses based on their packages

**Affected definitions**:
- StackExchange.Redis 2.0.519,- System.IdentityModel.Tokens.Jwt 5.3.0,- Libuv 1.9.0