### PR TITLE
Declared MIT and updated "nuspec" to include license and copyright

### DIFF
--- a/curations/nuget/nuget/-/SyslogNet.Client.yaml
+++ b/curations/nuget/nuget/-/SyslogNet.Client.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: SyslogNet.Client
+  provider: nuget
+  type: nuget
+revisions:
+  0.3.3:
+    files:
+      - attributions:
+          - Copyright (c) 2013 Andrew Smith
+        license: MIT
+        path: SyslogNet.Client.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT and updated "nuspec" to include license and copyright

**Details:**
Component found:  (https://github.com/emertechie/SyslogNet)
License found:  (https://github.com/emertechie/SyslogNet/blob/master/licence.md)

**Resolution:**
Declared MIT and updated "nuspec" to include license and copyright

**Affected definitions**:
- [SyslogNet.Client 0.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/SyslogNet.Client/0.3.3/0.3.3)