### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -56,6 +56,9 @@ revisions:
         path: Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
     licensed:
       declared: MIT
+  4.4.1:
+    licensed:
+      declared: MIT
   4.5.0:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Add MIT

**Resolution:**
NuGet license directs to MIT (closest version with license file : https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/v4.0.0/LICENSE)

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 4.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/4.4.1/4.4.1)