### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/MSBuild.Extension.Pack.yaml
+++ b/curations/nuget/nuget/-/MSBuild.Extension.Pack.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSBuild.Extension.Pack
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet page link says MS-PL

**Resolution:**
Links to codeplex.  Downloaded archive and the license file is MS-PL.

**Affected definitions**:
- [MSBuild.Extension.Pack 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuild.Extension.Pack/1.2.0/1.2.0)