### PR TITLE
Missing information for Microsoft.Azure.Services.AppAuthentication/1.3.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Services.AppAuthentication.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Services.AppAuthentication.yaml
@@ -9,3 +9,14 @@ revisions:
   1.0.3:
     licensed:
       declared: MIT
+  1.3.0:
+    described:
+      sourceLocation:
+        name: azure-sdk-for-net
+        namespace: azure
+        provider: github
+        revision: 2990ed9f8de07e6bba2cbc3411aff8ca5decb7be
+        type: git
+        url: 'https://github.com/azure/azure-sdk-for-net/commit/2990ed9f8de07e6bba2cbc3411aff8ca5decb7be'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Azure.Services.AppAuthentication/1.3.0

**Details:**
Adding source and license.

**Resolution:**
• Source:
• https://github.com/Azure/azure-sdk-for-net/tree/2990ed9f8de07e6bba2cbc3411aff8ca5decb7be
• MIT License:
• Copyright (c) 2015 Microsoft
https://github.com/Azure/azure-sdk-for-net/blob/2990ed9f8de07e6bba2cbc3411aff8ca5decb7be/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.Services.AppAuthentication 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Services.AppAuthentication/1.3.0/1.3.0)