### PR TITLE
Discovered license is NOASSERTION

### DIFF
--- a/curations/git/github/rnorth/duct-tape.yaml
+++ b/curations/git/github/rnorth/duct-tape.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: duct-tape
+  namespace: rnorth
+  provider: github
+  type: git
+revisions:
+  46e3e37b259906750f33edd7e5466887cf62c28a:
+    files:
+      - attributions:
+          - Copyright (c) 2014-2015 Richard North.
+        license: MIT
+        path: docs/index.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Discovered license is NOASSERTION

**Details:**
The discovered license for index.md file is NOASSERTION. I suspect it is due to the included license link which brings you to a 404 not found page when clicked. https://github.com/rnorth/duct-tape/blob/46e3e37b259906750f33edd7e5466887cf62c28a/docs/LICENSE

**Resolution:**
The component is under the MIT license per the license file: https://github.com/rnorth/duct-tape/blob/46e3e37b259906750f33edd7e5466887cf62c28a/LICENSE. As per the MIT license, the associated documentation of the software is bound by this license. Hence, index.md should be under the MIT license.

**Affected definitions**:
- duct-tape 46e3e37b259906750f33edd7e5466887cf62c28a