### PR TITLE
Declare project license

### DIFF
--- a/curations/git/github/baddstats/polyclip.yaml
+++ b/curations/git/github/baddstats/polyclip.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: polyclip
+  namespace: baddstats
+  provider: github
+  type: git
+revisions:
+  b761addb7a346c8ef7cce2dc26792a8b8f1fc747:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare project license

**Details:**
Declared license was missing.

**Resolution:**
Declared license: BSL-1.0
See: https://github.com/baddstats/polyclip/blob/b761addb7a346c8ef7cce2dc26792a8b8f1fc747/DESCRIPTION

**Affected definitions**:
- [polyclip b761addb7a346c8ef7cce2dc26792a8b8f1fc747](https://clearlydefined.io/definitions/git/github/baddstats/polyclip/b761addb7a346c8ef7cce2dc26792a8b8f1fc747/b761addb7a346c8ef7cce2dc26792a8b8f1fc747)