### PR TITLE
BSD-3 Clause License Declared

### DIFF
--- a/curations/git/github/libapps/libapps-mirror.yaml
+++ b/curations/git/github/libapps/libapps-mirror.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: libapps-mirror
+  namespace: libapps
+  provider: github
+  type: git
+revisions:
+  d23d3679a7e921ab80eb79dde47720362166bc59:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BSD-3 Clause License Declared

**Details:**
BSD-3 Clause License read ReadMe here (https://github.com/libapps/libapps-mirror/blob/d23d3679a7e921ab80eb79dde47720362166bc59/README.md) which took me to GitHub repo here (https://github.com/libapps/libapps-mirror) license here (https://github.com/libapps/libapps-mirror/blob/master/LICENSE)

**Resolution:**
BSD-3 Clause License Declared

**Affected definitions**:
- [libapps-mirror d23d3679a7e921ab80eb79dde47720362166bc59](https://clearlydefined.io/definitions/git/github/libapps/libapps-mirror/d23d3679a7e921ab80eb79dde47720362166bc59/d23d3679a7e921ab80eb79dde47720362166bc59)