### PR TITLE
No license found

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Maps.MapControl.WPF.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Maps.MapControl.WPF.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Maps.MapControl.WPF
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
No license found

**Details:**
No license found on this component

**Resolution:**
No license found on this component

**Affected definitions**:
- [Microsoft.Maps.MapControl.WPF 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Maps.MapControl.WPF/1.0.1/1.0.1)