### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Polly.Extensions.Http.yaml
+++ b/curations/nuget/nuget/-/Polly.Extensions.Http.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Polly.Extensions.Http
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/App-vNext/Polly.Extensions.Http/blob/34936cf3f202810285288b6a2134058a6e882aea/LICENSE.txt

**Affected definitions**:
- [Polly.Extensions.Http 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Polly.Extensions.Http/2.0.1/2.0.1)