### PR TITLE
Adding missing declared license

### DIFF
--- a/curations/npm/npmjs/-/unique-stream.yaml
+++ b/curations/npm/npmjs/-/unique-stream.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: unique-stream
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared license

**Details:**
package.json states BSD, but package contents contains MIT license.  

**Resolution:**
https://github.com/eugeneware/unique-stream/blob/v1.0.0/LICENSE

https://clearlydefined.io/definitions/npm/npmjs/-/unique-stream/1.0.0

**Affected definitions**:
- [unique-stream 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/unique-stream/1.0.0)