### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.Cookies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.Cookies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Security.Cookies
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://github.com/aspnet/AspNetKatana/blob/v4.0.1/LICENSE.txt)

**Resolution:**
Declared Apache-2.0

**Affected definitions**:
- [Microsoft.Owin.Security.Cookies 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.Cookies/4.0.1/4.0.1)