### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/crypto.yaml
+++ b/curations/npm/npmjs/-/crypto.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: crypto
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/Gozala/crypto/blob/v0.0.3/package.json#L27
License link: http://pajhome.org.uk/site/legal.html#bsdlicense

**Affected definitions**:
- [crypto 0.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/crypto/0.0.3)