### PR TITLE
Missing Declared

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsch
+  namespace: com.jcraft
+  provider: mavencentral
+  type: maven
+revisions:
+  0.1.42:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
POM (https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.42/jsch-0.1.42.pom) points to http://www.jcraft.com/jsch/LICENSE.txt

**Resolution:**
BSD-3-clause

**Affected definitions**:
- [jsch 0.1.42](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch/0.1.42)