### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
@@ -6,3 +6,6 @@ revisions:
   3.6.1:
     licensed:
       declared: BSD-3-Clause
+  3.7.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found here (https://github.com/protocolbuffers/protobuf/blob/master/LICENSE)

**Resolution:**
Matches Project Site

**Affected definitions**:
- [Google.Protobuf.Tools 3.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf.Tools/3.7.0/3.7.0)