### PR TITLE
Update component license and source location

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-joda.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-joda.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: jackson-datatype-joda
+  namespace: com.fasterxml.jackson.datatype
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.8.4:
+    described:
+      sourceLocation:
+        name: jackson-datatype-joda
+        namespace: fasterxml
+        provider: github
+        revision: 37d697435b03e9c0c69a20aa00380b31a48e8c37
+        type: git
+        url: 'https://github.com/fasterxml/jackson-datatype-joda/commit/37d697435b03e9c0c69a20aa00380b31a48e8c37'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update component license and source location

**Details:**
Incorrect component license and source location

**Resolution:**
License and source location updated in accordance to project GH homepage:
https://github.com/FasterXML/jackson-datatype-joda/tree/jackson-datatype-joda-2.8.4


**Affected definitions**:
- jackson-datatype-joda 2.8.4