### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
@@ -47,6 +47,9 @@ revisions:
   5.1.0:
     licensed:
       declared: MIT
+  5.2.0:
+    licensed:
+      declared: MIT
   5.3.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding MIT

**Resolution:**
Package file points to GitHub repo Master license which is same as v5.2.0 : https://github.com/microsoft/bond/blob/5.2.0/LICENSE

**Affected definitions**:
- [Bond.Runtime.CSharp 5.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Runtime.CSharp/5.2.0/5.2.0)