### PR TITLE
Resolve case of NOASSERTION

### DIFF
--- a/curations/git/github/bitnami-labs/sealed-secrets.yaml
+++ b/curations/git/github/bitnami-labs/sealed-secrets.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: sealed-secrets
+  namespace: bitnami-labs
+  provider: github
+  type: git
+revisions:
+  409536c8a43b8fde5ebfccde3d6e5cd36283c95e:
+    files:
+      - license: OTHER
+        path: vendor/golang.org/x/crypto/PATENTS


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of NOASSERTION

**Details:**
Google's Additional IP Rights Grant (Patents) but is not represented explicitly in SPDX (either as a license or an exception).

https://github.com/bitnami-labs/sealed-secrets/blob/409536c8a43b8fde5ebfccde3d6e5cd36283c95e/vendor/golang.org/x/crypto/PATENTS

**Resolution:**
Curate as "OTHER".

**Affected definitions**:
- [sealed-secrets 409536c8a43b8fde5ebfccde3d6e5cd36283c95e](https://clearlydefined.io/definitions/git/github/bitnami-labs/sealed-secrets/409536c8a43b8fde5ebfccde3d6e5cd36283c95e)