### PR TITLE
MIT

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -34,6 +34,9 @@ revisions:
   6.0.4:
     licensed:
       declared: MIT
+  6.0.5:
+    licensed:
+      declared: MIT
   6.0.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT

**Details:**
https://github.com/JamesNK/Newtonsoft.Json/blob/6.0.5/LICENSE.md

Also confirmed in Nuspec.

**Resolution:**
Add MIT.

**Affected definitions**:
- [Newtonsoft.Json 6.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/6.0.5/6.0.5)