### PR TITLE
Add MIT license

### DIFF
--- a/curations/git/github/syntaxhighlighter/syntaxhighlighter.yaml
+++ b/curations/git/github/syntaxhighlighter/syntaxhighlighter.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: syntaxhighlighter
+  namespace: syntaxhighlighter
+  provider: github
+  type: git
+revisions:
+  682bf8cfd5a0686d51ed16325b72625ddf64ae11:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT license

**Details:**
No declared license in this source tree, but later version declares MIT from "2004-2013" -- indicating an intent to license the code base under MIT.

**Resolution:**
Adding MIT declared license.

**Affected definitions**:
- [syntaxhighlighter 682bf8cfd5a0686d51ed16325b72625ddf64ae11](https://clearlydefined.io/definitions/git/github/syntaxhighlighter/syntaxhighlighter/682bf8cfd5a0686d51ed16325b72625ddf64ae11/682bf8cfd5a0686d51ed16325b72625ddf64ae11)