### PR TITLE
Declare OTHER 

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform.yaml
@@ -6,3 +6,6 @@ revisions:
   6.2.3:
     licensed:
       declared: MIT
+  6.2.8:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare OTHER 

**Details:**
Declare OTHER - under MSFT EULA found here (https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT)

**Resolution:**
Matches project site

**Affected definitions**:
- [runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform 6.2.8](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm64-aot.Microsoft.NETCore.UniversalWindowsPlatform/6.2.8/6.2.8)