### PR TITLE
Missing license for Microsoft.Rest.ClientRuntime.Azure/3.3.15

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.Azure.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.Azure.yaml
@@ -3,11 +3,10 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
-
-  3.1.0:
+  2.5.4:
     licensed:
       declared: MIT
-  2.5.4:
+  3.1.0:
     licensed:
       declared: MIT
   3.3.10:
@@ -17,6 +16,9 @@ revisions:
     licensed:
       declared: MIT
   3.3.12:
+    licensed:
+      declared: MIT
+  3.3.15:
     licensed:
       declared: MIT
   3.3.18:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Rest.ClientRuntime.Azure/3.3.15

**Details:**
Adding license, which currently shows as "No Assertion".

**Resolution:**
MIT License found here:
https://www.nuget.org/packages/Microsoft.Rest.ClientRuntime.Azure/3.3.15
https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime.Azure 3.3.15](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime.Azure/3.3.15/3.3.15)