### PR TITLE
Missing declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/org.atteo/evo-inflector.yaml
+++ b/curations/sourcearchive/mavencentral/org.atteo/evo-inflector.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: evo-inflector
+  namespace: org.atteo
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing declared license

**Resolution:**
Declare license as Apache-2.0 as detailed on the Github repo.
https://github.com/atteo/evo-inflector/blob/1.2.2/LICENSE

**Affected definitions**:
- evo-inflector 1.2.2