### PR TITLE
Adding Other

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WebSockets.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WebSockets.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WebSockets
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Other

**Details:**
Nuget package https://www.nuget.org/packages/Microsoft.WebSockets/0.2.3 has no license.  The next version https://www.nuget.org/packages/Microsoft.WebSockets/0.2.3.1 has the .NET library license.

**Resolution:**
Adds 'other' for the .NET library license.

**Affected definitions**:
- [Microsoft.WebSockets 0.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WebSockets/0.2.3/0.2.3)