### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -6,6 +6,9 @@ revisions:
   1.14.5:
     licensed:
       declared: BSD-3-Clause
+  1.16.2:
+    licensed:
+      declared: BSD-3-Clause
   1.17.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://numpy.org/license.html#license

**Affected definitions**:
- [numpy 1.16.2](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.16.2)