### PR TITLE
Declared BSD-3-Clause License

### DIFF
--- a/curations/nuget/nuget/-/d3.yaml
+++ b/curations/nuget/nuget/-/d3.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: d3
+  provider: nuget
+  type: nuget
+revisions:
+  4.7.4:
+    files:
+      - attributions:
+          - Copyright 2010-2017 Mike Bostock
+        license: BSD-3-Clause
+        path: d3.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause License

**Details:**
Source identified BSD-2-Clause (https://www.nuget.org/packages/d3/4.7.4) but digging (https://github.com/d3/d3/blob/master/LICENSE) identified BSD-3-Clause

**Resolution:**
Added license to BSD-3-Clause and updated "nuspec" to include license and copyright

**Affected definitions**:
- [d3 4.7.4](https://clearlydefined.io/definitions/nuget/nuget/-/d3/4.7.4/4.7.4)