### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -21,6 +21,9 @@ revisions:
   1.4.6:
     licensed:
       declared: MS-PL
+  1.4.9:
+    licensed:
+      declared: MS-PL
   1.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MS-PL: https://htmlagilitypack.codeplex.com/license

**Affected definitions**:
- [HtmlAgilityPack 1.4.9](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.4.9/1.4.9)