### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETFramework.ReferenceAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-preview.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
Follow project link, and then package location, and it goes here https://dotnet.myget.org/feed/roslyn-tools/package/nuget/Microsoft.NETFramework.ReferenceAssemblies

**Resolution:**
Says:
License
MS-EULA 

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies 1.0.0-preview.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies/1.0.0-preview.2/1.0.0-preview.2)