### PR TITLE
Declared MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -27,6 +27,9 @@ revisions:
   2.3.6:
     licensed:
       declared: MIT
+  2.3.7:
+    licensed:
+      declared: MIT
   2.3.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT License

**Details:**
Found commit on date of this version 5/3/2017 at (https://github.com/Azure/autorest/blob/8b5b7f7bfac834a4bf37b807ba91aa7fdf22a4c6/LICENSE)

**Resolution:**
Declared MIT License

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 2.3.7](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/2.3.7/2.3.7)