### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.Services.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.Services.Client.yaml
@@ -6,6 +6,9 @@ revisions:
   5.6.4:
     licensed:
       declared: MIT
+  5.7.0:
+    licensed:
+      declared: MIT
   5.8.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add MIT

**Resolution:**
Per NuGet page license this component is under Odata.Net MIT license. License in in GitHub repo - https://github.com/OData/odata.net/blob/5.7.0/license.txt

**Affected definitions**:
- Microsoft.Data.Services.Client 5.7.0