### PR TITLE
Missing license and source location

### DIFF
--- a/curations/gem/rubygems/-/net-smtp-proxy.yaml
+++ b/curations/gem/rubygems/-/net-smtp-proxy.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: net-smtp-proxy
+  provider: rubygems
+  type: gem
+revisions:
+  2.0.0:
+    described:
+      sourceLocation:
+        name: net-smtp-proxy
+        namespace: camertron
+        provider: github
+        revision: f596f67d96bbf0e5866c28c84b7389e3c4c1a222
+        type: git
+        url: 'https://github.com/camertron/net-smtp-proxy/commit/f596f67d96bbf0e5866c28c84b7389e3c4c1a222'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license and source location

**Details:**
Declared license should be MIT and source location should be: https://github.com/camertron/net-smtp-proxy/tree/f596f67d96bbf0e5866c28c84b7389e3c4c1a222

**Resolution:**
- The source location is found on the author's homepage published on ruby gems project page: https://rubygems.org/gems/net-smtp-proxy
- The license is found from the GitHub source location: https://github.com/camertron/net-smtp-proxy/blob/f596f67d96bbf0e5866c28c84b7389e3c4c1a222/LICENSE  

**Affected definitions**:
- net-smtp-proxy 2.0.0