### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Cors.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Cors.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Cors
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt)

**Resolution:**
Matches project site

**Affected definitions**:
- [Microsoft.Owin.Cors 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Cors/4.0.1/4.0.1)