### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.abstractions.yaml
+++ b/curations/nuget/nuget/-/xunit.abstractions.yaml
@@ -27,6 +27,9 @@ revisions:
         url: 'https://github.com/xunit/xunit/commit/2671cc4378301e0fa0ac51e530f19530af565016'
     licensed:
       declared: Apache-2.0
+  2.0.1-rc2:
+    licensed:
+      declared: Apache-2.0
   2.0.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/xunit/xunit/blob/master/LICENSE)

**Resolution:**
Found in Project Site

**Affected definitions**:
- [xunit.abstractions 2.0.1-rc2](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.abstractions/2.0.1-rc2/2.0.1-rc2)