### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Web.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Web.yaml
@@ -27,6 +27,9 @@ revisions:
   2.5.1:
     licensed:
       declared: MIT
+  2.6.4:
+    licensed:
+      declared: MIT
   2.7.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License

**Details:**
Declaring license as MIT

**Resolution:**
Per NuGet license link https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE (and repo)

**Affected definitions**:
- [Microsoft.ApplicationInsights.Web 2.6.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.Web/2.6.4/2.6.4)