### PR TITLE
Missing Declared License

### DIFF
--- a/curations/git/github/jakerella/jquery-mockjax.yaml
+++ b/curations/git/github/jakerella/jquery-mockjax.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jquery-mockjax
+  namespace: jakerella
+  provider: github
+  type: git
+revisions:
+  e4969fd891a50f259e65a2f61a646038d773f2c1:
+    licensed:
+      declared: MIT OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared License

**Details:**
Readme says:License
Copyright (c) 2014 appendTo, Jordan Kasper
NOTE: This repository was taken over by Jordan Kasper (@jakerella) October, 2014
Dual licensed under the MIT or GPL licenses: http://opensource.org/licenses/MIT http://www.gnu.org/licenses/gpl-2.0.html

**Resolution:**
See above

**Affected definitions**:
- [jquery-mockjax e4969fd891a50f259e65a2f61a646038d773f2c1](https://clearlydefined.io/definitions/git/github/jakerella/jquery-mockjax/e4969fd891a50f259e65a2f61a646038d773f2c1/e4969fd891a50f259e65a2f61a646038d773f2c1)