### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -12,3 +12,6 @@ revisions:
   3.0.0:
     licensed:
       declared: MIT
+  4.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v4.0.1/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/4.0.1/4.0.1)