### PR TITLE
Missing Declared license

### DIFF
--- a/curations/git/github/driftyco/ionic-site.yaml
+++ b/curations/git/github/driftyco/ionic-site.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ionic-site
+  namespace: driftyco
+  provider: github
+  type: git
+revisions:
+  a914b37f41bd0968c2a3db6e3436be9b44b7f4aa:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared license

**Details:**
Followed source link

**Resolution:**
License is Apachev2

**Affected definitions**:
- [ionic-site a914b37f41bd0968c2a3db6e3436be9b44b7f4aa](https://clearlydefined.io/definitions/git/github/driftyco/ionic-site/a914b37f41bd0968c2a3db6e3436be9b44b7f4aa/a914b37f41bd0968c2a3db6e3436be9b44b7f4aa)