### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/jquery.yaml
+++ b/curations/nuget/nuget/-/jquery.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: jquery
+  provider: nuget
+  type: nuget
+revisions:
+  1.10.2:
+    files:
+      - attributions:
+          - 'Copyright 2005, 2012 jQuery Foundation, Inc. and other contributors'
+        license: MIT
+        path: Content/Scripts/jquery-1.10.2-vsdoc.js
+      - attributions:
+          - 'Copyright 2005, 2013 jQuery Foundation, Inc. and other contributors'
+        license: MIT
+        path: Content/Scripts/jquery-1.10.2.js
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Declared License

**Details:**
The NuGet page license link directs to a page indicating MIT use.  Attributions and explicit MIT license declaration found in the JS script files.

**Resolution:**
Adds the relevant licenses and attributions.

**Affected definitions**:
- [jquery 1.10.2](https://clearlydefined.io/definitions/nuget/nuget/-/jquery/1.10.2/1.10.2)