### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Pipelines.Sockets.Unofficial.yaml
+++ b/curations/nuget/nuget/-/Pipelines.Sockets.Unofficial.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.7:
     licensed:
       declared: MIT
+  2.0.22:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/mgravell/Pipelines.Sockets.Unofficial/blob/2.0.22/LICENSE

**Affected definitions**:
- [Pipelines.Sockets.Unofficial 2.0.22](https://clearlydefined.io/definitions/nuget/nuget/-/Pipelines.Sockets.Unofficial/2.0.22/2.0.22)