### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -15,3 +15,6 @@ revisions:
   4.0.1:
     licensed:
       declared: MIT
+  5.0.0-rc2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding MIT

**Resolution:**
License in package and on NuGet is MIT: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

GitHub project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.0.0-rc2/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 5.0.0-rc2](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.0.0-rc2/5.0.0-rc2)