### PR TITLE
Update file-level discovered licenses

### DIFF
--- a/curations/git/github/stuk/jszip.yaml
+++ b/curations/git/github/stuk/jszip.yaml
@@ -29,7 +29,7 @@ revisions:
       - license: MIT OR GPL-3.0
         path: bower.json
       - attributions:
-          - Copyright (c) 1989 - 2007 PKWARE Inc.
+          - Copyright (c) 1989 - 2007 PKWARE Inc., All Rights Reserved.
         license: OTHER
         path: docs/APPNOTE.TXT
       - attributions:

--- a/curations/git/github/stuk/jszip.yaml
+++ b/curations/git/github/stuk/jszip.yaml
@@ -1,0 +1,45 @@
+coordinates:
+  name: jszip
+  namespace: stuk
+  provider: github
+  type: git
+revisions:
+  265c959b1f15f8cd5ebe152154b88796e4a82f42:
+    files:
+      - license: MIT OR GPL-3.0
+        path: index.html
+      - attributions:
+          - (c) 1995-2013 Jean-loup Gailly and Mark Adler
+          - (c) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0
+        path: dist/jszip.js
+      - license: MIT OR GPL-3.0
+        path: README.markdown
+      - license: MIT
+        path: vendor/FileSaver.js
+      - license: MIT OR GPL-3.0
+        path: component.json
+      - license: OTHER
+        path: lib/zipEntry.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0
+        path: dist/jszip.min.js
+      - license: MIT OR GPL-3.0
+        path: bower.json
+      - attributions:
+          - Copyright (c) 1989 - 2007 PKWARE Inc.
+        license: OTHER
+        path: docs/APPNOTE.TXT
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
+        license: MIT OR GPL-3.0
+        path: LICENSE.markdown
+      - license: MIT
+        path: test/jquery-1.8.3.min.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0
+        path: lib/license_header.js

--- a/curations/git/github/stuk/jszip.yaml
+++ b/curations/git/github/stuk/jszip.yaml
@@ -20,7 +20,7 @@ revisions:
         path: vendor/FileSaver.js
       - license: MIT OR GPL-3.0
         path: component.json
-      - license: OTHER
+      - license: NONE
         path: lib/zipEntry.js
       - attributions:
           - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>

--- a/curations/git/github/stuk/jszip.yaml
+++ b/curations/git/github/stuk/jszip.yaml
@@ -12,7 +12,7 @@ revisions:
           - (c) 1995-2013 Jean-loup Gailly and Mark Adler
           - (c) 2014-2017 Vitaly Puzrin and Andrey Tupitsin
           - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
-        license: MIT OR GPL-3.0
+        license: (MIT OR GPL-3.0) AND MIT AND ZLIB
         path: dist/jszip.js
       - license: MIT OR GPL-3.0
         path: README.markdown
@@ -33,7 +33,6 @@ revisions:
         license: OTHER
         path: docs/APPNOTE.TXT
       - attributions:
-          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
           - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
         license: MIT OR GPL-3.0
         path: LICENSE.markdown
@@ -41,5 +40,5 @@ revisions:
         path: test/jquery-1.8.3.min.js
       - attributions:
           - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
-        license: MIT OR GPL-3.0
+        license: (MIT OR GPL-3.0) AND MIT
         path: lib/license_header.js


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Update file-level discovered licenses

**Details:**
Some of the discovered licenses at the file-level are incorrect.

**Resolution:**
Update cases of incorrect file-level licenses. Here, these are files that are discovered NOASSERTION or multi-license (AND) when they should actually be dual-license (OR).

(See bottom of https://github.com/stuk/jszip/)

**Affected definitions**:
- jszip 265c959b1f15f8cd5ebe152154b88796e4a82f42