### PR TITLE
Adding Declared license

### DIFF
--- a/curations/nuget/nuget/-/AntiXSS.yaml
+++ b/curations/nuget/nuget/-/AntiXSS.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AntiXSS
+  provider: nuget
+  type: nuget
+revisions:
+  4.3.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
NuGet page says MS-PL

**Resolution:**
Download says The AntiXSS Library is licensed under the Microsoft Public License, an open source license the text of which can be read at http://www.microsoft.com/opensource/licenses.mspx

**Affected definitions**:
- [AntiXSS 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/AntiXSS/4.3.0/4.3.0)