### PR TITLE
Curating Declared license

### DIFF
--- a/curations/pypi/pypi/-/sacremoses.yaml
+++ b/curations/pypi/pypi/-/sacremoses.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sacremoses
+  provider: pypi
+  type: pypi
+revisions:
+  0.0.35:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Curating Declared license

**Details:**
Per https://github.com/alvations/sacremoses/issues/7 , putting NONE as the "Declared" license.

**Resolution:**
See above

**Affected definitions**:
- [sacremoses 0.0.35](https://clearlydefined.io/definitions/pypi/pypi/-/sacremoses/0.0.35/0.0.35)