### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0-beta-final:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
NuGet license link - Apache 2.0

**Resolution:**
Source link license file - Apache 2.0

**Affected definitions**:
- [NuGet.Frameworks 3.5.0-beta-final](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Frameworks/3.5.0-beta-final/3.5.0-beta-final)