### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/caseless.yaml
+++ b/curations/npm/npmjs/-/caseless.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.8.0:
+    licensed:
+      declared: Apache-2.0
   0.9.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing declared

**Resolution:**
Package states BSD, but which one is never declared. Per this conversation, it looks like it was supposed to Apache but was created incorrectly in the beginning so I am submitting Apache. https://github.com/request/caseless/issues/28

**Affected definitions**:
- [caseless 0.8.0](https://clearlydefined.io/definitions/npm/npmjs/-/caseless/0.8.0)