### PR TITLE
Incorrect declared license

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.javacsv/javacsv.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.javacsv/javacsv.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javacsv
+  namespace: net.sourceforge.javacsv
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.0':
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Incorrect declared license

**Details:**
The declared license should be LGPL v2.1.



**Resolution:**
Set declared license to LGPL v2.1 as shown in the latest source jar for this project (2.1).

See: https://sourceforge.net/projects/javacsv; https://sourceforge.net/projects/javacsv/files/JavaCsv/JavaCsv%202.1/

When you look inside the JAR, all files under <root>/src bear an LGPL v2.1 header. 

**Affected definitions**:
- javacsv 2.0