### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -6,3 +6,6 @@ revisions:
   2.7.2:
     licensed:
       declared: NONE
+  2.8.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE)

**Resolution:**
Declared MIT

**Affected definitions**:
- [DocumentFormat.OpenXml 2.8.1](https://clearlydefined.io/definitions/nuget/nuget/-/DocumentFormat.OpenXml/2.8.1/2.8.1)