### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/protobuf-net.yaml
+++ b/curations/nuget/nuget/-/protobuf-net.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.1.0:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-3-Clause
   2.4.0:
     licensed:
       declared: Apache-2.0 AND BSD-3-Clause

--- a/curations/nuget/nuget/-/protobuf-net.yaml
+++ b/curations/nuget/nuget/-/protobuf-net.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.0:
     licensed:
       declared: Apache-2.0
+  2.4.0:
+    licensed:
+      declared: Apache-2.0 AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Per license, declaring BSD-3-Clause for underlying code and Apache-2.0 for this .NET implementation.

**Resolution:**
https://github.com/protobuf-net/protobuf-net/blob/master/Licence.txt

**Affected definitions**:
- [protobuf-net 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/protobuf-net/2.4.0/2.4.0)