### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/bytes.yaml
+++ b/curations/npm/npmjs/-/bytes.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.1.0:
+    licensed:
+      declared: MIT
   1.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://github.com/visionmedia/bytes.js/blob/88ef37c617a8890d17b45ad23584e9c7e28342b7/Readme.md#license

There is a tag in the source repo, but it isn't what was published for the package.  The tag is from July but the package was published in August with the above commit ID.

**Affected definitions**:
- [bytes 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/bytes/0.1.0)