### PR TITLE
Specify license for vsls

### DIFF
--- a/curations/npm/npmjs/-/vsls.yaml
+++ b/curations/npm/npmjs/-/vsls.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: vsls
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.1291:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Specify license for vsls

**Details:**
Uses a EULA as a license and guidance in #114 says to set the license as "OTHER".

**Resolution:**
Sets the license to "OTHER".

**Affected definitions**:
- [vsls 0.3.1291](https://clearlydefined.io/definitions/npm/npmjs/-/vsls/0.3.1291/0.3.1291)