### PR TITLE
Declared BSD-3-Clause license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Maps.MapControl.WPF.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Maps.MapControl.WPF.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: Microsoft.Maps.MapControl.WPF
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    files:
+      - attributions:
+          - © 2006-2018 Microsoft
+        license: BSD-3-Clause
+        path: Microsoft.Maps.MapControl.WPF.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause license

**Details:**
Nuget repo links to SharpBITS code base which claims BSD-3-Clause found (https://archive.codeplex.com/?p=sharpbits) download archive and in license file

**Resolution:**
Updated license to BSD-3-Clause and "nuspec" with license and copyright

**Affected definitions**:
- [Microsoft.Maps.MapControl.WPF 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Maps.MapControl.WPF/1.0.1/1.0.1)