### PR TITLE
Delcared MIT and updated "nuspec"

### DIFF
--- a/curations/nuget/nuget/-/WinJS.yaml
+++ b/curations/nuget/nuget/-/WinJS.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: WinJS
+  provider: nuget
+  type: nuget
+revisions:
+  4.4.0:
+    files:
+      - attributions:
+          - Copyright (c) Microsoft Corporation
+        license: MIT
+        path: WinJS.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Delcared MIT and updated "nuspec"

**Details:**
Component (https://github.com/winjs/winjs/tree/v4.4.0) LIcense (https://github.com/winjs/winjs/blob/v4.4.0/License.txt)

**Resolution:**
Updated to MIT License and "nuspec"

**Affected definitions**:
- [WinJS 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/WinJS/4.4.0/4.4.0)