### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/hat.yaml
+++ b/curations/npm/npmjs/-/hat.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hat
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Declared in package.json: https://github.com/substack/node-hat/blob/c3f69995dd791e1b63e2439d1317d401f2e18054/package.json#L35

**Affected definitions**:
- [hat 0.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/hat/0.0.3)