### PR TITLE
Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/boost_filesystem-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_filesystem-vc141.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_filesystem-vc141
+  provider: nuget
+  type: nuget
+revisions:
+  1.65.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Apache 2.0 License

**Details:**
Followed to commits (https://github.com/sergey-shandar/getboost/commits/master) "Browse Files" license here (https://github.com/sergey-shandar/getboost/tree/4b5f7f68f72eeaf0dfa7b587f2a37243b92374f9)

**Resolution:**
Apache 2.0 license found here: (https://github.com/sergey-shandar/getboost/blob/4b5f7f68f72eeaf0dfa7b587f2a37243b92374f9/LICENSE)

**Affected definitions**:
- [boost_filesystem-vc141 1.65.1](https://clearlydefined.io/definitions/nuget/nuget/-/boost_filesystem-vc141/1.65.1/1.65.1)