### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/git/github/agershun/alasql.yaml
+++ b/curations/git/github/agershun/alasql.yaml
@@ -1,0 +1,22 @@
+coordinates:
+  name: alasql
+  namespace: agershun
+  provider: github
+  type: git
+revisions:
+  dc00c4dbf0346b78b56064f591e68b1834bbfa87:
+    files:
+      - license: OTHER
+        path: test/test237.js
+      - license: OTHER
+        path: test/test359.js
+      - attributions:
+          - '(c) 2005, 2013 jQuery Foundation, Inc.'
+        license: MIT
+        path: examples/simple/jquery.js
+      - license: MIT
+        path: lib/lodash/lodash.min.js
+      - attributions:
+          - '(c) 2005, 2014 jQuery Foundation, Inc.'
+        license: MIT
+        path: lib/jquery/jquery.min.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
The referenced files all had cases of NOASSERTION. Some are Transact-SQL sample code and other are minified code discovered to be under MIT license.

**Resolution:**
For the two files under /test/:
test237.js	
test359.js

Declare license as OTHER since I cannot find any license detail for sample code except the following limitation: https://docs.microsoft.com/en-ca/legal/termsofuse#personal-and-non-commercial-use-limitation

**Affected definitions**:
- [alasql dc00c4dbf0346b78b56064f591e68b1834bbfa87](https://clearlydefined.io/definitions/git/github/agershun/alasql/dc00c4dbf0346b78b56064f591e68b1834bbfa87)