### PR TITLE
Declared Apache 2.0 license

### DIFF
--- a/curations/nuget/nuget/-/Owin.Types.yaml
+++ b/curations/nuget/nuget/-/Owin.Types.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Owin.Types
+  provider: nuget
+  type: nuget
+revisions:
+  0.8.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0 license

**Details:**
Declared Apache 2.0 license through last commit on component (https://github.com/owin-contrib/owin-hosting/blob/e592ab4fc96d98adbfd2303793f7f2cc6fdf26a3/LICENSE.txt)

**Resolution:**
Declared Apache 2.0 license 

**Affected definitions**:
- [Owin.Types 0.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/Owin.Types/0.8.5/0.8.5)