### PR TITLE
Declared License

### DIFF
--- a/curations/git/github/hrnet/hrnet-semantic-segmentation.yaml
+++ b/curations/git/github/hrnet/hrnet-semantic-segmentation.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hrnet-semantic-segmentation
+  namespace: hrnet
+  provider: github
+  type: git
+revisions:
+  06142dc1c7026e256a7561c3e875b06622b5670f:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT as Declared License. There is a BSD-3-Clause reference for an included component.

**Resolution:**
https://github.com/HRNet/HRNet-Semantic-Segmentation/blob/06142dc1c7026e256a7561c3e875b06622b5670f/LICENSE

**Affected definitions**:
- [hrnet-semantic-segmentation 06142dc1c7026e256a7561c3e875b06622b5670f](https://clearlydefined.io/definitions/git/github/hrnet/hrnet-semantic-segmentation/06142dc1c7026e256a7561c3e875b06622b5670f/06142dc1c7026e256a7561c3e875b06622b5670f)