### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.Analyzers.Unstable.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.Unstable.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StyleCop.Analyzers.Unstable
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.1.61:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/c2dfa48b48/LICENSE) and here (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/LICENSE)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [StyleCop.Analyzers.Unstable 1.1.1.61](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.Analyzers.Unstable/1.1.1.61/1.1.1.61)