### PR TITLE
Corrected license info for NetMQ.

### DIFF
--- a/curations/nuget/nuget/-/NetMQ.yaml
+++ b/curations/nuget/nuget/-/NetMQ.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.0.0.1:
     licensed:
-      declared: LGPL-3.0-only
+      declared: OTHER

--- a/curations/nuget/nuget/-/NetMQ.yaml
+++ b/curations/nuget/nuget/-/NetMQ.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NetMQ
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0.1:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Corrected license info for NetMQ.

**Details:**
The license was marked as NOTDECLARED.

**Resolution:**
The license was updated to the correct definition of LGPL 3.0 (exact).

**Affected definitions**:
- [NetMQ 4.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/NetMQ/4.0.0.1)