### PR TITLE
Adding Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Tokens.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Tokens.yaml
@@ -12,6 +12,9 @@ revisions:
   5.1.4:
     licensed:
       declared: MIT
+  5.1.5:
+    licensed:
+      declared: MIT
   5.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
No license on this version https://www.nuget.org/packages/Microsoft.IdentityModel.Tokens/5.1.5, but a later version says MIT https://www.nuget.org/packages/Microsoft.IdentityModel.Tokens/5.6.0

**Resolution:**
Curating MIT, per our guidelines

**Affected definitions**:
- [Microsoft.IdentityModel.Tokens 5.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Tokens/5.1.5/5.1.5)