### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/git/github/microsoft/stl.yaml
+++ b/curations/git/github/microsoft/stl.yaml
@@ -7,3 +7,9 @@ revisions:
   447f879b136950baf3ca35dfb54c359494fa2a77:
     licensed:
       declared: Apache-2.0 WITH LLVM-exception
+  70e49a01568ea6b64cfc56c6baa8881dc992ff72:
+    files:
+      - license: Apache-2.0 WITH LLVM-exception
+        path: LICENSE.txt
+    licensed:
+      declared: Apache-2.0 AND NOASSERTION

--- a/curations/git/github/microsoft/stl.yaml
+++ b/curations/git/github/microsoft/stl.yaml
@@ -12,4 +12,4 @@ revisions:
       - license: Apache-2.0 WITH LLVM-exception
         path: LICENSE.txt
     licensed:
-      declared: Apache-2.0 AND NOASSERTION
+      declared: Apache-2.0 WITH LLVM-exception


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Updating NOASSERTION

**Details:**
Not sure if it worked, but trying to update the LICENSE file and Declared field to Apache-2.0 WITH LLVM-exception

**Resolution:**
Following the format here: https://spdx.org/licenses/exceptions-index.html.

**Affected definitions**:
- [stl 70e49a01568ea6b64cfc56c6baa8881dc992ff72](https://clearlydefined.io/definitions/git/github/microsoft/stl/70e49a01568ea6b64cfc56c6baa8881dc992ff72/70e49a01568ea6b64cfc56c6baa8881dc992ff72)