### PR TITLE
No license information displayed

### DIFF
--- a/curations/git/github/tidyverse/blob.yaml
+++ b/curations/git/github/tidyverse/blob.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: blob
+  namespace: tidyverse
+  provider: github
+  type: git
+revisions:
+  f2e93d7dce9c47d6b6e5fc69d9edb1b35fd7d651:
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
No license information displayed

**Details:**
The DESCRIPTION file mentions the GPL 3, but this information is not represented in the Declared or Discovered license fields

**Resolution:**
I have set the Declared license to be GPL-3.0 according to the DESCRIPTION file (https://github.com/tidyverse/blob/blob/f2e93d7dce9c47d6b6e5fc69d9edb1b35fd7d651/DESCRIPTION)

**Affected definitions**:
- [blob f2e93d7dce9c47d6b6e5fc69d9edb1b35fd7d651](https://clearlydefined.io/definitions/git/github/tidyverse/blob/f2e93d7dce9c47d6b6e5fc69d9edb1b35fd7d651/f2e93d7dce9c47d6b6e5fc69d9edb1b35fd7d651)