### PR TITLE
Declaring OTHER

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.SqlServer.TransactSql.ScriptDom.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.TransactSql.ScriptDom.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.SqlServer.TransactSql.ScriptDom
+  provider: nuget
+  type: nuget
+revisions:
+  13.0.1700.77:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring OTHER

**Details:**
No license link or project link on NuGet page.  No license info on other versions.  Says its: NOTE: THIS IS NOT AN OFFICIAL MICROSOFT PACKAGE. And points to official package:https://www.nuget.org/packages/Microsoft.SqlServer.DacFx.x64/ 

**Resolution:**
Official package is under a EULA.  So curating OTHER for this NuGet, as well.  

**Affected definitions**:
- [Microsoft.SqlServer.TransactSql.ScriptDom 13.0.1700.77](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.SqlServer.TransactSql.ScriptDom/13.0.1700.77/13.0.1700.77)