### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/torch.yaml
+++ b/curations/pypi/pypi/-/torch.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.0:
     licensed:
-      declared: BSD-1-Clause
+      declared: BSD-3-Clause

--- a/curations/pypi/pypi/-/torch.yaml
+++ b/curations/pypi/pypi/-/torch.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: torch
+  provider: pypi
+  type: pypi
+revisions:
+  1.1.0:
+    licensed:
+      declared: BSD-1-Clause


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding BSD-3-Clause 

**Resolution:**
Followed version 1.2.0 which notes BSD-3-Clause on pypi.org page, clicked version Homepage which goes to https://pytorch.org/, has direct link to GitHub repo, searched license for 1.1.0 - https://github.com/pytorch/pytorch/blob/v1.1.0/LICENSE

**Affected definitions**:
- [torch 1.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/torch/1.1.0/1.1.0)