### PR TITLE
Declared

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: aopalliance-repackaged
+  namespace: org.glassfish.hk2.external
+  provider: mavencentral
+  type: maven
+revisions:
+  2.4.0-b34:
+    licensed:
+      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.4.0-b34:
     licensed:
-      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
Should be "GPL-2.0-only WITH Classpath-exception-2.0" - http://central.maven.org/maven2/org/glassfish/hk2/external/aopalliance-repackaged/2.4.0-b34/aopalliance-repackaged-2.4.0-b34.pom

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [aopalliance-repackaged 2.4.0-b34](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b34/2.4.0-b34)