### PR TITLE
Declaring

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-common.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-common
+  namespace: org.glassfish.jersey.core
+  provider: mavencentral
+  type: maven
+revisions:
+  2.22.2:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-common.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-common.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.22.2:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.1
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Declaring

**Details:**
The tooling isn't letting me put GPL-2.0-only WITH Classpath-exception-2.0.  I updated the yaml.

**Resolution:**
https://javaee.github.io/glassfish/LICENSE

**Affected definitions**:
- [jersey-common 2.22.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.core/jersey-common/2.22.2/2.22.2)