### PR TITLE
Declare the license for didyoumean 1.2.1

### DIFF
--- a/curations/npm/npmjs/-/didyoumean.yaml
+++ b/curations/npm/npmjs/-/didyoumean.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: didyoumean
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare the license for didyoumean 1.2.1

**Details:**
Was flagged as both Apache 2 and NOASSERTION while the data on npm shows Apache.

**Resolution:**
License specified as Apache 2 as listed at https://www.npmjs.com/package/didyoumean and
https://github.com/dcporter/didyoumean.js/blob/v1.2.0/LICENSE

**Affected definitions**:
- [didyoumean 1.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/didyoumean/1.2.1)