### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/git/github/open-mpi/ompi.yaml
+++ b/curations/git/github/open-mpi/ompi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ompi
+  namespace: open-mpi
+  provider: github
+  type: git
+revisions:
+  e0c0c3b07f11024785d902a00790621306e6ff99:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Declared BSD-3-Clause found here (https://github.com/open-mpi/ompi/blob/e0c0c3b07f11024785d902a00790621306e6ff99/LICENSE)

**Resolution:**
Declared BSD-3-Clause

**Affected definitions**:
- [ompi e0c0c3b07f11024785d902a00790621306e6ff99](https://clearlydefined.io/definitions/git/github/open-mpi/ompi/e0c0c3b07f11024785d902a00790621306e6ff99/e0c0c3b07f11024785d902a00790621306e6ff99)