### PR TITLE
Declared Apache 2.0 license

### DIFF
--- a/curations/nuget/nuget/-/OneOf.Linq.yaml
+++ b/curations/nuget/nuget/-/OneOf.Linq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OneOf.Linq
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0 license

**Details:**
Apache 2.0 found here - this is only version of the component (https://github.com/ndrwrbgs/OneOf.Linq/blob/master/LICENSE)

**Resolution:**
Declared Apache 2.0 license

**Affected definitions**:
- [OneOf.Linq 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/OneOf.Linq/1.0.0/1.0.0)