### PR TITLE
grizzly license is not clear

### DIFF
--- a/curations/maven/mavencentral/com.sun.grizzly/grizzly-lzma.yaml
+++ b/curations/maven/mavencentral/com.sun.grizzly/grizzly-lzma.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: grizzly-lzma
+  namespace: com.sun.grizzly
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.46u1:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.1


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
grizzly license is not clear

**Details:**
There is archived source code for grizzly-lzma.
lzma has dual license Gpl-2 only with class path exception, CDDL 1.1.

**Resolution:**
based on code headers
https://github.com/javaee/grizzly/blob/master/modules/grizzly/src/main/java/org/glassfish/grizzly/compression/lzma/LZMAFilter.java

**Affected definitions**:
- [grizzly-lzma 1.9.46u1](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.grizzly/grizzly-lzma/1.9.46u1/1.9.46u1)