### PR TITLE
Missing information for Microsoft.Diagnostics.Tracing.TraceEvent/2.0.44

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -25,3 +25,14 @@ revisions:
   2.0.43:
     licensed:
       declared: MIT
+  2.0.44:
+    described:
+      sourceLocation:
+        name: perfview
+        namespace: microsoft
+        provider: github
+        revision: 6ccbcb4c3d762a03facee49afd04087fc080ceed
+        type: git
+        url: 'https://github.com/microsoft/perfview/commit/6ccbcb4c3d762a03facee49afd04087fc080ceed'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Diagnostics.Tracing.TraceEvent/2.0.44

**Details:**
Adding source and license.

**Resolution:**
• Source:
• https://github.com/microsoft/perfview/tree/6ccbcb4c3d762a03facee49afd04087fc080ceed
• MIT License:
• Copyright (c) .NET Foundation and Contributors
https://github.com/microsoft/perfview/blob/6ccbcb4c3d762a03facee49afd04087fc080ceed/LICENSE.TXT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.44](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.44/2.0.44)