### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.DependencyModel.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.DependencyModel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0-rc2-002702:
+    licensed:
+      declared: MIT
   1.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
No license link on this version's NuGet download page, but a more recent version is MIT

**Resolution:**
https://www.nuget.org/packages/Microsoft.Extensions.DependencyModel/3.1.0/License

**Affected definitions**:
- [Microsoft.Extensions.DependencyModel 1.0.0-rc2-002702](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.DependencyModel/1.0.0-rc2-002702/1.0.0-rc2-002702)