### PR TITLE
Correcting license

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: paramiko
+  provider: pypi
+  type: pypi
+revisions:
+  2.6.0:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting license

**Details:**
Had GPLv3 declared, but per https://github.com/paramiko/paramiko/blob/ca304fef5ba3543323c294e5c85dec87bd17280e/LICENSE, and the ReadMe, the license is LGPL2.1

**Resolution:**
Submitting LGPL2.1

**Affected definitions**:
- [paramiko 2.6.0](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.6.0/2.6.0)