### PR TITLE
MIT License Declared

### DIFF
--- a/curations/git/github/microsoft/vscode.yaml
+++ b/curations/git/github/microsoft/vscode.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: vscode
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  91da4276775da6adafaed44281946344f57800cd:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License Declared

**Details:**
MIT License found here (https://github.com/microsoft/vscode/blob/91da4276775da6adafaed44281946344f57800cd/LICENSE.txt)

**Resolution:**
MIT License Declared

**Affected definitions**:
- [vscode 91da4276775da6adafaed44281946344f57800cd](https://clearlydefined.io/definitions/git/github/microsoft/vscode/91da4276775da6adafaed44281946344f57800cd/91da4276775da6adafaed44281946344f57800cd)