### PR TITLE
Declared BSD-2-Clause

### DIFF
--- a/curations/npm/npmjs/-/css-what.yaml
+++ b/curations/npm/npmjs/-/css-what.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: css-what
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-2-Clause

**Details:**
Declared BSD-2-Clause found here (https://github.com/fb55/css-what/blob/v2.1.0/LICENSE)

**Resolution:**
Declared BSD-2-Clause

**Affected definitions**:
- [css-what 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/css-what/2.1.0/2.1.0)