### PR TITLE
Update declared license

### DIFF
--- a/curations/git/github/jenkinsci/analysis-model-api-plugin.yaml
+++ b/curations/git/github/jenkinsci/analysis-model-api-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: analysis-model-api-plugin
+  namespace: jenkinsci
+  provider: github
+  type: git
+revisions:
+  d65dccaedcb417b4b509e07ad520cba5c52c9a80:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update declared license

**Details:**
The declared license was originally discovered as NOASSERTION. However, upon further investigation of the project pom.xml file, we can see that the declared license should be MIT.

https://github.com/jenkinsci/analysis-model-api-plugin/blob/d65dccaedcb417b4b509e07ad520cba5c52c9a80/pom.xml

**Resolution:**
Update declared license to MIT.

**Affected definitions**:
- [analysis-model-api-plugin d65dccaedcb417b4b509e07ad520cba5c52c9a80](https://clearlydefined.io/definitions/git/github/jenkinsci/analysis-model-api-plugin/d65dccaedcb417b4b509e07ad520cba5c52c9a80)