### PR TITLE
NuGet for Azure

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0.174:
     licensed:
       declared: MS-PL
+  2.1.0.176:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure

**Details:**
This one is tricky.  The closest version to 2.1.0.176 looks like https://github.com/System-IO-Abstractions/System.IO.Abstractions/tree/v2.1.0.183, which is MS-PL.  It appears the move to MIT starts with v2.1.0.234.  Also, the license link on NuGet is broken, as I think it points to the old license.


**Resolution:**
Per the above, declared MS-PL

**Affected definitions**:
- System.IO.Abstractions.TestingHelpers 2.1.0.176