### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/SQLitePCLRaw.provider.e_sqlite3.netstandard11.yaml
+++ b/curations/nuget/nuget/-/SQLitePCLRaw.provider.e_sqlite3.netstandard11.yaml
@@ -6,6 +6,9 @@ revisions:
   1.1.11:
     licensed:
       declared: Apache-2.0
+  1.1.12:
+    licensed:
+      declared: Apache-2.0
   1.1.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://github.com/ericsink/SQLitePCL.raw/blob/1.1.12/LICENSE.TXT)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [SQLitePCLRaw.provider.e_sqlite3.netstandard11 1.1.12](https://clearlydefined.io/definitions/nuget/nuget/-/SQLitePCLRaw.provider.e_sqlite3.netstandard11/1.1.12/1.1.12)