### PR TITLE
Declared license incorrect

### DIFF
--- a/curations/git/github/actframework/actframework.yaml
+++ b/curations/git/github/actframework/actframework.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: actframework
+  namespace: actframework
+  provider: github
+  type: git
+revisions:
+  e09438ddc29ab34fc95e736f8052e9f9151385cf:
+    files:
+      - attributions:
+          - (c) JS Foundation and other contributors
+        license: MIT
+        path: src/main/resources/asset/~act/js/jquery.js
+      - license: BSD-3-Clause
+        path: src/main/resources/asset/~act/js/highlight.min.js
+      - attributions:
+          - (c) jQuery Foundation
+        license: MIT
+        path: testapps/GHIssues/src/main/resources/asset/jquery.min.js


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Declared license incorrect

**Details:**
The licenses of these files were declared "NOASSERTION":

src/main/resources/asset/~act/js/jquery.js - MIT
testapps/GHIssues/src/main/resources/asset/jquery.min.js - MIT
src/main/resources/asset/~act/js/highlight.min.js - BSD 3-Clause

**Resolution:**
Updated file's licenses to match the content of their license headers.

**Affected definitions**:
- actframework e09438ddc29ab34fc95e736f8052e9f9151385cf