### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
@@ -24,3 +24,6 @@ revisions:
   2.1.7:
     licensed:
       declared: MIT
+  3.0.0-preview6-27804-01:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [Microsoft.NETCore.App 3.0.0-preview6-27804-01](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App/3.0.0-preview6-27804-01/3.0.0-preview6-27804-01)