### PR TITLE
Add declared license

### DIFF
--- a/curations/git/github/yihui/tinytex.yaml
+++ b/curations/git/github/yihui/tinytex.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tinytex
+  namespace: yihui
+  provider: github
+  type: git
+revisions:
+  0f582c23d9c0b0155e064fd6a4c21a518a763ac9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add declared license

**Details:**
No declared license exists for this component.

**Resolution:**
Declared license: MIT
See: https://github.com/yihui/tinytex/blob/0f582c23d9c0b0155e064fd6a4c21a518a763ac9/DESCRIPTION

**Affected definitions**:
- [tinytex 0f582c23d9c0b0155e064fd6a4c21a518a763ac9](https://clearlydefined.io/definitions/git/github/yihui/tinytex/0f582c23d9c0b0155e064fd6a4c21a518a763ac9/0f582c23d9c0b0155e064fd6a4c21a518a763ac9)