### PR TITLE
Merge pull request #3316 from clearlydefined/ariel11_200110_013450.925

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
@@ -29,3 +29,6 @@ revisions:
   2.4.1:
     licensed:
       declared: Apache-2.0
+  2.4.1-pre.build.4059:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link not going to any license text.  Project link goes to source repo.

**Resolution:**
Tagged version license - https://github.com/xunit/xunit/blob/ad20ed120a3653d6af533b76cf8a04f096095349/license.txt. 

**Affected definitions**:
- [xunit.runner.visualstudio 2.4.1-pre.build.4059](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.visualstudio/2.4.1-pre.build.4059/2.4.1-pre.build.4059)