### PR TITLE
Homepage and declared license was missing for infinispan-query-dsl

### DIFF
--- a/curations/sourcearchive/mavencentral/org.infinispan/infinispan-query-dsl.yaml
+++ b/curations/sourcearchive/mavencentral/org.infinispan/infinispan-query-dsl.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: infinispan-query-dsl
+  namespace: org.infinispan
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  10.0.1.Final:
+    described:
+      sourceLocation:
+        name: infinispan
+        namespace: infinispan
+        provider: github
+        revision: 2187dd8433a5916397b1ef235a2ca708e723866e
+        type: git
+        url: 'https://github.com/infinispan/infinispan/commit/2187dd8433a5916397b1ef235a2ca708e723866e'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Homepage and declared license was missing for infinispan-query-dsl

**Details:**
infinispan-query-dsl is sub-package of the infinispan. 

**Resolution:**
*homepage updated. (This is the whole package's homepage). the most appropriate homepage would be: https://github.com/infinispan/infinispan/tree/10.0.1.Final/query-dsl which is a sub-tree, but clrealy-defined does not allow this.
*Declared license updated

**Affected definitions**:
- [infinispan-query-dsl 10.0.1.Final](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.infinispan/infinispan-query-dsl/10.0.1.Final/10.0.1.Final)