### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.yaml
@@ -24,3 +24,6 @@ revisions:
   4.1.0:
     licensed:
       declared: Apache-2.0
+  4.1.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Aprache-2.0 found here (https://github.com/dotnet/reactive/blob/master/LICENSE)

**Resolution:**
Matches project site

**Affected definitions**:
- [System.Reactive 4.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive/4.1.2/4.1.2)