### PR TITLE
Add Source & License Info

### DIFF
--- a/curations/nuget/nuget/-/DeltaCompressionDotNet.yaml
+++ b/curations/nuget/nuget/-/DeltaCompressionDotNet.yaml
@@ -1,0 +1,19 @@
+coordinates:
+  name: DeltaCompressionDotNet
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    described:
+      sourceLocation:
+        name: deltacompressiondotnet
+        namespace: taspeotis
+        provider: github
+        revision: a339eddf0e6d432e036e2d20c91ee227f436d142
+        type: git
+        url: 'https://github.com/taspeotis/deltacompressiondotnet/commit/a339eddf0e6d432e036e2d20c91ee227f436d142'
+    files:
+      - license: MS-PL
+        path: DeltaCompressionDotNet.nuspec
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Source & License Info

**Details:**
Source (apparently by same author) here: https://github.com/taspeotis/DeltaCompressionDotNet/tree/1.1.0

License described in Readme of Source here: https://github.com/taspeotis/DeltaCompressionDotNet/blob/1.1.0/README.md

Copyright Statement on NuGet page.

**Resolution:**
Added them.

**Affected definitions**:
- [DeltaCompressionDotNet 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/DeltaCompressionDotNet/1.1.0)