### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/esquery.yaml
+++ b/curations/npm/npmjs/-/esquery.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: esquery
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/estools/esquery/blob/v1.0.0/license.txt

**Affected definitions**:
- [esquery 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/esquery/1.0.0)