### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -12,6 +12,9 @@ revisions:
   1.0.27:
     licensed:
       declared: MIT
+  1.0.28:
+    licensed:
+      declared: MIT
   1.0.29:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.28](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.28/1.0.28)