### PR TITLE
Declare BSD-2-Clause

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NLog.Extensions.Logging
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-2-Clause

**Details:**
Declare BSD-2-Clause found here (https://github.com/NLog/NLog.Extensions.Logging/blob/master/LICENSE)

**Resolution:**
Matches project site

**Affected definitions**:
- [NLog.Extensions.Logging 1.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.4.0/1.4.0)