### PR TITLE
Add BSD 3 Clause

### DIFF
--- a/curations/nuget/nuget/-/Polly.yaml
+++ b/curations/nuget/nuget/-/Polly.yaml
@@ -15,3 +15,6 @@ revisions:
   6.1.0:
     licensed:
       declared: BSD-3-Clause
+  6.1.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3 Clause

**Details:**
Nuget points to BSD location, confirmed in source tree at 6.1.2 tag.  https://github.com/App-vNext/Polly/blob/6.1.2%2B4/LICENSE.txt

**Resolution:**
Added BSD 3 Clause

**Affected definitions**:
- [Polly 6.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Polly/6.1.2/6.1.2)