### PR TITLE
Missing Declared License

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcmail-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcmail-jdk15on.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: bcmail-jdk15on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.61':
+    files:
+      - attributions:
+          - 'Copyright (c) 2000 - 2019 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org) '
+        license: ''
+        path: META-INF/MANIFEST.MF
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared License

**Details:**
The http://www.bouncycastle.org/licence.html is identical to the MIT license, so curated MIT.

**Resolution:**
Also, added the copyright. 

**Affected definitions**:
- [bcmail-jdk15on 1.61](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcmail-jdk15on/1.61/1.61)