### PR TITLE
Missing information for Microsoft.Extensions.Configuration.Binder/2.2.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.Binder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.Binder.yaml
@@ -21,3 +21,6 @@ revisions:
   2.2.0:
     licensed:
       declared: Apache-2.0
+  2.2.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Extensions.Configuration.Binder/2.2.4

**Details:**
Adding license.

**Resolution:**
• Source:
• https://github.com/aspnet/Extensions/tree/e2f51bb31a313fd329765b6fcff1b6923f6d0fc3
• Apache 2.0 License:
https://github.com/aspnet/Extensions/blob/e2f51bb31a313fd329765b6fcff1b6923f6d0fc3/LICENSE.txt

**Affected definitions**:
- [Microsoft.Extensions.Configuration.Binder 2.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Configuration.Binder/2.2.4/2.2.4)