### PR TITLE
Librdkafka license

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -6,3 +6,6 @@ revisions:
   0.11.3:
     licensed:
       declared: BSD-2-Clause
+  1.0.0:
+    licensed:
+      declared: Other


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Librdkafka license

**Details:**
Librdkafka has a special custom license: 
https://github.com/edenhill/librdkafka/blob/master/LICENSES.txt


**Resolution:**
Librdkafka license

**Affected definitions**:
- [librdkafka.redist 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.0.0/1.0.0)