### PR TITLE
Update source location

### DIFF
--- a/curations/maven/mavencentral/com.fasterxml.uuid/java-uuid-generator.yaml
+++ b/curations/maven/mavencentral/com.fasterxml.uuid/java-uuid-generator.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: java-uuid-generator
+  namespace: com.fasterxml.uuid
+  provider: mavencentral
+  type: maven
+revisions:
+  3.1.5:
+    described:
+      sourceLocation:
+        name: java-uuid-generator
+        namespace: cowtowncoder
+        provider: github
+        revision: 97348913e008c6bda081320bef0c841cdabec6bc
+        type: git
+        url: 'https://github.com/cowtowncoder/java-uuid-generator/commit/97348913e008c6bda081320bef0c841cdabec6bc'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update source location

**Details:**
The source location was incorrect. I've updated it to reflect the home repository of this project's as communicated in the Maven pom.xml for version 3.1.5 of the project:

https://repo1.maven.org/maven2/com/fasterxml/uuid/java-uuid-generator/3.1.5/java-uuid-generator-3.1.5.pom

**Resolution:**
Update source location to: https://github.com/cowtowncoder/java-uuid-generator/tree/97348913e008c6bda081320bef0c841cdabec6bc

**Affected definitions**:
- [java-uuid-generator 3.1.5](https://clearlydefined.io/definitions/maven/mavencentral/com.fasterxml.uuid/java-uuid-generator/3.1.5/3.1.5)