### PR TITLE
Add Zlib license and updated "nuspec" to include licence and copyright

### DIFF
--- a/curations/nuget/nuget/-/zlib.v140.windesktop.msvcstl.dyn.rt-dyn.yaml
+++ b/curations/nuget/nuget/-/zlib.v140.windesktop.msvcstl.dyn.rt-dyn.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: zlib.v140.windesktop.msvcstl.dyn.rt-dyn
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.8.8:
+    files:
+      - attributions:
+          - Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+        license: Zlib
+        path: zlib.v140.windesktop.msvcstl.dyn.rt-dyn.nuspec
+    licensed:
+      declared: Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Zlib license and updated "nuspec" to include licence and copyright

**Details:**
Source found (https://www.nuget.org/packages/zlib.v140.windesktop.msvcstl.dyn.rt-dyn) Zlib license found (http://www.zlib.net/zlib_license.html)

**Resolution:**
Add Zlib license and updated "nuspec" to include license and copyright

**Affected definitions**:
- [zlib.v140.windesktop.msvcstl.dyn.rt-dyn 1.2.8.8](https://clearlydefined.io/definitions/nuget/nuget/-/zlib.v140.windesktop.msvcstl.dyn.rt-dyn/1.2.8.8/1.2.8.8)