### PR TITLE
MIT License Declared

### DIFF
--- a/curations/git/github/medialize/uri.js.yaml
+++ b/curations/git/github/medialize/uri.js.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: uri.js
+  namespace: medialize
+  provider: github
+  type: git
+revisions:
+  2a98b53606bbef249ec694210621eef109314c66:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License Declared

**Details:**
MIT License found here (https://github.com/medialize/URI.js/blob/2a98b53606bbef249ec694210621eef109314c66/LICENSE.txt)

**Resolution:**
MIT License Declared

**Affected definitions**:
- [uri.js 2a98b53606bbef249ec694210621eef109314c66](https://clearlydefined.io/definitions/git/github/medialize/uri.js/2a98b53606bbef249ec694210621eef109314c66/2a98b53606bbef249ec694210621eef109314c66)