### PR TITLE
Curating NOASSERTION on package.json

### DIFF
--- a/curations/npm/npmjs/-/html.yaml
+++ b/curations/npm/npmjs/-/html.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: html
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    files:
+      - license: BSD-3-Clause
+        path: package/package.json


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Curating NOASSERTION on package.json

**Details:**
Package.json says  "license": "BSD"

**Resolution:**
Per our guidelines, curating BSD-3-Clause for "BSD"

**Affected definitions**:
- [html 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/html/1.0.0/1.0.0)