### PR TITLE
Missing license for Microsoft.Diagnostics.Tracing.TraceEvent/2.0.42

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -6,3 +6,19 @@ revisions:
   2.0.41:
     licensed:
       declared: MIT
+  2.0.42:
+    described:
+      sourceLocation:
+        name: perfview
+        namespace: microsoft
+        provider: github
+        revision: 919f5fa7918e5e2dfe7a49ad8b3cbac71c8bbecf
+        type: git
+        url: 'https://github.com/microsoft/perfview/commit/919f5fa7918e5e2dfe7a49ad8b3cbac71c8bbecf'
+    files:
+      - attributions:
+          - Copyright (c) .NET Foundation and Contributors
+        license: MIT
+        path: Microsoft.Diagnostics.Tracing.TraceEvent.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Diagnostics.Tracing.TraceEvent/2.0.42

**Details:**
Adding source, license, and attributions. 

**Resolution:**
Source:
https://github.com/microsoft/perfview/tree/919f5fa7918e5e2dfe7a49ad8b3cbac71c8bbecf
MIT License:
Copyright (c) .NET Foundation and Contributors
https://github.com/microsoft/perfview/blob/919f5fa7918e5e2dfe7a49ad8b3cbac71c8bbecf/LICENSE.TXT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.42](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.42/2.0.42)