### PR TITLE
Missing Declared license

### DIFF
--- a/curations/npm/npmjs/-/engine.io.yaml
+++ b/curations/npm/npmjs/-/engine.io.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: engine.io
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared license

**Details:**
Followed source link

**Resolution:**
ReadMe has MIT license

**Affected definitions**:
- [engine.io 1.5.1](https://clearlydefined.io/definitions/npm/npmjs/-/engine.io/1.5.1)