### PR TITLE
Apachev2

### DIFF
--- a/curations/git/github/xeipuuv/gojsonschema.yaml
+++ b/curations/git/github/xeipuuv/gojsonschema.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: gojsonschema
+  namespace: xeipuuv
+  provider: github
+  type: git
+revisions:
+  c539bca196be50ccdd1f0bcd9076de95f9081831:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Apachev2

**Details:**
Top level license is apachev2 and all .go files.

**Resolution:**
Add apachev2.

**Affected definitions**:
- [gojsonschema c539bca196be50ccdd1f0bcd9076de95f9081831](https://clearlydefined.io/definitions/git/github/xeipuuv/gojsonschema/c539bca196be50ccdd1f0bcd9076de95f9081831/c539bca196be50ccdd1f0bcd9076de95f9081831)