### PR TITLE
MIT License for https://www.nuget.org/packages/runtime.native.System.Data.SqlClient.sni

### DIFF
--- a/curations/nuget/nuget/-/runtime.native.System.Data.SqlClient.sni.yaml
+++ b/curations/nuget/nuget/-/runtime.native.System.Data.SqlClient.sni.yaml
@@ -6,3 +6,6 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License for https://www.nuget.org/packages/runtime.native.System.Data.SqlClient.sni

**Details:**
https://www.nuget.org/packages/runtime.native.System.Data.SqlClient.sni

**Resolution:**
https://www.nuget.org/packages/runtime.native.System.Data.SqlClient.sni

**Affected definitions**:
- runtime.native.System.Data.SqlClient.sni 4.5.0