### PR TITLE
Missing license info for icons

### DIFF
--- a/curations/git/github/simplesamlphp/simplesamlphp.yaml
+++ b/curations/git/github/simplesamlphp/simplesamlphp.yaml
@@ -48,3 +48,47 @@ revisions:
         path: www/resources/icons/experience/gtk-dialog-warning.48x48.png
       - license: GPL-2.0
         path: www/resources/icons/experience/readme.txt
+  f5ff7c4643b9b784957f5e1fbf86fc740cd6b78a:
+    files:
+      - license: LGPL-2.1
+        path: www/resources/icons/crystal_project/date.32x32.png
+      - license: LGPL-2.1
+        path: www/resources/icons/crystal_project/kchart.32x32.png
+      - attributions:
+          - Copyright (c) 2006-2007 Everaldo Coelho.
+        license: LGPL-2.1
+        path: www/resources/icons/crystal_project/readme.txt
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-about.64x64.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-about.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-authentication.48x48.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-authentication.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-error.48x48.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-error.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-warning.48x48.png
+      - license: GPL-2.0
+        path: www/resources/icons/experience/gtk-dialog-warning.svg.gz
+      - license: GPL-2.0
+        path: www/resources/icons/experience/readme.txt
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/accept.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/delete.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/error.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/exclamation.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/heart.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/magnifier.png
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/readme.txt
+      - license: CC-BY-2.5
+        path: www/resources/icons/silk/star.png


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Missing license info for icons

**Details:**
Several icon files were missing license information

**Resolution:**
Declared license info for the icons

The icons found in /www/resources/icons/crystal_project/* are all under the LGPL 2.1 as shown in https://web.archive.org/web/20120215111707/http://www.everaldo.com/crystal/?action=license

The icons found in /www/resources/icons/experience/* are all under the the GPL 2.0 as shown in https://web.archive.org/web/20100323174847/http://art.gnome.org:80/themes/icon

The icons found in /www/resources/icons/silk/* are all under the Creative Commons Attribution 2.5 license as shown in http://famfamfam.com/lab/icons/silk/


**Affected definitions**:
- [simplesamlphp f5ff7c4643b9b784957f5e1fbf86fc740cd6b78a](https://clearlydefined.io/definitions/git/github/simplesamlphp/simplesamlphp/f5ff7c4643b9b784957f5e1fbf86fc740cd6b78a)