### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/html-escape.yaml
+++ b/curations/npm/npmjs/-/html-escape.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: html-escape
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Public domain declared in package.json: https://github.com/parshap/html-escape/blob/0e42410116f02d7a9ee6cfdd18bd185e0f24eb89/package.json#L20

**Affected definitions**:
- [html-escape 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/html-escape/2.0.0)