### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Management.Infrastructure.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Management.Infrastructure.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Management.Infrastructure
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-alpha08:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add MIT

**Resolution:**
Microsoft Management Infracture is part of the PowerShell core licensed under MIT - 
https://powershell.myget.org/feed/powershell-core/package/nuget/Microsoft.Management.Infrastructure/1.0.0-alpha08

**Affected definitions**:
- Microsoft.Management.Infrastructure 1.0.0-alpha08