### PR TITLE
Replace BSD-2-Clause with BSD-3-Clause

### DIFF
--- a/curations/pypi/pypi/-/ipywidgets.yaml
+++ b/curations/pypi/pypi/-/ipywidgets.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: ipywidgets
+  provider: pypi
+  type: pypi
+revisions:
+  7.4.2:
+    described:
+      sourceLocation:
+        name: ipywidgets
+        namespace: jupyter-widgets
+        provider: github
+        revision: e27c7a81fd7ff96ea74726575845b61e81c5c855
+        type: git
+        url: 'https://github.com/jupyter-widgets/ipywidgets/commit/e27c7a81fd7ff96ea74726575845b61e81c5c855'
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Replace BSD-2-Clause with BSD-3-Clause

**Details:**
Declared and discovered license includes BSD-2-Clause but it should be BSD-3-Clause.

**Resolution:**
The Python definition is ambiguous as it just says "BSD License", however, the copyright statements in the files (e.g. https://github.com/jupyter-widgets/ipywidgets/blame/master/ipywidgets/_version.py#L2) say "Modified BSD License" which is a synonym for BSD-3-Clause.

**Affected definitions**:
- ipywidgets 7.4.2