### PR TITLE
MIT License for EventHub

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.EventHubs.Processor.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.EventHubs.Processor.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.3:
     licensed:
       declared: MIT
+  2.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License for EventHub

**Details:**
Add MIT License

**Resolution:**
Add MIT License

**Affected definitions**:
- Microsoft.Azure.EventHubs.Processor 2.2.1