### PR TITLE
Missing Declared license

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: bcprov-jdk15on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.61':
+    files:
+      - attributions:
+          - 'Copyright (c) 2000 - 2019 The Legion of the Bouncy Castle Inc. (https://www.bouncycastle.org) '
+        license: ''
+        path: META-INF/MANIFEST.MF
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared license

**Details:**
Curated MIT as that is the same as the http://www.bouncycastle.org/licence.html.  There is no SPDX for the bouncy castle license.

**Resolution:**
I also curated the copyright.

**Affected definitions**:
- [bcprov-jdk15on 1.61](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.61/1.61)