### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/System.Net.Http.WinHttpHandler.yaml
+++ b/curations/nuget/nuget/-/System.Net.Http.WinHttpHandler.yaml
@@ -6,6 +6,9 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.5.0:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/dotnet/core/blob/master/LICENSE.TXT

**Affected definitions**:
- [System.Net.Http.WinHttpHandler 4.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Net.Http.WinHttpHandler/4.5.0/4.5.0)