### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/expose-loader.yaml
+++ b/curations/npm/npmjs/-/expose-loader.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.7.1:
+    licensed:
+      declared: MIT
   0.7.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT in README: https://github.com/webpack-contrib/expose-loader/blob/v0.7.1/README.md#license

**Affected definitions**:
- [expose-loader 0.7.1](https://clearlydefined.io/definitions/npm/npmjs/-/expose-loader/0.7.1)