### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.PerfCounterCollector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.PerfCounterCollector.yaml
@@ -45,6 +45,9 @@ revisions:
   2.2.0-beta1:
     licensed:
       declared: MIT
+  2.3.0:
+    licensed:
+      declared: MIT
   2.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
NuGet license link goes to MIT

**Resolution:**
MIT license in source

**Affected definitions**:
- [Microsoft.ApplicationInsights.PerfCounterCollector 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.PerfCounterCollector/2.3.0/2.3.0)