### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.ProjectModel.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.ProjectModel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.DotNet.ProjectModel
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-rc2-002702:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
No license or project source information for this version or any of the other versions.  

**Resolution:**
No license info on the nuspec.  Curating as NONE.

**Affected definitions**:
- [Microsoft.DotNet.ProjectModel 1.0.0-rc2-002702](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.ProjectModel/1.0.0-rc2-002702/1.0.0-rc2-002702)