### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -11,6 +11,9 @@ revisions:
       releaseDate: '2015-08-26'
     licensed:
       declared: Apache-2.0
+  106.6.10:
+    licensed:
+      declared: Apache-2.0
   106.6.9:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
NuGet license link - Apache 2.0

**Resolution:**
Source link license file - Apache 2.0

**Affected definitions**:
- [RestSharp 106.6.10](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/106.6.10/106.6.10)