### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/git/github/alpinelinux/aports.yaml
+++ b/curations/git/github/alpinelinux/aports.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: aports
+  namespace: alpinelinux
+  provider: github
+  type: git
+revisions:
+  b8229586a20eea5fc0f782a383ef666b6a60e054:
+    files:
+      - attributions:
+          - 'Copyright (c) 2012 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
+          - 'Copyright (c) 2012, 2013 Digia Plc and/or its subsidiary(-ies). + Contact http://www.qt-project.org/legal'
+        license: (GPL-3.0-only OR LGPL-2.1-only) OR (OTHER )
+        path: main/qt/qt-aarch64.patch


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
This file includes Qt project code, starting on lines #80 and 168, which is dual-licensed under GPL-3.0 and LGPL-2.1.

It also mentions an exception to the LGPL, but I can't represent it in SPDX.

I believe it to be this but cannot verify: https://spdx.org/licenses/Qt-LGPL-exception-1.1.html

**Resolution:**
Declaring file license as SPDX: "GPL-3.0-only OR LGPL-2.1-only OR OTHER".

There are also mentions of commercial terms, OR one of the listed GPL licenses. Hence the "OTHER" being appropriate.

**Affected definitions**:
- [aports b8229586a20eea5fc0f782a383ef666b6a60e054](https://clearlydefined.io/definitions/git/github/alpinelinux/aports/b8229586a20eea5fc0f782a383ef666b6a60e054)