### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.24:
+    licensed:
+      declared: MIT
   1.0.27:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/Azure/azure-functions-vs-build-sdk/blob/41b908117c518bf7c9e3762fcfcaecafe3fe910e/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.24](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.24/1.0.24)