### PR TITLE
NLog License

### DIFF
--- a/curations/git/github/nlog/nlog.yaml
+++ b/curations/git/github/nlog/nlog.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: nlog
+  namespace: nlog
+  provider: github
+  type: git
+revisions:
+  808874fbbe43b398326cd6e637199f4ff040a0ac:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NLog License

**Details:**
Missing license entry

**Resolution:**
Added BSD-3-Clause license entry per License file on associated source code repository:
https://github.com/NLog/NLog/blob/dev/LICENSE.txt

**Affected definitions**:
- [nlog 808874fbbe43b398326cd6e637199f4ff040a0ac](https://clearlydefined.io/definitions/git/github/nlog/nlog/808874fbbe43b398326cd6e637199f4ff040a0ac)