### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  3.7.4:
+    licensed:
+      declared: Python-2.0
   3.7.4.1:
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Python 2.0: https://github.com/python/typing/blob/3.7.4/typing_extensions/LICENSE

**Affected definitions**:
- [typing-extensions 3.7.4](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/3.7.4/3.7.4)