### PR TITLE
Add declared license

### DIFF
--- a/curations/npm/npmjs/-/graceful-fs.yaml
+++ b/curations/npm/npmjs/-/graceful-fs.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: graceful-fs
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.3:
+    files:
+      - license: BSD-2-Clause
+        path: package/package.json


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add declared license

**Details:**
The "declared" license in the package.json was "BSD" the License file resolves this ambiguity because it is a 2-clause BSD license.

**Resolution:**
Add 2-Clause BSD license to declared license and curate the package.json to BSD-2-Clause.

**Affected definitions**:
- [graceful-fs 1.2.3](https://clearlydefined.io/definitions/npm/npmjs/-/graceful-fs/1.2.3/1.2.3)