### PR TITLE
Changed from BSD-2-Clause to BSD-3-Clause

### DIFF
--- a/curations/pypi/pypi/-/prompt-toolkit.yaml
+++ b/curations/pypi/pypi/-/prompt-toolkit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: prompt-toolkit
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.9:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changed from BSD-2-Clause to BSD-3-Clause

**Details:**
Changed from BSD-2-Clause to BSD-3-Clause license found here (https://github.com/prompt-toolkit/python-prompt-toolkit/blob/2.0.9/LICENSE)

**Resolution:**
Changed from BSD-2-Clause to BSD-3-Clause

**Affected definitions**:
- [prompt-toolkit 2.0.9](https://clearlydefined.io/definitions/pypi/pypi/-/prompt-toolkit/2.0.9/2.0.9)