### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/html-escape.yaml
+++ b/curations/npm/npmjs/-/html-escape.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: html-escape
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Public Domain: https://github.com/parshap/html-escape/blob/v2.0.0/package.json#L20

**Affected definitions**:
- [html-escape 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/html-escape/2.0.0)