### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.core.yaml
+++ b/curations/nuget/nuget/-/xunit.core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: Apache-2.0
   2.2.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://github.com/xunit/xunit/commit/3a40411e1fa3066f84065b35d2f7865b199666a2)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [xunit.core 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.core/2.1.0/2.1.0)