### PR TITLE
Missing Declared license

### DIFF
--- a/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
+++ b/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.0.45:
     licensed:
-      declared: CPL-1.0 AND EPL-2.0 OR (LGPL-2.1-or-later OR GPL-2.0-or-later)
+      declared: CPL-1.0 AND EPL-2.0 OR (LGPL-2.1 OR GPL-2.0)

--- a/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
+++ b/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jnr-posix
+  namespace: com.github.jnr
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.45:
+    licensed:
+      declared: CPL-1.0 AND EPL-2.0 OR (LGPL-2.1-or-later OR GPL-2.0-or-later)


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
Missing Declared license

**Details:**
This one has some inconsistencies. 4 licenses are listed here: https://mvnrepository.com/artifact/com.github.jnr/jnr-posix/3.0.45. Note it says EPL 1.0.

**Resolution:**
However, on the code header it says "The contents of this file are subject to the Eclipse Public
License Version 2.0 (the "License")" but then the link it gives for the license goes to the CPL 1.0.  So, I didn't curate EPL 1.0 and wasn't sure to curate CPL 1.0 AND EPL 2.0? 

**Affected definitions**:
- [jnr-posix 3.0.45](https://clearlydefined.io/definitions/maven/mavencentral/com.github.jnr/jnr-posix/3.0.45/3.0.45)