### PR TITLE
Add a declared license

### DIFF
--- a/curations/git/github/cran/codetools.yaml
+++ b/curations/git/github/cran/codetools.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: codetools
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  e10d13c12831c8cb869c7564a058eb183a884245:
+    licensed:
+      declared: GPL-1.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add a declared license

**Details:**
The declared license for this component was missing.

https://github.com/cran/codetools/blob/e10d13c12831c8cb869c7564a058eb183a884245/DESCRIPTION declares "GPL" as the applicable license for this project.

**Resolution:**
Set declared license as SPDX : "GPL-1.0-or-later".

**Affected definitions**:
- [codetools e10d13c12831c8cb869c7564a058eb183a884245](https://clearlydefined.io/definitions/git/github/cran/codetools/e10d13c12831c8cb869c7564a058eb183a884245/e10d13c12831c8cb869c7564a058eb183a884245)