### PR TITLE
Supplying a license for Microsoft.PowerShell.5.1.ReferenceAssemblies

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.5.1.ReferenceAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.5.1.ReferenceAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.5.1.ReferenceAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Supplying a license for Microsoft.PowerShell.5.1.ReferenceAssemblies

**Details:**
The component license was not present.

**Resolution:**
The license information can be found here:
https://github.com/PowerShell/PowerShell/blob/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.PowerShell.5.1.ReferenceAssemblies 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.5.1.ReferenceAssemblies/1.0.0/1.0.0)