### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Pillow
+  provider: pypi
+  type: pypi
+revisions:
+  6.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
PIL: https://github.com/python-pillow/Pillow/blob/6.1.0/LICENSE

**Affected definitions**:
- [Pillow 6.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/6.1.0)