### PR TITLE
Merge pull request #3299 from clearlydefined/ariel11_200108_205539.531

### DIFF
--- a/curations/nuget/nuget/-/Mono.Posix.NETStandard.yaml
+++ b/curations/nuget/nuget/-/Mono.Posix.NETStandard.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Mono.Posix.NETStandard
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-beta2:
+    licensed:
+      declared: MIT AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
This one is tricky.  NuGet link lists several "unspecified" versions of license - says "Apache-2.0 License, BSD-UNSPECIFIED License, GPL-UNSPECIFIED-MIT License, LGPL-UNSPECIFIED License, MIT License."  The link itself points to https://github.com/mono/mono/blob/master/LICENSE.

**Resolution:**
For the "Declared" license field, opting to do "MIT and BSD-3-Clause" based on the top of the LICENSE file linked to above (see where it says "In general, the runtime and its class libraries..."). The rest should be "Discovered" licenses. 

**Affected definitions**:
- [Mono.Posix.NETStandard 1.0.0-beta2](https://clearlydefined.io/definitions/nuget/nuget/-/Mono.Posix.NETStandard/1.0.0-beta2/1.0.0-beta2)