### PR TITLE
Declaring MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.EventHubs.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.EventHubs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.1:
+    licensed:
+      declared: MIT
   1.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring MIT

**Details:**
NuGet license link matches repo license

**Resolution:**
https://raw.githubusercontent.com/Azure/azure-event-hubs-dotnet/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.EventHubs 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.EventHubs/1.0.1/1.0.1)