### PR TITLE
Declared Apache 2.0 license

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: RestSharp
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
+  105.0.1:
+    licensed:
+      declared: Apache-2.0
   105.2.3:
     described:
       releaseDate: '2015-08-26'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0 license

**Details:**
Declared Apache 2.0 license found in 105.0.1 Tag (https://github.com/restsharp/RestSharp/tree/105.0.1) license (https://github.com/restsharp/RestSharp/blob/105.0.1/LICENSE.txt)

**Resolution:**
Declared Apache 2.0 license

**Affected definitions**:
- [RestSharp 105.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/105.0.1/105.0.1)