### PR TITLE
Declared license missing

### DIFF
--- a/curations/git/github/joshuaulrich/xts.yaml
+++ b/curations/git/github/joshuaulrich/xts.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: xts
+  namespace: joshuaulrich
+  provider: github
+  type: git
+revisions:
+  cbacd5de87d7cc19fdae26176d49c73585836e22:
+    files:
+      - attributions:
+          - Copyright 2009. Jeffrey A. Ryan.
+          - Copyright (c) 2008 Jeffrey A. Ryan jeff.a.ryan gmail.com
+        license: GPL-2.0-or-later
+        path: R/parse8601.R
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license missing

**Details:**
There is no license declared for this project

**Resolution:**
1. Updated declared license: GPL-2.0-or-later

See: https://github.com/joshuaulrich/xts/blob/cbacd5de87d7cc19fdae26176d49c73585836e22/DESCRIPTION

2. Updated one case of incorrect use of "AND" operator.

**Affected definitions**:
- [xts cbacd5de87d7cc19fdae26176d49c73585836e22](https://clearlydefined.io/definitions/git/github/joshuaulrich/xts/cbacd5de87d7cc19fdae26176d49c73585836e22/cbacd5de87d7cc19fdae26176d49c73585836e22)