### PR TITLE
Fix declared license

### DIFF
--- a/curations/pypi/pypi/-/pexpect.yaml
+++ b/curations/pypi/pypi/-/pexpect.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pexpect
+  provider: pypi
+  type: pypi
+revisions:
+  4.7.0:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fix declared license

**Details:**
GPL-1.0 was a declared license.  This appears to be an error based on the ISC text stating that ISC is GPL compatabile.

**Resolution:**
Removed GPL-1.0

**Affected definitions**:
- [pexpect 4.7.0](https://clearlydefined.io/definitions/pypi/pypi/-/pexpect/4.7.0/4.7.0)