### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNetCore.OData
+  provider: nuget
+  type: nuget
+revisions:
+  7.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link goes to MIT https://raw.githubusercontent.com/OData/WebApi/master/License.txt

**Resolution:**
Matches license at Source link

**Affected definitions**:
- [Microsoft.AspNetCore.OData 7.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.OData/7.1.0/7.1.0)