### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/MSBuildTasks.yaml
+++ b/curations/nuget/nuget/-/MSBuildTasks.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSBuildTasks
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.0.214:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add BSD-2-Clause

**Resolution:**
All tags in repo include BSD-2-Clause. License file for version 1.5.0.214 in repo - https://github.com/loresoft/msbuildtasks/blob/1.5.0.214/LICENSE.

**Affected definitions**:
- MSBuildTasks 1.5.0.214