### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/CommonServiceLocator.yaml
+++ b/curations/nuget/nuget/-/CommonServiceLocator.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: MS-PL
   1.3.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MS-PL: Archive on codeplex states MS-PL and, after moving to GitHub, it is still MS-PL.
https://github.com/unitycontainer/commonservicelocator/blob/master/LICENSE

**Affected definitions**:
- [CommonServiceLocator 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommonServiceLocator/1.0.0/1.0.0)