### PR TITLE
Adding Declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -9,6 +9,9 @@ revisions:
   3.8.0:
     licensed:
       declared: BSD-3-Clause
+  3.9.0:
+    licensed:
+      declared: BSD-3-Clause
   3.9.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
Package metadata says BSD-3-Clause https://pypi.org/project/protobuf/3.9.0/

**Resolution:**
Matches source - https://github.com/protocolbuffers/protobuf/blob/6a59a2ad1f61d9696092f79b6d74368b4d7970a3/LICENSE

**Affected definitions**:
- [protobuf 3.9.0](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.9.0/3.9.0)