### PR TITLE
declare MIT license for wordwrap npm

### DIFF
--- a/curations/npm/npmjs/-/wordwrap.yaml
+++ b/curations/npm/npmjs/-/wordwrap.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wordwrap
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
declare MIT license for wordwrap npm

**Details:**
the license is declared as `MIT/X11` where X11 is an alias

**Resolution:**
The alias was eventually dropped
https://github.com/substack/node-wordwrap/commit/b0265414e9fbce0413d5bf26179685786b759d8a

**Affected definitions**:
- wordwrap 0.0.2