### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: MIT
   2.21.301221612:
     licensed:
-      declared: Apache-2.0
+      declared: MIT
   2.22.302111727:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -9,6 +9,9 @@ revisions:
   2.19.208020213:
     licensed:
       declared: MIT
+  2.21.301221612:
+    licensed:
+      declared: Apache-2.0
   2.22.302111727:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
Package license link leads to GitHub Master repo license which was changed after v.2.21.301221612. Closest timed release is 2.22.302111727 which is under Apache 2.0.

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 2.21.301221612](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/2.21.301221612/2.21.301221612)