### PR TITLE
Declared MIT

### DIFF
--- a/curations/git/github/moment/momentjs.com.yaml
+++ b/curations/git/github/moment/momentjs.com.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: momentjs.com
+  namespace: moment
+  provider: github
+  type: git
+revisions:
+  1b8a95c475f9a6cfc49d0e10af3ee668af833fe0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT - no license at landing page or in ReadMe - went to (https://momentjs.com/) then GitHub from there to license file here (https://github.com/moment/moment/blob/develop/LICENSE)

**Resolution:**
Declared MIT

**Affected definitions**:
- [momentjs.com 1b8a95c475f9a6cfc49d0e10af3ee668af833fe0](https://clearlydefined.io/definitions/git/github/moment/momentjs.com/1b8a95c475f9a6cfc49d0e10af3ee668af833fe0/1b8a95c475f9a6cfc49d0e10af3ee668af833fe0)