### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/http-browserify.yaml
+++ b/curations/npm/npmjs/-/http-browserify.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: http-browserify
+  provider: npmjs
+  type: npm
+revisions:
+  1.7.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/browserify/http-browserify/blob/1.7.0/LICENSE

**Affected definitions**:
- [http-browserify 1.7.0](https://clearlydefined.io/definitions/npm/npmjs/-/http-browserify/1.7.0)