### PR TITLE
Declared MIT license

### DIFF
--- a/curations/nuget/nuget/-/OneOf.yaml
+++ b/curations/nuget/nuget/-/OneOf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OneOf
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.127:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT license

**Details:**
MIT license found in commits (https://github.com/mcintyre321/OneOf/commits/master) on date of the 2.1.127 component (https://github.com/mcintyre321/OneOf/blob/c08d1d3d6312d2e3cd8144feec28de0e9a051dea/licence.md)

**Resolution:**
Declared MIT license

**Affected definitions**:
- [OneOf 2.1.127](https://clearlydefined.io/definitions/nuget/nuget/-/OneOf/2.1.127/2.1.127)