### PR TITLE
Missing Declared

### DIFF
--- a/curations/maven/mavencentral/classworlds/classworlds.yaml
+++ b/curations/maven/mavencentral/classworlds/classworlds.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: classworlds
+  namespace: classworlds
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1-alpha-2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
Found license file in jar\META-INF\ folder.  License file looks like BSD 4 clause, plus  clause 5. Due credit should be given to The Codehaus.
    (http://classworlds.codehaus.org/).

**Resolution:**
Not aware of an SPDX identifier for this, so curating OTHER.

**Affected definitions**:
- [classworlds 1.1-alpha-2](https://clearlydefined.io/definitions/maven/mavencentral/classworlds/classworlds/1.1-alpha-2)