### PR TITLE
Adding Declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -6,6 +6,9 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.7.1:
+    licensed:
+      declared: BSD-3-Clause
   3.8.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
Setup.py file says license='3-Clause BSD License'

**Resolution:**
Matches https://pypi.org/project/protobuf/3.7.1/

**Affected definitions**:
- [protobuf 3.7.1](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.7.1/3.7.1)