### PR TITLE
Missing license for Microsoft.Owin.Security.ActiveDirectory/4.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.ActiveDirectory.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Owin.Security.ActiveDirectory/4.0.1

**Details:**
Adding license, which currently shows as "No Assertion".

**Resolution:**
Source:
https://github.com/aspnet/AspNetKatana/tree/d63e1435934c1f8aff68cde0dc4a3f3e6d8085b5
Apache 2.0 License
Copyright (c) .NET Foundation and Contributors
https://github.com/aspnet/AspNetKatana/blob/d63e1435934c1f8aff68cde0dc4a3f3e6d8085b5/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Security.ActiveDirectory 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.ActiveDirectory/4.0.1/4.0.1)