### PR TITLE
Updating Declared field

### DIFF
--- a/curations/git/github/microsoft/stl.yaml
+++ b/curations/git/github/microsoft/stl.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   447f879b136950baf3ca35dfb54c359494fa2a77:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 WITH LLVM-exception

--- a/curations/git/github/microsoft/stl.yaml
+++ b/curations/git/github/microsoft/stl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: stl
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  447f879b136950baf3ca35dfb54c359494fa2a77:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updating Declared field

**Details:**
The Declared field should say: Apache-2.0 WITH LLVM-exception, but I am having trouble inputting that in the UI.

**Resolution:**
SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

**Affected definitions**:
- [stl 447f879b136950baf3ca35dfb54c359494fa2a77](https://clearlydefined.io/definitions/git/github/microsoft/stl/447f879b136950baf3ca35dfb54c359494fa2a77/447f879b136950baf3ca35dfb54c359494fa2a77)