### PR TITLE
Removing licenses other than BSD 3 from LICENSE

### DIFF
--- a/curations/npm/npmjs/-/tough-cookie.yaml
+++ b/curations/npm/npmjs/-/tough-cookie.yaml
@@ -8,5 +8,5 @@ revisions:
       - attributions:
           - Copyright (c) 2007
           - 'Copyright (c) 2015, Salesforce.com, Inc.'
-        license: BSD-3 AND MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later AND CC0-1.0
+        license: BSD-3 AND CC0-1.0 AND MPL-1.1 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
         path: package/LICENSE

--- a/curations/npm/npmjs/-/tough-cookie.yaml
+++ b/curations/npm/npmjs/-/tough-cookie.yaml
@@ -8,5 +8,5 @@ revisions:
       - attributions:
           - Copyright (c) 2007
           - 'Copyright (c) 2015, Salesforce.com, Inc.'
-        license: BSD-3-Clause
+        license: BSD-3 AND MPL-1.1 OR GPL-2.0-or-later OR LGPL-2.1-or-later AND CC0-1.0
         path: package/LICENSE

--- a/curations/npm/npmjs/-/tough-cookie.yaml
+++ b/curations/npm/npmjs/-/tough-cookie.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: tough-cookie
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.0:
+    files:
+      - attributions:
+          - Copyright (c) 2007
+          - 'Copyright (c) 2015, Salesforce.com, Inc.'
+        license: BSD-3-Clause
+        path: package/LICENSE


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Removing licenses other than BSD 3 from LICENSE

**Details:**
Component says it has multiple licenses from the license file, but I believe it's getting that data from other components tough-cookie depends on. 

**Resolution:**
I believe this is licensed only under BSD-3 per https://github.com/salesforce/tough-cookie/blob/74e59de50b719bb9a1b01c8c9db57fa31401ed1a/LICENSE

**Affected definitions**:
- tough-cookie 1.2.0