### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  3.7.2:
+    licensed:
+      declared: Python-2.0
   3.7.4:
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Python 2.0

**Resolution:**
Pypi.org meta is Python 2.0, license reference on ClearlyDefined, and in GitHub repo as final check.

**Affected definitions**:
- [typing-extensions 3.7.2](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/3.7.2/3.7.2)