### PR TITLE
Tech team scan skia

### DIFF
--- a/curations/git/github/mono/skia.yaml
+++ b/curations/git/github/mono/skia.yaml
@@ -12,19 +12,12 @@ revisions:
         path: gm/addarc.cpp
       - attributions:
           - Copyright 2006 The Android Open Source Project
-        license: Apache-2.0
+        license: BSD-3-Clause AND Apache-2.0
         path: src/effects/SkBlurMask.cpp
-      - attributions:
-          - Copyright (c) 1998 the Initial Developer.
-        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1
+        license: MPL-1.1 OR (GPL-2.0-or later OR LGPL-2.1-or-later)
         path: third_party/gif/LICENSE
       - attributions:
-          - Copyright (c) 1998 the Initial Developer.
-          - Copyright property of CompuServe Incorporated.
-          - copyright property of CompuServe Incorporated. Only CompuServe Incorporated
-        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        license: MPL-1.1 OR (GPL-2.0-or later OR LGPL-2.1-or-later)
         path: third_party/gif/SkGifImageReader.cpp
-      - attributions:
-          - Copyright (c) 1998 the Initial Developer.
-        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        license: MPL-1.1 OR (GPL-2.0-or later OR LGPL-2.1-or-later)
         path: third_party/gif/SkGifImageReader.h

--- a/curations/git/github/mono/skia.yaml
+++ b/curations/git/github/mono/skia.yaml
@@ -7,7 +7,7 @@ revisions:
   79502c2199bcf7364e055371a9a0e2a12478de20:
     files:
       - attributions:
-          - // Copyright 2015 The Chromium Authors. All rights reserved.
+          - Copyright 2015 The Chromium Authors. All rights reserved.
         license: BSD-3-Clause
         path: gm/addarc.cpp
       - attributions:

--- a/curations/git/github/mono/skia.yaml
+++ b/curations/git/github/mono/skia.yaml
@@ -1,0 +1,30 @@
+coordinates:
+  name: skia
+  namespace: mono
+  provider: github
+  type: git
+revisions:
+  79502c2199bcf7364e055371a9a0e2a12478de20:
+    files:
+      - attributions:
+          - // Copyright 2015 The Chromium Authors. All rights reserved.
+        license: BSD-3-Clause
+        path: gm/addarc.cpp
+      - attributions:
+          - Copyright 2006 The Android Open Source Project
+        license: Apache-2.0
+        path: src/effects/SkBlurMask.cpp
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1
+        path: third_party/gif/LICENSE
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+          - Copyright property of CompuServe Incorporated.
+          - copyright property of CompuServe Incorporated. Only CompuServe Incorporated
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        path: third_party/gif/SkGifImageReader.cpp
+      - attributions:
+          - Copyright (c) 1998 the Initial Developer.
+        license: MPL-1.1 OR (GPL-2.0 OR LGPL-2.1)
+        path: third_party/gif/SkGifImageReader.h

--- a/curations/git/github/mono/skia.yaml
+++ b/curations/git/github/mono/skia.yaml
@@ -16,7 +16,6 @@ revisions:
         path: src/effects/SkBlurMask.cpp
         license: MPL-1.1 OR (GPL-2.0-or later OR LGPL-2.1-or-later)
         path: third_party/gif/LICENSE
-      - attributions:
         license: MPL-1.1 OR (GPL-2.0-or later OR LGPL-2.1-or-later)
         path: third_party/gif/SkGifImageReader.cpp
         license: MPL-1.1 OR (GPL-2.0-or later OR LGPL-2.1-or-later)


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech team scan skia

**Details:**
Update copyright to include reference for chromium based on these references: File containing code prefaced by the following statements: 

// Lifted from canvas-arc-circumference-fill-diffs.html
or
// Lifted from https://bugs.chromium.org/p/chromium/issues/detail?id=640031


**Resolution:**
The code that follows these statements (in details) originates with Chromium, "an open-source browser project that aims to build a safer, faster, and more stable way for all Internet users to experience the web." See https://www.chromium.org/Home. Chromium is licensed under the BSD License (s

**Affected definitions**:
- [skia 79502c2199bcf7364e055371a9a0e2a12478de20](https://clearlydefined.io/definitions/git/github/mono/skia/79502c2199bcf7364e055371a9a0e2a12478de20/79502c2199bcf7364e055371a9a0e2a12478de20)