### PR TITLE
ANTLR runtime is under BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.antlr/antlr-runtime.yaml
+++ b/curations/maven/mavencentral/org.antlr/antlr-runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: antlr-runtime
+  namespace: org.antlr
+  provider: mavencentral
+  type: maven
+revisions:
+  3.5.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ANTLR runtime is under BSD-3-Clause

**Details:**
Eclipse Foundation Scans have determined that ANTLR Runtime is under BSD-3-Clause

**Resolution:**
Adds curated license information.

**Affected definitions**:
- [antlr-runtime 3.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/antlr-runtime/3.5.2/3.5.2)