### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/NUnit.yaml
+++ b/curations/nuget/nuget/-/NUnit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.6.3:
+    licensed:
+      declared: Nunit
   2.6.4:
     licensed:
       declared: Zlib

--- a/curations/nuget/nuget/-/NUnit.yaml
+++ b/curations/nuget/nuget/-/NUnit.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: Nunit
   2.6.4:
     licensed:
-      declared: Zlib
+      declared: Nunit
   3.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding NUnit

**Resolution:**
ClearlyDefined license link references Zlib acknowledgement.

License in package and on NuGet is NUnit license.

**Affected definitions**:
- [NUnit 2.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/NUnit/2.6.3/2.6.3)