### PR TITLE
Declared license field was blank

### DIFF
--- a/curations/git/github/rabbitmq/hop.yaml
+++ b/curations/git/github/rabbitmq/hop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hop
+  namespace: rabbitmq
+  provider: github
+  type: git
+revisions:
+  ede52eec6e3370cf673b3dc2051185f8b515857b:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license field was blank

**Details:**
Declared license field was empty despite there being a license file (probably because the license file is named LICENSE-2.0.txt)

**Resolution:**
I've included a link to the license file, which shows that this component comes with the Apache 2.0 license: https://github.com/rabbitmq/hop/blob/ede52eec6e3370cf673b3dc2051185f8b515857b/LICENSE-2.0.txt

**Affected definitions**:
- [hop ede52eec6e3370cf673b3dc2051185f8b515857b](https://clearlydefined.io/definitions/git/github/rabbitmq/hop/ede52eec6e3370cf673b3dc2051185f8b515857b/ede52eec6e3370cf673b3dc2051185f8b515857b)