### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/opt-einsum.yaml
+++ b/curations/pypi/pypi/-/opt-einsum.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: opt-einsum
+  provider: pypi
+  type: pypi
+revisions:
+  3.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding MIT

**Resolution:**
ClearlyDefined package info has MIT license, Pypi meta notes MIT.

GitHub repo license: https://github.com/dgasmith/opt_einsum/blob/v3.1.0/LICENSE

**Affected definitions**:
- [opt-einsum 3.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/opt-einsum/3.1.0/3.1.0)