### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/btoa.yaml
+++ b/curations/npm/npmjs/-/btoa.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.2:
     licensed:
-      declared: Apache-2.0 OR MIT
+      declared: Apache-2.0

--- a/curations/npm/npmjs/-/btoa.yaml
+++ b/curations/npm/npmjs/-/btoa.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: btoa
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.2:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Dual licensed as noted on Npm page and GitHub repo so I have added Apache 2.0 or MIT, although I only found the Apache 2.0 license file in the repo for this version.

**Resolution:**
https://git.coolaj86.com/coolaj86/btoa.js/src/tag/v1.1.2/LICENSE

**Affected definitions**:
- [btoa 1.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/btoa/1.1.2/1.1.2)