### PR TITLE
License states MIT

### DIFF
--- a/curations/maven/mavencentral/org.mockito/mockito-core.yaml
+++ b/curations/maven/mavencentral/org.mockito/mockito-core.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: mockito-core
+  namespace: org.mockito
+  provider: mavencentral
+  type: maven
+revisions:
+  2.8.9:
+    files:
+      - attributions:
+          - Copyright (c) 2007 Mockito contributors
+        license: MIT
+        path: LICENSE
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
License states MIT

**Details:**
The declared license is MIT

**Resolution:**
NOASSERTION is incorrect. The LICENSE file included in the source build (and in the project's GitHub repository) indicates MIT.

**Affected definitions**:
- [mockito-core 2.8.9](https://clearlydefined.io/definitions/maven/mavencentral/org.mockito/mockito-core/2.8.9/2.8.9)