### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
@@ -36,3 +36,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE)

**Resolution:**
Declared MIT

**Affected definitions**:
- [Microsoft.ApplicationInsights.TraceListener 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener/2.2.0/2.2.0)