### PR TITLE
Declared

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-client.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-client.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.22.2:
     licensed:
-      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-client.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-client.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-client
+  namespace: org.glassfish.jersey.core
+  provider: mavencentral
+  type: maven
+revisions:
+  2.22.2:
+    licensed:
+      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
http://central.maven.org/maven2/org/glassfish/jersey/core/jersey-client/2.22.2/jersey-client-2.22.2.pom

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1

**Affected definitions**:
- [jersey-client 2.22.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.core/jersey-client/2.22.2/2.22.2)