### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.Runtime.win-x64.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.Runtime.win-x64.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETCore.App.Runtime.win-x64
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT)

**Resolution:**
Declared MIT

**Affected definitions**:
- [Microsoft.NETCore.App.Runtime.win-x64 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App.Runtime.win-x64/3.0.0/3.0.0)