### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/nuget/nuget/-/NLog.yaml
+++ b/curations/nuget/nuget/-/NLog.yaml
@@ -176,6 +176,9 @@ revisions:
   4.6.2:
     licensed:
       declared: BSD-3-Clause
+  4.6.7:
+    licensed:
+      declared: BSD-3-Clause
   5.0.0-beta05:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found here (https://github.com/NLog/NLog/blob/master/LICENSE.txt)

**Resolution:**
Matches source.

**Affected definitions**:
- [NLog 4.6.7](https://clearlydefined.io/definitions/nuget/nuget/-/NLog/4.6.7/4.6.7)