### PR TITLE
NuGet for Azure

### DIFF
--- a/curations/nuget/nuget/-/Rx-Interfaces.yaml
+++ b/curations/nuget/nuget/-/Rx-Interfaces.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.4:
     licensed:
       declared: Apache-2.0
+  2.2.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure

**Details:**

https://github.com/dotnet/reactive/tree/v2.2.5


**Resolution:**
Note:  the license link on the NuGet page says "EULA," however the link goes to the Apache v2 license

**Affected definitions**:
- Rx-Interfaces 2.2.5