### PR TITLE
Update component license and source location

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.jackson.dataformat/jackson-dataformat-xml.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: jackson-dataformat-xml
+  namespace: com.fasterxml.jackson.dataformat
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.8.4:
+    described:
+      sourceLocation:
+        name: jackson-dataformat-xml
+        namespace: fasterxml
+        provider: github
+        revision: 0521d21d66147a85f17682dcc1fee6a4720c8351
+        type: git
+        url: 'https://github.com/fasterxml/jackson-dataformat-xml/commit/0521d21d66147a85f17682dcc1fee6a4720c8351'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update component license and source location

**Details:**
Incorrect component license and source location

**Resolution:**
License and source location updated in accordance to project GH homepage:
https://github.com/FasterXML/jackson-dataformat-xml/tree/jackson-dataformat-xml-2.8.4

**Affected definitions**:
- jackson-dataformat-xml 2.8.4