### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/configstore.yaml
+++ b/curations/npm/npmjs/-/configstore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: configstore
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-2-Clause: https://github.com/yeoman/configstore/blob/v0.3.2/readme.md#license.

Also clarified in a later pull request: https://github.com/yeoman/configstore/pull/21/commits/e6fac72983db068718b1c6dc20b67696098b5609

**Affected definitions**:
- [configstore 0.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/configstore/0.3.2)