### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pillow
+  provider: pypi
+  type: pypi
+revisions:
+  6.2.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Declaring "Other" for Python Imaging Library License

**Resolution:**
https://github.com/python-pillow/Pillow/blob/6.2.1/LICENSE

**Affected definitions**:
- [pillow 6.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/6.2.1/6.2.1)