### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Cryptography.OpenSsl.yaml
+++ b/curations/nuget/nuget/-/System.Security.Cryptography.OpenSsl.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Security.Cryptography.OpenSsl
+  provider: nuget
+  type: nuget
+revisions:
+  4.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/dotnet/corefx/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [System.Security.Cryptography.OpenSsl 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Cryptography.OpenSsl/4.4.0/4.4.0)