### PR TITLE
Update license and source location

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
+++ b/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: eclipselink
+  namespace: org.eclipse.persistence
+  provider: mavencentral
+  type: maven
+revisions:
+  2.6.4-RC1:
+    licensed:
+      declared: EPL-1.0

--- a/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
+++ b/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.6.4-RC1:
     licensed:
-      declared: EPL-1.0
+      declared: EPL-1.0 AND BSD-3-Clause

--- a/curations/sourcearchive/mavencentral/org.eclipse.persistence/eclipselink.yaml
+++ b/curations/sourcearchive/mavencentral/org.eclipse.persistence/eclipselink.yaml
@@ -14,4 +14,4 @@ revisions:
         type: git
         url: 'https://github.com/eclipse-ee4j/eclipselink/commit/44060b6642658a40a9329b1c0a3138539144f1f7'
     licensed:
-      declared: 'EPL-1.0 '
+      declared: 'EPL-1.0 AND BSD-3-Clause'

--- a/curations/sourcearchive/mavencentral/org.eclipse.persistence/eclipselink.yaml
+++ b/curations/sourcearchive/mavencentral/org.eclipse.persistence/eclipselink.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: eclipselink
+  namespace: org.eclipse.persistence
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.6.4-RC1:
+    described:
+      sourceLocation:
+        name: eclipselink
+        namespace: eclipse-ee4j
+        provider: github
+        revision: 44060b6642658a40a9329b1c0a3138539144f1f7
+        type: git
+        url: 'https://github.com/eclipse-ee4j/eclipselink/commit/44060b6642658a40a9329b1c0a3138539144f1f7'
+    licensed:
+      declared: 'EPL-1.0 '


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update license and source location

**Details:**
The declared license and source location currently on the definition is invalid.

**Resolution:**
Updated license to EPL-1.0 and source location to project's GH repo.

**Affected definitions**:
- eclipselink 2.6.4-RC1,- eclipselink 2.6.4-RC1