### PR TITLE
License and source data for several packages

### DIFF
--- a/curations/nuget/nuget/-/Hl7.Fhir.ElementModel.yaml
+++ b/curations/nuget/nuget/-/Hl7.Fhir.ElementModel.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Hl7.Fhir.ElementModel
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    described:
+      sourceLocation:
+        name: fhir-net-api
+        namespace: firelyteam
+        provider: github
+        revision: 5dd79b45f272822e2030e330a46425ed5452e374
+        type: git
+        url: 'https://github.com/firelyteam/fhir-net-api/commit/5dd79b45f272822e2030e330a46425ed5452e374'
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/nuget/nuget/-/Hl7.Fhir.STU3.yaml
+++ b/curations/nuget/nuget/-/Hl7.Fhir.STU3.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Hl7.Fhir.STU3
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    described:
+      sourceLocation:
+        name: fhir-net-api
+        namespace: firelyteam
+        provider: github
+        revision: 5dd79b45f272822e2030e330a46425ed5452e374
+        type: git
+        url: 'https://github.com/firelyteam/fhir-net-api/commit/5dd79b45f272822e2030e330a46425ed5452e374'
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/nuget/nuget/-/Hl7.Fhir.Serialization.yaml
+++ b/curations/nuget/nuget/-/Hl7.Fhir.Serialization.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Hl7.Fhir.Serialization
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    described:
+      sourceLocation:
+        name: fhir-net-api
+        namespace: firelyteam
+        provider: github
+        revision: 5dd79b45f272822e2030e330a46425ed5452e374
+        type: git
+        url: 'https://github.com/firelyteam/fhir-net-api/commit/5dd79b45f272822e2030e330a46425ed5452e374'
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/nuget/nuget/-/Hl7.Fhir.Support.yaml
+++ b/curations/nuget/nuget/-/Hl7.Fhir.Support.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Hl7.Fhir.Support
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    described:
+      sourceLocation:
+        name: fhir-net-api
+        namespace: firelyteam
+        provider: github
+        revision: 5dd79b45f272822e2030e330a46425ed5452e374
+        type: git
+        url: 'https://github.com/firelyteam/fhir-net-api/commit/5dd79b45f272822e2030e330a46425ed5452e374'
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/nuget/nuget/-/Hl7.FhirPath.yaml
+++ b/curations/nuget/nuget/-/Hl7.FhirPath.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Hl7.FhirPath
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    described:
+      sourceLocation:
+        name: fhir-net-api
+        namespace: firelyteam
+        provider: github
+        revision: 5dd79b45f272822e2030e330a46425ed5452e374
+        type: git
+        url: 'https://github.com/firelyteam/fhir-net-api/commit/5dd79b45f272822e2030e330a46425ed5452e374'
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/nuget/nuget/-/Microsoft.AppCenter.Analytics.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AppCenter.Analytics.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Microsoft.AppCenter.Analytics
+  provider: nuget
+  type: nuget
+revisions:
+  1.13.2:
+    described:
+      sourceLocation:
+        name: appcenter-sdk-dotnet
+        namespace: microsoft
+        provider: github
+        revision: c6ed4d663d040c412313e5bcd84dc5d300b4740e
+        type: git
+        url: 'https://github.com/microsoft/appcenter-sdk-dotnet/commit/c6ed4d663d040c412313e5bcd84dc5d300b4740e'
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.AppCenter.Crashes.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AppCenter.Crashes.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Microsoft.AppCenter.Crashes
+  provider: nuget
+  type: nuget
+revisions:
+  1.13.2:
+    described:
+      sourceLocation:
+        name: appcenter-sdk-dotnet
+        namespace: microsoft
+        provider: github
+        revision: c6ed4d663d040c412313e5bcd84dc5d300b4740e
+        type: git
+        url: 'https://github.com/microsoft/appcenter-sdk-dotnet/commit/c6ed4d663d040c412313e5bcd84dc5d300b4740e'
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.AppCenter.Distribute.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AppCenter.Distribute.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Microsoft.AppCenter.Distribute
+  provider: nuget
+  type: nuget
+revisions:
+  1.13.2:
+    described:
+      sourceLocation:
+        name: appcenter-sdk-dotnet
+        namespace: microsoft
+        provider: github
+        revision: c6ed4d663d040c412313e5bcd84dc5d300b4740e
+        type: git
+        url: 'https://github.com/microsoft/appcenter-sdk-dotnet/commit/c6ed4d663d040c412313e5bcd84dc5d300b4740e'
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.AppCenter.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AppCenter.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Microsoft.AppCenter
+  provider: nuget
+  type: nuget
+revisions:
+  1.13.2:
+    described:
+      sourceLocation:
+        name: appcenter-sdk-dotnet
+        namespace: microsoft
+        provider: github
+        revision: c6ed4d663d040c412313e5bcd84dc5d300b4740e
+        type: git
+        url: 'https://github.com/microsoft/appcenter-sdk-dotnet/commit/c6ed4d663d040c412313e5bcd84dc5d300b4740e'
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Identity.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Identity.Client.yaml
@@ -12,3 +12,6 @@ revisions:
   1.1.4-preview0002:
     licensed:
       declared: MIT
+  2.7.1:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.JsonWebTokens.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.JsonWebTokens.yaml
@@ -9,3 +9,6 @@ revisions:
   5.3.0:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Logging.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Logging.yaml
@@ -29,3 +29,6 @@ revisions:
   5.3.0:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Tokens.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Tokens.yaml
@@ -29,3 +29,6 @@ revisions:
   5.3.0:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
@@ -21,3 +21,6 @@ revisions:
   1.1.0-beta004:
     licensed:
       declared: Apache-2.0
+  1.1.0-beta008:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
+++ b/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
@@ -27,3 +27,6 @@ revisions:
   5.3.0:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License and source data for several packages

**Details:**
Provided license and source location info for:

Hl7.Fhir
Microsoft.AppCenter
Microsoft.Identity

**Resolution:**
I pulled the license links from the Nuget packages. From there I worked back to the main repo and the tag for the release I was using.

**Affected definitions**:
- Hl7.Fhir.ElementModel 1.1.2,- Hl7.Fhir.STU3 1.1.2,- Hl7.Fhir.Serialization 1.1.2,- Hl7.Fhir.Support 1.1.2,- Hl7.FhirPath 1.1.2,- Microsoft.AppCenter 1.13.2,- Microsoft.AppCenter.Analytics 1.13.2,- Microsoft.AppCenter.Crashes 1.13.2,- Microsoft.AppCenter.Distribute 1.13.2,- Microsoft.Identity.Client 2.7.1,- Microsoft.IdentityModel.JsonWebTokens 5.4.0,- Microsoft.IdentityModel.Logging 5.4.0,- Microsoft.IdentityModel.Tokens 5.4.0,- StyleCop.Analyzers 1.1.0-beta008,- System.IdentityModel.Tokens.Jwt 5.4.0