### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/highcharts-react-official.yaml
+++ b/curations/npm/npmjs/-/highcharts-react-official.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: highcharts-react-official
+  provider: npmjs
+  type: npm
+revisions:
+  2.2.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Went with OTHER since the MIT license includes additional verbiage about requiring a HighCharts license for commercial use. If it should be something else, please update. https://github.com/highcharts/highcharts-react/blob/v2.2.2/LICENSE

**Affected definitions**:
- [highcharts-react-official 2.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-react-official/2.2.2)