### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -9,3 +9,6 @@ revisions:
   3.5.0:
     licensed:
       declared: Apache-2.0
+  4.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Apache 2.0: https://github.com/NuGet/NuGet.Client/blob/d4072ccfc11de9e0a345c61da8e2e0bc57a0614d/LICENSE.txt

**Affected definitions**:
- [NuGet.CommandLine 4.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.4.1/4.4.1)