### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: protobuf
+  provider: pypi
+  type: pypi
+revisions:
+  3.9.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license

**Details:**
Followed source link to https://github.com/protocolbuffers/protobuf/blob/655310ca192a6e3a050e0ca0b7084a2968072260/LICENSE

**Resolution:**
BSD-3-clause

**Affected definitions**:
- [protobuf 3.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.9.1/3.9.1)