### PR TITLE
Declared MIT

### DIFF
--- a/curations/npm/npmjs/-/bitsyntax.yaml
+++ b/curations/npm/npmjs/-/bitsyntax.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: bitsyntax
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/squaremo/bitsyntax-js/blob/master/LICENSE)

**Resolution:**
Declared MIT

**Affected definitions**:
- [bitsyntax 0.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/bitsyntax/0.0.4/0.0.4)