### PR TITLE
Merge pull request #3335 from clearlydefined/clearlyoss_200113_184125.564

### DIFF
--- a/curations/git/github/bvaughn/react-window.yaml
+++ b/curations/git/github/bvaughn/react-window.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: react-window
+  namespace: bvaughn
+  provider: github
+  type: git
+revisions:
+  550c2c194a5728d63bd91d30a23d6eacdb791b1e:
+    files:
+      - attributions:
+          - Copyright (c) 2014 Call-Em-All
+        license: MIT
+        path: src/domHelpers.js
+      - attributions:
+          - Copyright (c) 2016 Jason Miller
+        license: MIT
+        path: src/shallowDiffers.js
+      - attributions:
+          - 'Copyright 2011, Joe Lambert.'
+        license: MIT
+        path: src/timer.js
+      - attributions:
+          - Copyright (c) Sindre Sorhus <sindresorhus@gmail.com> (sindresorhus.com)
+        license: MIT
+        path: website/scripts/utils/verifyPackageTree.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team scan react-window

**Details:**
File prefaced by the following notice:

// This utility copied from "dom-helpers" package.

The code that follows this notice originates with Material-UI, providing "React components that implement Google's Material Design." 

**Resolution:**
See http://gitlab.arizona.com.br/third-party/material-ui/tree/master (see specifically http://gitlab.arizona.com.br/third-party/material-ui/blob/master/umd/material-ui.development.js#L8894-8909). This material is licensed under the MIT License (see http://gitlab.arizona.com.br/third-party/material-u

**Affected definitions**:
- [react-window 550c2c194a5728d63bd91d30a23d6eacdb791b1e](https://clearlydefined.io/definitions/git/github/bvaughn/react-window/550c2c194a5728d63bd91d30a23d6eacdb791b1e/550c2c194a5728d63bd91d30a23d6eacdb791b1e)