### PR TITLE
Missing declared license information

### DIFF
--- a/curations/git/github/cran/urca.yaml
+++ b/curations/git/github/cran/urca.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: urca
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  7219e5ef43df32787ca50a2e4ef6207594a8ba51:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license information

**Details:**
Declared license field was blank

**Resolution:**
The DESCRIPTION file states this is GPL 2.0 or later (https://github.com/cran/urca/blob/7219e5ef43df32787ca50a2e4ef6207594a8ba51/DESCRIPTION)

**Affected definitions**:
- [urca 7219e5ef43df32787ca50a2e4ef6207594a8ba51](https://clearlydefined.io/definitions/git/github/cran/urca/7219e5ef43df32787ca50a2e4ef6207594a8ba51/7219e5ef43df32787ca50a2e4ef6207594a8ba51)