### PR TITLE
Declaring license

### DIFF
--- a/curations/npm/npmjs/-/source-map-loader.yaml
+++ b/curations/npm/npmjs/-/source-map-loader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: source-map-loader
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
package.json in ClearlyDefined files matches NPM registry - http://registry.npmjs.com/source-map-loader/0.1.5

**Resolution:**
licenses":[{"type":"MIT","url":"http://www.opensource.org/licenses/mit-license.php"}],

**Affected definitions**:
- [source-map-loader 0.1.5](https://clearlydefined.io/definitions/npm/npmjs/-/source-map-loader/0.1.5/0.1.5)