### PR TITLE
Missing license for Moq/4.11.0

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -6,6 +6,9 @@ revisions:
   4.10.1:
     licensed:
       declared: BSD-3-Clause
+  4.11.0:
+    licensed:
+      declared: BSD-3-Clause
   4.2.1402.2112:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Moq/4.11.0

**Details:**
Adding license.

**Resolution:**
BSD 3-Clause "New" or "Revised" License:
Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD. All rights reserved.
https://github.com/moq/moq4/blob/639575193b62a5fba56e4a9446f322cce46c920a/License.txt

**Affected definitions**:
- [Moq 4.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.11.0/4.11.0)