### PR TITLE
Declared MIT License and updated "nuspec" with license and copyright

### DIFF
--- a/curations/nuget/nuget/-/SharpCompress.yaml
+++ b/curations/nuget/nuget/-/SharpCompress.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: SharpCompress
+  provider: nuget
+  type: nuget
+revisions:
+  0.22.0:
+    files:
+      - attributions:
+          - Copyright (c) 2014  Adam Hathcock
+        license: MIT
+        path: SharpCompress.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License and updated "nuspec" with license and copyright

**Details:**
Source found (https://www.nuget.org/packages/sharpcompress/0.22.0) license found (https://github.com/adamhathcock/sharpcompress/blob/master/LICENSE.txt)

**Resolution:**
Updated with Declared license and "nuspec" with license and copyright

**Affected definitions**:
- [SharpCompress 0.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/SharpCompress/0.22.0/0.22.0)