### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
@@ -12,18 +12,20 @@ revisions:
     described:
       releaseDate: '2017-05-29'
       sourceLocation:
+        name: StyleCopAnalyzers
+        namespace: DotNetAnalyzers
         provider: github
         revision: 21559d870f78956a08d15e05ad1e52b445f8c2c9
         type: git
-        url: >-
-          https://github.com/DotNetAnalyzers/StyleCopAnalyzers/commit/21559d870f78956a08d15e05ad1e52b445f8c2c9
-        name: StyleCopAnalyzers
-        namespace: DotNetAnalyzers
+        url: 'https://github.com/DotNetAnalyzers/StyleCopAnalyzers/commit/21559d870f78956a08d15e05ad1e52b445f8c2c9'
     licensed:
       declared: Apache-2.0
   1.1.0-beta004:
     licensed:
       declared: Apache-2.0
   1.1.0-beta008:
+    licensed:
+      declared: Apache-2.0
+  1.1.0-beta009:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/1.1.0-beta009/LICENSE)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [StyleCop.Analyzers 1.1.0-beta009](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.Analyzers/1.1.0-beta009/1.1.0-beta009)