### PR TITLE
Adding Declared License

### DIFF
--- a/curations/nuget/nuget/-/EntityFramework.Extended.yaml
+++ b/curations/nuget/nuget/-/EntityFramework.Extended.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: EntityFramework.Extended
+  provider: nuget
+  type: nuget
+revisions:
+  6.1.0.95:
+    files:
+      - license: BSD-3-Clause
+        path: EntityFramework.Extended.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
Project page here at relevant commit shows BSD-3-Clause: https://github.com/zzzprojects/EntityFramework.Extended/blob/8ae1c7922e19afb7fd22ab9c81e527df9bd427f8/License.txt

**Resolution:**
added declared license and attribution to .nuspec.

**Affected definitions**:
- [EntityFramework.Extended 6.1.0.95](https://clearlydefined.io/definitions/nuget/nuget/-/EntityFramework.Extended/6.1.0.95)