### PR TITLE
Merge pull request #3302 from clearlydefined/clearlyoss_200108_230115.393

### DIFF
--- a/curations/git/github/kitware/cmake.yaml
+++ b/curations/git/github/kitware/cmake.yaml
@@ -1,0 +1,48 @@
+coordinates:
+  name: cmake
+  namespace: kitware
+  provider: github
+  type: git
+revisions:
+  1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6:
+    files:
+      - attributions:
+          - 'Copyright 2000-2019 Kitware, Inc. and Contributors All '
+        license: BSD-3-Clause
+        path: Copyright.txt
+      - license: GPL-2.0-only
+        path: Help/cpack_gen/rpm.rst
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzdiff
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzdiff.1
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzgrep
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzgrep.1
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzip2.1
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzmore
+      - license: GPL-2.0-only
+        path: Utilities/cmbzip2/bzmore.1
+      - attributions:
+          - 'Copyright (c) 2010, Howard Chu, <hyc@highlandsun.com>'
+          - 'Copyright (c) 2012 - 2019, Daniel Stenberg, <daniel@haxx.se>'
+        license: GPL-2.0-only
+        path: Utilities/cmcurl/lib/curl_rtmp.c
+      - attributions:
+          - 'Copyright (c) 1998 - 2018, Daniel Stenberg, <daniel@haxx.se>'
+        license: GPL-2.0-only
+        path: Utilities/cmcurl/lib/hostip4.c
+      - attributions:
+          - 'Copyright (c) 1998 - 2019, Daniel Stenberg, <daniel@haxx.se>'
+        license: CC-BY-SA-4.0
+        path: Utilities/cmcurl/lib/vtls/openssl.c
+      - attributions:
+          - 'Copyright (c) 1989, 1993'
+          - '* The Regents of the University of California.  All rights reserved.'
+        license: BSD-3-Clause
+        path: Utilities/cmlibuv/src/unix/tty.c
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech Team scan of cmake

**Details:**
Fix license and copyright attribution on this file.  Has SRC in file from NETBSD

**Resolution:**
corrects the license and copyright

**Affected definitions**:
- [cmake 1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6](https://clearlydefined.io/definitions/git/github/kitware/cmake/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6/1b4482f65dd41f21ec8abc0777b8dc1f0381bbd6)