### PR TITLE
Adding Declared license

### DIFF
--- a/curations/git/github/azure/azure-c-shared-utility.yaml
+++ b/curations/git/github/azure/azure-c-shared-utility.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: azure-c-shared-utility
+  namespace: azure
+  provider: github
+  type: git
+revisions:
+  1a6cb28931fa47680ee3189c02abf0658a2bda30:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
https://github.com/Azure/azure-c-shared-utility/blob/1a6cb28931fa47680ee3189c02abf0658a2bda30/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [azure-c-shared-utility 1a6cb28931fa47680ee3189c02abf0658a2bda30](https://clearlydefined.io/definitions/git/github/azure/azure-c-shared-utility/1a6cb28931fa47680ee3189c02abf0658a2bda30/1a6cb28931fa47680ee3189c02abf0658a2bda30)