### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: Apache-2.0
   2.2.0:
     described:
       releaseDate: '2017-02-20'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://github.com/xunit/xunit/blob/master/LICENSE)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [xunit.runner.visualstudio 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.visualstudio/2.1.0/2.1.0)