### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/commondir.yaml
+++ b/curations/npm/npmjs/-/commondir.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: commondir
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
No commit on the published date. Went with commit that was a month prior that contains version bump. 
https://github.com/substack/node-commondir/blob/cb4107799110e2b42b03caeb36c9ddfcaccf3df1/package.json#L36

**Affected definitions**:
- [commondir 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/commondir/0.0.1)