### PR TITLE
Declaring license and License file

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: AGPL-3.0 OR OTHER
   3.0.11:
     files:
-      - license: AGPL-3.0-or-later
+      - license: AGPL-3.0-or-later OR OTHER
         path: LICENSE.md
     licensed:
-      declared: AGPL-3.0-or-later
+      declared: AGPL-3.0-or-later OR OTHER

--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -6,3 +6,9 @@ revisions:
   3.0.10:
     licensed:
       declared: AGPL-3.0 OR OTHER
+  3.0.11:
+    files:
+      - license: AGPL-3.0-or-later
+        path: LICENSE.md
+    licensed:
+      declared: AGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license and License file

**Details:**
Not sure if this should be AGPL-3.0-only or -or-later.  The license file says "..either version 3 of the License," so I think it was supposed to be "either version 3...or later."

**Resolution:**
https://clearlydefined.io/file/304de4d159ae692655bbb038824c7675bbcf10541583b6fe1402198e7332eba0

**Affected definitions**:
- [Newtonsoft.Json.Schema 3.0.11](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json.Schema/3.0.11/3.0.11)