### PR TITLE
Update component license and source location

### DIFF
--- a/curations/maven/mavencentral/org.wildfly.common/wildfly-common.yaml
+++ b/curations/maven/mavencentral/org.wildfly.common/wildfly-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: wildfly-common
+  namespace: org.wildfly.common
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.0.CR1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/sourcearchive/mavencentral/org.wildfly.common/wildfly-common.yaml
+++ b/curations/sourcearchive/mavencentral/org.wildfly.common/wildfly-common.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: wildfly-common
+  namespace: org.wildfly.common
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.2.0.CR1:
+    described:
+      sourceLocation:
+        name: wildfly-common
+        namespace: wildfly
+        provider: github
+        revision: 0589f59681a910615ecac433809a11f8cd679cae
+        type: git
+        url: 'https://github.com/wildfly/wildfly-common/commit/0589f59681a910615ecac433809a11f8cd679cae'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update component license and source location

**Details:**
Incorrect component license and source location

**Resolution:**
License and source location updated in accordance to project GH homepage:
https://github.com/wildfly/wildfly-common/tree/1.2.0.CR1

**Affected definitions**:
- wildfly-common 1.2.0.CR1,- wildfly-common 1.2.0.CR1