### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/flexboxgrid.yaml
+++ b/curations/npm/npmjs/-/flexboxgrid.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: flexboxgrid
+  provider: npmjs
+  type: npm
+revisions:
+  6.3.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://github.com/kristoferjoseph/flexboxgrid/blob/v6.3.1/LICENSE

**Affected definitions**:
- [flexboxgrid 6.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/flexboxgrid/6.3.1)