### PR TITLE
Added Declared License

### DIFF
--- a/curations/nuget/nuget/-/system.interactive.async.yaml
+++ b/curations/nuget/nuget/-/system.interactive.async.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: system.interactive.async
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added Declared License

**Details:**
License link broken on NuGet download page, but repo shows Apache https://github.com/dotnet/reactive/commits/master/LICENSE

**Resolution:**
History of license shows it has always been Apache 

**Affected definitions**:
- [system.interactive.async 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/system.interactive.async/3.2.0/3.2.0)