### PR TITLE
Adding missing declared licenses

### DIFF
--- a/curations/npm/npmjs/-/error.yaml
+++ b/curations/npm/npmjs/-/error.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: error
+  provider: npmjs
+  type: npm
+revisions:
+  7.0.2:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/fstream.yaml
+++ b/curations/npm/npmjs/-/fstream.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fstream
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.31:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/npm/npmjs/-/gitconfiglocal.yaml
+++ b/curations/npm/npmjs/-/gitconfiglocal.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: gitconfiglocal
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared licenses

**Details:**
Missing licenses

**Resolution:**
License in README: https://www.npmjs.com/package/error/v/7.0.2
https://github.com/npm/fstream/blob/v0.1.31/LICENSE
gitconfiglocal states with no link.BSD-3-clause license file added later:https://github.com/soldair/node-gitconfiglocal/blob/9202725ae2ad9848df965ee490f59526f758ea77/LICENSE

**Affected definitions**:
- [error 7.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/error/7.0.2),- [fstream 0.1.31](https://clearlydefined.io/definitions/npm/npmjs/-/fstream/0.1.31),- [gitconfiglocal 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/gitconfiglocal/1.0.0)