### PR TITLE
Tech Team Scan of CMAKE

### DIFF
--- a/curations/git/github/kitware/cmake.yaml
+++ b/curations/git/github/kitware/cmake.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: cmake
+  namespace: kitware
+  provider: github
+  type: git
+revisions:
+  1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6:
+    files:
+      - attributions:
+          - 'Copyright 2000-2019 Kitware, Inc. and Contributors All '
+        license: BSD-3-Clause
+        path: Copyright.txt
+      - attributions:
+          - 'Copyright (c) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>'
+        license: CC-BY-SA-4.0
+        path: Utilities/cmcurl/lib/vtls/openssl.c
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team Scan of CMAKE

**Details:**
Provide missing license for attribution on this file

**Resolution:**
provides correct attribution for this file

**Affected definitions**:
- [cmake 1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6](https://clearlydefined.io/definitions/git/github/kitware/cmake/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6)