### PR TITLE
Tech Team Scan

### DIFF
--- a/curations/git/github/kitware/cmake.yaml
+++ b/curations/git/github/kitware/cmake.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: cmake
+  namespace: kitware
+  provider: github
+  type: git
+revisions:
+  1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6:
+    files:
+      - attributions:
+          - 'Copyright 2000-2019 Kitware, Inc. and Contributors All '
+        license: BSD-3-Clause
+        path: Copyright.txt
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team Scan

**Details:**
Setting the overall license and updating copyright text

**Resolution:**
sets the overall license for the component

**Affected definitions**:
- [cmake 1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6](https://clearlydefined.io/definitions/git/github/kitware/cmake/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6)