### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.19.208020213:
+    licensed:
+      declared: Apache-2.0
   2.22.302111727:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.19.208020213:
     licensed:
-      declared: Apache-2.0
+      declared: MIT
   2.22.302111727:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Apache 2.0: https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/2.19.208020213/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 2.19.208020213](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/2.19.208020213/2.19.208020213)