### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.481:
     licensed:
       declared: MIT
+  1.2.6:
+    licensed:
+      declared: MIT
   2.0.519:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/StackExchange/StackExchange.Redis/blob/1.2.6/LICENSE

**Affected definitions**:
- [StackExchange.Redis 1.2.6](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/1.2.6/1.2.6)