### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/DotNetSeleniumExtras.WaitHelpers.yaml
+++ b/curations/nuget/nuget/-/DotNetSeleniumExtras.WaitHelpers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetSeleniumExtras.WaitHelpers
+  provider: nuget
+  type: nuget
+revisions:
+  3.11.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding None

**Resolution:**
No license found in package and no GitHub source repo located.

**Affected definitions**:
- [DotNetSeleniumExtras.WaitHelpers 3.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetSeleniumExtras.WaitHelpers/3.11.0/3.11.0)