### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/subprocess32.yaml
+++ b/curations/pypi/pypi/-/subprocess32.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: subprocess32
+  provider: pypi
+  type: pypi
+revisions:
+  3.5.4:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Python-2.0: https://github.com/google/python-subprocess32/blob/3.5.4/LICENSE

**Affected definitions**:
- [subprocess32 3.5.4](https://clearlydefined.io/definitions/pypi/pypi/-/subprocess32/3.5.4)