### PR TITLE
Clarify file level licenses

### DIFF
--- a/curations/git/github/spring-projects/spring-ldap.yaml
+++ b/curations/git/github/spring-projects/spring-ldap.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: spring-ldap
+  namespace: spring-projects
+  provider: github
+  type: git
+revisions:
+  e34028e1e2e3d6dee785853d05454a66bcf22a40:
+    files:
+      - attributions:
+          - '(c) 2005, 2013 jQuery Foundation, Inc.'
+        license: MIT
+        path: samples/user-admin/src/main/webapp/resources/jquery/jquery.min.js
+      - license: NOASSERTION
+        path: lib/ldapbp.jar


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Clarify file level licenses

**Details:**
I have attempted to clarify the license for some files that have a value of 'NOASSERTION' .

<root>/samples/user-admin/src/main/webapp/resources/jquery/jquery.min.js : should be MIT

<root>/lib/ldapbp.jar : was unable to confirm applicable SPDX license, so setting to NOASSERTION.

**Resolution:**
I have attempted to clarify the license for some files that have a value of 'NOASSERTION' .

<root>/samples/user-admin/src/main/webapp/resources/jquery/jquery.min.js : should be MIT

<root>/lib/ldapbp.jar : was unable to confirm applicable SPDX license, so setting to NOASSERTION.

**Affected definitions**:
- spring-ldap e34028e1e2e3d6dee785853d05454a66bcf22a40