### PR TITLE
Tech Team Scan results

### DIFF
--- a/curations/git/github/azure/azure-relay-dotnet.yaml
+++ b/curations/git/github/azure/azure-relay-dotnet.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: azure-relay-dotnet
+  namespace: azure
+  provider: github
+  type: git
+revisions:
+  13ff04770abe8ca4e14cc6d58f00d0d9d712437d:
+    files:
+      - attributions:
+          - Copyright (c) .NET Foundation and Contributors
+        license: MIT
+        path: src/Microsoft.Azure.Relay/Common/UriHelper.cs
+      - attributions:
+          - Copyright (c) .NET Foundation and Contributors
+        license: MIT
+        path: src/Microsoft.Azure.Relay/Common/UriScheme.cs
+      - attributions:
+          - Copyright (c) Microsoft.
+        license: OTHER
+        path: src/Microsoft.Azure.Relay/System/Net/HttpStatusDescription.cs
+      - attributions:
+          - '  Copyright (c) .NET Foundation and Contributors'
+        license: Apache-2.0
+        path: src/Microsoft.Azure.Relay/WebSockets/NetStandard20/ManagedWebSocket.cs


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Tech Team Scan results

**Details:**
Incorrect copyright and set license to MIT - due to code from .NET Core FX

**Resolution:**
Update Copyright and set license to MIT

**Affected definitions**:
- [azure-relay-dotnet 13ff04770abe8ca4e14cc6d58f00d0d9d712437d](https://clearlydefined.io/definitions/git/github/azure/azure-relay-dotnet/13ff04770abe8ca4e14cc6d58f00d0d9d712437d/13ff04770abe8ca4e14cc6d58f00d0d9d712437d)