### PR TITLE
Clarify source file licenses

### DIFF
--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -1,0 +1,83 @@
+coordinates:
+  name: jruby
+  namespace: jruby
+  provider: github
+  type: git
+revisions:
+  8a269e34ff3d242ec90fb08061f79c2757a5e157:
+    files:
+      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: core/src/main/java/org/jruby/embed/osgi/internal/BundleWiringOSGiClassLoaderAdapter.java
+      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: core/src/main/java/org/jruby/embed/osgi/internal/IOSGiClassLoaderAdapter.java
+      - attributions:
+          - Copyright (c) 2002-2011 JRuby Community
+        license: EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: core/src/main/java/org/jruby/embed/osgi/internal/JRubyOSGiBundleClassLoader.java
+      - attributions:
+          - Copyright (c) 2002-2011 JRuby Community
+        license: EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: core/src/main/java/org/jruby/embed/osgi/internal/OSGiBundleLibrary.java
+      - attributions:
+          - Copyright (c) 2002-2011 JRuby Community
+        license: EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: core/src/main/java/org/jruby/embed/osgi/internal/OSGiLoadService.java
+      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: core/src/main/java/org/jruby/embed/osgi/internal/ReflectiveOSGiClassLoaderAdapter.java
+      - attributions:
+          - Copyright (c) 2014 Timur Duehr <tduehr@gmail.com>
+          - Copyright (c) 2004-2005 Thomas E Enebo <enebo@acm.org>
+          - Copyright (c) 2002-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
+        license: AFL-3.0
+        path: core/src/main/java/org/jruby/internal/runtime/methods/NullMethod.java
+      - license: OTHER
+        path: core/src/main/java/org/jruby/util/MurmurHash.java
+      - license: (EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)) AND OTHER
+        path: core/src/main/java/org/jruby/util/collections/ConcurrentWeakHashMap.java
+      - license: OTHER
+        path: core/src/main/java/org/jruby/util/collections/NonBlockingHashMapLong.java
+      - license: OTHER
+        path: core/src/test/java/org/jruby/util/MurmurHashTest.java
+      - attributions:
+          - Copyright (c) 2008-2010 Wayne Meissner
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/autopointer.rb
+      - attributions:
+          - Copyright (c) 2008 Wayne Meissner
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/errno.rb
+      - attributions:
+          - Copyright (c) 2008 JRuby project
+          - 'Copyright (c) 2007, 2008 Evan Phoenix'
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/ffi.rb
+      - attributions:
+          - Copyright (c) 2008 Wayne Meissner
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/io.rb
+      - attributions:
+          - Copyright (c) 2008-2010 Wayne Meissner
+          - Copyright (c) 2008 Luc Heinrich <luc@honk-honk.com>
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/library.rb
+      - attributions:
+          - Copyright (c) 2008-2010 Wayne Meissner
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/struct_layout_builder.rb
+      - attributions:
+          - Copyright (c) 2009-2010 Andrea Fazzi
+          - Copyright (c) 2009-2010 Wayne Meissner
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/union.rb
+      - attributions:
+          - Copyright (c) 2008-2010 Wayne Meissner
+        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: lib/ruby/stdlib/ffi/variadic.rb
+      - attributions:
+          - 'Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.'
+        license: OTHER
+        path: lib/ruby/stdlib/rubygems/specification.rb
+      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: maven/jruby/src/templates/osgi_all_inclusive/src/test/java/org/jruby/embed/osgi/test/JRubyOsgiEmbedTest.java
+      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        path: maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/test/src/test/java/org/jruby/embed/osgi/test/JRubyOsgiEmbedTest.java

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -62,7 +62,7 @@ revisions:
         path: lib/ruby/stdlib/ffi/library.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/struct_layout_builder.rb
       - attributions:
           - Copyright (c) 2009-2010 Andrea Fazzi

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -71,7 +71,7 @@ revisions:
         path: lib/ruby/stdlib/ffi/union.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/variadic.rb
       - attributions:
           - 'Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.'

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -67,7 +67,7 @@ revisions:
       - attributions:
           - Copyright (c) 2009-2010 Andrea Fazzi
           - Copyright (c) 2009-2010 Wayne Meissner
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: (EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND BSD-3-Clause
         path: lib/ruby/stdlib/ffi/union.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -6,23 +6,23 @@ coordinates:
 revisions:
   8a269e34ff3d242ec90fb08061f79c2757a5e157:
     files:
-      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+      - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/embed/osgi/internal/BundleWiringOSGiClassLoaderAdapter.java
-      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+      - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/embed/osgi/internal/IOSGiClassLoaderAdapter.java
       - attributions:
           - Copyright (c) 2002-2011 JRuby Community
-        license: EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/embed/osgi/internal/JRubyOSGiBundleClassLoader.java
       - attributions:
           - Copyright (c) 2002-2011 JRuby Community
-        license: EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/embed/osgi/internal/OSGiBundleLibrary.java
       - attributions:
           - Copyright (c) 2002-2011 JRuby Community
-        license: EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/embed/osgi/internal/OSGiLoadService.java
-      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+      - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/embed/osgi/internal/ReflectiveOSGiClassLoaderAdapter.java
       - attributions:
           - Copyright (c) 2014 Timur Duehr <tduehr@gmail.com>
@@ -32,7 +32,7 @@ revisions:
         path: core/src/main/java/org/jruby/internal/runtime/methods/NullMethod.java
       - license: OTHER
         path: core/src/main/java/org/jruby/util/MurmurHash.java
-      - license: (EPL-2.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)) AND OTHER
+      - license: (EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND OTHER
         path: core/src/main/java/org/jruby/util/collections/ConcurrentWeakHashMap.java
       - license: OTHER
         path: core/src/main/java/org/jruby/util/collections/NonBlockingHashMapLong.java
@@ -40,44 +40,44 @@ revisions:
         path: core/src/test/java/org/jruby/util/MurmurHashTest.java
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/autopointer.rb
       - attributions:
           - Copyright (c) 2008 Wayne Meissner
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/errno.rb
       - attributions:
           - Copyright (c) 2008 JRuby project
           - 'Copyright (c) 2007, 2008 Evan Phoenix'
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/ffi.rb
       - attributions:
           - Copyright (c) 2008 Wayne Meissner
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/io.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
           - Copyright (c) 2008 Luc Heinrich <luc@honk-honk.com>
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/library.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/struct_layout_builder.rb
       - attributions:
           - Copyright (c) 2009-2010 Andrea Fazzi
           - Copyright (c) 2009-2010 Wayne Meissner
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/union.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
-        license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/variadic.rb
       - attributions:
           - 'Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.'
         license: OTHER
         path: lib/ruby/stdlib/rubygems/specification.rb
-      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+      - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: maven/jruby/src/templates/osgi_all_inclusive/src/test/java/org/jruby/embed/osgi/test/JRubyOsgiEmbedTest.java
-      - license: CPL-1.0 OR (GPL-2.0-or-later OR LGPL-2.1-or-later)
+      - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/test/src/test/java/org/jruby/embed/osgi/test/JRubyOsgiEmbedTest.java

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -30,9 +30,6 @@ revisions:
           - Copyright (c) 2002-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
         license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/internal/runtime/methods/NullMethod.java
-    licensed:
-      declared: EPL-2.0 OR GPL-2.0 OR LGPL-2.1
-    files:
       - license: OTHER
         path: core/src/main/java/org/jruby/util/MurmurHash.java
       - license: (EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND OTHER
@@ -85,5 +82,6 @@ revisions:
       - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: maven/jruby-complete/src/templates/osgi_many_bundles_with_embedded_gems/test/src/test/java/org/jruby/embed/osgi/test/JRubyOsgiEmbedTest.java
 
-
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0 OR LGPL-2.1
 

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -28,7 +28,7 @@ revisions:
           - Copyright (c) 2014 Timur Duehr <tduehr@gmail.com>
           - Copyright (c) 2004-2005 Thomas E Enebo <enebo@acm.org>
           - Copyright (c) 2002-2004 Jan Arne Petersen <jpetersen@uni-bonn.de>
-        license: AFL-3.0
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: core/src/main/java/org/jruby/internal/runtime/methods/NullMethod.java
       - license: OTHER
         path: core/src/main/java/org/jruby/util/MurmurHash.java

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -40,11 +40,11 @@ revisions:
         path: core/src/test/java/org/jruby/util/MurmurHashTest.java
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/autopointer.rb
       - attributions:
           - Copyright (c) 2008 Wayne Meissner
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/errno.rb
       - attributions:
           - Copyright (c) 2008 JRuby project

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -48,8 +48,8 @@ revisions:
         path: lib/ruby/stdlib/ffi/errno.rb
       - attributions:
           - Copyright (c) 2008 JRuby project
-          - 'Copyright (c) 2007, 2008 Evan Phoenix'
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+          - Copyright (c) 2007, 2008 Evan Phoenix All rights reserved.
+        license: (EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND BSD-3-Clause
         path: lib/ruby/stdlib/ffi/ffi.rb
       - attributions:
           - Copyright (c) 2008 Wayne Meissner

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -74,7 +74,7 @@ revisions:
         license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/variadic.rb
       - attributions:
-          - 'Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others.'
+          - Copyright 2006 by Chad Fowler, Rich Kilmer, Jim Weirich and others. All rights reserved.
         license: OTHER
         path: lib/ruby/stdlib/rubygems/specification.rb
       - license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -53,7 +53,7 @@ revisions:
         path: lib/ruby/stdlib/ffi/ffi.rb
       - attributions:
           - Copyright (c) 2008 Wayne Meissner
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
         path: lib/ruby/stdlib/ffi/io.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner

--- a/curations/git/github/jruby/jruby.yaml
+++ b/curations/git/github/jruby/jruby.yaml
@@ -58,7 +58,7 @@ revisions:
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner
           - Copyright (c) 2008 Luc Heinrich <luc@honk-honk.com>
-        license: CPL-1.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later
+        license: (EPL-2.0 OR GPL-2.0-or-later OR LGPL-2.1-or-later) AND BSD-3-Clause
         path: lib/ruby/stdlib/ffi/library.rb
       - attributions:
           - Copyright (c) 2008-2010 Wayne Meissner


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Clarify source file licenses

**Details:**
The source files have incomplete discovered licenses.

**Resolution:**
Updated each source file's license to reflect contents of their license header.

**Affected definitions**:
- [jruby 8a269e34ff3d242ec90fb08061f79c2757a5e157](https://clearlydefined.io/definitions/git/github/jruby/jruby/8a269e34ff3d242ec90fb08061f79c2757a5e157/8a269e34ff3d242ec90fb08061f79c2757a5e157)