### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/git/github/agershun/alasql.yaml
+++ b/curations/git/github/agershun/alasql.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: alasql
+  namespace: agershun
+  provider: github
+  type: git
+revisions:
+  dc00c4dbf0346b78b56064f591e68b1834bbfa87:
+    files:
+      - license: Apache-2.0
+        path: utils/closure/compiler.jar


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
File /utils/closure/compiler.jar was incorrectly discovered as "NOASSERTION".

It is actually a version of Google's Closure compiler which is licensed under Apache-2.0.

Did a file-level binary diff of discovered JAR against a official release closest to date of version discovered and found files are similar.

Discovered JAR Archive: https://github.com/agershun/alasql/blob/dc00c4dbf0346b78b56064f591e68b1834bbfa87/utils/closure/compiler.jar

Official Release JAR Archive: 
https://github.com/google/closure-compiler/wiki/Binary-Downloads#v20150609

Result of diff:
<img width="290" alt="2019-11-26_14-40-49" src="https://user-images.githubusercontent.com/31491646/69678594-e008de00-105a-11ea-8d8b-40657d65b93d.png">

**Resolution:**
Updated file declared license to "Apache-2.0" based on results from investigation.

**Affected definitions**:
- [alasql dc00c4dbf0346b78b56064f591e68b1834bbfa87](https://clearlydefined.io/definitions/git/github/agershun/alasql/dc00c4dbf0346b78b56064f591e68b1834bbfa87)