### PR TITLE
Declare BSD-2-Clause

### DIFF
--- a/curations/npm/npmjs/-/css-select.yaml
+++ b/curations/npm/npmjs/-/css-select.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: BSD-2-Clause
+  1.3.0-rc0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-2-Clause

**Details:**
Declare BDS-2-Clause found here (https://github.com/fb55/css-select/blob/master/LICENSE)

**Resolution:**
matches source

**Affected definitions**:
- [css-select 1.3.0-rc0](https://clearlydefined.io/definitions/npm/npmjs/-/css-select/1.3.0-rc0/1.3.0-rc0)