### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.MSBuild.yaml
+++ b/curations/nuget/nuget/-/StyleCop.MSBuild.yaml
@@ -33,3 +33,9 @@ revisions:
   5.0.0:
     licensed:
       declared: MS-PL
+  6.1.0:
+    files:
+      - license: MS-PL
+        path: license.txt
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link and license file in ClearlyDefined are MS-PL

**Resolution:**
MS-PL

**Affected definitions**:
- [StyleCop.MSBuild 6.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.MSBuild/6.1.0/6.1.0)