### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Protocol.yaml
+++ b/curations/nuget/nuget/-/NuGet.Protocol.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Protocol
+  provider: nuget
+  type: nuget
+revisions:
+  4.9.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
Package includes link to this license on NuGet https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt, and source license is at https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt.

**Affected definitions**:
- [NuGet.Protocol 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Protocol/4.9.4/4.9.4)