### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -96,6 +96,9 @@ revisions:
   4.8.2:
     licensed:
       declared: BSD-3-Clause
+  4.8.3:
+    licensed:
+      declared: BSD-3-Clause
   4.9.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Declared BSD-3-Clause found here (https://github.com/moq/moq4/blob/v4.8.3/License.txt)

**Resolution:**
Declared BSD-3-Clause

**Affected definitions**:
- [Moq 4.8.3](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.8.3/4.8.3)