### PR TITLE
Declared BSD-3-Clause license

### DIFF
--- a/curations/nuget/nuget/-/SharpBITS.yaml
+++ b/curations/nuget/nuget/-/SharpBITS.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: SharpBITS
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.0:
+    files:
+      - license: BSD-3-Clause
+        path: SharpBITS.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause license

**Details:**
Nuget repo links to SharpBITS code base which claims BSD-3-Clause found (https://archive.codeplex.com/?p=sharpbits) download archive and in license file

**Resolution:**
Updated license to BSD-3-Clause and "nuspec" with license 

**Affected definitions**:
- [SharpBITS 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/SharpBITS/2.1.0/2.1.0)