### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/argsparser.yaml
+++ b/curations/npm/npmjs/-/argsparser.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: argsparser
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
No license for the version. Only license found was in GitHub repo is MIT added in 2015 

**Resolution:**
https://github.com/kof/node-argsparser/commit/e4966bc029493cc5b537ff2ca4a74ff0c6ae2233#diff-9879d6db96fd29134fc802214163b95a

**Affected definitions**:
- [argsparser 0.0.6](https://clearlydefined.io/definitions/npm/npmjs/-/argsparser/0.0.6/0.0.6)