### PR TITLE
Add Declared license

### DIFF
--- a/curations/nuget/nuget/-/CefSharp.WinForms.yaml
+++ b/curations/nuget/nuget/-/CefSharp.WinForms.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: CefSharp.WinForms
+  provider: nuget
+  type: nuget
+revisions:
+  63.0.3:
+    files:
+      - attributions:
+          - Copyright © 2010-2017 The CefSharp Authors.
+        license: BSD-3-Clause
+        path: CefSharp.WinForms.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Declared license

**Details:**
both source location and nuget page point to same license.
https://raw.githubusercontent.com/cefsharp/CefSharp/master/LICENSE
https://github.com/cefsharp/CefSharp/blob/15c9f5753b7277229ed2f2ac2c3c601defa5981b/LICENSE

**Resolution:**
Added licnese.

**Affected definitions**:
- [CefSharp.WinForms 63.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/CefSharp.WinForms/63.0.3)