### PR TITLE
Correcting license

### DIFF
--- a/curations/pypi/pypi/-/rope.yaml
+++ b/curations/pypi/pypi/-/rope.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rope
+  provider: pypi
+  type: pypi
+revisions:
+  0.14.0:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting license

**Details:**
Said GPL instead of LGPL, per https://github.com/python-rope/rope/blob/d8b70ae76f160403b51b2291a112c11505298a24/COPYING

**Resolution:**
Also, LGPL here https://pypi.org/project/rope/0.14.0/

**Affected definitions**:
- [rope 0.14.0](https://clearlydefined.io/definitions/pypi/pypi/-/rope/0.14.0/0.14.0)