### PR TITLE
Update component license and source location

### DIFF
--- a/curations/sourcearchive/mavencentral/com.esotericsoftware/kryo.yaml
+++ b/curations/sourcearchive/mavencentral/com.esotericsoftware/kryo.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: kryo
+  namespace: com.esotericsoftware
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  4.0.1:
+    described:
+      sourceLocation:
+        name: kryo
+        namespace: esotericsoftware
+        provider: github
+        revision: 513f23630f7bdcc313677f1f1b89271bc723a330
+        type: git
+        url: 'https://github.com/esotericsoftware/kryo/commit/513f23630f7bdcc313677f1f1b89271bc723a330'
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update component license and source location

**Details:**
Incorrect component license and source location

**Resolution:**
License and source location updated in accordance to project GH homepage: 
https://github.com/EsotericSoftware/kryo/blob/kryo-parent-4.0.1

**Affected definitions**:
- kryo 4.0.1