### PR TITLE
Missing license for Moq/4.11.0

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -6,6 +6,9 @@ revisions:
   4.10.1:
     licensed:
       declared: BSD-3-Clause
+  4.11.0:
+    licensed:
+      declared: BSD-3-Clause
   4.2.1402.2112:
     licensed:
       declared: BSD-3-Clause
@@ -13,6 +16,8 @@ revisions:
     described:
       releaseDate: '2015-10-22'
       sourceLocation:
+        name: moq4
+        namespace: moq
         provider: github
         revision: 71cf92ff113e08511512e0bf19c754d98dab218e
         type: git
@@ -26,6 +31,8 @@ revisions:
     described:
       releaseDate: '2016-08-12'
       sourceLocation:
+        name: moq4
+        namespace: moq
         provider: github
         revision: 756bf4e3e7b213c6d819ae7acd5e04280a07a040
         type: git
@@ -36,6 +43,8 @@ revisions:
     described:
       releaseDate: '2016-10-11'
       sourceLocation:
+        name: moq4
+        namespace: moq
         provider: github
         revision: 8772a49d4565a03d8455685f5633ffed80bb2cc9
         type: git
@@ -49,6 +58,8 @@ revisions:
     described:
       releaseDate: '2017-02-28'
       sourceLocation:
+        name: moq4
+        namespace: moq
         provider: github
         revision: b776fc2216a591427f4ffe9d3453eeebf9581b3d
         type: git


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Missing license for Moq/4.11.0

**Details:**
Adding license.

**Resolution:**
BSD 3-Clause "New" or "Revised" License:
Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD. All rights reserved.
https://github.com/moq/moq4/blob/639575193b62a5fba56e4a9446f322cce46c920a/License.txt

**Affected definitions**:
- [Moq 4.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.11.0/4.11.0)