### PR TITLE
Specify license for doctrine 0.7.2

### DIFF
--- a/curations/npm/npmjs/-/doctrine.yaml
+++ b/curations/npm/npmjs/-/doctrine.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.7.2:
+    licensed:
+      declared: Apache-2.0
   1.5.0:
     licensed:
       declared: BSD-2-Clause

--- a/curations/npm/npmjs/-/doctrine.yaml
+++ b/curations/npm/npmjs/-/doctrine.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   0.7.2:
     licensed:
-      declared: Apache-2.0
+      declared: BSD-2-Clause
   1.5.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Specify license for doctrine 0.7.2

**Details:**
License was not declared, is Apache 2.

**Resolution:**
https://www.npmjs.com/package/doctrine

**Affected definitions**:
- [doctrine 0.7.2](https://clearlydefined.io/definitions/npm/npmjs/-/doctrine/0.7.2)