### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/system.windows.extensions.yaml
+++ b/curations/nuget/nuget/-/system.windows.extensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: system.windows.extensions
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.0-preview8.19405.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here in License info and history show always MIT (https://github.com/dotnet/corefx/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [system.windows.extensions 4.6.0-preview8.19405.3](https://clearlydefined.io/definitions/nuget/nuget/-/system.windows.extensions/4.6.0-preview8.19405.3/4.6.0-preview8.19405.3)