### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.481:
     licensed:
       declared: MIT
+  1.1.608:
+    licensed:
+      declared: MIT
   1.2.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link - MIT

**Resolution:**
Source link license file - MIT

**Affected definitions**:
- [StackExchange.Redis 1.1.608](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/1.1.608/1.1.608)