### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -6,6 +6,9 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.6.1:
+    licensed:
+      declared: BSD-3-Clause
   3.7.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding BSD-3-Clause

**Resolution:**
ClearlyDefined package info includes BSD-3-Clause
License in package is BSD-3-Clause

GitHub source license: https://github.com/protocolbuffers/protobuf/blob/48cb18e5c419ddd23d9badcfe4e9df7bde1979b2/LICENSE

**Affected definitions**:
- [protobuf 3.6.1](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.6.1/3.6.1)