### PR TITLE
Changed the license from NOASSERTION to Apache 2.0

### DIFF
--- a/curations/git/github/javamoney/jsr354-ri.yaml
+++ b/curations/git/github/javamoney/jsr354-ri.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsr354-ri
+  namespace: javamoney
+  provider: github
+  type: git
+revisions:
+  b5903ced588feeac321ca22463c1867c6b462c76:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Changed the license from NOASSERTION to Apache 2.0

**Details:**
The license for this component was set to NOASSERTION, even though the documents show an Apache 2.0 license

**Resolution:**
I've set the license to Apache 2.0 since that's what the documentation shows (https://github.com/JavaMoney/jsr354-ri/blob/b5903ced588feeac321ca22463c1867c6b462c76/LICENSE.txt)

**Affected definitions**:
- [jsr354-ri b5903ced588feeac321ca22463c1867c6b462c76](https://clearlydefined.io/definitions/git/github/javamoney/jsr354-ri/b5903ced588feeac321ca22463c1867c6b462c76/b5903ced588feeac321ca22463c1867c6b462c76)