### PR TITLE
Declared License (Azure samples)

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Schema
+  provider: nuget
+  type: nuget
+revisions:
+  4.4.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License (Azure samples)

**Details:**
Add MIT

**Resolution:**
Link on NuGet page goes to GitHub repo master MIT license. Closest version is 4.4.0 with MIT license - https://github.com/microsoft/botbuilder-dotnet/blob/4.4.0/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Schema 4.4.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.4.5/4.4.5)