### PR TITLE
Adding missing declared licenses

### DIFF
--- a/curations/npm/npmjs/-/graceful-fs.yaml
+++ b/curations/npm/npmjs/-/graceful-fs.yaml
@@ -7,3 +7,6 @@ revisions:
     files:
       - license: BSD-2-Clause
         path: package/package.json
+  2.0.3:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/npm/npmjs/-/mkdirp.yaml
+++ b/curations/npm/npmjs/-/mkdirp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mkdirp
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.0:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/nugget.yaml
+++ b/curations/npm/npmjs/-/nugget.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: nugget
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared licenses

**Details:**
Missing licenses

**Resolution:**
https://github.com/isaacs/node-graceful-fs/blob/v2.0.3/LICENSE
https://github.com/substack/node-mkdirp/blob/0.3.0/LICENSE
nugget states BSD with no license file or link. BSD-3-clause license added later: https://github.com/maxogden/nugget/blob/277b17b5af618e07a3fbb9bd44987719e1d1a109/LICENSE

**Affected definitions**:
- [graceful-fs 2.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/graceful-fs/2.0.3),- [mkdirp 0.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/mkdirp/0.3.0),- [nugget 2.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/nugget/2.0.1)