### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/exports-loader.yaml
+++ b/curations/npm/npmjs/-/exports-loader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: exports-loader
+  provider: npmjs
+  type: npm
+revisions:
+  0.6.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT in README: https://github.com/webpack-contrib/exports-loader/blob/35184000279c00e105a3506aff164bfd81f8a476/README.md#license

**Affected definitions**:
- [exports-loader 0.6.3](https://clearlydefined.io/definitions/npm/npmjs/-/exports-loader/0.6.3)