### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.8.2:
+    licensed:
+      declared: MIT
   2.3.10:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found commits before and after this version on 12/7/2015 at (https://github.com/Azure/autorest/blob/130fb65cdc741a15b05994dfd7771546e357fbdb/LICENSE) and 12/28/2015 at (https://github.com/Azure/autorest/blob/726d752491eb4fd287896be984e13d51eed61c68/LICENSE)



**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 1.8.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/1.8.2/1.8.2)