### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -6,6 +6,9 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.8.0:
+    licensed:
+      declared: BSD-3-Clause
   3.9.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/protocolbuffers/protobuf/blob/v3.8.0/LICENSE

**Affected definitions**:
- [protobuf 3.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.8.0/3.8.0)