### PR TITLE
Adding MIT declared license

### DIFF
--- a/curations/git/github/requirejs/requirejs.yaml
+++ b/curations/git/github/requirejs/requirejs.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: requirejs
+  namespace: requirejs
+  provider: github
+  type: git
+revisions:
+  4316f8f19f981c726eb32b5335c36237e0125948:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding MIT declared license

**Details:**
MIT is declared as the overall license of the project in the LICENSE file.

**Resolution:**
Added MIT licnese

**Affected definitions**:
- [requirejs 4316f8f19f981c726eb32b5335c36237e0125948](https://clearlydefined.io/definitions/git/github/requirejs/requirejs/4316f8f19f981c726eb32b5335c36237e0125948/4316f8f19f981c726eb32b5335c36237e0125948)