### PR TITLE
Updating NOASSERTION at file level

### DIFF
--- a/curations/pypi/pypi/-/antlr4-python2-runtime.yaml
+++ b/curations/pypi/pypi/-/antlr4-python2-runtime.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: antlr4-python2-runtime
+  provider: pypi
+  type: pypi
+revisions:
+  4.7.2:
+    files:
+      - license: BSD-3-Clause
+        path: antlr4-python2-runtime-4.7/setup.py
+      - license: BSD-3-Clause
+        path: antlr4-python2-runtime-4.7/PKG-INFO


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Updating NOASSERTION at file level

**Details:**
Updating NOASSERTION on setup.py and PKG-INFO to BSD-3-Clause

**Resolution:**
Both say BSD.  Antler is BSD-3-Clause (https://www.antlr.org/license.html)

**Affected definitions**:
- [antlr4-python2-runtime 4.7.2](https://clearlydefined.io/definitions/pypi/pypi/-/antlr4-python2-runtime/4.7.2/4.7.2)