### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/filesize.yaml
+++ b/curations/npm/npmjs/-/filesize.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: filesize
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/avoidwork/filesize.js/blob/2.0.4/LICENSE

**Affected definitions**:
- [filesize 2.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/filesize/2.0.4)