### PR TITLE
Declared MIT

### DIFF
--- a/curations/npm/npmjs/-/config-chain.yaml
+++ b/curations/npm/npmjs/-/config-chain.yaml
@@ -9,3 +9,6 @@ revisions:
   1.1.11:
     licensed:
       declared: MIT
+  1.1.12:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/dawsbot/config-chain/blob/v1.1.12/LICENCE)

**Resolution:**
Declared MIT

**Affected definitions**:
- [config-chain 1.1.12](https://clearlydefined.io/definitions/npm/npmjs/-/config-chain/1.1.12/1.1.12)