### PR TITLE
BSD-3 Clause license declared

### DIFF
--- a/curations/git/github/macton/libdot.yaml
+++ b/curations/git/github/macton/libdot.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: libdot
+  namespace: macton
+  provider: github
+  type: git
+revisions:
+  be8c52cb78b27f941534abcff6f111c7ca4235e0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BSD-3 Clause license declared

**Details:**
BSD-3 Clause license found here (https://github.com/macton/libdot/blob/be8c52cb78b27f941534abcff6f111c7ca4235e0/LICENSE

**Resolution:**
BSD-3 Clause license declared

**Affected definitions**:
- [libdot be8c52cb78b27f941534abcff6f111c7ca4235e0](https://clearlydefined.io/definitions/git/github/macton/libdot/be8c52cb78b27f941534abcff6f111c7ca4235e0/be8c52cb78b27f941534abcff6f111c7ca4235e0)