### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: jruby
+  namespace: jruby
+  provider: github
+  type: git
+revisions:
+  8a269e34ff3d242ec90fb08061f79c2757a5e157:
+    files:
+      - license: OTHER
+        path: core/src/main/java/org/jruby/util/MurmurHash.java
+      - license: (EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)) AND OTHER
+        path: core/src/main/java/org/jruby/util/collections/ConcurrentWeakHashMap.java
+      - license: OTHER
+        path: core/src/main/java/org/jruby/util/collections/NonBlockingHashMapLong.java
+      - license: OTHER
+        path: core/src/test/java/org/jruby/util/MurmurHashTest.java


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
These files were identified as "NOASSERTION". They either have a valid SPDX license or are said to be in the public domain.

**Resolution:**
Updated each file's declared license according to their header contents.

**Affected definitions**:
- [jruby 8a269e34ff3d242ec90fb08061f79c2757a5e157](https://clearlydefined.io/definitions/git/github/jruby/jruby/8a269e34ff3d242ec90fb08061f79c2757a5e157/8a269e34ff3d242ec90fb08061f79c2757a5e157)