### PR TITLE
Update component license and source location

### DIFF
--- a/curations/sourcearchive/mavencentral/org.codehaus.mojo/keytool-maven-plugin.yaml
+++ b/curations/sourcearchive/mavencentral/org.codehaus.mojo/keytool-maven-plugin.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: keytool-maven-plugin
+  namespace: org.codehaus.mojo
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '1.5':
+    described:
+      sourceLocation:
+        name: keytool
+        namespace: mojohaus
+        provider: github
+        revision: 2695a7ead19bb6980a9b1009e7836b9f3ffbbdad
+        type: git
+        url: 'https://github.com/mojohaus/keytool/commit/2695a7ead19bb6980a9b1009e7836b9f3ffbbdad'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update component license and source location

**Details:**
Incorrect component license and source location

**Resolution:**
License and source location updated in accordance to project GH homepage:
https://github.com/mojohaus/keytool/tree/keytool-1.5

**Affected definitions**:
- keytool-maven-plugin 1.5