### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -18,3 +18,6 @@ revisions:
   5.0.0-rc2:
     licensed:
       declared: MIT
+  5.0.0-rc4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE)

**Resolution:**
Matches project site

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 5.0.0-rc4](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.0.0-rc4/5.0.0-rc4)