### PR TITLE
Missing information for Microsoft.IdentityModel.Clients.ActiveDirectory/5.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -116,3 +116,14 @@ revisions:
         url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/99f1dd308ad4ad8aeb3ca90014e0f1c12e219490'
     licensed:
       declared: MIT
+  5.1.0:
+    described:
+      sourceLocation:
+        name: azure-activedirectory-library-for-dotnet
+        namespace: azuread
+        provider: github
+        revision: 9f4472ab6dff4fa74bddfa622da4ac3823beb4b8
+        type: git
+        url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/9f4472ab6dff4fa74bddfa622da4ac3823beb4b8'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.IdentityModel.Clients.ActiveDirectory/5.1.0

**Details:**
Adding source and license.

**Resolution:**
• Source:
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/tree/9f4472ab6dff4fa74bddfa622da4ac3823beb4b8
MIT License:
Copyright (c) Microsoft Corporation
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/9f4472ab6dff4fa74bddfa622da4ac3823beb4b8/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.1.0/5.1.0)