### PR TITLE
Declared BSD-2-Clause and updated "nuspec" with license and copyright

### DIFF
--- a/curations/nuget/nuget/-/RocksDbNative.yaml
+++ b/curations/nuget/nuget/-/RocksDbNative.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: RocksDbNative
+  provider: nuget
+  type: nuget
+revisions:
+  5.4.6.10:
+    files:
+      - attributions:
+          - 'Copyright (c) 2015, Warren Falk'
+        license: BSD-2-Clause
+        path: RocksDbNative.nuspec
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/nuget/nuget/-/RocksDbNative.yaml
+++ b/curations/nuget/nuget/-/RocksDbNative.yaml
@@ -6,7 +6,7 @@ revisions:
   5.4.6.10:
     files:
       - attributions:
-          - 'Copyright (c) 2015, Warren Falk'
+          - 'Copyright (c) 2015, Warren Falk. All rights reserved.'
         license: BSD-2-Clause
         path: RocksDbNative.nuspec
     licensed:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-2-Clause and updated "nuspec" with license and copyright

**Details:**
Component found (https://github.com/warrenfalk/rocksdb-sharp/tree/v5.4.6.10)
License found (https://github.com/warrenfalk/rocksdb-sharp/blob/v5.4.6.10/LICENSE)

**Resolution:**
Declared BSD-2-Clause and updated "nuspec" with license and copyright

**Affected definitions**:
- [RocksDbNative 5.4.6.10](https://clearlydefined.io/definitions/nuget/nuget/-/RocksDbNative/5.4.6.10/5.4.6.10)