### PR TITLE
microsoft.extensions.caching.sqlserver/2.2.0 

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Caching.SqlServer.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Caching.SqlServer.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.2:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
microsoft.extensions.caching.sqlserver/2.2.0 

**Details:**
DotNet core 2.2.0 binaries are missing license.

**Resolution:**
microsoft.extensions.caching.sqlserver/2.2.0 is fixed with this PR, but we should update all 2.2.0 binaries from DotNetCore

**Affected definitions**:
- [Microsoft.Extensions.Caching.SqlServer 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Caching.SqlServer/2.2.0)