### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/respond.yaml
+++ b/curations/nuget/nuget/-/respond.yaml
@@ -7,11 +7,11 @@ revisions:
     files:
       - attributions:
           - '(c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas'
-        license: MIT OR OTHER
+        license: (MIT OR OTHER) AND (MIT OR GPL-2.0-only)
         path: content/Scripts/respond.js
       - attributions:
           - '(c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas'
-        license: MIT OR OTHER
+        license: (MIT OR OTHER) AND (AND (MIT OR GPL-2.0-only)
         path: content/Scripts/respond.min.js
     licensed:
       declared: MIT OR GPL-2.0-only

--- a/curations/nuget/nuget/-/respond.yaml
+++ b/curations/nuget/nuget/-/respond.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: respond
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    files:
+      - attributions:
+          - '(c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas'
+        license: MIT OR OTHER
+        path: content/Scripts/respond.js
+      - attributions:
+          - '(c) 2012: Scott Jehl, Paul Irish, Nicholas Zakas'
+        license: MIT OR OTHER
+        path: content/Scripts/respond.min.js
+    licensed:
+      declared: MIT OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Declared License

**Details:**
Source declares MIT/GPLv2 dual: https://github.com/scottjehl/Respond/tree/b21c5785e8442cca651f532ce72e6e515817ad3d

Some scripts declare dual MIT/BSD.  Because type of BSD is not specified, coded to "OTHER."  

**Resolution:**
Added declared license, copyright information.

**Affected definitions**:
- [respond 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/respond/1.2.0/1.2.0)