### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -24,6 +24,9 @@ revisions:
   2.2.1:
     licensed:
       declared: MIT
+  2.3.0:
+    licensed:
+      declared: MIT
   2.4.3:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/commandlineparser/commandline/blob/v2.3.0/License.md)

**Resolution:**
Declared MIT

**Affected definitions**:
- [CommandLineParser 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser/2.3.0/2.3.0)