### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Nito.AsyncEx.yaml
+++ b/curations/nuget/nuget/-/Nito.AsyncEx.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Nito.AsyncEx
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Declared MIT license found commits before and after the 3.0.1 component with MIT - before (https://github.com/StephenCleary/AsyncEx/blob/77b9711c2c5fd4ca28b220ce4c93d209eeca2b4a/LICENSE) after (https://github.com/StephenCleary/AsyncEx/blob/d07933ab1aca8118763e899f06def73a64727de4/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Nito.AsyncEx 3.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.AsyncEx/3.0.1/3.0.1)