### PR TITLE
Missing information for Microsoft.Azure.Devices.Shared/1.16.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -9,6 +9,17 @@ revisions:
   1.15.1:
     licensed:
       declared: MIT
+  1.16.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: b1041109d4daded8f5dbf64a438497de1660cc16
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/b1041109d4daded8f5dbf64a438497de1660cc16'
+    licensed:
+      declared: MIT
   1.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Azure.Devices.Shared/1.16.0

**Details:**
Adding source and license.

**Resolution:**
• Source:
• https://github.com/Azure/azure-iot-sdk-csharp/tree/b1041109d4daded8f5dbf64a438497de1660cc16
• MIT License:
• Copyright (c) Microsoft Corporation
https://github.com/Azure/azure-iot-sdk-csharp/blob/b1041109d4daded8f5dbf64a438497de1660cc16/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices.Shared 1.16.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices.Shared/1.16.0/1.16.0)