### PR TITLE
Fixing license

### DIFF
--- a/curations/pypi/pypi/-/chardet.yaml
+++ b/curations/pypi/pypi/-/chardet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: chardet
+  provider: pypi
+  type: pypi
+revisions:
+  3.0.4:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing license

**Details:**
Declared was GPLv3, but per source link (https://github.com/chardet/chardet/blob/9b8c5c2fb118d76c6beeab9affd01c332732a530/LICENSE) and pypi.org, the license is LGPLv2.1

**Resolution:**
LGPLv2.1

**Affected definitions**:
- [chardet 3.0.4](https://clearlydefined.io/definitions/pypi/pypi/-/chardet/3.0.4/3.0.4)