### PR TITLE
Update project's declared license

### DIFF
--- a/curations/maven/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
+++ b/curations/maven/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: amazon-kinesis-producer
+  namespace: com.amazonaws
+  provider: mavencentral
+  type: maven
+revisions:
+  0.12.11:
+    licensed:
+      declared: OTHER

--- a/curations/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
+++ b/curations/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: amazon-kinesis-producer
+  namespace: com.amazonaws
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  0.12.11:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Update project's declared license

**Details:**
The declared license for this project should actually be the Amazon Software License (ASL).

See: https://aws.amazon.com/asl/

Versions 0.13.0 and later are under Apache-2.0.

**Resolution:**
According to:
a) project's LICENSE.MD file: https://clearlydefined.io/file/5463e441fe0cfc09af3f7287dc5cbb254ce3389b3b08f75019eb23ae9944e3c2 

and b) project's Maven pom.xml file: 
https://clearlydefined.io/file/871b7d120c954761cb37f312b905c3199a9daa91254a003f80230fd6911bf8cc

The Amazon Software License is applicable. The Amazon Software License is not a valid SPDX license, so therefore "OTHER" is used.

**Affected definitions**:
- [amazon-kinesis-producer 0.12.11](https://clearlydefined.io/definitions/maven/mavencentral/com.amazonaws/amazon-kinesis-producer/0.12.11),- [amazon-kinesis-producer 0.12.11](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.amazonaws/amazon-kinesis-producer/0.12.11)