### PR TITLE
MIT License Declared

### DIFF
--- a/curations/git/github/owensd/vscode-swift.yaml
+++ b/curations/git/github/owensd/vscode-swift.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: vscode-swift
+  namespace: owensd
+  provider: github
+  type: git
+revisions:
+  cdfa70be73dd877137a535085cf91ada37757277:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIT License Declared

**Details:**
MIT License found here (https://github.com/owensd/vscode-swift/blob/cdfa70be73dd877137a535085cf91ada37757277/license)

**Resolution:**
MIT License Declared

**Affected definitions**:
- [vscode-swift cdfa70be73dd877137a535085cf91ada37757277](https://clearlydefined.io/definitions/git/github/owensd/vscode-swift/cdfa70be73dd877137a535085cf91ada37757277/cdfa70be73dd877137a535085cf91ada37757277)