### PR TITLE
License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WindowsAzure.Management.Monitoring.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WindowsAzure.Management.Monitoring.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WindowsAzure.Management.Monitoring
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License

**Details:**
Add Apache 2.0

**Resolution:**
4.1.0 was released on 1.30.2015 and per the license history in the repo the licensed changed from Apache 2.0 to MIT after this release on 8.15.2015. Also, confirmed against old scan 4.1.0 is licensed under Apache 2.0. 

**Affected definitions**:
- Microsoft.WindowsAzure.Management.Monitoring 4.1.0