### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.2:
+    licensed:
+      declared: MIT
   2.1.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding MIT

**Resolution:**
Package license links to GitHub master repo license which was updated in 2016 before this release to MIT: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.Protocols 2.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocols/2.1.2/2.1.2)