### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Baseclass.Contrib.Nuget.Output.yaml
+++ b/curations/nuget/nuget/-/Baseclass.Contrib.Nuget.Output.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Baseclass.Contrib.Nuget.Output
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.7:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding NONE

**Resolution:**
All license links are broken. Package includes a file name MIT.txt but there's no license text

**Affected definitions**:
- [Baseclass.Contrib.Nuget.Output 1.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Baseclass.Contrib.Nuget.Output/1.0.7/1.0.7)