### PR TITLE
Missing Source Location

### DIFF
--- a/curations/npm/npmjs/-/ts-morph.yaml
+++ b/curations/npm/npmjs/-/ts-morph.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: ts-morph
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.0:
+    described:
+      sourceLocation:
+        name: ts-morph
+        namespace: dsherret
+        provider: github
+        revision: 504b8db49c080da379d2f534170c3bc6f79062e7
+        type: git
+        url: 'https://github.com/dsherret/ts-morph/commit/504b8db49c080da379d2f534170c3bc6f79062e7'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Source Location

**Details:**
There is no source location specified. 

**Resolution:**
-> On github repo, the released versions can be found on this URL: https://github.com/dsherret/ts-morph/releases
-> Version 1.2.0's latest commit source location should be: https://github.com/dsherret/ts-morph/tree/504b8db49c080da379d2f534170c3bc6f79062e7

**Affected definitions**:
- ts-morph 1.2.0