### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/thrift.yaml
+++ b/curations/pypi/pypi/-/thrift.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: thrift
+  provider: pypi
+  type: pypi
+revisions:
+  0.11.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Apache 2.0: https://github.com/apache/thrift/blob/0.11.0/LICENSE

**Affected definitions**:
- [thrift 0.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/thrift/0.11.0)