### PR TITLE
Update file-level discovered licenses

### DIFF
--- a/curations/npm/npmjs/-/jszip.yaml
+++ b/curations/npm/npmjs/-/jszip.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: jszip
+  provider: npmjs
+  type: npm
+revisions:
+  3.2.0:
+    files:
+      - license: MIT
+        path: package/vendor/FileSaver.js
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: MIT OR GPL-3.0
+        path: package/lib/license_header.js
+      - license: OTHER
+        path: package/lib/zipEntry.js
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
+        license: MIT OR GPL-3.0
+        path: package/LICENSE.markdown
+      - license: MIT OR GPL-3.0
+        path: package/README.markdown
+    licensed:
+      declared: MIT OR GPL-3.0

--- a/curations/npm/npmjs/-/jszip.yaml
+++ b/curations/npm/npmjs/-/jszip.yaml
@@ -14,8 +14,7 @@ revisions:
       - license: NONE
         path: package/lib/zipEntry.js
       - attributions:
-          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
-          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
+              - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
         license: MIT OR GPL-3.0
         path: package/LICENSE.markdown
       - license: MIT OR GPL-3.0

--- a/curations/npm/npmjs/-/jszip.yaml
+++ b/curations/npm/npmjs/-/jszip.yaml
@@ -8,10 +8,10 @@ revisions:
       - license: MIT
         path: package/vendor/FileSaver.js
       - attributions:
-          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+          - (c) 2009-2016 Stuart Knightley <stuart [at] stuartk.com>
         license: MIT OR GPL-3.0
         path: package/lib/license_header.js
-      - license: OTHER
+      - license: NONE
         path: package/lib/zipEntry.js
       - attributions:
           - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Update file-level discovered licenses

**Details:**
Some of the discovered licenses at the file-level are incorrect.

**Resolution:**
Update cases of incorrect file-level licenses. Here, these are files that are discovered NOASSERTION or multi-license (AND) when they should actually be dual-license (OR).

(See bottom of https://github.com/stuk/jszip/)

**Affected definitions**:
- jszip 3.2.0