### PR TITLE
Declaring license

### DIFF
--- a/curations/npm/npmjs/-/taffydb.yaml
+++ b/curations/npm/npmjs/-/taffydb.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: taffydb
+  provider: npmjs
+  type: npm
+revisions:
+  2.6.2:
+    licensed:
+      declared: BSD-1-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Opened an issue to clarify the license: https://github.com/typicaljoe/taffydb/issues/166.  The registry has no license info for this version (http://registry.npmjs.com/taffydb/2.6.2).  Package files includes taffy.js with BSD-1-Clause.

**Resolution:**
Curating BSD-1-Clause for now, pending resolution of the above issue.

**Affected definitions**:
- [taffydb 2.6.2](https://clearlydefined.io/definitions/npm/npmjs/-/taffydb/2.6.2/2.6.2)