### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/vswhere.yaml
+++ b/curations/nuget/nuget/-/vswhere.yaml
@@ -6,6 +6,9 @@ revisions:
   2.2.11:
     licensed:
       declared: MIT
+  2.5.2:
+    licensed:
+      declared: MIT
   2.6.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/microsoft/vswhere/blob/ebb9f26a3d3355598a9e5c97deec05a3717ead41/LICENSE.txt)

**Resolution:**
Matches Project Site

**Affected definitions**:
- [vswhere 2.5.2](https://clearlydefined.io/definitions/nuget/nuget/-/vswhere/2.5.2/2.5.2)