### PR TITLE
Updated Declared License and Copyright in "nuspec" section

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IO.RecyclableMemoryStream.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IO.RecyclableMemoryStream.yaml
@@ -4,5 +4,10 @@ coordinates:
   type: nuget
 revisions:
   1.2.2:
+    files:
+      - attributions:
+          - Copyright (c) 2015-2016 Microsoft
+        license: MIT
+        path: Microsoft.IO.RecyclableMemoryStream.nuspec
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updated Declared License and Copyright in "nuspec" section

**Details:**
License was declared but copyright not updated

**Resolution:**
Updated "nuspec" to include Declared License and Copyright 

**Affected definitions**:
- [Microsoft.IO.RecyclableMemoryStream 1.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IO.RecyclableMemoryStream/1.2.2/1.2.2)