### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -15,6 +15,9 @@ revisions:
   2.23.302261847:
     licensed:
       declared: Apache-2.0
+  2.24.304111323:
+    licensed:
+      declared: Apache-2.0
   2.28.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -17,7 +17,7 @@ revisions:
       declared: Apache-2.0
   2.24.304111323:
     licensed:
-      declared: Apache-2.0
+      declared: MIT
   2.28.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
Package license link is GitHub repo master license. Apache 2.0 at time of this release - https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/v2.24.304111323/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 2.24.304111323](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/2.24.304111323/2.24.304111323)