### PR TITLE
Declared License

### DIFF
--- a/curations/pypi/pypi/-/matplotlib.yaml
+++ b/curations/pypi/pypi/-/matplotlib.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: matplotlib
+  provider: pypi
+  type: pypi
+revisions:
+  3.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
https://matplotlib.org/users/license.html

**Resolution:**
Declared OTHER, per above link (modified/custom license)

**Affected definitions**:
- [matplotlib 3.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/matplotlib/3.0.2/3.0.2)