### PR TITLE
Declared MIT

### DIFF
--- a/curations/git/github/halide/halide.yaml
+++ b/curations/git/github/halide/halide.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: halide
+  namespace: halide
+  provider: github
+  type: git
+revisions:
+  65c26cba6a3eca2d08a0bccf113ca28746012cc3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/halide/Halide/blob/65c26cba6a3eca2d08a0bccf113ca28746012cc3/LICENSE.txt)

**Resolution:**
Declared MIT

**Affected definitions**:
- [halide 65c26cba6a3eca2d08a0bccf113ca28746012cc3](https://clearlydefined.io/definitions/git/github/halide/halide/65c26cba6a3eca2d08a0bccf113ca28746012cc3/65c26cba6a3eca2d08a0bccf113ca28746012cc3)