### PR TITLE
License = Apache-2.0

### DIFF
--- a/curations/maven/mavencentral/org.json4s/json4s-jackson_2.11.yaml
+++ b/curations/maven/mavencentral/org.json4s/json4s-jackson_2.11.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: json4s-jackson_2.11
+  namespace: org.json4s
+  provider: mavencentral
+  type: maven
+revisions:
+  3.2.11:
+    described:
+      sourceLocation:
+        name: json4s
+        namespace: json4s
+        provider: github
+        revision: 59355f589baec5ced3809c44492ed1a582a549c2
+        type: git
+        url: 'https://github.com/json4s/json4s/commit/59355f589baec5ced3809c44492ed1a582a549c2'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License = Apache-2.0

**Details:**
Eclipse IP Team has determined the license is Apache-2.0

**Resolution:**
Please update!

**Affected definitions**:
- [json4s-jackson_2.11 3.2.11](https://clearlydefined.io/definitions/maven/mavencentral/org.json4s/json4s-jackson_2.11/3.2.11/3.2.11)