### PR TITLE
Changing AND to OR

### DIFF
--- a/curations/git/github/eclipse/mosquitto.yaml
+++ b/curations/git/github/eclipse/mosquitto.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mosquitto
+  namespace: eclipse
+  provider: github
+  type: git
+revisions:
+  a26157643d01a9a985ae125df5031d3433ebe216:
+    licensed:
+      declared: BSD-3-Clause OR EPL-1.0


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Changing AND to OR

**Details:**
Dual licensed typically means OR

**Resolution:**
https://github.com/eclipse/mosquitto/blob/a26157643d01a9a985ae125df5031d3433ebe216/LICENSE.txt

**Affected definitions**:
- [mosquitto a26157643d01a9a985ae125df5031d3433ebe216](https://clearlydefined.io/definitions/git/github/eclipse/mosquitto/a26157643d01a9a985ae125df5031d3433ebe216/a26157643d01a9a985ae125df5031d3433ebe216)