### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/esprima-fb.yaml
+++ b/curations/npm/npmjs/-/esprima-fb.yaml
@@ -9,3 +9,6 @@ revisions:
   15001.1.0-dev-harmony-fb:
     licensed:
       declared: BSD-2-Clause
+  3001.1.0-dev-harmony-fb:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-2-Clause: https://github.com/facebookarchive/esprima/blob/7f5bf884b68fbe283f1891df2a11e76502a4c272/LICENSE.BSD

**Affected definitions**:
- [esprima-fb 3001.1.0-dev-harmony-fb](https://clearlydefined.io/definitions/npm/npmjs/-/esprima-fb/3001.1.0-dev-harmony-fb)