### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/grunt-contrib-concat.yaml
+++ b/curations/npm/npmjs/-/grunt-contrib-concat.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: grunt-contrib-concat
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
https://github.com/gruntjs/grunt-contrib-concat/blob/v0.5.1/LICENSE-MIT

**Affected definitions**:
- [grunt-contrib-concat 0.5.1](https://clearlydefined.io/definitions/npm/npmjs/-/grunt-contrib-concat/0.5.1)