### PR TITLE
BSD-2 Clause Declared

### DIFF
--- a/curations/git/github/pkg/errors.yaml
+++ b/curations/git/github/pkg/errors.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: errors
+  namespace: pkg
+  provider: github
+  type: git
+revisions:
+  a2d6902c6d2a2f194eb3fb474981ab7867c81505:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BSD-2 Clause Declared

**Details:**
BSD-2 Clause found here (https://github.com/pkg/errors/blob/a2d6902c6d2a2f194eb3fb474981ab7867c81505/LICENSE

**Resolution:**
BSD-2 Clause Declared

**Affected definitions**:
- [errors a2d6902c6d2a2f194eb3fb474981ab7867c81505](https://clearlydefined.io/definitions/git/github/pkg/errors/a2d6902c6d2a2f194eb3fb474981ab7867c81505/a2d6902c6d2a2f194eb3fb474981ab7867c81505)