### PR TITLE
Resolve case of NOASSERTION

### DIFF
--- a/curations/maven/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
+++ b/curations/maven/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: amazon-kinesis-producer
+  namespace: com.amazonaws
+  provider: mavencentral
+  type: maven
+revisions:
+  0.12.11:
+    files:
+      - license: OTHER
+        path: META-INF/LICENSE


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of NOASSERTION

**Details:**
The files referenced were incorrectly declared as "NOASSERTION".

They are actually all under Amazon Software License (ASL) which is not a valid SPDX license.

See: https://aws.amazon.com/asl/

**Resolution:**
Updated the declared license of all references files in accordance with their content/headers. 

Because the Amazon Software License is not a valid SPDX license, files were declared as "OTHER".

**Affected definitions**:
- [amazon-kinesis-producer 0.12.11](https://clearlydefined.io/definitions/maven/mavencentral/com.amazonaws/amazon-kinesis-producer/0.12.11)