### PR TITLE
Provides a license for Microsoft.AspNetCore.Authentication.MicrosoftAccount 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.MicrosoftAccount.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.MicrosoftAccount.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.2:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Provides a license for Microsoft.AspNetCore.Authentication.MicrosoftAccount 2.2.0

**Details:**
The license of this project has not been correctly discovered.

**Resolution:**
The license is here: 

https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt

**Affected definitions**:
- [Microsoft.AspNetCore.Authentication.MicrosoftAccount 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Authentication.MicrosoftAccount/2.2.0)