### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -24,6 +24,9 @@ revisions:
   2.3.20:
     licensed:
       declared: MIT
+  2.3.4:
+    licensed:
+      declared: MIT
   2.3.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found commit on date of this version 11/22/2016 at (https://github.com/Azure/autorest/blob/ef05c9d2a77f0509d74efd9f4695f8c0c07daaac/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 2.3.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/2.3.4/2.3.4)