### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSTest.TestAdapter
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/microsoft/testfx/blob/v2.0.0/LICENSE.txt

**Affected definitions**:
- [MSTest.TestAdapter 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestAdapter/2.0.0/2.0.0)