### PR TITLE
Changed declared license

### DIFF
--- a/curations/git/github/google/guice.yaml
+++ b/curations/git/github/google/guice.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: guice
+  namespace: google
+  provider: github
+  type: git
+revisions:
+  86a88f0728ca477b4e33e3c1cb042e0ec02f2feb:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changed declared license

**Details:**
The declared license was set to NOASSERTION

**Resolution:**
The github page for this definition has a COPYING file that shows the Apache 2.0 license (https://github.com/google/guice/blob/4.2.2/COPYING)

**Affected definitions**:
- [guice 86a88f0728ca477b4e33e3c1cb042e0ec02f2feb](https://clearlydefined.io/definitions/git/github/google/guice/86a88f0728ca477b4e33e3c1cb042e0ec02f2feb/86a88f0728ca477b4e33e3c1cb042e0ec02f2feb)