### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/CefSharp.Common.yaml
+++ b/curations/nuget/nuget/-/CefSharp.Common.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: CefSharp.Common
+  provider: nuget
+  type: nuget
+revisions:
+  63.0.3:
+    files:
+      - attributions:
+          - 'Copyright © The CefSharp Authors. '
+        license: BSD-3-Clause
+        path: CefSharp.Common.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Declared License

**Details:**
Both the NuGet page and source location indicate BSD-3-Clause
https://github.com/cefsharp/CefSharp/blob/15c9f5753b7277229ed2f2ac2c3c601defa5981b/LICENSE
https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE


**Resolution:**
Add BSD 3-Clause and Copyright statement.

**Affected definitions**:
- [CefSharp.Common 63.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/CefSharp.Common/63.0.3)