### PR TITLE
Declared License (Azure sample)

### DIFF
--- a/curations/nuget/nuget/-/BuildTools.FxCop.yaml
+++ b/curations/nuget/nuget/-/BuildTools.FxCop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: BuildTools.FxCop
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License (Azure sample)

**Details:**
Add MS-PL

**Resolution:**
NuGet license link goes to https://opensource.org/licenses/ms-pl.html, no GitHub repo located.

**Affected definitions**:
- [BuildTools.FxCop 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/BuildTools.FxCop/1.0.1/1.0.1)