### PR TITLE
Add Apachev2 Declared License

### DIFF
--- a/curations/git/github/mongodb/mongo-csharp-driver.yaml
+++ b/curations/git/github/mongodb/mongo-csharp-driver.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mongo-csharp-driver
+  namespace: mongodb
+  provider: github
+  type: git
+revisions:
+  v2.4.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apachev2 Declared License

**Details:**
There were two copies of the apache2-0 license in the top level directory.

**Resolution:**
Add Apachev2 declared license

**Affected definitions**:
- mongo-csharp-driver v2.4.4