### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/Node.js.yaml
+++ b/curations/nuget/nuget/-/Node.js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Node.js
+  provider: nuget
+  type: nuget
+revisions:
+  5.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
NuGet license info link MIT

**Resolution:**
Source link MIT

**Affected definitions**:
- [Node.js 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Node.js/5.3.0/5.3.0)