### PR TITLE
Adding declared licenses

### DIFF
--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -3,9 +3,15 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.5.0:
+    licensed:
+      declared: MIT
   2.7.2:
     licensed:
       declared: NONE
   2.8.1:
+    licensed:
+      declared: MIT
+  2.9.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Adding declared licenses

**Details:**
Adding declared licenses

**Resolution:**
2.5.0 doesn't contain license info but later versions, like 2.9.1, point to https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE and https://licenses.nuget.org/MIT, which are both MIT.

**Affected definitions**:
- [DocumentFormat.OpenXml 2.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/DocumentFormat.OpenXml/2.9.1)