### PR TITLE
Missing declared license

### DIFF
--- a/curations/git/github/cran/clisymbols.yaml
+++ b/curations/git/github/cran/clisymbols.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: clisymbols
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  8ecc778383c9ef455b744e4bc48d96e002f25b22:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Component is missing a declared license

**Resolution:**
Declared license: MIT
See: https://github.com/cran/clisymbols/blob/8ecc778383c9ef455b744e4bc48d96e002f25b22/DESCRIPTION

**Affected definitions**:
- [clisymbols 8ecc778383c9ef455b744e4bc48d96e002f25b22](https://clearlydefined.io/definitions/git/github/cran/clisymbols/8ecc778383c9ef455b744e4bc48d96e002f25b22/8ecc778383c9ef455b744e4bc48d96e002f25b22)