### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
+++ b/curations/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
@@ -1,0 +1,66 @@
+coordinates:
+  name: amazon-kinesis-producer
+  namespace: com.amazonaws
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  0.12.11:
+    files:
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/DaemonException.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/Metric.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/KinesisProducer.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/UserRecordFailedException.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/KinesisProducerConfiguration.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/_ConfigTemplate.java
+      - attributions:
+          - 'Copyright 2018 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/HashedFileCopier.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/Attempt.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/IrrecoverableError.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/UserRecordResult.java
+      - attributions:
+          - 'Copyright 2016 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/FileAgeManager.java
+      - attributions:
+          - 'Copyright 2015 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/Daemon.java
+      - attributions:
+          - 'Copyright 2017 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/CertificateExtractor.java
+      - attributions:
+          - 'Copyright 2017 Amazon.com, Inc.'
+        license: OTHER
+        path: com/amazonaws/services/kinesis/producer/LogInputStreamReader.java
+      - license: OTHER
+        path: META-INF/LICENSE


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
All of the files referenced were incorrectly declared as "NOASSERTION".

They are actually all under Amazon Software License (ASL) which is not a valid SPDX license.

See: https://aws.amazon.com/asl/

**Resolution:**
Updated the declared license of all references files in accordance with their content/headers. Because the Amazon Software License is not a valid SPDX license, files were declared as "OTHER".

**Affected definitions**:
- [amazon-kinesis-producer 0.12.11](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer/0.12.11)