### PR TITLE
Updating Declared License

### DIFF
--- a/curations/pypi/pypi/-/sacremoses.yaml
+++ b/curations/pypi/pypi/-/sacremoses.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.0.35:
     licensed:
-      declared: NONE
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Other

**Summary:**
Updating Declared License

**Details:**
I originally curated NONE per the Issue where the author noted he was purposefully leaving the license blank.  Since then though, the ReadMe states LGPL 2.1 or later https://github.com/alvations/sacremoses and the package description includes "LGPL" in the name (says "LGPL MosesTokenizer in Python")

**Resolution:**
Updating NONE to LGPL-2.1-or later.

**Affected definitions**:
- [sacremoses 0.0.35](https://clearlydefined.io/definitions/pypi/pypi/-/sacremoses/0.0.35/0.0.35)