### PR TITLE
Declared MIT license

### DIFF
--- a/curations/nuget/nuget/-/PowerArgs.yaml
+++ b/curations/nuget/nuget/-/PowerArgs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.7.0:
+    licensed:
+      declared: MIT
   2.7.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT license

**Details:**
Declared MIT license from commit on day of component (https://github.com/adamabdelhamed/PowerArgs/blob/ce436f00025997ccff24ddbe80b3e684cb957d65/LICENSE.txt)

**Resolution:**
Declared MIT license

**Affected definitions**:
- [PowerArgs 2.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/PowerArgs/2.7.0/2.7.0)