### PR TITLE
Declaring license

### DIFF
--- a/curations/git/github/libusb/libusb.yaml
+++ b/curations/git/github/libusb/libusb.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: libusb
+  namespace: libusb
+  provider: github
+  type: git
+revisions:
+  b5991a9e02e59a842a8ea2e0235cf319f2ec6cd1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
The readme says: licensed under the GNU
Lesser General Public License version 2.1 or, at your option, any later
version (see COPYING).

**Resolution:**
Followed source link and declared license, per the ReadMe.

**Affected definitions**:
- libusb b5991a9e02e59a842a8ea2e0235cf319f2ec6cd1