### PR TITLE
Missing Declared License

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: bcpkix-jdk15on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.61':
+    files:
+      - attributions:
+          - 'Copyright (c) 2000 - 2019 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org) '
+        license: ''
+        path: META-INF/MANIFEST.MF
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared License

**Details:**
Curated MIT, which is identical to http://www.bouncycastle.org/licence.html.  There is not a SPDX for the bouncy castle license. 

**Resolution:**
And added the copyright. 

**Affected definitions**:
- [bcpkix-jdk15on 1.61](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.61/1.61)