### PR TITLE
Declared license field was missing

### DIFF
--- a/curations/git/github/jupyter/nbconvert.yaml
+++ b/curations/git/github/jupyter/nbconvert.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: nbconvert
+  namespace: jupyter
+  provider: github
+  type: git
+revisions:
+  203656bd7a98691a2f0aba51f417b193f112fbea:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license field was missing

**Details:**
The entry for the declared license field was not populated

**Resolution:**
The license for this project appears to be the 3-clause BSD license (see here: https://github.com/jupyter/nbconvert/blob/203656bd7a98691a2f0aba51f417b193f112fbea/LICENSE). I have set the declared license field to reflect this.

**Affected definitions**:
- [nbconvert 203656bd7a98691a2f0aba51f417b193f112fbea](https://clearlydefined.io/definitions/git/github/jupyter/nbconvert/203656bd7a98691a2f0aba51f417b193f112fbea/203656bd7a98691a2f0aba51f417b193f112fbea)