### PR TITLE
Declaring licenses

### DIFF
--- a/curations/nuget/nuget/-/RhinoMocks.yaml
+++ b/curations/nuget/nuget/-/RhinoMocks.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RhinoMocks
+  provider: nuget
+  type: nuget
+revisions:
+  3.6.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring licenses

**Details:**
Package download page broken link.  Went to repo, found license closest to date of package

**Resolution:**
https://github.com/RhinoMocks/RhinoMocks/blob/da77754eb2031341a74bef2d34f443f18f76e393/license.txt

**Affected definitions**:
- [RhinoMocks 3.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/RhinoMocks/3.6.1/3.6.1)