### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -21,6 +21,9 @@ revisions:
   1.4.6:
     licensed:
       declared: MS-PL
+  1.4.9.5:
+    licensed:
+      declared: MS-PL
   1.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
The NuGet license link says MS-PL.  Links to archive download from CodePlex.  Archive download license file is MS-PL.  

**Resolution:**
Current project is MIT, but based on above, curated MS-PL.

**Affected definitions**:
- [HtmlAgilityPack 1.4.9.5](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.4.9.5/1.4.9.5)