### PR TITLE
Missing information for Microsoft.Azure.Devices.Client/1.20.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Client.yaml
@@ -9,6 +9,17 @@ revisions:
   1.18.1:
     licensed:
       declared: MIT
+  1.20.3:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: ec9f2365d7b2315c09d3aad1992e3e3814a7e5c0
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/ec9f2365d7b2315c09d3aad1992e3e3814a7e5c0'
+    licensed:
+      declared: MIT
   1.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Azure.Devices.Client/1.20.3

**Details:**
Added source and license.

**Resolution:**
• Source:
• https://github.com/Azure/azure-iot-sdk-csharp/tree/ec9f2365d7b2315c09d3aad1992e3e3814a7e5c0
• MIT License:
• Copyright (c) Microsoft Corporation
https://github.com/Azure/azure-iot-sdk-csharp/blob/ec9f2365d7b2315c09d3aad1992e3e3814a7e5c0/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices.Client 1.20.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices.Client/1.20.3/1.20.3)