### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/SQLitePCLRaw.core.yaml
+++ b/curations/nuget/nuget/-/SQLitePCLRaw.core.yaml
@@ -6,6 +6,9 @@ revisions:
   1.1.11:
     licensed:
       declared: Apache-2.0
+  1.1.12:
+    licensed:
+      declared: Apache-2.0
   1.1.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://raw.githubusercontent.com/ericsink/SQLitePCL.raw/master/LICENSE.TXT) and here (https://github.com/ericsink/SQLitePCL.raw/blob/master/LICENSE.TXT)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [SQLitePCLRaw.core 1.1.12](https://clearlydefined.io/definitions/nuget/nuget/-/SQLitePCLRaw.core/1.1.12/1.1.12)