### PR TITLE
Declared -> BSD-2-Clause

### DIFF
--- a/curations/npm/npmjs/-/glob.yaml
+++ b/curations/npm/npmjs/-/glob.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: glob
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.21:
+    files:
+      - license: BSD-2-Clause
+        path: package/package.json
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared -> BSD-2-Clause

**Details:**
package.json says license "BSD" -- license file is BSD-2-Clause.

**Resolution:**
Made declared BSD-2-Clause.

**Affected definitions**:
- [glob 3.1.21](https://clearlydefined.io/definitions/npm/npmjs/-/glob/3.1.21/3.1.21)