### PR TITLE
Updating declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -80,6 +80,9 @@ revisions:
   3.19.2:
     licensed:
       declared: MIT
+  3.19.3:
+    licensed:
+      declared: MIT
   3.19.4:
     licensed:
       declared: MIT
@@ -162,7 +165,7 @@ revisions:
       declared: MIT
   5.2.1:
     licensed:
-      declared: MIT     
+      declared: MIT
   5.2.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -172,3 +172,6 @@ revisions:
   5.2.3:
     licensed:
       declared: MIT
+  5.2.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Updating declared license

**Details:**
Updating NOASSERTION to MIT

**Resolution:**
MIT license per https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/dev/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 3.19.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/3.19.3/3.19.3)
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.4/5.2.4)