### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/ValueInjecter.yaml
+++ b/curations/nuget/nuget/-/ValueInjecter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ValueInjecter
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.1.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT License - Commits on April 18, 2017 and December 22 2017 both MIT

**Resolution:**
Declared MIT License - Commits on April 18, 2017 (https://github.com/omuleanu/ValueInjecter/tree/45dad4a1c2fdc65a15a881e1dd6638fa093e9ee7) and December 22 2017 (https://github.com/omuleanu/ValueInjecter/tree/fa19fa2e0bff7f02bd8958a2633525745aab8729) both MIT

**Affected definitions**:
- [ValueInjecter 3.1.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/ValueInjecter/3.1.1.5/3.1.1.5)