### PR TITLE
Some files were missing copyright info

### DIFF
--- a/curations/git/github/banchichen/tzimagepickercontroller.yaml
+++ b/curations/git/github/banchichen/tzimagepickercontroller.yaml
@@ -7,18 +7,18 @@ revisions:
   3b06d1a4eaf67c6a1f37fe69fb8923f185ce3b57:
     files:
       - attributions:
-          - Copyright (c) 2013-2015 Flipboard.
+          - Copyright (c) 2013-2015 Flipboard. All rights reserved.
         license: MIT
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.h
       - attributions:
-          - Copyright (c) 2013-2015 Flipboard.
+          - Copyright (c) 2013-2015 Flipboard. All rights reserved.
         license: MIT
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.m
       - attributions:
-          - Copyright (c) 2013-2015 Flipboard.
+          - Copyright (c) 2013-2015 Flipboard. All rights reserved.
         license: MIT
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.h
       - attributions:
-          - Copyright (c) 2013-2015 Flipboard.
+          - Copyright (c) 2013-2015 Flipboard. All rights reserved.
         license: MIT
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.m

--- a/curations/git/github/banchichen/tzimagepickercontroller.yaml
+++ b/curations/git/github/banchichen/tzimagepickercontroller.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: tzimagepickercontroller
+  namespace: banchichen
+  provider: github
+  type: git
+revisions:
+  3b06d1a4eaf67c6a1f37fe69fb8923f185ce3b57:
+    files:
+      - attributions:
+          - Copyright (c) 2013-2015 Flipboard.
+        license: MIT
+        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.h
+      - attributions:
+          - Copyright (c) 2013-2015 Flipboard.
+        license: MIT
+        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.m
+      - attributions:
+          - Copyright (c) 2013-2015 Flipboard.
+        license: MIT
+        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.h
+      - attributions:
+          - Copyright (c) 2013-2015 Flipboard.
+        license: MIT
+        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.m

--- a/curations/git/github/banchichen/tzimagepickercontroller.yaml
+++ b/curations/git/github/banchichen/tzimagepickercontroller.yaml
@@ -8,17 +8,13 @@ revisions:
     files:
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
-        license: MIT
-        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.h
+           path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.h
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
-        license: MIT
-        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.m
+         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.m
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
-        license: MIT
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.h
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
-        license: MIT
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.m

--- a/curations/git/github/banchichen/tzimagepickercontroller.yaml
+++ b/curations/git/github/banchichen/tzimagepickercontroller.yaml
@@ -8,10 +8,10 @@ revisions:
     files:
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
-           path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.h
+        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.h
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
-         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.m
+        path: TZImagePickerController/FLAnimatedImage/FLAnimatedImage.m
       - attributions:
           - Copyright (c) 2013-2015 Flipboard. All rights reserved.
         path: TZImagePickerController/FLAnimatedImage/FLAnimatedImageView.h


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Some files were missing copyright info

**Details:**
There were files in the folder /TZImagePickerController/FLAnimatedImage/ that only had a copyright header stating "Copyright (c) 2013-2015 Flipboard. All rights reserved." which implies that we have no specific rights to do anything with those files.

**Resolution:**
I checked the github page for the Flipboard project where these files originated (https://github.com/Flipboard/FLAnimatedImage) and noticed that the overall project is licensed under MIT. I have updated the contents of /TZImagePickerController/FLAnimatedImage/ to have the MIT license.

**Affected definitions**:
- [tzimagepickercontroller 3b06d1a4eaf67c6a1f37fe69fb8923f185ce3b57](https://clearlydefined.io/definitions/git/github/banchichen/tzimagepickercontroller/3b06d1a4eaf67c6a1f37fe69fb8923f185ce3b57/3b06d1a4eaf67c6a1f37fe69fb8923f185ce3b57)