### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/AutoMapper.yaml
+++ b/curations/nuget/nuget/-/AutoMapper.yaml
@@ -105,3 +105,6 @@ revisions:
   8.1.1:
     licensed:
       declared: MIT
+  9.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
NuGet license link - MIT

**Resolution:**
Source link license file - MIT

**Affected definitions**:
- [AutoMapper 9.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/AutoMapper/9.0.0/9.0.0)