### PR TITLE
Missing information for oauth2-oidc-sdk/6.5

### DIFF
--- a/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
+++ b/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
@@ -10,3 +10,6 @@ revisions:
   5.64.4:
     licensed:
       declared: Apache-2.0
+  '6.5':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for oauth2-oidc-sdk/6.5

**Details:**
Adding license.

**Resolution:**
Apache 2.0 License:
https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk/6.5

**Affected definitions**:
- [oauth2-oidc-sdk 6.5](https://clearlydefined.io/definitions/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/6.5/6.5)