### PR TITLE
Declared BSD-3-Clause License and updated "nuspec" with licence and copyright

### DIFF
--- a/curations/nuget/nuget/-/cef.redist.x64.yaml
+++ b/curations/nuget/nuget/-/cef.redist.x64.yaml
@@ -9,3 +9,9 @@ revisions:
         path: cef.redist.x64.nuspec
     licensed:
       declared: BSD-3-Clause
+  3.3239.1723:
+    files:
+      - license: BSD-3-Clause
+        path: cef.redist.x64.nuspec
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause License and updated "nuspec" with licence and copyright

**Details:**
Found  (https://www.nuget.org/packages/cef.redist.x64/3.3239.1723) license found (https://raw.githubusercontent.com/cefsharp/cef-binary/master/LICENSE.txt)

**Resolution:**
Declared BSD-3-Clause License and updated "nuspec" with licence and copyright

**Affected definitions**:
- [cef.redist.x64 3.3239.1723](https://clearlydefined.io/definitions/nuget/nuget/-/cef.redist.x64/3.3239.1723/3.3239.1723)