### PR TITLE
Changing to MIT license

### DIFF
--- a/curations/npm/npmjs/-/jquery-mousewheel.yaml
+++ b/curations/npm/npmjs/-/jquery-mousewheel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jquery-mousewheel
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.13:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changing to MIT license

**Details:**
Declaring license as MIT per https://github.com/jquery/jquery-mousewheel/blob/67289b6b2aa0066d7d78a5807f520387135ffb22/LICENSE.txt

**Resolution:**
I believe the license is MIT per https://github.com/jquery/jquery-mousewheel/blob/67289b6b2aa0066d7d78a5807f520387135ffb22/LICENSE.txt

**Affected definitions**:
- jquery-mousewheel 3.1.13