### PR TITLE
ASM License is BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -15,3 +15,6 @@ revisions:
   5.0.4:
     licensed:
       declared: BSD-3-Clause
+  '7.1':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ASM License is BSD-3-Clause

**Details:**
The Eclipse IP Team determined that the license for this content is BSD-3-Clause.

Source Git repo is here: https://gitlab.ow2.org/asm/asm/tree/ASM_7_1

**Resolution:**
Update license data.

**Affected definitions**:
- [asm 7.1](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm/7.1/7.1)