### PR TITLE
Missing declared licenses

### DIFF
--- a/curations/pypi/pypi/-/pypiwin32.yaml
+++ b/curations/pypi/pypi/-/pypiwin32.yaml
@@ -6,3 +6,6 @@ revisions:
   '219':
     licensed:
       declared: Python-2.0
+  '223':
+    licensed:
+      declared: Python-2.0

--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  '224':
+    licensed:
+      declared: Python-2.0
   '225':
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared licenses

**Details:**
Missing licenses

**Resolution:**
Pywin32/224 states Python 2.0.

Pypiwin32/223 looks to be an alias of pywin32, which is Python 2.0. Previous version, 219, was declared Python 2.0. 

**Affected definitions**:
- [pypiwin32 223](https://clearlydefined.io/definitions/pypi/pypi/-/pypiwin32/223),- [pywin32 224](https://clearlydefined.io/definitions/pypi/pypi/-/pywin32/224)