### PR TITLE
Declared 

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
@@ -23,12 +23,15 @@ revisions:
   1.1.0-beta004:
     licensed:
       declared: Apache-2.0
+  1.1.0-beta006:
+    licensed:
+      declared: Apache-2.0
   1.1.0-beta008:
     licensed:
       declared: Apache-2.0
   1.1.0-beta009:
     licensed:
       declared: Apache-2.0
-  1.1.1-beta.61:      
+  1.1.1-beta.61:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared 

**Details:**
Apache 2.0 based off NuGet license info link

**Resolution:**
Apache 2.0

**Affected definitions**:
- [StyleCop.Analyzers 1.1.0-beta006](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.Analyzers/1.1.0-beta006/1.1.0-beta006)