### PR TITLE
Adding NONE

### DIFF
--- a/curations/nuget/nuget/-/jit-analyze.yaml
+++ b/curations/nuget/nuget/-/jit-analyze.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jit-analyze
+  provider: nuget
+  type: nuget
+revisions:
+  0.0.1.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding NONE

**Details:**
NuGet doesn't have any license info - https://www.nuget.org/packages/jit-analyze/0.0.1.1. 

**Resolution:**
May have found source, but the dates do not line up (https://github.com/dotnet/jitutils/tree/master/src/jit-analyze), so put NONE for the license for this unlisted package.

**Affected definitions**:
- [jit-analyze 0.0.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/jit-analyze/0.0.1.1/0.0.1.1)