### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/StatsN.Contracts.yaml
+++ b/curations/nuget/nuget/-/StatsN.Contracts.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StatsN.Contracts
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link goes to MIT

**Resolution:**
Matches Project link

**Affected definitions**:
- [StatsN.Contracts 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/StatsN.Contracts/1.2.1/1.2.1)