### PR TITLE
Declared Apache 2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Options.DataAnnotations.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Options.DataAnnotations.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Extensions.Options.DataAnnotations
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0

**Details:**
Declared Apache 2.0 found here (https://clearlydefined.io/definitions/nuget/nuget/-/microsoft.extensions.options.dataannotations/2.2.0)

**Resolution:**
Declared Apache 2.0

**Affected definitions**:
- [Microsoft.Extensions.Options.DataAnnotations 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Options.DataAnnotations/2.2.0)