### PR TITLE
Missing license for System.Memory/4.5.3

### DIFF
--- a/curations/nuget/nuget/-/System.Memory.yaml
+++ b/curations/nuget/nuget/-/System.Memory.yaml
@@ -12,3 +12,19 @@ revisions:
   4.5.2:
     licensed:
       declared: MIT
+  4.5.3:
+    described:
+      sourceLocation:
+        name: corefx
+        namespace: dotnet
+        provider: github
+        revision: c6cf790234e063b855fcdb50f3fb1b3cfac73275
+        type: git
+        url: 'https://github.com/dotnet/corefx/commit/c6cf790234e063b855fcdb50f3fb1b3cfac73275'
+    files:
+      - attributions:
+          - Copyright (c) .NET Foundation and Contributors
+        license: MIT
+        path: System.Memory.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for 

**Details:**
Adding source, license, and attributions. 

**Resolution:**
Source:
https://github.com/dotnet/corefx/tree/c6cf790234e063b855fcdb50f3fb1b3cfac73275
MIT License:
Copyright (c) .NET Foundation and Contributors
https://github.com/dotnet/corefx/blob/c6cf790234e063b855fcdb50f3fb1b3cfac73275/LICENSE.TXT

**Affected definitions**:
- [System.Memory 4.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/System.Memory/4.5.3/4.5.3)