### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -18,3 +18,6 @@ revisions:
   4.6.2:
     licensed:
       declared: Apache-2.0
+  4.9.4:
+    licensed:
+      declared: Apache-2.0      

--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -15,3 +15,6 @@ revisions:
   4.4.1:
     licensed:
       declared: Apache-2.0
+  4.6.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link and repo match

**Resolution:**
Apache 2.0

**Affected definitions**:
- [NuGet.CommandLine 4.6.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.6.2/4.6.2)