### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -31,6 +31,9 @@ revisions:
   4.5.11:
     licensed:
       declared: MIT
+  5.0.6:
+    licensed:
+      declared: MIT
   5.0.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
license on NuGet page is MIT

**Resolution:**
matches repo

**Affected definitions**:
- [Newtonsoft.Json 5.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/5.0.6/5.0.6)