### PR TITLE
NuGet for Azure

### DIFF
--- a/curations/nuget/nuget/-/System.Management.Automation.yaml
+++ b/curations/nuget/nuget/-/System.Management.Automation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Management.Automation
+  provider: nuget
+  type: nuget
+revisions:
+  6.1.7601.17515:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure

**Details:**
This is an unlisted version with zero license or project link information. If we drop down to 6.1.3 it says MIT https://github.com/PowerShell/PowerShell/tree/v6.1.3 or go up https://github.com/PowerShell/PowerShell/tree/v6.2.0-preview.1, it says MIT.

**Resolution:**
Declaring MIT based on surrounding versions.

**Affected definitions**:
- System.Management.Automation 6.1.7601.17515