### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/Rx-Linq.yaml
+++ b/curations/nuget/nuget/-/Rx-Linq.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.30214:
+    licensed:
+      declared: Apache-2.0
   2.2.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/dotnet/reactive/blob/master/LICENSE)

**Resolution:**
Matches source.

**Affected definitions**:
- [Rx-Linq 2.1.30214](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Linq/2.1.30214/2.1.30214)