### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -15,3 +15,6 @@ revisions:
   3.6.1:
     licensed:
       declared: BSD-3-Clause
+  3.9.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Declared BSD-3-Clause found here (https://github.com/protocolbuffers/protobuf/blob/v3.9.1/LICENSE)

**Resolution:**
Declared BSD-3-Clause

**Affected definitions**:
- [Google.Protobuf 3.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.9.1)