### PR TITLE
Missing Declared License

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.utility.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.utility.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xunit.runner.utility
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.1-pre.build.4059:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
Package license link and link on NuGet is the same and does not resolve. Package includes link to source repo and license in repo is Apache 2.0 - https://github.com/xunit/xunit/blob/master/LICENSE

**Affected definitions**:
- [xunit.runner.utility 2.4.1-pre.build.4059](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.utility/2.4.1-pre.build.4059/2.4.1-pre.build.4059)