### PR TITLE
Update to MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector.yaml
@@ -27,3 +27,6 @@ revisions:
   2.8.1:
     licensed:
       declared: MIT
+  2.9.0-beta3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update to MIT

**Details:**
per https://www.nuget.org/packages/Microsoft.ApplicationInsights.DependencyCollector

**Resolution:**
Update license per https://www.nuget.org/packages/Microsoft.ApplicationInsights.DependencyCollector

**Affected definitions**:
- Microsoft.ApplicationInsights.DependencyCollector 2.9.0-beta3