### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -28,6 +28,9 @@ revisions:
   11.0.2:
     licensed:
       declared: MIT
+  4.5.11:
+    licensed:
+      declared: MIT
   5.0.8:
     licensed:
       declared: MIT
@@ -37,10 +40,10 @@ revisions:
   6.0.4:
     licensed:
       declared: MIT
-  6.0.6:
+  6.0.5:
     licensed:
       declared: MIT
-  6.0.5:
+  6.0.6:
     licensed:
       declared: MIT
   6.0.8:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/JamesNK/Newtonsoft.Json) and the license here (https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md)

**Resolution:**
Declared MIT

**Affected definitions**:
- [Newtonsoft.Json 4.5.11](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.5.11/4.5.11)