### PR TITLE
Tech Scan react-window #550c2c

### DIFF
--- a/curations/git/github/bvaughn/react-window.yaml
+++ b/curations/git/github/bvaughn/react-window.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: react-window
+  namespace: bvaughn
+  provider: github
+  type: git
+revisions:
+  550c2c194a5728d63bd91d30a23d6eacdb791b1e:
+    files:
+      - attributions:
+          - Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+        license: MIT
+        path: website/scripts/utils/verifyPackageTree.js


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Tech Scan react-window #550c2c

**Details:**
File with a section of code prefaced by the following notice:
// Inlined from semver-regex, MIT license.
The code that follows this notice originates with semver-regex, a "[r]egular expression for matching semver versions." See https://github.com/sindresorhus/semver-regex 

**Resolution:**
This material is licensed under the MIT License (see https://github.com/sindresorhus/semver-regex/blob/master/license) - setting license and copyright

**Affected definitions**:
- [react-window 550c2c194a5728d63bd91d30a23d6eacdb791b1e](https://clearlydefined.io/definitions/git/github/bvaughn/react-window/550c2c194a5728d63bd91d30a23d6eacdb791b1e/550c2c194a5728d63bd91d30a23d6eacdb791b1e)