### PR TITLE
Declared license

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-container-servlet
+  namespace: org.glassfish.jersey.containers
+  provider: mavencentral
+  type: maven
+revisions:
+  2.22.2:
+    licensed:
+      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.22.2:
     licensed:
-      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
http://central.maven.org/maven2/org/glassfish/jersey/containers/jersey-container-servlet/2.22.2/jersey-container-servlet-2.22.2.pom

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1

**Affected definitions**:
- [jersey-container-servlet 2.22.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.containers/jersey-container-servlet/2.22.2/2.22.2)