### PR TITLE
Adding Declared license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.ProjectModel.yaml
+++ b/curations/nuget/nuget/-/NuGet.ProjectModel.yaml
@@ -6,3 +6,6 @@ revisions:
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0
+  4.9.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
NuGet page goes to https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Resolution:**
Curate Apache

**Affected definitions**:
- [NuGet.ProjectModel 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.ProjectModel/4.9.4/4.9.4)