### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/@microsoft/loader-cased-file.yaml
+++ b/curations/npm/npmjs/@microsoft/loader-cased-file.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: loader-cased-file
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.8.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
SharePoint Framework EULA in EULA folder
**Affected definitions**:
- [loader-cased-file 1.8.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/loader-cased-file/1.8.2)