### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.CommandLine
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add Apache 2.0

**Resolution:**
NuGet page and repo point to Apache 2.0. No specified license for 3.3.0 but all other tags with licenses show Apache 2.0

**Affected definitions**:
- NuGet.CommandLine 3.3.0