### PR TITLE
Adding Declared

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -6,3 +6,6 @@ revisions:
   1.10.4:
     licensed:
       declared: MIT and BSD-3-Clause
+  1.12.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared

**Details:**
NuGet license link says MIT and goes to https://jquery.org/license/

**Resolution:**
MIT

**Affected definitions**:
- [jQuery.UI.Combined 1.12.1](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.12.1/1.12.1)