### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocol.Extensions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocol.Extensions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.2.206221351:
+    licensed:
+      declared: Apache-2.0
   1.0.4.403061554:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
NuGet license to GitHub master MIT. Closest commits with Apache 2.0 -
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/c2b8bfa6a24eb4d6941ae7f44fcbebb6bb8aba71/LICENSE.txt (June 21, 2015) and https://github.com/AzureAD/azure-activedirectory-identitymodel-exte

**Affected definitions**:
- [Microsoft.IdentityModel.Protocol.Extensions 1.0.2.206221351](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocol.Extensions/1.0.2.206221351/1.0.2.206221351)