### PR TITLE
Declared Apache 2.0 

### DIFF
--- a/curations/nuget/nuget/-/xunit.core.yaml
+++ b/curations/nuget/nuget/-/xunit.core.yaml
@@ -9,3 +9,6 @@ revisions:
   2.3.1:
     licensed:
       declared: Apache-2.0
+  2.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0 

**Details:**
Declared Apache 2.0 found here (https://github.com/xunit/xunit/blob/2.4.1/license.txt)

**Resolution:**
Declared Apache 2.0 

**Affected definitions**:
- [xunit.core 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.core/2.4.1/2.4.1)