### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -24,6 +24,9 @@ revisions:
   2.3.20:
     licensed:
       declared: MIT
+  2.3.5:
+    licensed:
+      declared: MIT
   2.3.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found commits before and after this version on 2/2/2017 at (https://github.com/Azure/autorest/blob/9e7956e6196bf380d58023d9eed0dde09c4ad3d1/LICENSE) and 2/7/2017 at (https://github.com/Azure/autorest/blob/9e1bcda7b21bb7b9ff2a449667e0ef0b0cab63c1/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 2.3.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/2.3.5/2.3.5)