### PR TITLE
Tech Team scan mono-skia

### DIFF
--- a/curations/git/github/mono/skia.yaml
+++ b/curations/git/github/mono/skia.yaml
@@ -1,0 +1,26 @@
+coordinates:
+  name: skia
+  namespace: mono
+  provider: github
+  type: git
+revisions:
+  79502c2199bcf7364e055371a9a0e2a12478de20:
+    files:
+      - attributions:
+          - Copyright 2006 The Android Open Source Project
+        license: Apache-2.0
+        path: src/effects/SkBlurMask.cpp
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1
+        path: third_party/gif/LICENSE
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+          - Copyright property of CompuServe Incorporated.
+          - copyright property of CompuServe Incorporated. Only CompuServe Incorporated
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        path: third_party/gif/SkGifImageReader.cpp
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        path: third_party/gif/SkGifImageReader.h


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team scan mono-skia

**Details:**
File prefaced with the following notice: 

// Implementation adapted from Michael Herf's approach:
// http://stereopsis.com/shadowrect/


**Resolution:**
The code that follows this statement is based on a Michael Herf article entitled "Fast Shadows on Rectangles." See http://stereopsis.com/shadowrect/ and https://github.com/herf/shadowrect/. This material is licensed under the Apache Software License v2.0 (see license on github)

**Affected definitions**:
- [skia 79502c2199bcf7364e055371a9a0e2a12478de20](https://clearlydefined.io/definitions/git/github/mono/skia/79502c2199bcf7364e055371a9a0e2a12478de20/79502c2199bcf7364e055371a9a0e2a12478de20)