### PR TITLE
Adding missing declared licenses

### DIFF
--- a/curations/maven/mavencentral/org.hamcrest/hamcrest-library.yaml
+++ b/curations/maven/mavencentral/org.hamcrest/hamcrest-library.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hamcrest-library
+  namespace: org.hamcrest
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.3':
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/npm/npmjs/-/glob-to-regexp.yaml
+++ b/curations/npm/npmjs/-/glob-to-regexp.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.1.0:
+    licensed:
+      declared: BSD-2-Clause
   0.3.0:
     licensed:
       declared: BSD-2-Clause

--- a/curations/npm/npmjs/-/growl.yaml
+++ b/curations/npm/npmjs/-/growl.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: growl
+  provider: npmjs
+  type: npm
+revisions:
+  1.8.1:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/hawk.yaml
+++ b/curations/npm/npmjs/-/hawk.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hawk
+  provider: npmjs
+  type: npm
+revisions:
+  2.3.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared licenses

**Details:**
Missing licenses

**Resolution:**
https://github.com/fitzgen/glob-to-regexp/blob/0.1.0/README.md#license
https://github.com/tj/node-growl/blob/v1.8.1/Readme.md#license
hamcrest-library: License.txt in package states BSD-3-Clause
https://github.com/hapijs/hawk/blob/v2.3.1/LICENSE


**Affected definitions**:
- [glob-to-regexp 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/glob-to-regexp/0.1.0),- [growl 1.8.1](https://clearlydefined.io/definitions/npm/npmjs/-/growl/1.8.1),- [hamcrest-library 1.3](https://clearlydefined.io/definitions/maven/mavencentral/org.hamcrest/hamcrest-library/1.3),- [hawk 2.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/hawk/2.3.1)