### PR TITLE
Declaring license

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -3,6 +3,12 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  6.2.0:
+    files:
+      - license: HPND
+        path: Pillow-6.2.0/setup.py
+    licensed:
+      declared: HPND
   6.2.1:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Pypi page says HPND.  License and setup.py are HPND

**Resolution:**
HPND

**Affected definitions**:
- [pillow 6.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/6.2.0/6.2.0)