### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -11,3 +11,6 @@ revisions:
       releaseDate: '2015-08-26'
     licensed:
       declared: Apache-2.0
+  106.6.9:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/restsharp/RestSharp/blob/master/LICENSE.txt)

**Resolution:**
Matches source repository 

**Affected definitions**:
- [RestSharp 106.6.9](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/106.6.9/106.6.9)