### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/busboy.yaml
+++ b/curations/npm/npmjs/-/busboy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: busboy
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.14:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://github.com/mscdex/busboy/blob/v0.2.14/LICENSE

**Affected definitions**:
- [busboy 0.2.14](https://clearlydefined.io/definitions/npm/npmjs/-/busboy/0.2.14)