### PR TITLE
Adding missing licenses

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.Cookies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.Cookies.yaml
@@ -11,7 +11,10 @@ revisions:
       declared: Apache-2.0
   2.1.1:
     licensed:
-      declared: Apache-2.0      
+      declared: Apache-2.0
   2.1.2:
+    licensed:
+      declared: Apache-2.0
+  2.2.0:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.OAuth.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.OAuth.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.2:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.OpenIdConnect.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.OpenIdConnect.yaml
@@ -11,7 +11,10 @@ revisions:
       declared: Apache-2.0
   2.1.1:
     licensed:
-      declared: Apache-2.0      
+      declared: Apache-2.0
   2.1.2:
+    licensed:
+      declared: Apache-2.0
+  2.2.0:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.CookiePolicy.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.CookiePolicy.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.2:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.ResponseCompression.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.ResponseCompression.yaml
@@ -12,3 +12,6 @@ revisions:
   2.1.1:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.SignalR.Common.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.SignalR.Common.yaml
@@ -15,3 +15,6 @@ revisions:
   1.0.3:
     licensed:
       declared: Apache-2.0
+  1.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.Ini.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.Ini.yaml
@@ -12,3 +12,6 @@ revisions:
   2.1.1:
     licensed:
       declared: Apache 2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Extensions.DiagnosticAdapter.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.DiagnosticAdapter.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing licenses

**Details:**
Versions were already curated but, due to casing issue, ended up in wrong filename

**Resolution:**
Resubmitting so they show up correctly

**Affected definitions**:
- [Microsoft.AspNetCore.Authentication.Cookies 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Authentication.Cookies/2.2.0),- [Microsoft.AspNetCore.Authentication.OAuth 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Authentication.OAuth/2.2.0),- [Microsoft.AspNetCore.Authentication.OpenIdConnect 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Authentication.OpenIdConnect/2.2.0),- [Microsoft.AspNetCore.ResponseCompression 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.ResponseCompression/2.2.0),- [Microsoft.Extensions.DiagnosticAdapter 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.DiagnosticAdapter/2.2.0),- [Microsoft.Extensions.Configuration.Ini 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Configuration.Ini/2.2.0),- [Microsoft.AspNetCore.CookiePolicy 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.CookiePolicy/2.2.0),- [Microsoft.AspNetCore.SignalR.Common 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.SignalR.Common/1.1.0)