### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/RhinoMocks.yaml
+++ b/curations/nuget/nuget/-/RhinoMocks.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.6.0:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
No license specified for this version, but latest version point to https://github.com/meisinger/rhino-mocks, which has BSD-3-Clause: https://github.com/meisinger/rhino-mocks/blob/documentation/license.txt

**Affected definitions**:
- [RhinoMocks 3.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/RhinoMocks/3.6.0/3.6.0)