### PR TITLE
Update component license and source location

### DIFF
--- a/curations/maven/mavencentral/org.mozilla/rhino.yaml
+++ b/curations/maven/mavencentral/org.mozilla/rhino.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: rhino
+  namespace: org.mozilla
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7R5:
+    licensed:
+      declared: MPL-2.0

--- a/curations/sourcearchive/mavencentral/org.mozilla/rhino.yaml
+++ b/curations/sourcearchive/mavencentral/org.mozilla/rhino.yaml
@@ -1,0 +1,23 @@
+coordinates:
+  name: rhino
+  namespace: org.mozilla
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.7R5:
+    described:
+      facets:
+        data: []
+        examples:
+          - /examples/**
+        tests:
+          - /testsrc/**
+      sourceLocation:
+        name: rhino
+        namespace: mozilla
+        provider: github
+        revision: 584e7ec09c84de6b5e556a450a6b581f087a4aea
+        type: git
+        url: 'https://github.com/mozilla/rhino/commit/584e7ec09c84de6b5e556a450a6b581f087a4aea'
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update component license and source location

**Details:**
Incorrect component license and source location

**Resolution:**
License and source location updated in accordance to project GH homepage:
https://github.com/mozilla/rhino/tree/Rhino1_7R5_RELEASE

Faceted folders containing 'test' and 'example' code.

**Affected definitions**:
- rhino 1.7R5,- rhino 1.7R5