### PR TITLE
Adding missing declared licenses

### DIFF
--- a/curations/npm/npmjs/-/adal-node.yaml
+++ b/curations/npm/npmjs/-/adal-node.yaml
@@ -7,7 +7,7 @@ revisions:
     licensed:
       declared: Apache-2.0
   0.1.22:
-      licensed:
+    licensed:
       declared: Apache-2.0
   0.1.16:
     licensed:

--- a/curations/npm/npmjs/-/adal-node.yaml
+++ b/curations/npm/npmjs/-/adal-node.yaml
@@ -6,3 +6,6 @@ revisions:
   0.1.15:
     licensed:
       declared: Apache-2.0
+  0.1.22:
+    licensed:
+      declared: Apache-2.0

--- a/curations/npm/npmjs/-/busboy.yaml
+++ b/curations/npm/npmjs/-/busboy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: busboy
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.14:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/console-stream.yaml
+++ b/curations/npm/npmjs/-/console-stream.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: console-stream
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/dicer.yaml
+++ b/curations/npm/npmjs/-/dicer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dicer
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared licenses

**Details:**
Missing licenses

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-library-for-nodejs/blob/v0.1.22/LICENSE.txt
https://github.com/mscdex/busboy/blob/v0.2.14/LICENSE
https://github.com/Raynos/console-stream/blob/343dd07bbefb17023aafd78065fe2ba3739fbc49/LICENCE
https://github.com/mscdex/dicer/blob/v0.2.5/LICENSE


**Affected definitions**:
- [adal-node 0.1.22](https://clearlydefined.io/definitions/npm/npmjs/-/adal-node/0.1.22),- [busboy 0.2.14](https://clearlydefined.io/definitions/npm/npmjs/-/busboy/0.2.14),- [console-stream 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/console-stream/0.1.1),- [dicer 0.2.5](https://clearlydefined.io/definitions/npm/npmjs/-/dicer/0.2.5)