### PR TITLE
Declared license is MIT

### DIFF
--- a/curations/npm/npmjs/-/fmt.yaml
+++ b/curations/npm/npmjs/-/fmt.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fmt
+  provider: npmjs
+  type: npm
+revisions:
+  0.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license is MIT

**Details:**
The LICENSE file provides the only statement of license and it indicates MIT (by reference; the full text is not included).

**Resolution:**
Set the declared license to MIT.

**Affected definitions**:
- [fmt 0.4.0](https://clearlydefined.io/definitions/npm/npmjs/-/fmt/0.4.0/0.4.0)