### PR TITLE
Declared MIT License and updated "nuspec" to include license and copyright

### DIFF
--- a/curations/nuget/nuget/-/valueinjecter.yaml
+++ b/curations/nuget/nuget/-/valueinjecter.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: valueinjecter
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.1:
+    files:
+      - attributions:
+          - Copyright (c) 2015 Valentin Plamadeala
+        license: MIT
+        path: valueinjecter.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License and updated "nuspec" to include license and copyright

**Details:**
Found source (https://www.nuget.org/packages/ValueInjecter/3.1.1) license file send to (https://archive.codeplex.com/?p=valueinjecter) went to project site (https://github.com/omuleanu/ValueInjecter) license here (https://github.com/omuleanu/ValueInjecter/blob/master/LICENSE)

**Resolution:**
Declared MIT License and updated "nuspec" to include license and copyright

**Affected definitions**:
- [valueinjecter 3.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/valueinjecter/3.1.1/3.1.1)