### PR TITLE
Curation of JSON Select

### DIFF
--- a/curations/npm/npmjs/-/JSONSelect.yaml
+++ b/curations/npm/npmjs/-/JSONSelect.yaml
@@ -3,6 +3,30 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.2.1:
+    files:
+      - attributions:
+          - 'Copyright (c) 2011, Lloyd Hilaiel, ISC'
+        license: ISC
+        path: package/src/dist/jsonselect.js
+      - attributions:
+          - Copyright (c) 2007 John Fraser.
+          - 'Copyright (c) 2004-2005 John Gruber <http://daringfireball.net/projects/markdown/>'
+        license: BSD-2-Clause
+        path: package/site/js/showdown.js
+      - attributions:
+          - 'Copyright (c) 2011, Lloyd Hilaiel, ISC'
+        license: ISC
+        path: package/src/jsonselect.js
+      - attributions:
+          - 'Copyright 2011, John Resig'
+          - 'Copyright 2011, The Dojo Foundation'
+        license: MIT OR GPL-2.0-only OR BSD-3-Clause
+        path: package/site/js/jquery-1.6.1.min.js
+      - license: OTHER
+        path: package/site/js/json2.js
+    licensed:
+      declared: ISC
   0.4.0:
     licensed:
       declared: ISC

--- a/curations/npm/npmjs/-/JSONSelect.yaml
+++ b/curations/npm/npmjs/-/JSONSelect.yaml
@@ -6,7 +6,7 @@ revisions:
   0.2.1:
     files:
       - attributions:
-          - 'Copyright (c) 2011, Lloyd Hilaiel, ISC'
+          - 'Copyright (c) 2011, Lloyd Hilaiel, ISC License'
         license: ISC
         path: package/src/dist/jsonselect.js
       - attributions:
@@ -15,7 +15,7 @@ revisions:
         license: BSD-2-Clause
         path: package/site/js/showdown.js
       - attributions:
-          - 'Copyright (c) 2011, Lloyd Hilaiel, ISC'
+          - 'Copyright (c) 2011, Lloyd Hilaiel, ISC License'
         license: ISC
         path: package/src/jsonselect.js
       - attributions:


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Curation of JSON Select

**Details:**
Declared license: ISC as found in the Source repo linked from the the component homepage: https://github.com/lloyd/JSONSelect/blob/0.2.1/LICENSE

jquery-1.6.1.min.js: file includes tri-licensed code from jsizzle: https://github.com/jquery/sizzle/blob/1.7.1/LICENSE

**Resolution:**
Fixed files above.
No assertion -> other.  File said public domain.
No assertion -> ISC. File said "ISC License"

**Affected definitions**:
- JSONSelect 0.2.1