### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.yaml
@@ -10,13 +10,15 @@ revisions:
     described:
       releaseDate: '2016-11-21'
       sourceLocation:
+        name: Rx.NET
+        namespace: Reactive-Extensions
         provider: github
         revision: e0b6af3e204feb8aa13841a8a873d78ae6c43467
         type: git
-        url: >-
-          https://github.com/Reactive-Extensions/Rx.NET/commit/e0b6af3e204feb8aa13841a8a873d78ae6c43467
-        name: Rx.NET
-        namespace: Reactive-Extensions
+        url: 'https://github.com/Reactive-Extensions/Rx.NET/commit/e0b6af3e204feb8aa13841a8a873d78ae6c43467'
+    licensed:
+      declared: Apache-2.0
+  4.0.0:
     licensed:
       declared: Apache-2.0
   4.1.0:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/dotnet/reactive/blob/master/LICENSE)

**Resolution:**
Matches Project Site

**Affected definitions**:
- [System.Reactive 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive/4.0.0/4.0.0)