### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.WebApi.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.WebApi.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.WebApi.Client
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.30506:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding None

**Resolution:**
No license found on NuGet or project page

**Affected definitions**:
- [Microsoft.AspNet.WebApi.Client 4.0.30506](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.WebApi.Client/4.0.30506/4.0.30506)