### PR TITLE
MS-PL Declared

### DIFF
--- a/curations/git/github/neuecc/linq.js.yaml
+++ b/curations/git/github/neuecc/linq.js.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: linq.js
+  namespace: neuecc
+  provider: github
+  type: git
+revisions:
+  b5b4be8724c6e53fa6dab3900d23c5675f732dcd:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MS-PL Declared

**Details:**
MS-PL identified as license in the ReadMe file here (https://github.com/neuecc/linq.js/blob/b5b4be8724c6e53fa6dab3900d23c5675f732dcd/ReadMe.txt)

**Resolution:**
MS-PL Declared

**Affected definitions**:
- [linq.js b5b4be8724c6e53fa6dab3900d23c5675f732dcd](https://clearlydefined.io/definitions/git/github/neuecc/linq.js/b5b4be8724c6e53fa6dab3900d23c5675f732dcd/b5b4be8724c6e53fa6dab3900d23c5675f732dcd)