### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/chromium-pickle-js.yaml
+++ b/curations/npm/npmjs/-/chromium-pickle-js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: chromium-pickle-js
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
package.json states MIT: https://github.com/electron/node-chromium-pickle-js/blob/v0.2.0/package.json#L6

**Affected definitions**:
- [chromium-pickle-js 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/chromium-pickle-js/0.1.0)