### PR TITLE
Missing Declared

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.jettison/jettison.yaml
+++ b/curations/maven/mavencentral/org.codehaus.jettison/jettison.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jettison
+  namespace: org.codehaus.jettison
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
GitHub POM indicates license is Apache v2

**Resolution:**
https://github.com/codehaus/jettison/blob/master/pom.xml

**Affected definitions**:
- [jettison 1.1](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.jettison/jettison/1.1)