### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/nuget/nuget/-/cef.redist.x64.yaml
+++ b/curations/nuget/nuget/-/cef.redist.x64.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: cef.redist.x64
+  provider: nuget
+  type: nuget
+revisions:
+  3.3239.1716:
+    files:
+      - license: BSD-3-Clause
+        path: cef.redist.x64.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Source found (https://www.nuget.org/packages/cef.redist.x64/3.3239.1723) license found (https://raw.githubusercontent.com/cefsharp/cef-binary/master/LICENSE.txt)

**Resolution:**
Updated with BSD-3-Clause 

**Affected definitions**:
- [cef.redist.x64 3.3239.1716](https://clearlydefined.io/definitions/nuget/nuget/-/cef.redist.x64/3.3239.1716/3.3239.1716)