### PR TITLE
Missing license for Microsoft.Azure.Management.ResourceManager/2.0.0-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.ResourceManager.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.ResourceManager.yaml
@@ -15,3 +15,11 @@ revisions:
   1.9.0-preview:
     licensed:
       declared: MIT
+  2.0.0-preview:
+    files:
+      - attributions:
+          - Copyright (c) 2018 Microsoft
+        license: MIT
+        path: Microsoft.Azure.Management.ResourceManager.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Azure.Management.ResourceManager/2.0.0-preview

**Details:**
Adding license, and attributions. 

**Resolution:**
MIT License:
Copyright (c) 2018 Microsoft
https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Management.ResourceManager 2.0.0-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Management.ResourceManager/2.0.0-preview)