### PR TITLE
Declared Apache 2.0

### DIFF
--- a/curations/nuget/nuget/-/microsoft.aspnetcore.authentication.oauth.yaml
+++ b/curations/nuget/nuget/-/microsoft.aspnetcore.authentication.oauth.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: microsoft.aspnetcore.authentication.oauth
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache 2.0

**Details:**
Declared Apache 2.0 found here (https://github.com/aspnet/Security/blob/2.2.0/LICENSE.txt)

**Resolution:**
Declared Apache 2.0

**Affected definitions**:
- [microsoft.aspnetcore.authentication.oauth 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/microsoft.aspnetcore.authentication.oauth/2.2.0/2.2.0)