### PR TITLE
Missing license for Microsoft.Azure.DocumentDB.Core/2.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
@@ -6,3 +6,19 @@ revisions:
   2.1.3:
     licensed:
       declared: NOASSERTION
+  2.4.0:
+    described:
+      sourceLocation:
+        name: azure-cosmos-dotnet-v2
+        namespace: azure
+        provider: github
+        revision: d38ffeb950904206b9a7ed50f40a101f3219b2ab
+        type: git
+        url: 'https://github.com/azure/azure-cosmos-dotnet-v2/commit/d38ffeb950904206b9a7ed50f40a101f3219b2ab'
+    files:
+      - attributions:
+          - Copyright (c) 2014 Microsoft Corporation
+        license: MIT
+        path: Microsoft.Azure.DocumentDB.Core.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Azure.DocumentDB.Core/2.4.0

**Details:**
Adding source, license, and attributions. 

**Resolution:**
Source:
https://github.com/Azure/azure-cosmos-dotnet-v2/tree/d38ffeb950904206b9a7ed50f40a101f3219b2ab
MIT License:
Copyright (c) 2014 Microsoft Corporation
https://github.com/Azure/azure-cosmos-dotnet-v2/blob/d38ffeb950904206b9a7ed50f40a101f3219b2ab/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DocumentDB.Core 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core/2.4.0)