### PR TITLE
Update declared license

### DIFF
--- a/curations/git/github/tommyjones/textminer.yaml
+++ b/curations/git/github/tommyjones/textminer.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: textminer
+  namespace: tommyjones
+  provider: github
+  type: git
+revisions:
+  1ec38621a2ee9193f6627973a04b70cf512c2daa:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update declared license

**Details:**
Declared license was missing

**Resolution:**
According to package metadata, the license should be MIT.

https://github.com/TommyJones/textmineR/blob/1ec38621a2ee9193f6627973a04b70cf512c2daa/DESCRIPTION

(File "LICENSE.MD" only contains copyright year and name of holder)

**Affected definitions**:
- [textminer 1ec38621a2ee9193f6627973a04b70cf512c2daa](https://clearlydefined.io/definitions/git/github/tommyjones/textminer/1ec38621a2ee9193f6627973a04b70cf512c2daa)