### PR TITLE
Tech Team scan report

### DIFF
--- a/curations/git/github/sheetjs/sheetjs.yaml
+++ b/curations/git/github/sheetjs/sheetjs.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: sheetjs
+  namespace: sheetjs
+  provider: github
+  type: git
+revisions:
+  1a5bba267b6544b0015e3afd3c37483641ff053b:
+    files:
+      - attributions: []
+        license: GPL-3.0-only OR MIT
+        path: jszip.js
+    licensed:
+      declared: Apache-2.0

--- a/curations/git/github/sheetjs/sheetjs.yaml
+++ b/curations/git/github/sheetjs/sheetjs.yaml
@@ -6,7 +6,8 @@ coordinates:
 revisions:
   1a5bba267b6544b0015e3afd3c37483641ff053b:
     files:
-      - attributions: []
+      - attributions: 
+          - 'Copyright (c) 2009-2016 Stuart Knightley, David Duponchel, Franz Buchinger, António Afonso'
         license: GPL-3.0-only OR MIT
         path: jszip.js
     licensed:


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech Team scan report

**Details:**
Fix license to be GPL v3.0 OR MIT and fix the copyright which was missing text

**Resolution:**
Correctly sets the license (with OR instead of AND) and sets the correct text in the copyright

**Affected definitions**:
- [sheetjs 1a5bba267b6544b0015e3afd3c37483641ff053b](https://clearlydefined.io/definitions/git/github/sheetjs/sheetjs/1a5bba267b6544b0015e3afd3c37483641ff053b/1a5bba267b6544b0015e3afd3c37483641ff053b)