### PR TITLE
Added MIT license and updated "nuspec" with license and copyright

### DIFF
--- a/curations/nuget/nuget/-/valueinjecter.yaml
+++ b/curations/nuget/nuget/-/valueinjecter.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: valueinjecter
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.1.2:
+    files:
+      - attributions:
+          - Copyright (c) 2015 Valentin Plamadeala
+        license: MIT
+        path: valueinjecter.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added MIT license and updated "nuspec" with license and copyright

**Details:**
Source found (https://www.nuget.org/packages/ValueInjecter/3.1.1.2) license went to (https://archive.codeplex.com/?p=valueinjecter) went to project site (https://github.com/omuleanu/ValueInjecter) license here (https://github.com/omuleanu/ValueInjecter/blob/master/LICENSE)

**Resolution:**
Added MIT license and updated "nuspec" with license and copyright

**Affected definitions**:
- [valueinjecter 3.1.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/valueinjecter/3.1.1.2/3.1.1.2)