### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/StreamJsonRpc.yaml
+++ b/curations/nuget/nuget/-/StreamJsonRpc.yaml
@@ -9,3 +9,9 @@ revisions:
   1.4.44-beta:
     licensed:
       declared: MIT
+  1.4.46-beta:
+    files:
+      - license: MIT
+        path: StreamJsonRpc.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Source found (https://clearlydefined.io/definitions/nuget/nuget/-/StreamJsonRpc/1.4.46-beta) license found (https://raw.githubusercontent.com/Microsoft/vs-streamjsonrpc/fdc97b3aeb/LICENSE)

**Resolution:**
Updated with MIT LIcense

**Affected definitions**:
- [StreamJsonRpc 1.4.46-beta](https://clearlydefined.io/definitions/nuget/nuget/-/StreamJsonRpc/1.4.46-beta/1.4.46-beta)