### PR TITLE
Missing Declared license

### DIFF
--- a/curations/git/github/gildas-lormeau/zip.js.yaml
+++ b/curations/git/github/gildas-lormeau/zip.js.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   563fe1da2579e55ae0ab1fed38a3b37a234e239e:
     licensed:
-      declared: BSD-2-Clause AND BSD-3-Clause
+      declared: BSD-3-Clause

--- a/curations/git/github/gildas-lormeau/zip.js.yaml
+++ b/curations/git/github/gildas-lormeau/zip.js.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: zip.js
+  namespace: gildas-lormeau
+  provider: github
+  type: git
+revisions:
+  563fe1da2579e55ae0ab1fed38a3b37a234e239e:
+    licensed:
+      declared: BSD-2-Clause AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared license

**Details:**
Repo readme only says "BSD License."  Some files are BSD-2 clause and some are BSD 3-clause.  There is at least one MIT file.  

**Resolution:**
Since the readme says "BSD license," curating the declared license as BSD 2 and 3 clause.

**Affected definitions**:
- [zip.js 563fe1da2579e55ae0ab1fed38a3b37a234e239e](https://clearlydefined.io/definitions/git/github/gildas-lormeau/zip.js/563fe1da2579e55ae0ab1fed38a3b37a234e239e/563fe1da2579e55ae0ab1fed38a3b37a234e239e)