### PR TITLE
Declaring

### DIFF
--- a/curations/nuget/nuget/-/PhantomJS.yaml
+++ b/curations/nuget/nuget/-/PhantomJS.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PhantomJS
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring

**Details:**
Declared license bsd-3-clause based off NuGet page license link

**Resolution:**
Matches source repo

**Affected definitions**:
- [PhantomJS 2.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/PhantomJS/2.1.1/2.1.1)