### PR TITLE
Missing Declared license

### DIFF
--- a/curations/git/github/googlei18n/libphonenumber.yaml
+++ b/curations/git/github/googlei18n/libphonenumber.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: libphonenumber
+  namespace: googlei18n
+  provider: github
+  type: git
+revisions:
+  932279c6394430539c92007f69b303c6786c9b73:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared license

**Details:**
The declared license is Apache - https://github.com/google/libphonenumber/blob/932279c6394430539c92007f69b303c6786c9b73/LICENSE.  There are also BSD/Chromium files, but I think as a subset, they would be "discovered" licenses  - https://github.com/google/libphonenumber/blob/932279c6394430539c92007f6

**Resolution:**
Apache v2

**Affected definitions**:
- [libphonenumber 932279c6394430539c92007f69b303c6786c9b73](https://clearlydefined.io/definitions/git/github/googlei18n/libphonenumber/932279c6394430539c92007f69b303c6786c9b73/932279c6394430539c92007f69b303c6786c9b73)