### PR TITLE
Declared MIT LIcense

### DIFF
--- a/curations/nuget/nuget/-/System.Diagnostics.DiagnosticSource.yaml
+++ b/curations/nuget/nuget/-/System.Diagnostics.DiagnosticSource.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.0:
+    licensed:
+      declared: MIT
   4.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT LIcense

**Details:**
Declared MIT LIcense closest commits between 3.0 and 6.0 both under MIT

**Resolution:**
Declared MIT LIcense closest commits between 3.0 (https://github.com/dotnet/corefx/blob/release/3.0/LICENSE.TXT) and 6.0 (https://github.com/dotnet/corefx/blob/release/uwp6.0/LICENSE.TXT) both under MIT

**Affected definitions**:
- [System.Diagnostics.DiagnosticSource 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Diagnostics.DiagnosticSource/4.4.0/4.4.0)