### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/atob.yaml
+++ b/curations/npm/npmjs/-/atob.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: atob
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.2:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
No license for specific version in GitHub repo. Both Npm page and GitHub give option of Apache 2.0 or MIT.

**Resolution:**
https://git.coolaj86.com/coolaj86/atob.js/src/tag/v1.1.2/LICENSE

**Affected definitions**:
- [atob 1.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/atob/1.1.2/1.1.2)