### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/simplegeneric.yaml
+++ b/curations/pypi/pypi/-/simplegeneric.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: simplegeneric
+  provider: pypi
+  type: pypi
+revisions:
+  0.8.1:
+    licensed:
+      declared: ZPL-2.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
ZPL-2.1: Declared on pypi page and in PKG-INFO in the package contents

**Affected definitions**:
- [simplegeneric 0.8.1](https://clearlydefined.io/definitions/pypi/pypi/-/simplegeneric/0.8.1/0.8.1)