### PR TITLE
Declared BSD-2-Clause and GPL 2.0

### DIFF
--- a/curations/git/github/lz4/lz4.yaml
+++ b/curations/git/github/lz4/lz4.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  69dbafc1c4806f6c05e28c01117799087f498a2f:
+    licensed:
+      declared: BSD-2-Clause AND GPL-2.0-only
   dfed9fa1d77f0434306d377c4da1f7191d3ba08a:
     described:
       facets:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-2-Clause and GPL 2.0

**Details:**
Declared BSD-2-Clause and GPL 2.0 found here (https://github.com/lz4/lz4/blob/69dbafc1c4806f6c05e28c01117799087f498a2f/LICENSE)

**Resolution:**
Declared BSD-2-Clause and GPL 2.0

**Affected definitions**:
- [lz4 69dbafc1c4806f6c05e28c01117799087f498a2f](https://clearlydefined.io/definitions/git/github/lz4/lz4/69dbafc1c4806f6c05e28c01117799087f498a2f/69dbafc1c4806f6c05e28c01117799087f498a2f)