### PR TITLE
Set worthwile 0.0.2 to Apache-2.0

### DIFF
--- a/curations/gem/rubygems/-/worthwhile.yaml
+++ b/curations/gem/rubygems/-/worthwhile.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: worthwhile
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Set worthwile 0.0.2 to Apache-2.0

**Details:**
The gemspec declares 'APACHE2' which is not spdx parseable, but is really close and the License.txt file is detected as Apache-2.0

**Resolution:**
Set the declared license from NOASSERTION to Apache-2.0

**Affected definitions**:
- worthwhile 0.0.2