### PR TITLE
Update declared license

### DIFF
--- a/curations/git/github/krlmlr/plogr.yaml
+++ b/curations/git/github/krlmlr/plogr.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: plogr
+  namespace: krlmlr
+  provider: github
+  type: git
+revisions:
+  ac3ad19936febb12e1aa5540af29152940eafdf6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update declared license

**Details:**
Declared license was "NOASSERTION", should be "MIT License".

**Resolution:**
Updated declared license to be MIT as per the GH page:  https://github.com/krlmlr/plogr/blob/ac3ad19936febb12e1aa5540af29152940eafdf6/DESCRIPTION

**Affected definitions**:
- [plogr ac3ad19936febb12e1aa5540af29152940eafdf6](https://clearlydefined.io/definitions/git/github/krlmlr/plogr/ac3ad19936febb12e1aa5540af29152940eafdf6/ac3ad19936febb12e1aa5540af29152940eafdf6)