### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.All.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.All.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: Apache-2.0
+  2.1.8:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 (https://raw.githubusercontent.com/aspnet/AspNetCore/2.0.0/LICENSE.txt)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [Microsoft.AspNetCore.All 2.1.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.All/2.1.8)