### PR TITLE
Missing declared license

### DIFF
--- a/curations/npm/npmjs/-/markdown.yaml
+++ b/curations/npm/npmjs/-/markdown.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: markdown
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/evilstreak/markdown-js/blob/v0.5.0/README.markdown#contributing

**Affected definitions**:
- [markdown 0.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/markdown/0.5.0)