### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -9,3 +9,6 @@ revisions:
   1.17.0:
     licensed:
       declared: BSD-3-Clause
+  1.17.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/numpy/numpy/blob/v1.17.2/LICENSE.txt

**Affected definitions**:
- [numpy 1.17.2](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.17.2/1.17.2)