### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/jQuery.Validation.yaml
+++ b/curations/nuget/nuget/-/jQuery.Validation.yaml
@@ -4,14 +4,26 @@ coordinates:
   type: nuget
 revisions:
   1.10.0:
+    files:
+      - license: BSD-3-Clause
+        path: jQuery.Validation.nuspec
     licensed:
       declared: MIT
   1.13.1:
+    files:
+      - license: BSD-3-Clause
+        path: jQuery.Validation.nuspec
     licensed:
-      declared: MIT and BSD-3-Clause
+      declared: MIT
   1.15.1:
+    files:
+      - license: BSD-3-Clause
+        path: jQuery.Validation.nuspec
     licensed:
-      declared: MIT and BSD-3-Clause
+      declared: MIT
   1.17.0:
+    files:
+      - license: BSD-3-Clause
+        path: jQuery.Validation.nuspec
     licensed:
-      declared: MIT and BSD-3-Clause
+      declared: MIT

--- a/curations/nuget/nuget/-/jQuery.Validation.yaml
+++ b/curations/nuget/nuget/-/jQuery.Validation.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.10.0:
+    licensed:
+      declared: MIT
   1.13.1:
     licensed:
       declared: MIT and BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet page does not have a license link.  Project site link says MIT

**Resolution:**
https://jqueryvalidation.org/

**Affected definitions**:
- [jQuery.Validation 1.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.Validation/1.10.0/1.10.0)