### PR TITLE
Add MIT license

### DIFF
--- a/curations/git/github/stevesanderson/knockout.mapping.yaml
+++ b/curations/git/github/stevesanderson/knockout.mapping.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: knockout.mapping
+  namespace: stevesanderson
+  provider: github
+  type: git
+revisions:
+  944e608ea59af85c8af8fdb610062741a7087a47:
+    files:
+      - license: MIT
+        path: Package.nuspec
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT license

**Details:**
MIT license pointed to in source and nuspec as the license.

**Resolution:**
Added MIT license.

**Affected definitions**:
- [knockout.mapping 944e608ea59af85c8af8fdb610062741a7087a47](https://clearlydefined.io/definitions/git/github/stevesanderson/knockout.mapping/944e608ea59af85c8af8fdb610062741a7087a47/944e608ea59af85c8af8fdb610062741a7087a47)