### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -6,6 +6,9 @@ revisions:
   3.3.0:
     licensed:
       declared: Apache-2.0
+  3.5.0-beta-final:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt)

**Resolution:**
Matches project site

**Affected definitions**:
- [NuGet.Versioning 3.5.0-beta-final](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/3.5.0-beta-final/3.5.0-beta-final)