### PR TITLE
Provides a license for Microsoft.AspNetCore.Http.Connections.Common1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Http.Connections.Common.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Http.Connections.Common.yaml
@@ -15,3 +15,6 @@ revisions:
   1.0.3:
     licensed:
       declared: Apache-2.0
+  1.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Provides a license for Microsoft.AspNetCore.Http.Connections.Common1.1.0

**Details:**
The license of this project has not been correctly discovered.

**Resolution:**
The license info is here:

https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt

**Affected definitions**:
- [Microsoft.AspNetCore.Http.Connections.Common 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Http.Connections.Common/1.1.0)