### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.2.0:
+    licensed:
+      declared: MIT
   2.3.10:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found a commit on the date of this version 5/11/2016 at (https://github.com/Azure/autorest/blob/e1d41ab6ba2f62ceadcc6716675ed25662fb6eeb/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/2.2.0/2.2.0)