### PR TITLE
Missing license for Microsoft.IdentityModel.Clients.ActiveDirectory/5.0.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -90,3 +90,14 @@ revisions:
         path: Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
     licensed:
       declared: MIT
+  5.0.5:
+    described:
+      sourceLocation:
+        name: azure-activedirectory-library-for-dotnet
+        namespace: azuread
+        provider: github
+        revision: 99f1dd308ad4ad8aeb3ca90014e0f1c12e219490
+        type: git
+        url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/99f1dd308ad4ad8aeb3ca90014e0f1c12e219490'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.IdentityModel.Clients.ActiveDirectory/5.0.5

**Details:**
Adding source and license.

**Resolution:**
Source:
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/tree/99f1dd308ad4ad8aeb3ca90014e0f1c12e219490
MIT License:
Copyright (c) Microsoft Corporation
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/99f1dd308ad4ad8aeb3ca90014e0f1c12e219490/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.0.5/5.0.5)