### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CSharp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CSharp.yaml
@@ -12,3 +12,6 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- [Microsoft.CSharp 4.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CSharp/4.6.0/4.6.0)