### PR TITLE
MediaTypeMap.Core

### DIFF
--- a/curations/nuget/nuget/-/MediaTypeMap.Core.yaml
+++ b/curations/nuget/nuget/-/MediaTypeMap.Core.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: MediaTypeMap.Core
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.3:
+    described:
+      sourceLocation:
+        name: mimetypemap
+        namespace: samuelneff
+        provider: github
+        revision: 6ddc67a6ddd873ca720f76847edc34d0c7ee5e06
+        type: git
+        url: 'https://github.com/samuelneff/mimetypemap/commit/6ddc67a6ddd873ca720f76847edc34d0c7ee5e06'
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/MediaTypeMap.Core.yaml
+++ b/curations/nuget/nuget/-/MediaTypeMap.Core.yaml
@@ -4,13 +4,5 @@ coordinates:
   type: nuget
 revisions:
   2.3.3:
-    described:
-      sourceLocation:
-        name: mimetypemap
-        namespace: samuelneff
-        provider: github
-        revision: 6ddc67a6ddd873ca720f76847edc34d0c7ee5e06
-        type: git
-        url: 'https://github.com/samuelneff/mimetypemap/commit/6ddc67a6ddd873ca720f76847edc34d0c7ee5e06'
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MediaTypeMap.Core

**Details:**
Entry missing.

**Resolution:**
Added source code repository found on associated NuGet gallery page:
https://www.nuget.org/packages/MediaTypeMap.Core/

Added license type found in source code repository.
https://github.com/samuelneff/MimeTypeMap

Not sure why author has differing names between NuGet and source repo.

**Affected definitions**:
- [MediaTypeMap.Core 2.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/MediaTypeMap.Core/2.3.3)