### PR TITLE
Adding license to couple of missing components

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -7,6 +7,8 @@ revisions:
     described:
       releaseDate: '2013-02-27'
       sourceLocation:
+        name: commandline
+        namespace: gsscoder
         provider: github
         revision: 205094c0c135ab5b6816f3eb0e6a84ddced5b0e2
         type: git

--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -33,6 +33,7 @@ revisions:
     licensed:
       declared: MIT
   2.5.0:
+    files:
       - attributions:
           - Copyright (c) 2005 - 2018 Giacomo Stelluti Scala & Contributors
         license: MIT

--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -30,3 +30,6 @@ revisions:
         path: CommandLineParser.nuspec
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/YamlDotNet.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.yaml
@@ -9,3 +9,6 @@ revisions:
   5.0.1:
     licensed:
       declared: MIT
+  6.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding license to couple of missing components

**Details:**
Missing packages used by Q#

**Resolution:**
Checked and both uses MIT.

**Affected definitions**:
- [CommandLineParser 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser/2.5.0),- [YamlDotNet 6.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet/6.0.0)