### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.DependencyResolver.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.DependencyResolver.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.DependencyResolver.Core
+  provider: nuget
+  type: nuget
+revisions:
+  3.5.0-beta2-1484:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Apache 2.0: https://github.com/NuGet/NuGet.Client/blob/3.5.0-beta2-final/LICENSE.txt

**Affected definitions**:
- [NuGet.DependencyResolver.Core 3.5.0-beta2-1484](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.DependencyResolver.Core/3.5.0-beta2-1484/3.5.0-beta2-1484)