### PR TITLE
add source location for async-limiter

### DIFF
--- a/curations/npm/npmjs/-/async-limiter.yaml
+++ b/curations/npm/npmjs/-/async-limiter.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: async-limiter
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    described:
+      sourceLocation:
+        name: async-limiter
+        namespace: strml
+        provider: github
+        revision: 02c8b498279dc7cc1ecc1c4f6fc9ca320c0ce39b
+        type: git
+        url: 'https://github.com/strml/async-limiter/commit/02c8b498279dc7cc1ecc1c4f6fc9ca320c0ce39b'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
add source location for async-limiter

**Details:**
no tags in this repo, but very few commits https://github.com/STRML/async-limiter/commits/master
Opened up the package.json from the npm and it had the change made in https://github.com/STRML/async-limiter/commit/02c8b498279dc7cc1ecc1c4f6fc9ca320c0ce39b
No commits for months since then

**Resolution:**
This package was published 2017-09-11 and lines up with this commit hash

**Affected definitions**:
- async-limiter 1.0.0