### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
@@ -9,3 +9,6 @@ revisions:
   0.15.0-build58334:
     licensed:
       declared: MIT
+  0.22.9-build00167:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link goes to MIT

**Resolution:**
MIT

**Affected definitions**:
- [Microsoft.ApplicationInsights.JavaScript 0.22.9-build00167](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript/0.22.9-build00167/0.22.9-build00167)