### PR TITLE
Declared MIT

### DIFF
--- a/curations/pypi/pypi/-/vsts-cd-manager.yaml
+++ b/curations/pypi/pypi/-/vsts-cd-manager.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: vsts-cd-manager
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/microsoft/vsts-cd-manager/blob/master/LICENSE)

**Resolution:**
Declared MIT

**Affected definitions**:
- [vsts-cd-manager 1.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/vsts-cd-manager/1.0.2/1.0.2)