### PR TITLE
Update declared license and source location

### DIFF
--- a/curations/maven/mavencentral/org.glassfish/javax.el.yaml
+++ b/curations/maven/mavencentral/org.glassfish/javax.el.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.el
+  namespace: org.glassfish
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.1-b08:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception

--- a/curations/sourcearchive/mavencentral/org.glassfish/javax.el.yaml
+++ b/curations/sourcearchive/mavencentral/org.glassfish/javax.el.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: javax.el
+  namespace: org.glassfish
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  3.0.1-b08:
+    described:
+      sourceLocation:
+        name: uel-ri
+        namespace: javaee
+        provider: github
+        revision: 3db30bd3a76056b1fdcc49388f7ef8a5f08706d0
+        type: git
+        url: 'https://github.com/javaee/uel-ri/commit/3db30bd3a76056b1fdcc49388f7ef8a5f08706d0'
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Update declared license and source location

**Details:**
The declared license should be CDDL-1.1 OR GPL-2.0-WITH-classpath-exception. 
Source location should be set to project's GH repo.

**Resolution:**
Set declared license to CDDL-1.1 OR GPL-2.0-WITH-classpath-exception for both mavencentral and sourcearchive definitions for this component.

Set source location to project's GH repo.

**Affected definitions**:
- javax.el 3.0.1-b08,- javax.el 3.0.1-b08