### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/ipaddress.yaml
+++ b/curations/pypi/pypi/-/ipaddress.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.22:
     licensed:
       declared: Python-2.0
+  1.0.23:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Python 2.0: https://github.com/phihag/ipaddress/blob/v1.0.23/LICENSE

**Affected definitions**:
- [ipaddress 1.0.23](https://clearlydefined.io/definitions/pypi/pypi/-/ipaddress/1.0.23/1.0.23)