### PR TITLE
Add Declared License

### DIFF
--- a/curations/npm/npmjs/-/regenerator.yaml
+++ b/curations/npm/npmjs/-/regenerator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: regenerator
+  provider: npmjs
+  type: npm
+revisions:
+  0.8.40:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding BSD-2-Clause

**Resolution:**
ClearlyDefined license is BSD-2-Clause,
NPM: http://registry.npmjs.com/regenerator/0.8.40, points to GitHub and mentions "BSD" for this version (license later changed to MIT in repo)
GitHub repo license: https://github.com/facebook/regenerator/blob/v0.8.40/LICENSE

**Affected definitions**:
- [regenerator 0.8.40](https://clearlydefined.io/definitions/npm/npmjs/-/regenerator/0.8.40/0.8.40)