### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.Azure.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.Azure.yaml
@@ -27,3 +27,6 @@ revisions:
   3.3.7:
     licensed:
       declared: MIT
+  3.3.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found a commit on the date of this version 6/2/2017 at (https://github.com/Azure/autorest/blob/a924a880ec6b54e383a1ac93abecd0f7bd5b424b/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime.Azure 3.3.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime.Azure/3.3.8/3.3.8)