### PR TITLE
Add Attribution to Newtonsoft.Json 10.0.1

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -4,6 +4,11 @@ coordinates:
   type: nuget
 revisions:
   10.0.1:
+    files:
+      - attributions:
+          - Copyright (c) 2007 James Newton-King
+        license: MIT
+        path: Newtonsoft.Json.nuspec
     licensed:
       declared: MIT
   10.0.2:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Attribution to Newtonsoft.Json 10.0.1

**Details:**
Followed the Nuspec link for "licnese to the MIT license here https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/master/LICENSE.md.  Agrees with tagged version here: https://github.com/JamesNK/Newtonsoft.Json/blob/10.0.1/LICENSE.md

**Resolution:**
Curated nuspec to MIT with James Newton King's copyright.

**Affected definitions**:
- [Newtonsoft.Json 10.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/10.0.1)