### PR TITLE
Declare MIT or GPL-3.0-only

### DIFF
--- a/curations/npm/npmjs/-/jszip.yaml
+++ b/curations/npm/npmjs/-/jszip.yaml
@@ -3,18 +3,21 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  2.5.0:
+    licensed:
+      declared: MIT OR GPL-3.0-only
   3.2.0:
     files:
       - license: MIT
         path: package/vendor/FileSaver.js
       - attributions:
-          - (c) 2009-2016 Stuart Knightley <stuart [at] stuartk.com>
+          - '(c) 2009-2016 Stuart Knightley <stuart [at] stuartk.com>'
         license: MIT OR GPL-3.0
         path: package/lib/license_header.js
       - license: NONE
         path: package/lib/zipEntry.js
       - attributions:
-              - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
+          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, Antonio Afonso'
         license: MIT OR GPL-3.0
         path: package/LICENSE.markdown
       - license: MIT OR GPL-3.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT or GPL-3.0-only

**Details:**
Declare MIT or GPL-3.0-only found here (https://github.com/Stuk/jszip/blob/v2.5.0/LICENSE.markdown)

**Resolution:**
Matches registry found here (http://registry.npmjs.com/jszip/2.5.0)

**Affected definitions**:
- [jszip 2.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/jszip/2.5.0/2.5.0)