### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.Platforms.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.Platforms.yaml
@@ -30,6 +30,9 @@ revisions:
   3.0.0:
     licensed:
       declared: MIT
+  3.0.0-preview7.19362.9:
+    licensed:
+      declared: MIT
   3.0.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
MIT license file in package contents.  NuGet license link goes to MIT.  Matches license at Source link.

**Resolution:**
MIT

**Affected definitions**:
- [Microsoft.NETCore.Platforms 3.0.0-preview7.19362.9](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.Platforms/3.0.0-preview7.19362.9/3.0.0-preview7.19362.9)