### PR TITLE
Update source location and declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/com.fasterxml.uuid/java-uuid-generator.yaml
+++ b/curations/sourcearchive/mavencentral/com.fasterxml.uuid/java-uuid-generator.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: java-uuid-generator
+  namespace: com.fasterxml.uuid
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  3.1.5:
+    described:
+      sourceLocation:
+        name: java-uuid-generator
+        namespace: cowtowncoder
+        provider: github
+        revision: 97348913e008c6bda081320bef0c841cdabec6bc
+        type: git
+        url: 'https://github.com/cowtowncoder/java-uuid-generator/commit/97348913e008c6bda081320bef0c841cdabec6bc'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update source location and declared license

**Details:**
The source location and declared license was incorrect for this component.

**Resolution:**
Updated source location and declared license to reflect the project's source repository according to the contents of Maven pom.xml for this version of the component.

https://repo1.maven.org/maven2/com/fasterxml/uuid/java-uuid-generator/3.1.5/java-uuid-generator-3.1.5.pom

**Affected definitions**:
- [java-uuid-generator 3.1.5](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.fasterxml.uuid/java-uuid-generator/3.1.5/3.1.5)