### PR TITLE
Missing declared license

### DIFF
--- a/curations/maven/mavencentral/javax.xml.stream/stax-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.stream/stax-api.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: GPL-2.0-or-later OR CDDL-1.0
   1.0-2:
     licensed:
-      declared: GPL-3.0-only OR CDDL-1.0
+      declared: GPL-2.0-or-later OR CDDL-1.0

--- a/curations/maven/mavencentral/javax.xml.stream/stax-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.stream/stax-api.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.0':
     licensed:
       declared: GPL-2.0-or-later OR CDDL-1.0
+  1.0-2:
+    licensed:
+      declared: GPL-3.0-only OR CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Dual GPL and CDDL 1.0: https://repo1.maven.org/maven2/javax/xml/stream/stax-api/1.0-2/stax-api-1.0-2.pom

**Affected definitions**:
- [stax-api 1.0-2](https://clearlydefined.io/definitions/maven/mavencentral/javax.xml.stream/stax-api/1.0-2/1.0-2)