### PR TITLE
Adding Declared License

### DIFF
--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pywin32
+  provider: pypi
+  type: pypi
+revisions:
+  '227':
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared License

**Details:**
Package metadata says Python license https://pypi.org/project/pywin32/227/#description

**Resolution:**
Package file also says License: PSF

**Affected definitions**:
- [pywin32 227](https://clearlydefined.io/definitions/pypi/pypi/-/pywin32/227/227)