### PR TITLE
Declared BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.janino/commons-compiler.yaml
+++ b/curations/maven/mavencentral/org.codehaus.janino/commons-compiler.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-compiler
+  namespace: org.codehaus.janino
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.8:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared BSD-3-Clause

**Details:**
Declared BSD-3-Clause found here under license (https://mvnrepository.com/artifact/org.codehaus.janino/commons-compiler/3.0.8)

**Resolution:**
Matched -sources.jar

**Affected definitions**:
- [commons-compiler 3.0.8](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.janino/commons-compiler/3.0.8/3.0.8)