### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Logging.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Logging.yaml
@@ -12,6 +12,9 @@ revisions:
   1.1.4:
     licensed:
       declared: MIT
+  1.1.5:
+    licensed:
+      declared: MIT
   5.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
There is no license info, but previous and latter version are MIT. Source repo was also MIT at the time the package was published: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/a566fa80fe2338cea5400fa24303af87f0a35f63/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.Logging 1.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Logging/1.1.5/1.1.5)