### PR TITLE
Update File Level Licenses

### DIFF
--- a/curations/git/github/javaee/javax.annotation.yaml
+++ b/curations/git/github/javaee/javax.annotation.yaml
@@ -7,67 +7,67 @@ revisions:
   9b07ccb6abe68f55f5d48ecfa84a300998d7c9a0:
     files:
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/Resources.java
       - attributions:
-          - Copyright (c) 2009-2010 Oracle and/or its affiliates.
+          - Copyright (c) 2009-2010 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/ManagedBean.java
       - attributions:
-          - Copyright (c) 2009-2012 Oracle and/or its affiliates.
+          - Copyright (c) 2009-2012 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/sql/DataSourceDefinitions.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/Resource.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/security/DenyAll.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/security/RolesAllowed.java
       - attributions:
-          - Copyright (c) 2005-2010 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/security/package.html
       - attributions:
-          - Copyright (c) 2005-2010 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2010 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/package.html
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/Generated.java
       - attributions:
-          - Copyright (c) 2009-2012 Oracle and/or its affiliates.
+          - Copyright (c) 2009-2012 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/sql/DataSourceDefinition.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/PostConstruct.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/security/RunAs.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/security/DeclareRoles.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/security/PermitAll.java
       - attributions:
-          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: src/main/java/javax/annotation/PreDestroy.java
       - attributions:
-          - Copyright (c) 1997-2012 Oracle and/or its affiliates.
+          - Copyright (c) 1997-2012 Oracle and/or its affiliates. All rights reserved.
         license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
         path: pom.xml
     licensed:

--- a/curations/git/github/javaee/javax.annotation.yaml
+++ b/curations/git/github/javaee/javax.annotation.yaml
@@ -5,5 +5,70 @@ coordinates:
   type: git
 revisions:
   9b07ccb6abe68f55f5d48ecfa84a300998d7c9a0:
+    files:
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/Resources.java
+      - attributions:
+          - Copyright (c) 2009-2010 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/ManagedBean.java
+      - attributions:
+          - Copyright (c) 2009-2012 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/sql/DataSourceDefinitions.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/Resource.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/security/DenyAll.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/security/RolesAllowed.java
+      - attributions:
+          - Copyright (c) 2005-2010 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/security/package.html
+      - attributions:
+          - Copyright (c) 2005-2010 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/package.html
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/Generated.java
+      - attributions:
+          - Copyright (c) 2009-2012 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/sql/DataSourceDefinition.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/PostConstruct.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/security/RunAs.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/security/DeclareRoles.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/security/PermitAll.java
+      - attributions:
+          - Copyright (c) 2005-2011 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: src/main/java/javax/annotation/PreDestroy.java
+      - attributions:
+          - Copyright (c) 1997-2012 Oracle and/or its affiliates.
+        license: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+        path: pom.xml
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Update File Level Licenses

**Details:**
All files that were previously marked "CDDL-1.1 OR NOASSERTION" were incorrectly declared. The licenses of these files are actually "CDDL-1.1 OR GPL-2.0-with-classpath-exception", same as the overall project level license.

**Resolution:**
Updated all files previously marked "CDDL-1.1 OR NOASSERTION", after verifying the contents of their license headers, and confirmed that they are all "CDDL-1.1 OR GPL-2.0-with-classpath-exception." This also matches the license metadata outlined in the project's Maven [pom.xml](https://github.com/javaee/javax.annotation/blob/1.1/pom.xml).

**Affected definitions**:
- javax.annotation 9b07ccb6abe68f55f5d48ecfa84a300998d7c9a0