### PR TITLE
Missing Declared license info

### DIFF
--- a/curations/maven/mavencentral/com.sun.mail/javax.mail.yaml
+++ b/curations/maven/mavencentral/com.sun.mail/javax.mail.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.mail
+  namespace: com.sun.mail
+  provider: mavencentral
+  type: maven
+revisions:
+  1.6.1:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared license info

**Details:**
Downloaded package

**Resolution:**
Found license file and pom refers to license file and here: https://oss.oracle.com/licenses/CDDL+GPL-1.1


**Affected definitions**:
- javax.mail 1.6.1