### PR TITLE
Adding file level license info

### DIFF
--- a/curations/git/github/damienbod/selfhostwebapiwithowinandunityusingnuget.yaml
+++ b/curations/git/github/damienbod/selfhostwebapiwithowinandunityusingnuget.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: selfhostwebapiwithowinandunityusingnuget
+  namespace: damienbod
+  provider: github
+  type: git
+revisions:
+  d1660e12226e10db3791df0ac764e7a606ef86a8:
+    files:
+      - license: OTHER
+        path: Unity.SelfHostWebApiOwin/packages/Microsoft.Bcl.1.1.8/License-Stable.rtf
+      - license: OTHER
+        path: Unity.SelfHostWebApiOwin/packages/Microsoft.Bcl.Build.1.0.21/License-Stable.rtf
+      - license: Apache-2.0
+        path: Unity.SelfHostWebApiOwin/packages/Owin.1.0/Owin.1.0.nuspec


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding file level license info

**Details:**
Adding file level license info

**Resolution:**
See files in "Files" section for this 'component' entry

**Affected definitions**:
- [selfhostwebapiwithowinandunityusingnuget d1660e12226e10db3791df0ac764e7a606ef86a8](https://clearlydefined.io/definitions/git/github/damienbod/selfhostwebapiwithowinandunityusingnuget/d1660e12226e10db3791df0ac764e7a606ef86a8/d1660e12226e10db3791df0ac764e7a606ef86a8)