### PR TITLE
Missing license for CommandLineParser/2.5.0

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -30,3 +30,11 @@ revisions:
         path: CommandLineParser.nuspec
     licensed:
       declared: MIT
+  2.5.0:
+    files:
+      - attributions:
+          - Copyright (c) 2005 - 2018 Giacomo Stelluti Scala Contributors
+        license: MIT
+        path: CommandLineParser.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for CommandLineParser/2.5.0

**Details:**
Adding license.

**Resolution:**
Source:
https://github.com/commandlineparser/commandline/tree/4d69a3898b84c821161b2db948075cd9e162832c
MIT License:
Copyright (c) 2005 - 2015 Giacomo Stelluti Scala & Contributors
https://github.com/commandlineparser/commandline/blob/4d69a3898b84c821161b2db948075cd9e162832c/License.md

**Affected definitions**:
- [CommandLineParser 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser/2.5.0/2.5.0)