### PR TITLE
Missing information for Moq/4.12.0

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -9,6 +9,9 @@ revisions:
   4.11.0:
     licensed:
       declared: BSD-3-Clause
+  4.12.0:
+    licensed:
+      declared: BSD-3-Clause
   4.2.1402.2112:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Moq/4.12.0

**Details:**
Adding license.

**Resolution:**
• Source:
• https://github.com/moq/moq4/tree/271a12abdaa6edbe042e20d9984b8de64a4dad54
• BSD 3-Clause New License
Copyright (c) 2007, Clarius Consulting, Manas Technology Solutions, InSTEDD
All rights reserved.
https://github.com/moq/moq4/blob/271a12abdaa6edbe042e20d9984b8de64a4dad54/License.txt

**Affected definitions**:
- [Moq 4.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.12.0/4.12.0)