### PR TITLE
Adding Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.Cli.Utils.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.Cli.Utils.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.DotNet.Cli.Utils
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-preview2-003121:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
No license/project info on NuGet page.  

**Resolution:**
A search likely found the code here: https://github.com/dotnet/cli/tree/master/src/Microsoft.DotNet.Cli.Utils. It is under MIT.

**Affected definitions**:
- [Microsoft.DotNet.Cli.Utils 1.0.0-preview2-003121](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.Cli.Utils/1.0.0-preview2-003121/1.0.0-preview2-003121)