### PR TITLE
NuGet for Azure

### DIFF
--- a/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
@@ -9,6 +9,9 @@ revisions:
   7.2.1:
     licensed:
       declared: Apache-2.0
+  8.0.0:
+    licensed:
+      declared: Apache-2.0
   8.1.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet for Azure

**Details:**
Per https://github.com/Azure/azure-storage-net/tree/v8.0.0, the license is Apache.  Also, the license link on the download page says Apache, however the fwlink is pointing to a MIT license.  

**Resolution:**
Declaring Apache, per the repo.

**Affected definitions**:
- WindowsAzure.Storage 8.0.0