### PR TITLE
Resolve cases of NOASSERTION

### DIFF
--- a/curations/git/github/krb5/krb5.yaml
+++ b/curations/git/github/krb5/krb5.yaml
@@ -18,6 +18,43 @@ revisions:
         license: GPL-3.0-or-later AND OTHER
         path: src/config/config.sub
       - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc.'
+          - 'Copyright 1993 by OpenVision Technologies, Inc.'
+        license: BSD-3-Clause AND HPND-sell-variant
+        path: src/lib/gssapi/krb5/inq_context.c
+      - attributions:
+          - Copyright (c) 2011 by the Massachusetts Institute of Technology.
+          - 'Copyright (c) 2007 Kungliga Tekniska Hogskolan (Royal Institute of Technology, Stockholm, Sweden).'
+          - 'Copyright 1993 by OpenVision Technologies, Inc.'
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/crypto/krb/t_fortuna.c
+      - attributions:
+          - Copyright (c) 2011 by the Massachusetts Institute of Technology.
+          - 'Copyright (c) 1995, 1996, 1997 Kungliga Tekniska Hogskolan (Royal Institute of Technology, Stockholm, Sweden).'
+        license: BSD-3-Clause AND OTHER
+        path: src/util/support/gettimeofday.c
+      - attributions:
+          - 'Copyright (c) 2002, 2016 by the Massachusetts Institute of Technology.'
+          - 'Copyright (c) 1990, 1993, 1994 The Regents of the University of California.'
+        license: BSD-4-Clause-UC AND OTHER
+        path: src/plugins/kdb/db2/libdb2/btree/bt_seq.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc.'
+          - 'Copyright 1993 by OpenVision Technologies, Inc.'
+        license: BSD-3-Clause AND HPND-sell-variant
+        path: src/lib/gssapi/krb5/inq_context.c
+      - attributions:
+          - Copyright (c) 2011 by the Massachusetts Institute of Technology.
+          - 'Copyright (c) 2007 Kungliga Tekniska Hogskolan (Royal Institute of Technology, Stockholm, Sweden).'
+          - 'Copyright 1993 by OpenVision Technologies, Inc.'
+        license: BSD-3-Clause AND OTHER
+        path: src/lib/crypto/krb/t_fortuna.c
+      - attributions:
+          - Copyright (c) 2011 by the Massachusetts Institute of Technology.
+          - 'Copyright (c) 1995, 1996, 1997 Kungliga Tekniska Hogskolan (Royal Institute of Technology, Stockholm, Sweden).'
+        license: BSD-3-Clause AND OTHER
+        path: src/util/support/gettimeofday.c
+      - attributions:
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
           - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
         license: BSD-3-Clause AND OTHER
@@ -26,12 +63,12 @@ revisions:
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
           - Copyright 1990 by the Massachusetts Institute of Technology.All Rights Reserved.
         license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/copy_auth.c
+        path: src/lib/krb5/krb/authdata_enc.c
       - attributions:
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
           - Copyright 1990 by the Massachusetts Institute of Technology.All Rights Reserved.
         license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/authdata_enc.c
+        path: src/lib/krb5/krb/copy_auth.c
       - attributions:
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
           - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
@@ -92,3 +129,14 @@ revisions:
           - 'Copyright 1990, 1991, 2001, 2007, 2008, 2009, 2013, 2014 by the Massachusetts Institute of Technology. All Rights Reserved.'
         license: BSD-3-Clause AND OTHER
         path: src/kdc/do_tgs_req.c
+      - attributions:
+          - Copyright (c) 2005 Marko Kreen
+          - 'Copyright (c) 2010, 2011 by the Massachusetts Institute of Technology.'
+        license: BSD-2-Clause AND OTHER
+        path: src/lib/crypto/krb/prng_fortuna.c
+      - attributions:
+          - 'Copyright (c) 2006-2008, Novell, Inc.'
+          - 'Copyright (c) 1998 by the FundsXpress, INC.'
+          - 'Copyright 1993 by OpenVision Technologies, Inc.'
+        license: 'HPND-sell-variant AND BSD-3-Clause AND OTHER '
+        path: src/lib/gssapi/krb5/gssapi_krb5.c

--- a/curations/git/github/krb5/krb5.yaml
+++ b/curations/git/github/krb5/krb5.yaml
@@ -7,16 +7,16 @@ revisions:
   97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5:
     files:
       - attributions:
-          - Copyright (c) 2005 Marko Kreen
+          - 'Copyright 1992-2018 Free Software Foundation, Inc.'
           - 'Copyright (c) 2010, 2011 by the Massachusetts Institute of Technology.'
-        license: BSD-2-Clause AND OTHER
-        path: src/lib/crypto/krb/prng_fortuna.c
+        license: GPL-3.0-or-later AND OTHER
+        path: src/config/config.guess
       - attributions:
-          - 'Copyright (c) 2006-2008, Novell, Inc.'
+          - 'Copyright 1992-2018 Free Software Foundation, Inc.'
           - 'Copyright (c) 1998 by the FundsXpress, INC.'
           - 'Copyright 1993 by OpenVision Technologies, Inc.'
-        license: 'HPND-sell-variant AND BSD-3-Clause AND OTHER '
-        path: src/lib/gssapi/krb5/gssapi_krb5.c    
+        license: GPL-3.0-or-later AND OTHER
+        path: src/config/config.sub
       - attributions:
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
           - Copyright 1990 by the Massachusetts Institute of Technology. All Rights Reserved.
@@ -46,7 +46,7 @@ revisions:
           - 'Copyright (c) 2006-2008, Novell, Inc. All Rights Reserved.'
           - 'Copyright 1990,1991 by the Massachusetts Institute of Technology. All Rights Reserved.'
         license: BSD-3-Clause AND OTHER
-        path: src/lib/krb5/krb/rd_rep.c    
+        path: src/lib/krb5/krb/rd_rep.c
       - attributions:
           - 'Copyright 2013,2014 Red Hat, Inc.'
           - 'Copyright 1990,1991,2001,2002,2004,2005,2007,2008 by the Massachusetts Institute of Technology.'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve cases of NOASSERTION

**Details:**
The following files are indentified incorrectly as NOASSERTION.

src/config/config.sub

src/config/config.guess

**Resolution:**
Both files actually contain "GPL-3.0-or-later-WITH-autoconf-simple-exception". autoconf-simple-exception is not represented in SPDX at this moment, so will curate this portion as "OTHER".

**Affected definitions**:
- [krb5 97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5](https://clearlydefined.io/definitions/git/github/krb5/krb5/97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5/97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5)