### PR TITLE
Changed from  OTHER (PIL Software License) to  HPND which is OSI approved

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   6.2.1:
     licensed:
-      declared: OTHER
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changed from  OTHER (PIL Software License) to  HPND which is OSI approved

**Details:**
Changed from OTHER (PIL Software License) HPND which is OSI approved found here (https://pypi.org/project/Pillow/6.2.1/) and  (https://pypi.org/search/?c=License+%3A%3A+OSI+Approved+%3A%3A+Historical+Permission+Notice+and+Disclaimer+%28HPND%29)

**Resolution:**
Changed from OTHER (PIL Software License) to HPND which is OSI approved

**Affected definitions**:
- [pillow 6.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/6.2.1/6.2.1)