### PR TITLE
Declared license

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-server
+  namespace: org.glassfish.jersey.core
+  provider: mavencentral
+  type: maven
+revisions:
+  2.22.2:
+    licensed:
+      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.22.2:
     licensed:
-      declared: GPL-2.0-with-classpath-exception OR CDDL-1.1
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
http://central.maven.org/maven2/org/glassfish/jersey/core/jersey-server/2.22.2/jersey-server-2.22.2.pom

**Resolution:**
Correct format: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1

**Affected definitions**:
- [jersey-server 2.22.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.core/jersey-server/2.22.2/2.22.2)