### PR TITLE
Declare license for font files

### DIFF
--- a/curations/git/github/simplesamlphp/simplesamlphp.yaml
+++ b/curations/git/github/simplesamlphp/simplesamlphp.yaml
@@ -14,11 +14,11 @@ revisions:
         path: www/resources/icons/silk/exclamation.png
       - license: CC-BY-2.5
         path: www/resources/icons/silk/readme.txt
-      - license: LGPL-2.0
+      - license: LGPL-2.1
         path: www/resources/icons/crystal_project/kchart.32x32.png
       - attributions:
           - Copyright (c) 2006-2007 Everaldo Coelho.
-        license: LGPL-2.0
+        license: LGPL-2.1
         path: www/resources/icons/crystal_project/readme.txt
       - license: GPL-2.0
         path: www/resources/icons/experience/gtk-dialog-error.48x48.png
@@ -36,7 +36,7 @@ revisions:
         path: www/resources/icons/silk/error.png
       - license: CC-BY-2.5
         path: www/resources/icons/silk/accept.png
-      - license: LGPL-2.0
+      - license: LGPL-2.1
         path: www/resources/icons/crystal_project/date.32x32.png
       - license: GPL-2.0
         path: www/resources/icons/experience/gtk-dialog-warning.svg.gz

--- a/curations/git/github/simplesamlphp/simplesamlphp.yaml
+++ b/curations/git/github/simplesamlphp/simplesamlphp.yaml
@@ -1,0 +1,50 @@
+coordinates:
+  name: simplesamlphp
+  namespace: simplesamlphp
+  provider: github
+  type: git
+revisions:
+  92de42cb0a25ccbf46f78a0e2f3257272afb8ba2:
+    files:
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/delete.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/star.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/exclamation.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/readme.txt
+      - license: LGPL-2.0
+        path: www/resources/icons/crystal_project/kchart.32x32.png
+      - attributions:
+          - Copyright (c) 2006-2007 Everaldo Coelho.
+        license: LGPL-2.0
+        path: www/resources/icons/crystal_project/readme.txt
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-error.48x48.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-error.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-about.64x64.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-authentication.48x48.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/heart.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/magnifier.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/error.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/accept.png
+      - license: LGPL-2.0
+        path: www/resources/icons/crystal_project/date.32x32.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-warning.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-about.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-authentication.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-warning.48x48.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/readme.txt


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
Declare license for font files

**Details:**
Font files missing declared license info

**Resolution:**
Update declared licenses according to readme.txt in each below font directory:

<root>/www/resources/icons/crystal_project/* > LGPL-2.0
(see: https://web.archive.org/web/20110622084146/http://www.everaldo.com:80/crystal/?action=license)
(see: https://github.com/simplesamlphp/simplesamlphp/blob/92de42cb0a25ccbf46f78a0e2f3257272afb8ba2/www/resources/icons/crystal_project/readme.txt)

<root>/www/resources/icons/experience/* > GPL-2.0
(see: https://web.archive.org/web/20100323174847/http://art.gnome.org:80/themes/icon)
(see: https://github.com/simplesamlphp/simplesamlphp/blob/92de42cb0a25ccbf46f78a0e2f3257272afb8ba2/www/resources/icons/experience/readme.txt)

<root>/www/resources/icons/silk/* > CC-BY-2.5
(see: https://github.com/simplesamlphp/simplesamlphp/blob/92de42cb0a25ccbf46f78a0e2f3257272afb8ba2/www/resources/icons/silk/readme.txt)
(see: https://web.archive.org/web/20111210165148/http://famfamfam.com/lab/icons/silk/)

**Affected definitions**:
- simplesamlphp 92de42cb0a25ccbf46f78a0e2f3257272afb8ba2