### PR TITLE
NuGet for Azure Stack

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Frameworks
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure Stack

**Details:**
Add Apache 2.0

**Resolution:**
NuGet page includes Apache 2.0 license. Project repo license was updated in November 2017 to Apache 2.0.

**Affected definitions**:
- NuGet.Frameworks 4.0.0