### PR TITLE
Missing Declared License

### DIFF
--- a/curations/maven/mavencentral/org.reactivestreams/reactive-streams.yaml
+++ b/curations/maven/mavencentral/org.reactivestreams/reactive-streams.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: reactive-streams
+  namespace: org.reactivestreams
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.2:
+    licensed:
+      declared: CC0-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared License

**Details:**
Went here https://mvnrepository.com/artifact/org.reactivestreams/reactive-streams/1.0.2

**Resolution:**
License is listed as CC0
http://creativecommons.org/publicdomain/zero/1.0/ 

**Affected definitions**:
- reactive-streams 1.0.2