### PR TITLE
Curate source location

### DIFF
--- a/curations/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
+++ b/curations/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: amazon-kinesis-producer
+  namespace: com.amazonaws
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  0.12.11:
+    described:
+      sourceLocation:
+        name: amazon-kinesis-producer
+        namespace: awslabs
+        provider: github
+        revision: 123371ebced0b8df52b03539850978fb75675983
+        type: git
+        url: 'https://github.com/awslabs/amazon-kinesis-producer/commit/123371ebced0b8df52b03539850978fb75675983'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Curate source location

**Details:**
Source location as defined in pom.xml: 

https://clearlydefined.io/file/871b7d120c954761cb37f312b905c3199a9daa91254a003f80230fd6911bf8cc

**Resolution:**
Updated source location to appropriate version commit in accordance with information found under the project's Maven pom.xml file:

https://github.com/awslabs/amazon-kinesis-producer/tree/123371ebced0b8df52b03539850978fb75675983

**Affected definitions**:
- [amazon-kinesis-producer 0.12.11](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer/0.12.11)