### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.ApplicationInsights.HostingStartup.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.ApplicationInsights.HostingStartup.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.ApplicationInsights.HostingStartup
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT

**Resolution:**
MIT noted on Nuget page and only master has license - https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.AspNet.ApplicationInsights.HostingStartup 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.ApplicationInsights.HostingStartup/2.4.0/2.4.0)