### PR TITLE
Declared License

### DIFF
--- a/curations/pypi/pypi/-/ipaddress.yaml
+++ b/curations/pypi/pypi/-/ipaddress.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ipaddress
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.22:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Package says its under the PSF license https://pypi.org/project/ipaddress/1.0.22/. The repo license is not the full/overall PSF license, but it says it is based on the cpython ipaddress module, which would be, so put Python-2.0 as the license.  Let me know if you think it should be OTHER>

**Resolution:**
See above

**Affected definitions**:
- [ipaddress 1.0.22](https://clearlydefined.io/definitions/pypi/pypi/-/ipaddress/1.0.22/1.0.22)