### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/system.net.http.winhttphandler.yaml
+++ b/curations/nuget/nuget/-/system.net.http.winhttphandler.yaml
@@ -6,3 +6,6 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.6.0-preview8.19405.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here in License info and history show always MIT (https://github.com/dotnet/corefx/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [system.net.http.winhttphandler 4.6.0-preview8.19405.3](https://clearlydefined.io/definitions/nuget/nuget/-/system.net.http.winhttphandler/4.6.0-preview8.19405.3/4.6.0-preview8.19405.3)