### PR TITLE
Missing license for Microsoft.Rest.ClientRuntime/2.3.13

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Rest.ClientRuntime.yaml
@@ -3,16 +3,19 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
-  2.1.0:
+  1.8.2:
     licensed:
       declared: MIT
-  1.8.2:
+  2.1.0:
     licensed:
       declared: MIT
   2.3.10:
     licensed:
       declared: MIT
   2.3.11:
+    licensed:
+      declared: MIT
+  2.3.13:
     licensed:
       declared: MIT
   2.3.14:
@@ -30,10 +33,10 @@ revisions:
   2.3.20:
     licensed:
       declared: MIT
-  2.3.5:
+  2.3.4:
     licensed:
       declared: MIT
-  2.3.4:
+  2.3.5:
     licensed:
       declared: MIT
   2.3.6:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for Microsoft.Rest.ClientRuntime/2.3.13

**Details:**
Adding license, which currently shows as "No Assertion".

**Resolution:**
MIT License found here:
https://www.nuget.org/packages/Microsoft.Rest.ClientRuntime/2.3.13
https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE

**Affected definitions**:
- [Microsoft.Rest.ClientRuntime 2.3.13](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Rest.ClientRuntime/2.3.13/2.3.13)