### PR TITLE
Missing Declared License

### DIFF
--- a/curations/git/github/jakerella/jquery-mockjax.yaml
+++ b/curations/git/github/jakerella/jquery-mockjax.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jquery-mockjax
+  namespace: jakerella
+  provider: github
+  type: git
+revisions:
+  0850526a37265d2311f06fc2f9138369e3df70ac:
+    licensed:
+      declared: MIT OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared License

**Details:**
https://github.com/jakerella/jquery-mockjax/blob/0850526a37265d2311f06fc2f9138369e3df70ac/package.json points to MIT and GPLv2.  And Readme says MIT or GPL.

**Resolution:**
See above

**Affected definitions**:
- [jquery-mockjax 0850526a37265d2311f06fc2f9138369e3df70ac](https://clearlydefined.io/definitions/git/github/jakerella/jquery-mockjax/0850526a37265d2311f06fc2f9138369e3df70ac/0850526a37265d2311f06fc2f9138369e3df70ac)