### PR TITLE
MIT License for Microsoft.ApplicationInsights.WindowsServer.Telemetry

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.yaml
@@ -24,3 +24,6 @@ revisions:
   2.8.1:
     licensed:
       declared: MIT
+  2.9.0-beta3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License for Microsoft.ApplicationInsights.WindowsServer.Telemetry

**Details:**
https://www.nuget.org/packages/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel

**Resolution:**
https://www.nuget.org/packages/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel

**Affected definitions**:
- Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel 2.9.0-beta3