### PR TITLE
Adding Declared License

### DIFF
--- a/curations/nuget/nuget/-/Bond.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.CSharp.yaml
@@ -7,13 +7,12 @@ revisions:
     described:
       releaseDate: '2015-02-13'
       sourceLocation:
+        name: bond
+        namespace: Microsoft
         provider: github
         revision: ee7f38245619e1fd690817918dcd05e05da263ab
         type: git
-        url: >-
-          https://github.com/Microsoft/bond/commit/ee7f38245619e1fd690817918dcd05e05da263ab
-        name: bond
-        namespace: Microsoft
+        url: 'https://github.com/Microsoft/bond/commit/ee7f38245619e1fd690817918dcd05e05da263ab'
     licensed:
       declared: MIT
   3.0.5:
@@ -23,13 +22,12 @@ revisions:
     described:
       releaseDate: '2015-04-28'
       sourceLocation:
+        name: bond
+        namespace: Microsoft
         provider: github
         revision: 1b0031f5041ddbc8a3492e5f866f19e0cedab8c8
         type: git
-        url: >-
-          https://github.com/Microsoft/bond/commit/1b0031f5041ddbc8a3492e5f866f19e0cedab8c8
-        name: bond
-        namespace: Microsoft
+        url: 'https://github.com/Microsoft/bond/commit/1b0031f5041ddbc8a3492e5f866f19e0cedab8c8'
     licensed:
       declared: MIT
   3.0.7:
@@ -57,5 +55,8 @@ revisions:
     licensed:
       declared: MIT
   8.0.0:
+    licensed:
+      declared: MIT
+  8.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
License link on NuGet goes to MIT https://github.com/Microsoft/bond/blob/master/LICENSE

**Resolution:**
This matches the repo license, as well. https://github.com/microsoft/bond/blob/fdfc1276d2953727005a68c02d37bd42f96962b8/LICENSE

**Affected definitions**:
- [Bond.CSharp 8.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.CSharp/8.1.0/8.1.0)