### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/MicroBuild.Core.yaml
+++ b/curations/nuget/nuget/-/MicroBuild.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MicroBuild.Core
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
License link points to MIT: https://microsoft.mit-license.org

**Affected definitions**:
- [MicroBuild.Core 0.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/MicroBuild.Core/0.2.0/0.2.0)