### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -6,3 +6,6 @@ revisions:
   12.1.2:
     licensed:
       declared: Apache-2.0 AND MS-PL
+  2.16.3:
+    licensed:
+      declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link goes to license that says it is dual licensed MS-PL or Apache 2.0

**Resolution:**
Matches Source link

**Affected definitions**:
- [CsvHelper 2.16.3](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/2.16.3/2.16.3)