### PR TITLE
Confirmed License File is BSD-3-Clause

### DIFF
--- a/curations/git/github/mozilla/source-map.yaml
+++ b/curations/git/github/mozilla/source-map.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: source-map
+  namespace: mozilla
+  provider: github
+  type: git
+revisions:
+  0314b55e6cad0a3462070123bfdb2dffc05a83e9:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Confirmed License File is BSD-3-Clause

**Details:**
I confirmed the License file is BSD-3-Clause

**Resolution:**
Adds BSD-3-Clause

**Affected definitions**:
- [source-map 0314b55e6cad0a3462070123bfdb2dffc05a83e9](https://clearlydefined.io/definitions/git/github/mozilla/source-map/0314b55e6cad0a3462070123bfdb2dffc05a83e9/0314b55e6cad0a3462070123bfdb2dffc05a83e9)