### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/npm/npmjs/-/rebound.yaml
+++ b/curations/npm/npmjs/-/rebound.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rebound
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.13:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found here (https://github.com/facebook/rebound-js/blob/master/LICENSE) 

**Resolution:**
matches source

**Affected definitions**:
- [rebound 0.0.13](https://clearlydefined.io/definitions/npm/npmjs/-/rebound/0.0.13/0.0.13)