### PR TITLE
Adding missing declared licenses

### DIFF
--- a/curations/npm/npmjs/-/rx.yaml
+++ b/curations/npm/npmjs/-/rx.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  2.3.24:
+    licensed:
+      declared: Apache-2.0
   2.5.2:
     licensed:
       declared: Apache-2.0

--- a/curations/npm/npmjs/-/source-map.yaml
+++ b/curations/npm/npmjs/-/source-map.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.1.32:
+    licensed:
+      declared: BSD-3-Clause
   0.1.43:
     licensed:
       declared: BSD-3-Clause

--- a/curations/npm/npmjs/-/string-template.yaml
+++ b/curations/npm/npmjs/-/string-template.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: string-template
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared licenses

**Details:**
Missing licenses

**Resolution:**
https://github.com/Reactive-Extensions/RxJS/blob/v2.3.24/license.txt
https://github.com/mozilla/source-map/blob/0.1.32/LICENSE
https://github.com/Matt-Esch/string-template/blob/fe0823b9f885f80316d868ad02334f216de489d6/LICENCE

**Affected definitions**:
- [rx 2.3.24](https://clearlydefined.io/definitions/npm/npmjs/-/rx/2.3.24),- [source-map 0.1.32](https://clearlydefined.io/definitions/npm/npmjs/-/source-map/0.1.32),- [string-template 0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/string-template/0.2.1)