### PR TITLE
Changed some NOASSERTIONS

### DIFF
--- a/curations/git/github/afarkas/html5shiv.yaml
+++ b/curations/git/github/afarkas/html5shiv.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: html5shiv
+  namespace: afarkas
+  provider: github
+  type: git
+revisions:
+  f65f9b0d776ae3b88d4c7f0b27c64e384aee47aa:
+    files:
+      - license: MIT OR GPL-2.0-only
+        path: dist/html5shiv-printshiv.js
+      - license: MIT OR GPL-2.0-only
+        path: src/html5shiv.js
+      - license: MIT OR GPL-2.0-only
+        path: dist/html5shiv.js
+      - license: MIT OR GPL-2.0-only
+        path: src/html5shiv-printshiv.js
+    licensed:
+      declared: MIT OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changed some NOASSERTIONS

**Details:**
Files such as /dist/html5shiv-printshiv.js and /dist/html5shiv.js are marked as NOASSERTION, but the contents of the files state they are dual-licensed under MIT and GPL

**Resolution:**
I have set the licenses to be MIT OR GPL 2.0 because the source files say they have those licenses (see https://github.com/aFarkas/html5shiv/blob/a6b1be53e3e49f93d6d218f52bb08f6a6f91bada/dist/html5shiv.js for example)

**Affected definitions**:
- [html5shiv f65f9b0d776ae3b88d4c7f0b27c64e384aee47aa](https://clearlydefined.io/definitions/git/github/afarkas/html5shiv/f65f9b0d776ae3b88d4c7f0b27c64e384aee47aa/f65f9b0d776ae3b88d4c7f0b27c64e384aee47aa)