### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/System.Net.Http.Formatting.Extension.yaml
+++ b/curations/nuget/nuget/-/System.Net.Http.Formatting.Extension.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Net.Http.Formatting.Extension
+  provider: nuget
+  type: nuget
+revisions:
+  5.2.3:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
None: no source repo, no license link, and no license information in package. 

**Affected definitions**:
- [System.Net.Http.Formatting.Extension 5.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/System.Net.Http.Formatting.Extension/5.2.3/5.2.3)