### PR TITLE
Update licenses and source location

### DIFF
--- a/curations/pypi/pypi/-/Unidecode.yaml
+++ b/curations/pypi/pypi/-/Unidecode.yaml
@@ -1,0 +1,21 @@
+coordinates:
+  name: Unidecode
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.23:
+    described:
+      sourceLocation:
+        name: unidecode
+        namespace: avian2
+        provider: github
+        revision: e3c730e5830f15c613f65f1764258165f4e5f52f
+        type: git
+        url: 'https://github.com/avian2/unidecode/commit/e3c730e5830f15c613f65f1764258165f4e5f52f'
+    files:
+      - license: ''
+        path: Unidecode-1.0.23/setup.py
+      - license: GPL-2.0-or-later
+        path: Unidecode-1.0.23/ChangeLog
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
Update licenses and source location

**Details:**
1. The project level license should be 'GPL-2.0-or-later' so it matches  https://github.com/avian2/unidecode/blob/unidecode-1.0.23/README.rst (see bottom) and the [LICENSE ](https://github.com/avian2/unidecode/blob/unidecode-1.0.23/LICENSE)file.

2. File "[ChangeLog](https://github.com/avian2/unidecode/blob/unidecode-1.0.23/ChangeLog)" in root of project was originally discovered as 'NOASSERTION'.

3. Source location empty.

**Resolution:**
1. Declared project level license as 'GPL-2.0-or-later'.

2. Resolved file-level licenses that were initially discovered as 'NOASSERTION'.

3. Added source location of GH repo: https://github.com/avian2/unidecode.

**Affected definitions**:
- Unidecode 1.0.23