### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/antlr4-python3-runtime.yaml
+++ b/curations/pypi/pypi/-/antlr4-python3-runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: antlr4-python3-runtime
+  provider: pypi
+  type: pypi
+revisions:
+  4.7.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: https://github.com/antlr/antlr4/blob/4.7.2/LICENSE.txt

The MIT license info looks to apply to the  JavaScript section, not the Python per this PR: https://github.com/antlr/antlr4/pull/1628/files

**Affected definitions**:
- [antlr4-python3-runtime 4.7.2](https://clearlydefined.io/definitions/pypi/pypi/-/antlr4-python3-runtime/4.7.2/4.7.2)