### PR TITLE
Missing information for CommandLineParser/2.6.0

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -40,3 +40,6 @@ revisions:
         path: CommandLineParser.nuspec
     licensed:
       declared: MIT
+  2.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for CommandLineParser/2.6.0

**Details:**
Adding license.

**Resolution:**
Source:
https://github.com/commandlineparser/commandline/tree/cf64a6837283ec7a65f0b54695b4caade1a7d0c5
MIT License:
Copyright (c) 2005 - 2015 Giacomo Stelluti Scala & Contributors
https://github.com/commandlineparser/commandline/blob/cf64a6837283ec7a65f0b54695b4caade1a7d0c5/License.md

**Affected definitions**:
- [CommandLineParser 2.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser/2.6.0/2.6.0)