### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Common.yaml
+++ b/curations/nuget/nuget/-/NuGet.Common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Common
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add Apache 2.0

**Resolution:**
NuGet license is Apache 2.0, project repo has Apache 2.0 from version 4.6 and later.
https://github.com/NuGet/NuGet.Client/blob/4.6.0.4825/LICENSE.txt

**Affected definitions**:
- NuGet.Common 4.0.0