### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/git/github/pybind/pybind11.yaml
+++ b/curations/git/github/pybind/pybind11.yaml
@@ -7,3 +7,6 @@ revisions:
   a1041190c8b8ff0cd9e2f0752248ad5e3789ea0c:
     licensed:
       declared: BSD-3-Clause-LBNL
+  e43e1cc01ae6d4e4e5ba10557a057d7f3d5ece0d:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Declared BSD-3-Clause found here (https://github.com/pybind/pybind11/blob/e43e1cc01ae6d4e4e5ba10557a057d7f3d5ece0d/LICENSE)

**Resolution:**
Declared BSD-3-Clause

**Affected definitions**:
- [pybind11 e43e1cc01ae6d4e4e5ba10557a057d7f3d5ece0d](https://clearlydefined.io/definitions/git/github/pybind/pybind11/e43e1cc01ae6d4e4e5ba10557a057d7f3d5ece0d/e43e1cc01ae6d4e4e5ba10557a057d7f3d5ece0d)