### PR TITLE
Declared MS-PL

### DIFF
--- a/curations/nuget/nuget/-/linq.js.yaml
+++ b/curations/nuget/nuget/-/linq.js.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: linq.js
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0.2:
+    files:
+      - attributions:
+          - >-
+            * created and maintained by neuecc <ils@neue.cc> * licensed under Microsoft Public License(Ms-PL) * http://neue.cc/ *
+            http://linqjs.codeplex.com/
+        license: MS-PL
+        path: linq.js.nuspec
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MS-PL

**Details:**
Went to license:  https://archive.codeplex.com/?p=linqjs  Found close date in Master Branch (https://github.com/neuecc/linq.js/commits/master?after=74b4cf5bd6f2d9056d29b721cd654bcaf0f63604+34)  License found in ReadMe.txt (https://github.com/neuecc/linq.js/blob/37b7a0b3e8b102a25835d2c30f845c49d6cf36

**Resolution:**
Declared license and updated "nuspec" to include license and copyright

**Affected definitions**:
- [linq.js 2.2.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/linq.js/2.2.0.2/2.2.0.2)