### PR TITLE
Resolve case of NOASSERTION

### DIFF
--- a/curations/git/github/alpinelinux/aports.yaml
+++ b/curations/git/github/alpinelinux/aports.yaml
@@ -13,7 +13,7 @@ revisions:
           - 'Copyright (c) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006 + Free Software Foundation, Inc.'
         license: BSD-3-Clause AND GPL-2.0-with-bison-exception
         path: unmaintained/webkitgtk/webkitgtk-2.0.4-bison-3.0.patch
-        - attributions:
+      - attributions:
           - Copyright (c) 2015 Bob Beck <beck@openbsd.org>
           - Copyright (c) 1995-1998 Eric Young (eay@cryptsoft.com)
           - Copyright (c) 2016 Tai Chi Minh Ralph Eastwood <tcmreastwood@gmail.com>
@@ -27,5 +27,5 @@ revisions:
       - attributions:
           - 'Copyright (c) 2012 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
           - 'Copyright (c) 2012, 2013 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
-        license: (GPL-3.0-only OR LGPL-2.1-only) OR (OTHER)
+        license: (GPL-3.0-only OR LGPL-2.1-only) OR OTHER
         path: main/qt/qt-aarch64.patch

--- a/curations/git/github/alpinelinux/aports.yaml
+++ b/curations/git/github/alpinelinux/aports.yaml
@@ -13,6 +13,7 @@ revisions:
           - 'Copyright (c) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006 + Free Software Foundation, Inc.'
         license: BSD-3-Clause AND GPL-2.0-with-bison-exception
         path: unmaintained/webkitgtk/webkitgtk-2.0.4-bison-3.0.patch
+        - attributions:
           - 'Copyright (c) 2012 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
           - 'Copyright (c) 2012, 2013 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
         license: (GPL-3.0-only OR LGPL-2.1-only) OR (OTHER )

--- a/curations/git/github/alpinelinux/aports.yaml
+++ b/curations/git/github/alpinelinux/aports.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: aports
+  namespace: alpinelinux
+  provider: github
+  type: git
+revisions:
+  b8229586a20eea5fc0f782a383ef666b6a60e054:
+    files:
+      - attributions:
+          - Copyright (c) 2012 The ANGLE Project
+          - Copyright (c) 2002-2012 The ANGLE Project
+          - Copyright (c) 2002-2010 The ANGLE Project
+          - 'Copyright (c) 1984, 1989, 1990, 2000, 2001, 2002, 2003, 2004, 2005, 2006 + Free Software Foundation, Inc.'
+        license: BSD-3-Clause AND GPL-2.0-with-bison-exception
+        path: unmaintained/webkitgtk/webkitgtk-2.0.4-bison-3.0.patch

--- a/curations/git/github/alpinelinux/aports.yaml
+++ b/curations/git/github/alpinelinux/aports.yaml
@@ -24,7 +24,7 @@ revisions:
           - 'Portions Copyright (c) 1995 by International Business Machines, Inc.'
         license: ISC AND OTHER
         path: main/netcat-openbsd/base64.c
-      - attributions:        
+      - attributions:
           - 'Copyright (c) 2012 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
           - 'Copyright (c) 2012, 2013 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
         license: (GPL-3.0-only OR LGPL-2.1-only) OR (OTHER)


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of NOASSERTION

**Details:**
License was incorrectly discovered as "BSD-3-Clause AND NOASSERTION."

BSD code is from https://github.com/mikolalysenko/angle

Starting on line # 3052, there is also some GPL-licensed code generated from Bison project.

**Resolution:**
Leave BSD-3-Clause as-is, although header says "BSD-style" license, it can be confirmed here as BSD-3-Clause https://github.com/mikolalysenko/angle/blob/master/LICENSE.

But the NOASSERTION should be changed to "GPL-2.0-with-bison-exception" given discovery of the Bison code.

**Affected definitions**:
- [aports b8229586a20eea5fc0f782a383ef666b6a60e054](https://clearlydefined.io/definitions/git/github/alpinelinux/aports/b8229586a20eea5fc0f782a383ef666b6a60e054)