### PR TITLE
Adding missing declared licenses

### DIFF
--- a/curations/maven/mavencentral/commons-configuration/commons-configuration.yaml
+++ b/curations/maven/mavencentral/commons-configuration/commons-configuration.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-configuration
+  namespace: commons-configuration
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.6':
+    licensed:
+      declared: Apache-2.0

--- a/curations/npm/npmjs/-/cryptiles.yaml
+++ b/curations/npm/npmjs/-/cryptiles.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cryptiles
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.2:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/npm/npmjs/-/crypto-md5.yaml
+++ b/curations/npm/npmjs/-/crypto-md5.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: crypto-md5
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/npm/npmjs/-/debug.yaml
+++ b/curations/npm/npmjs/-/debug.yaml
@@ -6,3 +6,6 @@ revisions:
   0.7.4:
     licensed:
       declared: MIT
+  0.8.1:
+    licensed:
+      declared: MIT

--- a/curations/sourcearchive/mavencentral/commons-configuration/commons-configuration.yaml
+++ b/curations/sourcearchive/mavencentral/commons-configuration/commons-configuration.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-configuration
+  namespace: commons-configuration
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '1.6':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared licenses

**Details:**
Missing licenses

**Resolution:**
commons-configuration: License.txt in package states Apache 2.0
https://github.com/hapijs/cryptiles/blob/v0.2.2/LICENSE
https://github.com/jtblin/crypto-md5/blob/v1.0.0/LICENSE
https://github.com/visionmedia/debug/blob/0.8.1/Readme.md#license


**Affected definitions**:
- [commons-configuration 1.6](https://clearlydefined.io/definitions/maven/mavencentral/commons-configuration/commons-configuration/1.6),- [commons-configuration 1.6](https://clearlydefined.io/definitions/sourcearchive/mavencentral/commons-configuration/commons-configuration/1.6),- [cryptiles 0.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/cryptiles/0.2.2),- [crypto-md5 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/crypto-md5/1.0.0),- [debug 0.8.1](https://clearlydefined.io/definitions/npm/npmjs/-/debug/0.8.1)