### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/escope.yaml
+++ b/curations/npm/npmjs/-/escope.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: escope
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.16:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://github.com/estools/escope/blob/0.0.16/LICENSE.BSD

**Affected definitions**:
- [escope 0.0.16](https://clearlydefined.io/definitions/npm/npmjs/-/escope/0.0.16)