### PR TITLE
MIT License Declared

### DIFF
--- a/curations/nuget/nuget/-/xamarin.googleplayservices.gcm.yaml
+++ b/curations/nuget/nuget/-/xamarin.googleplayservices.gcm.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xamarin.googleplayservices.gcm
+  provider: nuget
+  type: nuget
+revisions:
+  60.1142.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License Declared

**Details:**
MIT license found here (https://github.com/xamarin/GooglePlayServicesComponents/blob/60.1142.1/LICENSE.md)

**Resolution:**
MIT License Declared

**Affected definitions**:
- [xamarin.googleplayservices.gcm 60.1142.1](https://clearlydefined.io/definitions/nuget/nuget/-/xamarin.googleplayservices.gcm/60.1142.1/60.1142.1)