### PR TITLE
Declare ISC

### DIFF
--- a/curations/npm/npmjs/-/graceful-fs.yaml
+++ b/curations/npm/npmjs/-/graceful-fs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.1.14:
+    licensed:
+      declared: ISC
   1.2.3:
     files:
       - license: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare ISC

**Details:**
Declare ISC found here (https://github.com/isaacs/node-graceful-fs/blob/master/LICENSE)

**Resolution:**
matches source.

**Affected definitions**:
- [graceful-fs 1.1.14](https://clearlydefined.io/definitions/npm/npmjs/-/graceful-fs/1.1.14/1.1.14)