### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/@microsoft/decorators.yaml
+++ b/curations/npm/npmjs/@microsoft/decorators.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: decorators
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.8.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Contains SharePoint Framework EULA in package contents. See also https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview#sharepoint-framework-license

**Affected definitions**:
- [decorators 1.8.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/decorators/1.8.2)