### PR TITLE
Declared BSD-3- Clause 

### DIFF
--- a/curations/git/github/zaphoyd/websocketpp.yaml
+++ b/curations/git/github/zaphoyd/websocketpp.yaml
@@ -7,3 +7,6 @@ revisions:
   378437aecdcb1dfe62096ffd5d944bf1f640ccc3:
     licensed:
       declared: BSD-3-Clause
+  e203dbed45409111c2e95cb3e4a1d178ee57d2bc:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3- Clause 

**Details:**
Declared BSD-3- Clause found here (https://github.com/zaphoyd/websocketpp/blob/e203dbed45409111c2e95cb3e4a1d178ee57d2bc/COPYING) and here (https://www.zaphoyd.com/websocketpp)

**Resolution:**
Declared BSD-3- Clause 

**Affected definitions**:
- [websocketpp e203dbed45409111c2e95cb3e4a1d178ee57d2bc](https://clearlydefined.io/definitions/git/github/zaphoyd/websocketpp/e203dbed45409111c2e95cb3e4a1d178ee57d2bc/e203dbed45409111c2e95cb3e4a1d178ee57d2bc)