### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/cffi.yaml
+++ b/curations/pypi/pypi/-/cffi.yaml
@@ -6,3 +6,6 @@ revisions:
   1.12.3:
     licensed:
       declared: MIT
+  1.13.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://bitbucket.org/cffi/cffi/src/v1.13.1/LICENSE

**Affected definitions**:
- [cffi 1.13.1](https://clearlydefined.io/definitions/pypi/pypi/-/cffi/1.13.1/1.13.1)