### PR TITLE
Missing Declared

### DIFF
--- a/curations/nuget/nuget/-/msbuild.ilmerge.task.yaml
+++ b/curations/nuget/nuget/-/msbuild.ilmerge.task.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: msbuild.ilmerge.task
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared

**Details:**
Set to MIT per license file in the download at https://archive.codeplex.com/?p=ilmergemsbuild - "Name":"The MIT License (MIT)","Text":"Copyright (c) 2013 Alexander Nosenko

**Resolution:**
Nuget link also says MIT

**Affected definitions**:
- [msbuild.ilmerge.task 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/msbuild.ilmerge.task/1.0.5/1.0.5)