### PR TITLE
Add MIT license details to RicoSuter components

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  10.0.21:
+    licensed:
+      declared: MIT
   9.10.63:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Namotion.Reflection.yaml
+++ b/curations/nuget/nuget/-/Namotion.Reflection.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Namotion.Reflection
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add MIT license details to RicoSuter components

**Details:**
MIT license declaration missing

**Resolution:**
https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md
https://github.com/RicoSuter/Namotion.Reflection/blob/master/LICENSE.md

**Affected definitions**:
- [NJsonSchema 10.0.21](https://clearlydefined.io/definitions/nuget/nuget/-/NJsonSchema/10.0.21),- [Namotion.Reflection 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Namotion.Reflection/1.0.5)