### PR TITLE
MIT License Declared

### DIFF
--- a/curations/git/github/knockout/knockout.yaml
+++ b/curations/git/github/knockout/knockout.yaml
@@ -7,3 +7,6 @@ revisions:
   212376a484f64d32cf49a6aaa4d5eee85aa7653a:
     licensed:
       declared: MIT
+  7a83820efc96d47742e2f8c9b4fcd2459c81dd21:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License Declared

**Details:**
MIT license found here (https://github.com/knockout/knockout/blob/7a83820efc96d47742e2f8c9b4fcd2459c81dd21/LICENSE)

**Resolution:**
MIT License Declared

**Affected definitions**:
- [knockout 7a83820efc96d47742e2f8c9b4fcd2459c81dd21](https://clearlydefined.io/definitions/git/github/knockout/knockout/7a83820efc96d47742e2f8c9b4fcd2459c81dd21/7a83820efc96d47742e2f8c9b4fcd2459c81dd21)