### PR TITLE
Update declared license

### DIFF
--- a/curations/git/github/ropensci/tokenizers.yaml
+++ b/curations/git/github/ropensci/tokenizers.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tokenizers
+  namespace: ropensci
+  provider: github
+  type: git
+revisions:
+  964ed405c03dd63856419bec1a1c618057b1cbe6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update declared license

**Details:**
Declared license was missing

**Resolution:**
Declared license: MIT
See: https://github.com/ropensci/tokenizers/blob/964ed405c03dd63856419bec1a1c618057b1cbe6/DESCRIPTION

**Affected definitions**:
- [tokenizers 964ed405c03dd63856419bec1a1c618057b1cbe6](https://clearlydefined.io/definitions/git/github/ropensci/tokenizers/964ed405c03dd63856419bec1a1c618057b1cbe6/964ed405c03dd63856419bec1a1c618057b1cbe6)