### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Core
+  provider: nuget
+  type: nuget
+revisions:
+  2.8.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add Apache 2.0

**Resolution:**
https://github.com/NuGet/NuGet2/blob/2.8.6/LICENSE.txt

**Affected definitions**:
- NuGet.Core 2.8.6