### PR TITLE
Erroneous publication date

### DIFF
--- a/curations/maven/mavencentral/org.orekit/orekit.yaml
+++ b/curations/maven/mavencentral/org.orekit/orekit.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: orekit
+  namespace: org.orekit
+  provider: mavencentral
+  type: maven
+revisions:
+  9.3.1:
+    described:
+      releaseDate: '2019-03-16'
+    files:
+      - license: Apache-2.0
+        path: META-INF/LICENSE.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Erroneous publication date

**Details:**
Orekit 9.3.1 was published in March, 16th 2019, not in 2000.

**Resolution:**
Publication date updated

**Affected definitions**:
- orekit 9.3.1