### PR TITLE
License

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -13,6 +13,9 @@ revisions:
         url: 'https://github.com/gsscoder/commandline/commit/205094c0c135ab5b6816f3eb0e6a84ddced5b0e2'
     licensed:
       declared: MIT
+  2.0.275-beta:
+    licensed:
+      declared: MIT
   2.1.1-beta:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
License

**Details:**
Add MIT

**Resolution:**
Last tag with MIT license is v1.9.71.2 -https://github.com/commandlineparser/commandline/blob/v1.9.71.2/doc/LICENSE. License hasn't changed for subsequent versions in repo.

**Affected definitions**:
- CommandLineParser 2.0.275-beta