### PR TITLE
Declared BSD-3-Clause Licence

### DIFF
--- a/curations/nuget/nuget/-/sinonjs.yaml
+++ b/curations/nuget/nuget/-/sinonjs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sinonjs
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause Licence

**Details:**
BSD-3 Clause declared 5/3/2014 (https://github.com/sinonjs/sinon/blob/320b1adca878f0be76a848ae4f50d3d23371c3ea/LICENSE) and 5/7/20/14 (https://github.com/sinonjs/sinon/blob/04bd4264b4d96f1082ef17d28dc7a5b942f2c8cb/LICENSE)

**Resolution:**
Declared BSD-3-Clause Licence

**Affected definitions**:
- [sinonjs 1.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/sinonjs/1.9.1/1.9.1)