### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.27:
     licensed:
       declared: MIT
+  1.0.29:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/Azure/azure-functions-vs-build-sdk/blob/2678a5df31d25ad4b5b2fe451f99eb664078d0f1/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.29](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.29/1.0.29)