### PR TITLE
Declaring license

### DIFF
--- a/curations/npm/npmjs/-/create-react-context.yaml
+++ b/curations/npm/npmjs/-/create-react-context.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.2.3:
     licensed:
-      declared: NOASSERTION
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Declaring "other" because this is a non-standard MIT license with additional restrictions

**Resolution:**
https://github.com/jamiebuilds/create-react-context/blob/43ae1133176584dbbfba4428228a4e66ef27fb5f/LICENSE

**Affected definitions**:
- [create-react-context 0.2.3](https://clearlydefined.io/definitions/npm/npmjs/-/create-react-context/0.2.3/0.2.3)