### PR TITLE
Declared GPL 2.0 or MIT

### DIFF
--- a/curations/git/github/jquery/jquery.yaml
+++ b/curations/git/github/jquery/jquery.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  13e9cde0efeadbbc5b3a375ee642bed394dd3a59:
+    licensed:
+      declared: GPL-2.0-only OR MIT
   15d261b9673e153f9e9710da897de62c306afe53:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared GPL 2.0 or MIT

**Details:**
Declared GPL 2.0 found here (https://github.com/jquery/jquery/blob/13e9cde0efeadbbc5b3a375ee642bed394dd3a59/GPL-LICENSE.txt) or MIT found here (https://github.com/jquery/jquery/blob/13e9cde0efeadbbc5b3a375ee642bed394dd3a59/MIT-LICENSE.txt)

**Resolution:**
Declared GPL 2.0 or MIT

**Affected definitions**:
- [jquery 13e9cde0efeadbbc5b3a375ee642bed394dd3a59](https://clearlydefined.io/definitions/git/github/jquery/jquery/13e9cde0efeadbbc5b3a375ee642bed394dd3a59/13e9cde0efeadbbc5b3a375ee642bed394dd3a59)