### PR TITLE
There is no declared license

### DIFF
--- a/curations/git/github/live-clones/hdf5.yaml
+++ b/curations/git/github/live-clones/hdf5.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hdf5
+  namespace: live-clones
+  provider: github
+  type: git
+revisions:
+  f3f29dc7df5f3cc41a5e9462d8c415e540cda3d6:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
There is no declared license

**Details:**
License is BSD-3 clause per COPYING file on github: https://github.com/live-clones/hdf5/blob/f3f29dc7df5f3cc41a5e9462d8c415e540cda3d6/COPYING_LBNL_HDF5 and on the original repository: https://bitbucket.hdfgroup.org/projects/HDFFV/repos/hdf5/browse/COPYING_LBNL_HDF5

**Resolution:**
Populated declared license with "BSD-3-Clause"

**Affected definitions**:
- [hdf5 f3f29dc7df5f3cc41a5e9462d8c415e540cda3d6](https://clearlydefined.io/definitions/git/github/live-clones/hdf5/f3f29dc7df5f3cc41a5e9462d8c415e540cda3d6/f3f29dc7df5f3cc41a5e9462d8c415e540cda3d6)