### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/StatsN.yaml
+++ b/curations/nuget/nuget/-/StatsN.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StatsN
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link matches repo 

**Resolution:**
https://raw.githubusercontent.com/TerribleDev/StatsN/master/LICENSE

**Affected definitions**:
- [StatsN 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/StatsN/1.2.1/1.2.1)