### PR TITLE
Adding Declared

### DIFF
--- a/curations/nuget/nuget/-/MSBuild.Extension.Pack.yaml
+++ b/curations/nuget/nuget/-/MSBuild.Extension.Pack.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSBuild.Extension.Pack
+  provider: nuget
+  type: nuget
+revisions:
+  1.6.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared

**Details:**
The NuGet license link says MS-PL and the archive for this version has a license file that says MS-PL.

**Resolution:**
The current project is MIT, but given the above, I curated this version as MS-PL.

**Affected definitions**:
- [MSBuild.Extension.Pack 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuild.Extension.Pack/1.6.0/1.6.0)