### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/system.io.ports.yaml
+++ b/curations/nuget/nuget/-/system.io.ports.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: system.io.ports
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.0-preview8.19405.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here in License info and history show always MIT (https://github.com/dotnet/corefx/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [system.io.ports 4.6.0-preview8.19405.3](https://clearlydefined.io/definitions/nuget/nuget/-/system.io.ports/4.6.0-preview8.19405.3/4.6.0-preview8.19405.3)