### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -145,6 +145,9 @@ revisions:
         url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/9f4472ab6dff4fa74bddfa622da4ac3823beb4b8'
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.2.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/dev/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.1/5.2.1)