### PR TITLE
Showing Incorrect Declared License

### DIFF
--- a/curations/git/github/tencent/rapidjson.yaml
+++ b/curations/git/github/tencent/rapidjson.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: MIT
   1a825d24fa322a5fe721624b2ed7a18b6de9b48a:
     licensed:
-      declared: ISC
+      declared: MIT

--- a/curations/git/github/tencent/rapidjson.yaml
+++ b/curations/git/github/tencent/rapidjson.yaml
@@ -7,3 +7,6 @@ revisions:
   17254e090e0dc3d5d1aca8efd6303cdbd07dbae1:
     licensed:
       declared: MIT
+  1a825d24fa322a5fe721624b2ed7a18b6de9b48a:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Showing Incorrect Declared License

**Details:**
Not sure why the Declared license is ISC.  Looks like MIT: https://github.com/Tencent/rapidjson/blob/1a825d24fa322a5fe721624b2ed7a18b6de9b48a/license.txt

**Resolution:**
Updating to MIT

**Affected definitions**:
- [rapidjson 1a825d24fa322a5fe721624b2ed7a18b6de9b48a](https://clearlydefined.io/definitions/git/github/tencent/rapidjson/1a825d24fa322a5fe721624b2ed7a18b6de9b48a/1a825d24fa322a5fe721624b2ed7a18b6de9b48a)