### PR TITLE
Add Declared license from license link in nuspec

### DIFF
--- a/curations/nuget/nuget/-/xunit.analyzers.yaml
+++ b/curations/nuget/nuget/-/xunit.analyzers.yaml
@@ -3,6 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.10.0:
+    files:
+      - license: Apache-2.0
+        path: xunit.analyzers.nuspec
+    licensed:
+      declared: Apache-2.0
   0.7.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Declared license from license link in nuspec

**Details:**
nuspec and webpage link to Apachev2 here: https://raw.githubusercontent.com/xunit/xunit.analyzers/master/LICENSE

**Resolution:**
Added Apachev2.

**Affected definitions**:
- [xunit.analyzers 0.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.analyzers/0.10.0/0.10.0)