### PR TITLE
Update rocksdb.yaml

### DIFF
--- a/curations/git/github/facebook/rocksdb.yaml
+++ b/curations/git/github/facebook/rocksdb.yaml
@@ -17,10 +17,10 @@ revisions:
         license: BSD-3-Clause
         path: port/win/win_jemalloc.cc
     licensed:
-      declared: GPL-2.0-only OR Apache-2.0
+      declared: Apache-2.0 OR GPL-2.0-only
   6d113fc066c5816887eb19c84d12c0677a68af2b:
     licensed:
-      declared: Apache-2.0 OR GPL-2.0
+      declared: Apache-2.0 OR GPL-2.0-only
   c2ca7a9f99ac972bb547ef940b0da05da2c4c02d:
     licensed:
       declared: OTHER


### PR DESCRIPTION
Wasn't aware GPL-2.0 has been listed as a deprecated SPDX identifier. See https://spdx.org/licenses/GPL-2.0.html. Correcting to GPL-2.0-only.