### PR TITLE
Added Declared Licnese

### DIFF
--- a/curations/npm/npmjs/-/regenerator-transform.yaml
+++ b/curations/npm/npmjs/-/regenerator-transform.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.10.1:
+    licensed:
+      declared: MIT
   0.9.8:
     licensed:
       declared: BSD-2-Clause AND OTHER

--- a/curations/npm/npmjs/-/regenerator-transform.yaml
+++ b/curations/npm/npmjs/-/regenerator-transform.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   0.10.1:
     licensed:
-      declared: MIT
+      declared: BSD-2-Clause AND OTHER
   0.9.8:
     licensed:
       declared: BSD-2-Clause AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added Declared Licnese

**Details:**
Package site says MIT -https://www.npmjs.com/package/regenerator-transform/v/0.10.1

**Resolution:**
And the license file history in the repo shows it has always been MIT too

**Affected definitions**:
- [regenerator-transform 0.10.1](https://clearlydefined.io/definitions/npm/npmjs/-/regenerator-transform/0.10.1/0.10.1)