### PR TITLE
Adding Declared License

### DIFF
--- a/curations/nuget/nuget/-/xunit.assert.yaml
+++ b/curations/nuget/nuget/-/xunit.assert.yaml
@@ -27,3 +27,6 @@ revisions:
   2.4.1:
     licensed:
       declared: Apache-2.0
+  2.4.1-pre.build.4059:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
License link on NuGet doesn't go to an actual license file, so looked in source.

**Resolution:**
https://github.com/xunit/xunit/blob/2.4.1-pre-4059/license.txt

**Affected definitions**:
- [xunit.assert 2.4.1-pre.build.4059](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.assert/2.4.1-pre.build.4059/2.4.1-pre.build.4059)