### PR TITLE
Tech Team - set overall license

### DIFF
--- a/curations/nuget/nuget/-/boost_serialization-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_serialization-vc141.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_serialization-vc141
+  provider: nuget
+  type: nuget
+revisions:
+  1.67.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team - set overall license

**Details:**
This component is licensed under the Boost Software License (BSL).

**Resolution:**
Set overall license

**Affected definitions**:
- [boost_serialization-vc141 1.67.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_serialization-vc141/1.67.0/1.67.0)