### PR TITLE
Tech Team scan - set overall license

### DIFF
--- a/curations/nuget/nuget/-/NAudio.yaml
+++ b/curations/nuget/nuget/-/NAudio.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.8.5:
+    licensed:
+      declared: MS-PL
   1.9.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team scan - set overall license

**Details:**
Per the license text the license for this component is MS-PL

**Resolution:**
Set the overall license to MS PL

**Affected definitions**:
- [NAudio 1.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/NAudio/1.8.5/1.8.5)