### PR TITLE
Adding Declared License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -6,6 +6,9 @@ revisions:
   3.3.0:
     licensed:
       declared: Apache-2.0
+  3.5.0-beta2-1484:
+    licensed:
+      declared: Apache-2.0
   4.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
License link on NuGet site goes to Apache. https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Resolution:**
The license at the "Project Site" link is also Apache. 

**Affected definitions**:
- [NuGet.Versioning 3.5.0-beta2-1484](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/3.5.0-beta2-1484/3.5.0-beta2-1484)