### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/espree.yaml
+++ b/curations/npm/npmjs/-/espree.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: espree
+  provider: npmjs
+  type: npm
+revisions:
+  2.2.5:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://github.com/eslint/espree/blob/v2.2.5/LICENSE

**Affected definitions**:
- [espree 2.2.5](https://clearlydefined.io/definitions/npm/npmjs/-/espree/2.2.5)