### PR TITLE
Set declared license to MIT

### DIFF
--- a/curations/git/github/whitequark/parser.yaml
+++ b/curations/git/github/whitequark/parser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: parser
+  namespace: whitequark
+  provider: github
+  type: git
+revisions:
+  9bf955022190f69f06e2413cb3828909322773f6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Set declared license to MIT

**Details:**
The declared license field was blank, even though the license.txt file states this is MIT

**Resolution:**
The license.txt file found here (https://github.com/whitequark/parser/blob/9bf955022190f69f06e2413cb3828909322773f6/LICENSE.txt) states this is MIT-licensed

**Affected definitions**:
- [parser 9bf955022190f69f06e2413cb3828909322773f6](https://clearlydefined.io/definitions/git/github/whitequark/parser/9bf955022190f69f06e2413cb3828909322773f6/9bf955022190f69f06e2413cb3828909322773f6)