### PR TITLE
Declare license for esutils 1.1.6

### DIFF
--- a/curations/npm/npmjs/-/esutils.yaml
+++ b/curations/npm/npmjs/-/esutils.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.0:
     licensed:
       declared: BSD-2-Clause
+  1.1.6:
+    licensed:
+      declared: BSD-2-Clause
   2.0.2:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare license for esutils 1.1.6

**Details:**
License had multiple discovered license, is specifically declared BSD-2.

**Resolution:**
https://www.npmjs.com/package/esutils

**Affected definitions**:
- [esutils 1.1.6](https://clearlydefined.io/definitions/npm/npmjs/-/esutils/1.1.6)