### PR TITLE
Declared Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -6,3 +6,6 @@ revisions:
   3.3.0:
     licensed:
       declared: Apache-2.0
+  3.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0 License

**Details:**
Found commits before and after 3.5.0 declaring Apache 2.0  - before (https://github.com/NuGet/NuGet.Client/blob/v3.4.3.855-VSIX-Dev14/LICENSE.txt) and after (https://github.com/NuGet/NuGet.Client/blob/4.6.0.4862/LICENSE.txt)

**Resolution:**
Declared Apache 2.0 License

**Affected definitions**:
- [NuGet.CommandLine 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/3.5.0/3.5.0)