### PR TITLE
Tech Team - set libpng overall license

### DIFF
--- a/curations/git/github/glennrp/libpng.yaml
+++ b/curations/git/github/glennrp/libpng.yaml
@@ -4,6 +4,19 @@ coordinates:
   provider: github
   type: git
 revisions:
+  a40189cf881e9f0db80511c382292a5604c3c3d1:
+    files:
+      - attributions:
+          - Copyright (c) 1995-2019
+          - Copyright (c) 2018-2019 Cosmin Truta.
+          - Copyright (c) 1996-1997 Andreas Dilger.
+          - Copyright (c) 1998-2000 Glenn Randers-Pehrson
+          - 'Copyright (c) 1995-1996 Guy Eric Schalnat, Group 42, Inc.'
+          - 'Copyright (c) 2000-2002, 2004, 2006-2018 Glenn Randers-Pehrson.'
+        license: libpng-2.0
+        path: LICENSE
+    licensed:
+      declared: libpng-2.0
   eddf9023206dc40974c26f589ee2ad63a4227a1e:
     licensed:
       declared: Libpng


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech Team - set libpng overall license

**Details:**
Updated license from no - assertion.  Files originating with, or related to, libpng v1.6.37,  See https://libpng.sourceforge.io and https://github.com/glennrp/libpng. This material is licensed under the PNG Reference Library License v2 (see file /libpng-1.6.37/LICENSE).

**Resolution:**
change the overall license to Libpng-2.0

**Affected definitions**:
- [libpng a40189cf881e9f0db80511c382292a5604c3c3d1](https://clearlydefined.io/definitions/git/github/glennrp/libpng/a40189cf881e9f0db80511c382292a5604c3c3d1/a40189cf881e9f0db80511c382292a5604c3c3d1)