### PR TITLE
Missing Declared license

### DIFF
--- a/curations/nuget/nuget/-/codeproject.objectpool.yaml
+++ b/curations/nuget/nuget/-/codeproject.objectpool.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: codeproject.objectpool
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.2:
+    licensed:
+      declared: CPOL-1.02


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared license

**Details:**
NuGet license link goes to https://www.codeproject.com/info/cpol10.aspx

**Resolution:**
The Code Project Open License (CPOL) 1.02

**Affected definitions**:
- [codeproject.objectpool 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/codeproject.objectpool/3.2.2/3.2.2)