### PR TITLE
Tech team scan mono-skia v1.58.0

### DIFF
--- a/curations/git/github/mono/skia.yaml
+++ b/curations/git/github/mono/skia.yaml
@@ -1,0 +1,22 @@
+coordinates:
+  name: skia
+  namespace: mono
+  provider: github
+  type: git
+revisions:
+  79502c2199bcf7364e055371a9a0e2a12478de20:
+    files:
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1
+        path: third_party/gif/LICENSE
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+          - Copyright property of CompuServe Incorporated.
+          - copyright property of CompuServe Incorporated. Only CompuServe Incorporated
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        path: third_party/gif/SkGifImageReader.cpp
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        path: third_party/gif/SkGifImageReader.h


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech team scan mono-skia v1.58.0

**Details:**
incorrect license for GPL v2.0 and LGPL v2.1 - removed "or later" SPDX qaualifier

**Resolution:**
Removed "or later" for GPL 2 and LGPL 2.1, should be:
[MPL v1.1] or [GPL v2] or [LGPL v2.1]

**Affected definitions**:
- [skia 79502c2199bcf7364e055371a9a0e2a12478de20](https://clearlydefined.io/definitions/git/github/mono/skia/79502c2199bcf7364e055371a9a0e2a12478de20/79502c2199bcf7364e055371a9a0e2a12478de20)