### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/System.Interactive.Async.yaml
+++ b/curations/nuget/nuget/-/System.Interactive.Async.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.0.0:
+    licensed:
+      declared: Apache-2.0
   3.1.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT)

**Resolution:**
Matches Project Site

**Affected definitions**:
- [System.Interactive.Async 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Interactive.Async/3.0.0/3.0.0)