### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/microsoft.win32.registry.accesscontrol.yaml
+++ b/curations/nuget/nuget/-/microsoft.win32.registry.accesscontrol.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: microsoft.win32.registry.accesscontrol
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.0-preview8.19405.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here in License info and history show always MIT (https://github.com/dotnet/corefx/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [microsoft.win32.registry.accesscontrol 4.6.0-preview8.19405.3](https://clearlydefined.io/definitions/nuget/nuget/-/microsoft.win32.registry.accesscontrol/4.6.0-preview8.19405.3/4.6.0-preview8.19405.3)