### PR TITLE
Missing Declared

### DIFF
--- a/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
+++ b/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.18.1:
+    licensed:
+      declared: Apache-2.0
   5.24.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
POM says Apache v2

**Resolution:**
https://repo1.maven.org/maven2/com/nimbusds/oauth2-oidc-sdk/5.18.1/oauth2-oidc-sdk-5.18.1.pom

**Affected definitions**:
- [oauth2-oidc-sdk 5.18.1](https://clearlydefined.io/definitions/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/5.18.1)