### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/cssmin.yaml
+++ b/curations/npm/npmjs/-/cssmin.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cssmin
+  provider: npmjs
+  type: npm
+revisions:
+  0.4.3:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
package states BSD, https://github.com/jbleuzen/node-cssmin/blob/91bae16fc3cd5db42fef2c90726815f48420a5d6/README.md#license, but is later clarified to BSD-2-Clause. https://github.com/jbleuzen/node-cssmin/commit/41d9b6755f8c5c9638008f860a52a5e8423d1734 

**Affected definitions**:
- [cssmin 0.4.3](https://clearlydefined.io/definitions/npm/npmjs/-/cssmin/0.4.3)