### PR TITLE
Declared BSD-2-Clause

### DIFF
--- a/curations/npm/npmjs/-/nth-check.yaml
+++ b/curations/npm/npmjs/-/nth-check.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: nth-check
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-2-Clause

**Details:**
Declared BSD-2-Clause found here (https://www.npmjs.com/package/nth-check/v/1.0.1) and here (https://github.com/fb55/nth-check/blob/master/LICENSE)

**Resolution:**
Declared BSD-2-Clause

**Affected definitions**:
- [nth-check 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/nth-check/1.0.1/1.0.1)