### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/pypi/pypi/-/contextlib2.yaml
+++ b/curations/pypi/pypi/-/contextlib2.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: contextlib2
+  provider: pypi
+  type: pypi
+revisions:
+  0.5.5:
+    files:
+      - license: Python-2.0
+        path: contextlib2-0.5.5/contextlib2.py
+      - license: Python-2.0
+        path: contextlib2-0.5.5/setup.py
+      - license: Python-2.0
+        path: contextlib2-0.5.5/PKG-INFO


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
Some files were automatically identified as "NOASSERTION". However, this identification is invalid.

**Resolution:**
Files are part of project, which is licensed under Python Software Foundation License 2.0 (Python-2.0).

**Affected definitions**:
- [contextlib2 0.5.5](https://clearlydefined.io/definitions/pypi/pypi/-/contextlib2/0.5.5/0.5.5)