### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -30,6 +30,9 @@ revisions:
   3.14.2:
     licensed:
       declared: MIT
+  3.16.1:
+    licensed:
+      declared: MIT
   3.17.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT

**Resolution:**
NuGet license is MIT, closest version 3.16.0 with MIT license (https://github.com/AzureAD/azure-activedirectory-library-for-dotnet)/blob/ver3.16.0/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 3.16.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/3.16.1/3.16.1)