### PR TITLE
Declared license was missing

### DIFF
--- a/curations/git/github/http4s/jawn-fs2.yaml
+++ b/curations/git/github/http4s/jawn-fs2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jawn-fs2
+  namespace: http4s
+  provider: github
+  type: git
+revisions:
+  36dd593b79fbdf46bb76dc921a04b9551d97c2d9:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license was missing

**Details:**
The declared license field did not contain an entry, even though the LICENSE file on the github page for this component states that this component comes under the Apache 2.0 License

**Resolution:**
Have checked the LICENSE file to confirm that this software comes with the Apache 2.0 License (can be verified here: https://github.com/http4s/jawn-fs2/blob/36dd593b79fbdf46bb76dc921a04b9551d97c2d9/LICENSE)

**Affected definitions**:
- [jawn-fs2 36dd593b79fbdf46bb76dc921a04b9551d97c2d9](https://clearlydefined.io/definitions/git/github/http4s/jawn-fs2/36dd593b79fbdf46bb76dc921a04b9551d97c2d9/36dd593b79fbdf46bb76dc921a04b9551d97c2d9)