### PR TITLE
Apache 2.0 for Confluent.kafka

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -21,6 +21,9 @@ revisions:
   0.11.6:
     licensed:
       declared: Apache-2.0
+  1.0.0:
+    licensed:
+      declared: Apache-2.0
   1.0.0-beta2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Apache 2.0 for Confluent.kafka

**Details:**
Apache 2.0 for Confluent.kafka

**Resolution:**
Apache 2.0 for Confluent.kafka

**Affected definitions**:
- [Confluent.Kafka 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.0.0)