### PR TITLE
Missing license for Microsoft.Azure.Management.Batch.Fluent/1.22.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.Batch.Fluent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.Batch.Fluent.yaml
@@ -6,3 +6,19 @@ revisions:
   1.21.0:
     licensed:
       declared: MIT
+  1.22.2:
+    described:
+      sourceLocation:
+        name: azure-libraries-for-net
+        namespace: azure
+        provider: github
+        revision: 594713fad170c9017a405ed66ac8c0d0c80ff77f
+        type: git
+        url: 'https://github.com/azure/azure-libraries-for-net/commit/594713fad170c9017a405ed66ac8c0d0c80ff77f'
+    files:
+      - attributions:
+          - Copyright (c) 2015 Microsoft
+        license: MIT
+        path: Microsoft.Azure.Management.Batch.Fluent.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Azure.Management.Batch.Fluent/1.22.2

**Details:**
Adding source, license, and attributions. 

**Resolution:**
Source:
https://github.com/Azure/azure-libraries-for-net/tree/594713fad170c9017a405ed66ac8c0d0c80ff77f
MIT License:
Copyright (c) 2015 Microsoft
https://github.com/Azure/azure-libraries-for-net/blob/594713fad170c9017a405ed66ac8c0d0c80ff77f/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.Management.Batch.Fluent 1.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Management.Batch.Fluent/1.22.2/1.22.2)