### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.Services.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.Services.Client.yaml
@@ -12,6 +12,9 @@ revisions:
   5.8.2:
     licensed:
       declared: MIT
+  5.8.3:
+    licensed:
+      declared: MIT
   5.8.4:
     licensed:
       declared: mit


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT

**Resolution:**
NuGet license is MIT (https://raw.githubusercontent.com/OData/odata.net/master/LICENSE.txt), and odata.github.io project site points to MIT (related to https://github.com/OData/WebApi/blob/v5.8.0/License.txt) 

**Affected definitions**:
- [Microsoft.Data.Services.Client 5.8.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.Services.Client/5.8.3/5.8.3)