### PR TITLE
Declared license incorrect

### DIFF
--- a/curations/git/github/locationtech/jts.yaml
+++ b/curations/git/github/locationtech/jts.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jts
+  namespace: locationtech
+  provider: github
+  type: git
+revisions:
+  b57d591be10906c1729eeb8a2b7d95d4238c2a66:
+    licensed:
+      declared: EPL-1.0 OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license incorrect

**Details:**
This project is dual-licensed under EPL-10 OR EDL-1.0 (BSD-like).

**Resolution:**
Updated the declared license to reflect the project's license according to 

https://github.com/locationtech/jts/blob/b57d591be10906c1729eeb8a2b7d95d4238c2a66/FAQ-LICENSING.md

**Affected definitions**:
- [jts b57d591be10906c1729eeb8a2b7d95d4238c2a66](https://clearlydefined.io/definitions/git/github/locationtech/jts/b57d591be10906c1729eeb8a2b7d95d4238c2a66/b57d591be10906c1729eeb8a2b7d95d4238c2a66)