### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/VsWhere.yaml
+++ b/curations/nuget/nuget/-/VsWhere.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VsWhere
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/microsoft/vswhere/blob/fb01ddad8121f68fee8f909e91fa23a642be85de/LICENSE.txt)

**Resolution:**
Declared MIT

**Affected definitions**:
- [VsWhere 2.3.7](https://clearlydefined.io/definitions/nuget/nuget/-/VsWhere/2.3.7/2.3.7)