### PR TITLE
Adding declared license

### DIFF
--- a/curations/pypi/pypi/-/typed-ast.yaml
+++ b/curations/pypi/pypi/-/typed-ast.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: typed-ast
+  provider: pypi
+  type: pypi
+revisions:
+  1.4.0:
+    licensed:
+      declared: Apache-2.0 AND Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Missing declared license

**Resolution:**
License file states files are under Apache 2.0 and Python 2.0. MIT license applies to a single file that is in the source repo, but couldn't find in the pypi package contents. 

**Affected definitions**:
- [typed-ast 1.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/typed-ast/1.4.0/1.4.0)