### PR TITLE
MIT for Microsoft.ApplicationInsights.AspNetCore/2.6.0-beta3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.AspNetCore.yaml
@@ -21,3 +21,6 @@ revisions:
   2.5.1:
     licensed:
       declared: MIT
+  2.6.0-beta3:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Net.Security.yaml
+++ b/curations/nuget/nuget/-/System.Net.Security.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Net.Security
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: ''

--- a/curations/nuget/nuget/-/System.Net.Security.yaml
+++ b/curations/nuget/nuget/-/System.Net.Security.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.0.0:
     licensed:
-      declared: ''
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT for Microsoft.ApplicationInsights.AspNetCore/2.6.0-beta3

**Details:**
Microsoft.ApplicationInsights.AspNetCore/2.6.0-beta3

**Resolution:**
Microsoft.ApplicationInsights.AspNetCore/2.6.0-beta3

**Affected definitions**:
- System.Net.Security 4.0.0,- Microsoft.ApplicationInsights.AspNetCore 2.6.0-beta3