### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Unity.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Unity.Abstractions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Unity.Abstractions
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link and source repo say Apache

**Resolution:**
Apache v2

**Affected definitions**:
- [Unity.Abstractions 3.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Abstractions/3.3.1/3.3.1)