### PR TITLE
librdkakfka.redist use BSD-2-Clause

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -6,3 +6,6 @@ revisions:
   0.11.3:
     licensed:
       declared: BSD-2-Clause
+  1.0.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkakfka.redist use BSD-2-Clause

**Details:**
BSD-2-Clause for librdkafka redist

**Resolution:**
Missing license

**Affected definitions**:
- [librdkafka.redist 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.0.0)