### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0.176:
     licensed:
       declared: MS-PL
+  2.1.0.178:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding MS-PL

**Resolution:**
License link in package and on NuGet is not working. GitHub repo license for closest version to 2.1.178 is 2.1.0.183 with MS-PL: https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v2.1.0.183/License.txt. License was changed after this version.

**Affected definitions**:
- [System.IO.Abstractions 2.1.0.178](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/2.1.0.178/2.1.0.178)