### PR TITLE
Added source location and license for abab 2.0.0

### DIFF
--- a/curations/npm/npmjs/-/abab.yaml
+++ b/curations/npm/npmjs/-/abab.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: abab
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.0:
+    described:
+      sourceLocation:
+        name: abab
+        namespace: jsdom
+        provider: github
+        revision: b13ba64f359c1160e03e3254afbf7ceb874f5cb1
+        type: git
+        url: 'https://github.com/jsdom/abab/commit/b13ba64f359c1160e03e3254afbf7ceb874f5cb1'
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Added source location and license for abab 2.0.0

**Details:**
https://github.com/jsdom/abab/commit/b13ba64f359c1160e03e3254afbf7ceb874f5cb1
https://github.com/jsdom/abab/blob/b13ba64f359c1160e03e3254afbf7ceb874f5cb1/LICENSE.md

**Resolution:**
The license was detected in the License.md, but the license field in package.json said SEE LICENSE IN LICENSE.md

**Affected definitions**:
- abab 2.0.0