### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -9,6 +9,9 @@ revisions:
   1.16.2:
     licensed:
       declared: BSD-3-Clause
+  1.16.3:
+    licensed:
+      declared: BSD-3-Clause
   1.17.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://numpy.org/license.html

**Affected definitions**:
- [numpy 1.16.3](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.16.3/1.16.3)