### PR TITLE
NuGet for Azure Stack 

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   4.2.1402.2112:
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause
   4.2.1510.2205:
     described:
       releaseDate: '2015-10-22'

--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.2.1402.2112:
+    licensed:
+      declared: BSD-2-Clause
   4.2.1510.2205:
     described:
       releaseDate: '2015-10-22'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack 

**Details:**
Add BSD-2-Clause

**Resolution:**
This version of the NuGet package points to BSD-2-Clause on the NuGet page. License was later changed on project site in Feb 2017 to MIT.

**Affected definitions**:
- Moq 4.2.1402.2112