### PR TITLE
Declaring license

### DIFF
--- a/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
+++ b/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: paranamer
+  namespace: com.thoughtworks.paranamer
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.3':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
No license on pom.  Downloaded sources jar.  Individual files include a BSD-3-Clause in the header.

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [paranamer 2.3](https://clearlydefined.io/definitions/maven/mavencentral/com.thoughtworks.paranamer/paranamer/2.3/2.3)