### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: javax.servlet-api
+  namespace: javax.servlet
+  provider: mavencentral
+  type: maven
+revisions:
+  3.1.0:
+    described:
+      sourceLocation:
+        name: servlet-spec
+        namespace: javaee
+        provider: github
+        revision: bf383f0b9274365c512b31d2e7cd29224e405515
+        type: git
+        url: 'https://github.com/javaee/servlet-spec/commit/bf383f0b9274365c512b31d2e7cd29224e405515'
+    licensed:
+      declared: Apache-2.0 AND (CDDL-1.1 OR GPL-2.0-with-classpath-exception)

--- a/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
@@ -14,4 +14,4 @@ revisions:
         type: git
         url: 'https://github.com/javaee/servlet-spec/commit/bf383f0b9274365c512b31d2e7cd29224e405515'
     licensed:
-      declared: Apache-2.0 AND (CDDL-1.1 OR GPL-2.0-with-classpath-exception)
+      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update license information

**Details:**
The Eclipse IP Team has determined that the license is Apache-2.0 AND (CDDL-1.1 or GPL-2.0-with-classpath)

**Resolution:**
Updates the declared license and source URL.

**Affected definitions**:
- [javax.servlet-api 3.1.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.servlet/javax.servlet-api/3.1.0/3.1.0)