### PR TITLE
Added Apache 2.0 as License

### DIFF
--- a/curations/nuget/nuget/-/boost.yaml
+++ b/curations/nuget/nuget/-/boost.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost
+  provider: nuget
+  type: nuget
+revisions:
+  1.65.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added Apache 2.0 as License

**Details:**
Found commit (https://github.com/sergey-shandar/getboost/commit/41407498e94e346dd66a5435bfbb2869bf1b27d1) browsed file (https://github.com/sergey-shandar/getboost/tree/41407498e94e346dd66a5435bfbb2869bf1b27d1) license found

**Resolution:**
Apache 2.0 identified here (https://clearlydefined.io/definitions/nuget/nuget/-/boost/1.65.0)

**Affected definitions**:
- [boost 1.65.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost/1.65.0/1.65.0)