### PR TITLE
Missing declared license

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.woodstox/stax2-api.yaml
+++ b/curations/maven/mavencentral/org.codehaus.woodstox/stax2-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: stax2-api
+  namespace: org.codehaus.woodstox
+  provider: mavencentral
+  type: maven
+revisions:
+  3.1.4:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/sourcearchive/mavencentral/org.codehaus.woodstox/stax2-api.yaml
+++ b/curations/sourcearchive/mavencentral/org.codehaus.woodstox/stax2-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: stax2-api
+  namespace: org.codehaus.woodstox
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  3.1.4:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
License URL in pom is https://opensource.org/licenses/bsd-license.php. Couldn't find any other license info.

**Affected definitions**:
- [stax2-api 3.1.4](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.woodstox/stax2-api/3.1.4),- [stax2-api 3.1.4](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.codehaus.woodstox/stax2-api/3.1.4)