### PR TITLE
Declared BSD-3-Clause License

### DIFF
--- a/curations/nuget/nuget/-/cef.redist.x86.yaml
+++ b/curations/nuget/nuget/-/cef.redist.x86.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: cef.redist.x86
+  provider: nuget
+  type: nuget
+revisions:
+  3.3239.1723:
+    files:
+      - license: BSD-3-Clause
+        path: cef.redist.x86.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause License

**Details:**
Found source (https://www.nuget.org/packages/cef.redist.x86/3.3239.1723) found license (https://raw.githubusercontent.com/cefsharp/cef-binary/master/LICENSE.txt)

**Resolution:**
Updates with Declared BSD-3-Clause License

**Affected definitions**:
- [cef.redist.x86 3.3239.1723](https://clearlydefined.io/definitions/nuget/nuget/-/cef.redist.x86/3.3239.1723/3.3239.1723)