### PR TITLE
Declaring license

### DIFF
--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -6,6 +6,9 @@ revisions:
   '225':
     licensed:
       declared: Python-2.0
+  '226':
+    licensed:
+      declared: Python-2.0 AND BSD-3-Clause
   '227':
     licensed:
       declared: Python-2.0


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Declaring license

**Details:**
The Pypi package meta data states the license is PSF - https://pypi.org/project/pywin32/226/.  However, inside the package and as listed on the setup.py file, there are 3 license.txt in the package.  All the same BSD-3-Clause license.  It may be that the "Declared" license should only be the Python Software Foundation license?

**Resolution:**
https://github.com/mhammond/pywin32/blob/master/setup.py -- 'pythonwin/license.txt', 'win32/license.txt', win32com', ('com/License.txt' (as well as, 'License :: OSI Approved :: Python Software Foundation License',).

**Affected definitions**:
- [pywin32 226](https://clearlydefined.io/definitions/pypi/pypi/-/pywin32/226/226)