### PR TITLE
Declare GPL2.0 or CDDL-1.0

### DIFF
--- a/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.2':
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-with-classpath-exception
+  1.3.2:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.0

--- a/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   '1.2':
     licensed:
-      declared: CDDL-1.0 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.0 OR GPL-2.0-only-WITH-Classpath-exception-2.0
   1.3.2:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.0
+      declared: CDDL-1.0 OR GPL-2.0-only-WITH-Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare GPL2.0 or CDDL-1.0

**Details:**
Declare GPL2.0 or CDDL-1.0 found here (http://central.maven.org/maven2/javax/annotation/javax.annotation-api/1.3.2/javax.annotation-api-1.3.2.pom)

**Resolution:**
matches source

**Affected definitions**:
- [javax.annotation-api 1.3.2](https://clearlydefined.io/definitions/maven/mavencentral/javax.annotation/javax.annotation-api/1.3.2/1.3.2)