### PR TITLE
Missing information for Microsoft.Azure.Management.Storage.Fluent/1.24.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.Storage.Fluent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.Storage.Fluent.yaml
@@ -22,3 +22,14 @@ revisions:
         path: Microsoft.Azure.Management.Storage.Fluent.nuspec
     licensed:
       declared: MIT
+  1.24.0:
+    described:
+      sourceLocation:
+        name: azure-libraries-for-net
+        namespace: azure
+        provider: github
+        revision: dcc2a32f1cbfef57fb6f028de3a4a1e331f319ab
+        type: git
+        url: 'https://github.com/azure/azure-libraries-for-net/commit/dcc2a32f1cbfef57fb6f028de3a4a1e331f319ab'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Azure.Management.Storage.Fluent/1.24.0

**Details:**
Adding source and license.

**Resolution:**
Source:
https://github.com/Azure/azure-libraries-for-net/tree/dcc2a32f1cbfef57fb6f028de3a4a1e331f319ab
MIT License:
Copyright (c) 2015 Microsoft
https://github.com/Azure/azure-libraries-for-net/blob/dcc2a32f1cbfef57fb6f028de3a4a1e331f319ab/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.Management.Storage.Fluent 1.24.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Management.Storage.Fluent/1.24.0/1.24.0)