### PR TITLE
Filled in declared license

### DIFF
--- a/curations/git/github/r-lib/progress.yaml
+++ b/curations/git/github/r-lib/progress.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: progress
+  namespace: r-lib
+  provider: github
+  type: git
+revisions:
+  4d349c74ebf6827d86a90a7c0a02b5a412dd1496:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Filled in declared license

**Details:**
The declared license field was empty

**Resolution:**
The LICENSE file associated with this definition did not actually provide any license information, but the DESCRIPTION file mentions that this is MIT-licensed (https://github.com/r-lib/progress/blob/4d349c74ebf6827d86a90a7c0a02b5a412dd1496/DESCRIPTION)

**Affected definitions**:
- [progress 4d349c74ebf6827d86a90a7c0a02b5a412dd1496](https://clearlydefined.io/definitions/git/github/r-lib/progress/4d349c74ebf6827d86a90a7c0a02b5a412dd1496/4d349c74ebf6827d86a90a7c0a02b5a412dd1496)