### PR TITLE
Declare BSD-2-Clause

### DIFF
--- a/curations/nuget/nuget/-/lz4net.yaml
+++ b/curations/nuget/nuget/-/lz4net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: lz4net
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.10.93:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-2-Clause

**Details:**
Declare BSD-2-Clause found here (https://github.com/MiloszKrajewski/lz4net/blob/master/LICENSE.md)

**Resolution:**
Matches source.

**Affected definitions**:
- [lz4net 1.0.10.93](https://clearlydefined.io/definitions/nuget/nuget/-/lz4net/1.0.10.93/1.0.10.93)