### PR TITLE
Add MIT

### DIFF
--- a/curations/git/github/stevesanderson/knockout.mapping.yaml
+++ b/curations/git/github/stevesanderson/knockout.mapping.yaml
@@ -4,6 +4,7 @@ coordinates:
   provider: github
   type: git
 revisions:
+  35482d03ee7520b1afe0b437a6e66150369378a7:
     files:
       - license: MIT
         path: Package.nuspec

--- a/curations/git/github/stevesanderson/knockout.mapping.yaml
+++ b/curations/git/github/stevesanderson/knockout.mapping.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: knockout.mapping
+  namespace: stevesanderson
+  provider: github
+  type: git
+revisions:
+  35482d03ee7520b1afe0b437a6e66150369378a7:
+    files:
+      - license: MIT
+        path: Package.nuspec
+    licensed:
+      declared: MIT

--- a/curations/git/github/stevesanderson/knockout.mapping.yaml
+++ b/curations/git/github/stevesanderson/knockout.mapping.yaml
@@ -10,3 +10,9 @@ revisions:
         path: Package.nuspec
     licensed:
       declared: MIT
+  944e608ea59af85c8af8fdb610062741a7087a47:
+    files:
+      - license: MIT
+        path: Package.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT

**Details:**
MIT license pointed to in nuspec file both in package and at source location.

**Resolution:**
Add MIT license.

**Affected definitions**:
- [knockout.mapping 35482d03ee7520b1afe0b437a6e66150369378a7](https://clearlydefined.io/definitions/git/github/stevesanderson/knockout.mapping/35482d03ee7520b1afe0b437a6e66150369378a7/35482d03ee7520b1afe0b437a6e66150369378a7)