### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/njsonschema.yaml
+++ b/curations/nuget/nuget/-/njsonschema.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: njsonschema
+  provider: nuget
+  type: nuget
+revisions:
+  10.0.22:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT license found at License Info in Master which was Changed to MIT from Ms-PL on 11/30/16 and not changed since (https://github.com/RicoSuter/NJsonSchema/commit/6798a34c8b76632a93aa36f7f9b9c1cca94e026e#diff-37854d19817c792316d481f5beb93cc7) 

**Resolution:**
Declared MIT - Master found here (https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md)

**Affected definitions**:
- [njsonschema 10.0.22](https://clearlydefined.io/definitions/nuget/nuget/-/njsonschema/10.0.22/10.0.22)