### PR TITLE
Tech Team - set BSL for Boost

### DIFF
--- a/curations/nuget/nuget/-/boost.yaml
+++ b/curations/nuget/nuget/-/boost.yaml
@@ -6,3 +6,6 @@ revisions:
   1.65.0:
     licensed:
       declared: Apache-2.0
+  1.67.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team - set BSL for Boost

**Details:**
Boost is licensed under the Boost Software License (BSL). 

**Resolution:**
Setting the overall license for this component

**Affected definitions**:
- [boost 1.67.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost/1.67.0/1.67.0)