### PR TITLE
Add MIT license and attribution informaiton

### DIFF
--- a/curations/maven/mavencentral/com.microsoft.azure/adal4j.yaml
+++ b/curations/maven/mavencentral/com.microsoft.azure/adal4j.yaml
@@ -7,3 +7,9 @@ revisions:
   1.2.0:
     licensed:
       declared: Apache-2.0
+  1.6.0:
+    files:
+      - attributions:
+          - Copyright (c) Microsoft Corporation
+        license: MIT
+        path: META-INF/maven/com.microsoft.azure/adal4j/pom.properties


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT license and attribution informaiton

**Details:**
The Source on the Maven page (and manifest) points to the github repo, which has the Microsoft corp. license.  https://github.com/AzureAD/azure-activedirectory-library-for-java/blob/1.6.0/LICENSE

**Resolution:**
Added the Microsoft license.

**Affected definitions**:
- [adal4j 1.6.0](https://clearlydefined.io/definitions/maven/mavencentral/com.microsoft.azure/adal4j/1.6.0)