### PR TITLE
Declared MIT and updated "nuspec"

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -3,6 +3,14 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.603:
+    files:
+      - attributions:
+          - Copyright (c) 2014 Stack Exchange
+        license: MIT
+        path: StackExchange.Redis.StrongName.nuspec
+    licensed:
+      declared: MIT
   1.1.608:
     described:
       releaseDate: '2016-10-06'

--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -15,6 +15,8 @@ revisions:
     described:
       releaseDate: '2016-10-06'
       sourceLocation:
+        name: stackexchange.redis
+        namespace: stackexchange
         provider: github
         revision: 1f514259be17897c22cbe73dc7b929ade458e56d
         type: git


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT and updated "nuspec"

**Details:**
Component (https://github.com/StackExchange/StackExchange.Redis/tree/0b47916a53e269835717c72a474785e10713e723)  License (https://github.com/StackExchange/StackExchange.Redis/blob/0b47916a53e269835717c72a474785e10713e723/LICENSE)

**Resolution:**
Declared MIT and also included SHAREALIKE in license and updated "nuspec"

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.1.603](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.1.603/1.1.603)