### PR TITLE
Add Declared License

### DIFF
--- a/curations/git/github/damienbod/selfhostwebapiwithowinandunityusingnuget.yaml
+++ b/curations/git/github/damienbod/selfhostwebapiwithowinandunityusingnuget.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: selfhostwebapiwithowinandunityusingnuget
+  namespace: damienbod
+  provider: github
+  type: git
+revisions:
+  d1660e12226e10db3791df0ac764e7a606ef86a8:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding NONE

**Resolution:**
Downloaded package and didn't find a license file or reference. GitHub repo and package directs to this link but no mention of a license : http://damienbod.wordpress.com/2013/10/12/self-hosted-web-api-using-owin-and-unity-nuget-package-documentation/

**Affected definitions**:
- [selfhostwebapiwithowinandunityusingnuget d1660e12226e10db3791df0ac764e7a606ef86a8](https://clearlydefined.io/definitions/git/github/damienbod/selfhostwebapiwithowinandunityusingnuget/d1660e12226e10db3791df0ac764e7a606ef86a8/d1660e12226e10db3791df0ac764e7a606ef86a8)