### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Mvc.Versioning.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Mvc.Versioning.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNetCore.Mvc.Versioning
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link - MIT

**Resolution:**
Matches Source link license file - https://github.com/microsoft/aspnet-api-versioning/blob/9d90ab855a73c48b22b5e73ff4f837b99c387206/LICENSE

**Affected definitions**:
- [Microsoft.AspNetCore.Mvc.Versioning 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Mvc.Versioning/2.3.0/2.3.0)