### PR TITLE
Declaring License

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-server.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-server.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-server
+  namespace: com.sun.jersey
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.9':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring License

**Details:**
POM https://repo1.maven.org/maven2/com/sun/jersey/jersey-server/1.9/jersey-server-1.9.pom

**Resolution:**
and https://javaee.github.io/glassfish/LICENSE

**Affected definitions**:
- [jersey-server 1.9](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-server/1.9)