### PR TITLE
Add Apache2

### DIFF
--- a/curations/sourcearchive/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
+++ b/curations/sourcearchive/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: oauth2-oidc-sdk
+  namespace: com.nimbusds
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  5.18.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache2

**Details:**
missing apache2

**Resolution:**
missing apache2

**Affected definitions**:
- [oauth2-oidc-sdk 5.18.1](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.nimbusds/oauth2-oidc-sdk/5.18.1)