### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.3.0:
+    licensed:
+      declared: Apache-2.0
   4.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
The license was updated at one point (thus the broken license link from nuget page), but the license in the repo has always been Apache v2

**Resolution:**
Declaring Apache v2

**Affected definitions**:
- [NuGet.Versioning 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/3.3.0)