### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/MessagePack.yaml
+++ b/curations/nuget/nuget/-/MessagePack.yaml
@@ -6,3 +6,6 @@ revisions:
   1.7.3.4:
     licensed:
       declared: MIT
+  1.7.3.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
No license link.  Project link goes to MIT.  More recent versions include MIT License link

**Resolution:**
MIT

**Affected definitions**:
- [MessagePack 1.7.3.7](https://clearlydefined.io/definitions/nuget/nuget/-/MessagePack/1.7.3.7/1.7.3.7)