### PR TITLE
Declaring license

### DIFF
--- a/curations/maven/mavencentral/javax.servlet/servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/servlet-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: servlet-api
+  namespace: javax.servlet
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.5':
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
CDDL-1.0 is what is in the maven jar on the files.  There is no license declared on the POM.

**Resolution:**
This older version may also be under Apache 2.0, per the Eclipse Foundation who now manages the project. 

**Affected definitions**:
- [servlet-api 2.5](https://clearlydefined.io/definitions/maven/mavencentral/javax.servlet/servlet-api/2.5)