### PR TITLE
Tech Team scan of cmake

### DIFF
--- a/curations/git/github/kitware/cmake.yaml
+++ b/curations/git/github/kitware/cmake.yaml
@@ -1,0 +1,27 @@
+coordinates:
+  name: cmake
+  namespace: kitware
+  provider: github
+  type: git
+revisions:
+  1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6:
+    files:
+      - attributions:
+          - 'Copyright 2000-2019 Kitware, Inc. and Contributors All '
+        license: BSD-3-Clause
+        path: Copyright.txt
+      - attributions:
+          - 'Copyright (c) 2010, Howard Chu, <hyc@highlandsun.com>'
+          - 'Copyright (c) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>'
+        license: GPL-2.0-only
+        path: Utilities/cmcurl/lib/curl_rtmp.c
+      - attributions:
+          - 'Copyright (c) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>'
+        license: GPL-2.0-only
+        path: Utilities/cmcurl/lib/hostip4.c
+      - attributions:
+          - 'Copyright (c) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>'
+        license: CC-BY-SA-4.0
+        path: Utilities/cmcurl/lib/vtls/openssl.c
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech Team scan of cmake

**Details:**
set license to GPL v2.0 since noted files have reference to items that are licensed under GPL v2.0 (copyleft)

**Resolution:**
Fix license information for copyleft items in cmake

**Affected definitions**:
- [cmake 1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6](https://clearlydefined.io/definitions/git/github/kitware/cmake/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6)