### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/SQLitePCLRaw.lib.e_sqlite3.v110_xp.yaml
+++ b/curations/nuget/nuget/-/SQLitePCLRaw.lib.e_sqlite3.v110_xp.yaml
@@ -9,6 +9,9 @@ revisions:
   1.1.12:
     licensed:
       declared: Apache-2.0
+  1.1.2:
+    licensed:
+      declared: Apache-2.0
   1.1.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://raw.githubusercontent.com/ericsink/SQLitePCL.raw/master/LICENSE.TXT)

**Resolution:**
matches project site

**Affected definitions**:
- [SQLitePCLRaw.lib.e_sqlite3.v110_xp 1.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/SQLitePCLRaw.lib.e_sqlite3.v110_xp/1.1.2/1.1.2)