### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/config-chain.yaml
+++ b/curations/npm/npmjs/-/config-chain.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.1.10:
+    licensed:
+      declared: MIT
   1.1.11:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT. No license found for this version but for version before and after is licensed under MIT.

**Resolution:**
https://github.com/dawsbot/config-chain/blob/v1.1.9/LICENCE

**Affected definitions**:
- [config-chain 1.1.10](https://clearlydefined.io/definitions/npm/npmjs/-/config-chain/1.1.10/1.1.10)