### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.KeyVault.WebKey.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.KeyVault.WebKey.yaml
@@ -13,6 +13,9 @@ revisions:
         url: 'https://github.com/Azure/azure-sdk-for-net/commit/5ae66289165a99e66a5bc6c3a588d99ad384163c'
     licensed:
       declared: MIT
+  2.0.6:
+    licensed:
+      declared: MIT
   2.0.7:
     described:
       releaseDate: '2017-06-28'


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT

**Resolution:**
License file was updated to MIT in 2015 before this release in 2016. Other versions before and after this release are under MIT.

https://github.com/Azure/azure-sdk-for-net/blob/965d305597f92331ffabb962426e02d5ed7b3ea2/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.KeyVault.WebKey 2.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.KeyVault.WebKey/2.0.6/2.0.6)