### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/blob.yaml
+++ b/curations/npm/npmjs/-/blob.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.2:
+    licensed:
+      declared: MIT
   0.0.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT

**Resolution:**
Npm page has MIT, the GitHub repo master license is also MIT, tags for the versions do not have a license file.

**Affected definitions**:
- [blob 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/blob/0.0.2/0.0.2)