### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -6,6 +6,12 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.11.0:
+    licensed:
+      declared: BSD-3-Clause
+  3.11.1:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Declared BSD-3-Clause for both versions

**Affected definitions**:
- [protobuf 3.11.1](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.11.1)