### PR TITLE
Missing Declared

### DIFF
--- a/curations/git/github/jquery/jquery-color.yaml
+++ b/curations/git/github/jquery/jquery-color.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jquery-color
+  namespace: jquery
+  provider: github
+  type: git
+revisions:
+  9e5e04c1c4ee66427fbe04cfce8155b76748ca64:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared

**Details:**
Source link and license files in ClearlyDefined all point to MIT

**Resolution:**
https://github.com/jquery/jquery-color/blob/9e5e04c1c4ee66427fbe04cfce8155b76748ca64/MIT-LICENSE.txt

**Affected definitions**:
- [jquery-color 9e5e04c1c4ee66427fbe04cfce8155b76748ca64](https://clearlydefined.io/definitions/git/github/jquery/jquery-color/9e5e04c1c4ee66427fbe04cfce8155b76748ca64/9e5e04c1c4ee66427fbe04cfce8155b76748ca64)