### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -21,3 +21,6 @@ revisions:
   3.9.1:
     licensed:
       declared: BSD-3-Clause
+  3.9.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
BSD-3-Clause:https://pypi.org/project/protobuf/3.9.2/

**Affected definitions**:
- [protobuf 3.9.2](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.9.2/3.9.2)