### PR TITLE
Missing Declared

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.plexus/plexus-container-default.yaml
+++ b/curations/maven/mavencentral/org.codehaus.plexus/plexus-container-default.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: plexus-container-default
+  namespace: org.codehaus.plexus
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0-alpha-9-stable-1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-container-default/1.0-alpha-9-stable-1 says Apache.  Team found GitHub repo https://github.com/codehaus-plexus/plexus-containers

**Resolution:**
Points to https://codehaus-plexus.github.io/plexus-containers/plexus-container-default/license.html

**Affected definitions**:
- [plexus-container-default 1.0-alpha-9-stable-1](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.plexus/plexus-container-default/1.0-alpha-9-stable-1)