### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: MIT
   2.3.10:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found a commit on this day of this version 3/1/2016 at (https://github.com/Azure/autorest/blob/9a379025c6b07728a6b30ab72d903c01e916533f/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/2.1.0/2.1.0)