### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pillow
+  provider: pypi
+  type: pypi
+revisions:
+  5.4.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license

**Details:**
Package page points to PIL and repo https://github.com/python-pillow/Pillow/blob/master/LICENSE

**Resolution:**
Do not see a SPDX for this, so putting OTHER.

**Affected definitions**:
- [pillow 5.4.1](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/5.4.1/5.4.1)