### PR TITLE
Missing Declared license

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm-analysis.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm-analysis.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: asm-analysis
+  namespace: org.ow2.asm
+  provider: mavencentral
+  type: maven
+revisions:
+  5.0.3:
+    files:
+      - attributions:
+          - 'Copyright (c) 2000-2011 INRIA, France Telecom All rights reserved.'
+        license: ''
+        path: META-INF/MANIFEST.MF
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared license

**Details:**
Declared license per https://asm.ow2.io/license.html

**Resolution:**
and added the copyright

**Affected definitions**:
- [asm-analysis 5.0.3](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm-analysis/5.0.3/5.0.3)