### PR TITLE
Missing information for entities/1.0.0

### DIFF
--- a/curations/npm/npmjs/-/entities.yaml
+++ b/curations/npm/npmjs/-/entities.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-2-Clause
   1.1.1:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for entities/1.0.0

**Details:**
Added license.

**Resolution:**
BSD-2 Clause License:
https://github.com/fb55/entities/blob/36f9838abe15470f161df6760cf9da2d6056c685/LICENSE

**Affected definitions**:
- [entities 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/entities/1.0.0/1.0.0)