### PR TITLE
Tech Team - adding copyright 

### DIFF
--- a/curations/git/github/zagum/android-expandicon.yaml
+++ b/curations/git/github/zagum/android-expandicon.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: android-expandicon
+  namespace: zagum
+  provider: github
+  type: git
+revisions:
+  62ec783f6bf35e34661ddea78df68701620aff91:
+    files:
+      - attributions:
+          - Copyright 2016 Evgenii Zagumennyi
+        license: Apache-2.0
+        path: LICENSE.txt


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team - adding copyright 

**Details:**
Adding copyright attribution to license text, license was correctly set.

**Resolution:**
Sets copyright for notices file.

**Affected definitions**:
- [android-expandicon 62ec783f6bf35e34661ddea78df68701620aff91](https://clearlydefined.io/definitions/git/github/zagum/android-expandicon/62ec783f6bf35e34661ddea78df68701620aff91/62ec783f6bf35e34661ddea78df68701620aff91)