### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -6,6 +6,9 @@ revisions:
   1.14.5:
     licensed:
       declared: BSD-3-Clause
+  1.16.1:
+    licensed:
+      declared: BSD-3-Clause
   1.16.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Declared BSD-3-Clause found on the package page Meta section and in the license text

**Resolution:**
Declared BSD-3-Clause

**Affected definitions**:
- [numpy 1.16.1](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.16.1/1.16.1)