### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/maven/mavencentral/org.json4s/json4s-core_2.11.yaml
+++ b/curations/maven/mavencentral/org.json4s/json4s-core_2.11.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: json4s-core_2.11
+  namespace: org.json4s
+  provider: mavencentral
+  type: maven
+revisions:
+  3.2.11:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://raw.githubusercontent.com/json4s/json4s/e776c4e639860439b5d6ad52a87e5df95f6a9bf9/LICENSE) and here (https://github.com/json4s/json4s/blob/master/LICENSE)

**Resolution:**
Matches source

**Affected definitions**:
- [json4s-core_2.11 3.2.11](https://clearlydefined.io/definitions/maven/mavencentral/org.json4s/json4s-core_2.11/3.2.11/3.2.11)