### PR TITLE
Declared Apache 2.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.assert.yaml
+++ b/curations/nuget/nuget/-/xunit.assert.yaml
@@ -7,17 +7,20 @@ revisions:
     described:
       releaseDate: '2015-09-27'
       sourceLocation:
+        name: xunit
+        namespace: xunit
         provider: github
         revision: 47fdc2669ae6aa28f6d642e202840193dfc7dbd7
         type: git
         url: 'https://github.com/xunit/xunit'
-        name: xunit
-        namespace: xunit
     licensed:
       declared: Apache-2.0
   2.2.0:
     licensed:
       declared: Apache-2.0
   2.3.1:
+    licensed:
+      declared: Apache-2.0
+  2.4.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0

**Details:**
Declared Apache 2.0 found here (https://github.com/xunit/xunit/blob/2.4.1/license.txt)

**Resolution:**
Declared Apache 2.0

**Affected definitions**:
- [xunit.assert 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.assert/2.4.1/2.4.1)