### PR TITLE
Declare license for png-js 0.1.1

### DIFF
--- a/curations/npm/npmjs/-/png-js.yaml
+++ b/curations/npm/npmjs/-/png-js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: png-js
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declare license for png-js 0.1.1

**Details:**
Discovered correctly, but declared empty.

**Resolution:**
https://github.com/foliojs/png.js/blob/master/LICENSE

**Affected definitions**:
- [png-js 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/png-js/0.1.1)