### PR TITLE
Updating curation

### DIFF
--- a/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
+++ b/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.0.45:
     licensed:
-      declared: (EPL-1.0 OR CPL-1.0) AND (GPL-2.0 OR LGPL-2.1)
+      declared: EPL-1.0 OR CPL-1.0 OR GPL-2.0 OR LGPL-2.1

--- a/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
+++ b/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.0.45:
     licensed:
-      declared: CPL-1.0 AND EPL-2.0 OR (LGPL-2.1 OR GPL-2.0)
+      declared: (EPL-1.0 OR CPL-1.0) AND (GPL-2.0 OR LGPL-2.1)


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating curation

**Details:**
Per team call, we want to curate https://mvnrepository.com/artifact/com.github.jnr/jnr-posix/3.0.45 to match the license metadata on the mvnrepository. 

**Resolution:**
So that would be: CPL 1.0 OR EPL 1.0 OR GPL 2.0 OR LGPL 2.1.  The tooling won't let me enter it this way, so will need to be fixed on the .yaml.

**Affected definitions**:
- [jnr-posix 3.0.45](https://clearlydefined.io/definitions/maven/mavencentral/com.github.jnr/jnr-posix/3.0.45/3.0.45)