### PR TITLE
Missing Declared

### DIFF
--- a/curations/maven/mavencentral/com.sun.xml.bind/jaxb-impl.yaml
+++ b/curations/maven/mavencentral/com.sun.xml.bind/jaxb-impl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jaxb-impl
+  namespace: com.sun.xml.bind
+  provider: mavencentral
+  type: maven
+revisions:
+  2.2.3-1:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
POM https://repo1.maven.org/maven2/com/sun/xml/bind/jaxb-impl/2.2.3-1/jaxb-impl-2.2.3-1.pom

**Resolution:**
And https://javaee.github.io/glassfish/LICENSE

**Affected definitions**:
- [jaxb-impl 2.2.3-1](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.xml.bind/jaxb-impl/2.2.3-1)