### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.OpenIdConnect.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.OpenIdConnect.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Security.OpenIdConnect
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
Package license link and NuGet license is Apache 2.0 - https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt, and https://github.com/aspnet/AspNetKatana/blob/dev/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Security.OpenIdConnect 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.OpenIdConnect/4.0.1/4.0.1)