### PR TITLE
Declared Apache 2.0 license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Core
+  provider: nuget
+  type: nuget
+revisions:
+  2.14.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0 license

**Details:**
Apache 2.0 found (https://github.com/NuGet/NuGet2/blob/2.14/LICENSE.txt)

**Resolution:**
Declared Apache 2.0 license

**Affected definitions**:
- [NuGet.Core 2.14.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Core/2.14.0/2.14.0)