### PR TITLE
Add license info for recarpet 2.0.0b

### DIFF
--- a/curations/gem/rubygems/-/flyboy.yaml
+++ b/curations/gem/rubygems/-/flyboy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: flyboy
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.5:
+    licensed:
+      declared: ''

--- a/curations/gem/rubygems/-/redcarpet.yaml
+++ b/curations/gem/rubygems/-/redcarpet.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: redcarpet
+  provider: rubygems
+  type: gem
+revisions:
+  2.0.0b:
+    described:
+      releaseDate: '2011-12-04'
+      sourceLocation:
+        name: redcarpet
+        namespace: vmg
+        provider: github
+        revision: f62f3ebe208e7cb7aedff0be0e03d8d9f03c8425
+        type: git
+        url: 'https://github.com/vmg/redcarpet/commit/f62f3ebe208e7cb7aedff0be0e03d8d9f03c8425'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add license info for recarpet 2.0.0b

**Details:**
Missing declared license, source location, and version.

**Resolution:**
Adds the correct declared license (MIT) found in the project's readme, identifies the source location for the right release of the software.

**Affected definitions**:
- [flyboy 0.0.5](https://clearlydefined.io/definitions/gem/rubygems/-/flyboy/0.0.5),- [redcarpet 2.0.0b](https://clearlydefined.io/definitions/gem/rubygems/-/redcarpet/2.0.0b)