### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/jQuery.Validation.yaml
+++ b/curations/nuget/nuget/-/jQuery.Validation.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.11.1:
+    licensed:
+      declared: MIT
   1.13.1:
     licensed:
       declared: MIT and BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
I wasn't sure if it should be MIT or NONE since the license isn't declared in the package or in a license URL. I went with MIT since it repackaged code from another project that is MIT.

**Affected definitions**:
- [jQuery.Validation 1.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.Validation/1.11.1/1.11.1)