### PR TITLE
Discovered license is NOASSERTION

### DIFF
--- a/curations/git/github/rnorth/visible-assertions.yaml
+++ b/curations/git/github/rnorth/visible-assertions.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: visible-assertions
+  namespace: rnorth
+  provider: github
+  type: git
+revisions:
+  1e31bd9f2b5c55bad97fb73fb5dff25657a2206a:
+    files:
+      - attributions:
+          - Copyright (c) 2015-2017 Richard North.
+        license: MIT
+        path: README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Discovered license is NOASSERTION

**Details:**
The discovered license for README.md file is NOASSERTION. 

**Resolution:**
The component is under the MIT license per the license file: https://github.com/rnorth/visible-assertions/blob/1e31bd9f2b5c55bad97fb73fb5dff25657a2206a/LICENSE. As per the MIT license, the associated documentation of the software is bound by this license. Hence, README should be under MIT.

**Affected definitions**:
- visible-assertions 1e31bd9f2b5c55bad97fb73fb5dff25657a2206a