### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/git/github/krb5/krb5.yaml
+++ b/curations/git/github/krb5/krb5.yaml
@@ -7,35 +7,39 @@ revisions:
   97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5:
     files:
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
-          - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
-        license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/authdata_dec.c
+          - 'Copyright 2013,2014 Red Hat, Inc.'
+          - 'Copyright 1990,1991,2001,2002,2004,2005,2007,2008 by the Massachusetts Institute of Technology.'
+        license: BSD-2-Clause AND OTHER
+        path: src/lib/krb5/os/sendto_kdc.c
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
-          - Copyright 1990 by the Massachusetts Institute of Technology.All Rights Reserved.
-        license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/copy_auth.c
+          - 'Copyright (c) 2006-2008, Novell, Inc.'
+          - 'Copyright (c) 1998 by the FundsXpress, INC.'
+          - 'Copyright 1993 by OpenVision Technologies, Inc.'
+        license: 'HPND-sell-variant AND BSD-3-Clause AND OTHER '
+        path: src/lib/gssapi/krb5/gssapi_krb5.c
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
-          - Copyright 1990 by the Massachusetts Institute of Technology.All Rights Reserved.
-        license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/authdata_enc.c
+          - Copyright (c) 2005 Marko Kreen
+          - 'Copyright (c) 2010, 2011 by the Massachusetts Institute of Technology.'
+        license: BSD-2-Clause AND OTHER
+        path: src/lib/crypto/krb/prng_fortuna.c
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
-          - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
+          - 'Copyright (c) 2004-2005, Novell, Inc.'
+          - 'Copyright (c) 1998 by the FundsXpress, INC.'
+          - '(c) Copyright 1990,1991, 1996, 2008 by the Massachusetts Institute of Technology.'
         license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/mk_rep.c
+        path: src/plugins/kdb/ldap/ldap_util/kdb5_ldap_util.c
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
-          - 'Copyright 1990-1998, 2009 by the Massachusetts Institute of Technology. All Rights Reserved.'
+          - 'Copyright (c) 2004-2005, Novell, Inc.'
+          - 'Copyright (c) 1998 by the FundsXpress, INC.'
+          - 'Copyright 1990,1991,2001, 2002, 2008 by the Massachusetts Institute of Technology.'
         license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/kfree.c
+        path: src/plugins/kdb/ldap/ldap_util/kdb5_ldap_realm.c
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
-          - 'Copyright 1990,1991 by the Massachusetts Institute of Technology. All Rights Reserved.'
+          - 'Copyright (c) 2006-2008, Novell, Inc.'
+          - 'Copyright (c) 1998 by the FundsXpress, INC.'
+          - 'Copyright 1995, 2003, 2007, 2009 by the Massachusetts Institute of Technology.'
         license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/rd_rep.c
+        path: src/kdc/kdc_preauth.c
       - attributions:
           - 'Copyright 2004 Sun Microsystems, Inc. All Rights Reserved.'
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'

--- a/curations/git/github/krb5/krb5.yaml
+++ b/curations/git/github/krb5/krb5.yaml
@@ -7,21 +7,51 @@ revisions:
   97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5:
     files:
       - attributions:
-          - 'Copyright 2013,2014 Red Hat, Inc.'
-          - 'Copyright 1990,1991,2001,2002,2004,2005,2007,2008 by the Massachusetts Institute of Technology.'
+          - Copyright (c) 2005 Marko Kreen
+          - 'Copyright (c) 2010, 2011 by the Massachusetts Institute of Technology.'
         license: BSD-2-Clause AND OTHER
-        path: src/lib/krb5/os/sendto_kdc.c
+        path: src/lib/crypto/krb/prng_fortuna.c
       - attributions:
           - 'Copyright (c) 2006-2008, Novell, Inc.'
           - 'Copyright (c) 1998 by the FundsXpress, INC.'
           - 'Copyright 1993 by OpenVision Technologies, Inc.'
         license: 'HPND-sell-variant AND BSD-3-Clause AND OTHER '
-        path: src/lib/gssapi/krb5/gssapi_krb5.c
+        path: src/lib/gssapi/krb5/gssapi_krb5.c    
       - attributions:
-          - Copyright (c) 2005 Marko Kreen
-          - 'Copyright (c) 2010, 2011 by the Massachusetts Institute of Technology.'
+          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
+          - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/krb5/krb/authdata_dec.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
+          - Copyright 1990 by the Massachusetts Institute of Technology.All Rights Reserved.
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/krb5/krb/copy_auth.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
+          - Copyright 1990 by the Massachusetts Institute of Technology.All Rights Reserved.
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/krb5/krb/authdata_enc.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
+          - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/krb5/krb/mk_rep.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
+          - 'Copyright 1990-1998, 2009 by the Massachusetts Institute of Technology. All Rights Reserved.'
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/krb5/krb/kfree.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
+          - 'Copyright 1990,1991 by the Massachusetts Institute of Technology. All Rights Reserved.'
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/krb5/krb/rd_rep.c    
+      - attributions:
+          - 'Copyright 2013,2014 Red Hat, Inc.'
+          - 'Copyright 1990,1991,2001,2002,2004,2005,2007,2008 by the Massachusetts Institute of Technology.'
         license: BSD-2-Clause AND OTHER
-        path: src/lib/crypto/krb/prng_fortuna.c
+        path: src/lib/krb5/os/sendto_kdc.c
       - attributions:
           - 'Copyright (c) 2004-2005, Novell, Inc.'
           - 'Copyright (c) 1998 by the FundsXpress, INC.'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
All of the referenced files captured by this curation have "MIT-no-advert-export" license (see: https://enterprise.dejacode.com/licenses/public/mit-no-advert-export-control/#license-text) which is not listed explicitly in SPDX, so "OTHER" is used instead.

**Resolution:**
In addition to the discovery of "MIT-no-advert-export" license mentioned above, some incorrectly discovered BSD findings were also found and corrected (i.e. discovered originally as BSD-2-Clause, but is actually  3-Clause).

**Affected definitions**:
- [krb5 97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5](https://clearlydefined.io/definitions/git/github/krb5/krb5/97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5/97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5)