### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/vswhere.yaml
+++ b/curations/nuget/nuget/-/vswhere.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: vswhere
+  provider: nuget
+  type: nuget
+revisions:
+  2.6.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/microsoft/vswhere/blob/91f4c1d09e2a88340fb30225798c0ce14f43b99d/LICENSE.txt

**Affected definitions**:
- [vswhere 2.6.7](https://clearlydefined.io/definitions/nuget/nuget/-/vswhere/2.6.7/2.6.7)