### PR TITLE
Mising Declared License

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: asm
+  namespace: org.ow2.asm
+  provider: mavencentral
+  type: maven
+revisions:
+  5.0.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Mising Declared License

**Details:**
Went here https://mvnrepository.com/artifact/org.ow2.asm/asm/5.0.4 and followed the BSD license link.

**Resolution:**
https://asm.ow2.io/license.html

**Affected definitions**:
- asm 5.0.4