### PR TITLE
Merge pull request #3334 from clearlydefined/clearlyoss_200113_183834.344

### DIFF
--- a/curations/git/github/bvaughn/react-window.yaml
+++ b/curations/git/github/bvaughn/react-window.yaml
@@ -1,0 +1,20 @@
+coordinates:
+  name: react-window
+  namespace: bvaughn
+  provider: github
+  type: git
+revisions:
+  550c2c194a5728d63bd91d30a23d6eacdb791b1e:
+    files:
+      - attributions:
+          - Copyright (c) 2016 Jason Miller
+        license: MIT
+        path: src/shallowDiffers.js
+      - attributions:
+          - 'Copyright 2011, Joe Lambert.'
+        license: MIT
+        path: src/timer.js
+      - attributions:
+          - Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+        license: MIT
+        path: website/scripts/utils/verifyPackageTree.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team scan react-window

**Details:**
File with a section of code prefaced by the following notice:

// Pulled from react-compat
// https://github.com/developit/preact-compat/blob/7c5de00e7c85e2ffd011bf3af02899b63f699d3a/src/index.js#L349


**Resolution:**
The code that follows this notice originates with react-compat, a "React compatibility layer for Preact." See https://github.com/preactjs/preact-compat. This material is licensed under the MIT License (see https://github.com/preactjs/preact-compat/blob/7c5de00e7c85e2ffd011bf3af02899b63f699d3a/LICENS

**Affected definitions**:
- [react-window 550c2c194a5728d63bd91d30a23d6eacdb791b1e](https://clearlydefined.io/definitions/git/github/bvaughn/react-window/550c2c194a5728d63bd91d30a23d6eacdb791b1e/550c2c194a5728d63bd91d30a23d6eacdb791b1e)