### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/System.Spatial.yaml
+++ b/curations/nuget/nuget/-/System.Spatial.yaml
@@ -9,6 +9,9 @@ revisions:
   5.8.2:
     licensed:
       declared: MIT
+  5.8.3:
+    licensed:
+      declared: MIT
   5.8.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found a system.spatial 5.8.0 with MIT license (https://github.com/OData/odata.net/tree/5.8.0) and a commit with MIT license on 9/26/2017 (https://github.com/OData/odata.net/blob/ebfec66596096e92dc46636903a4ecdf97f2fd64/LICENSE.txt)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [System.Spatial 5.8.3](https://clearlydefined.io/definitions/nuget/nuget/-/System.Spatial/5.8.3/5.8.3)