### PR TITLE
Tech Team - set declared license

### DIFF
--- a/curations/npm/npmjs/-/messageformat.yaml
+++ b/curations/npm/npmjs/-/messageformat.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: messageformat
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.8:
+    licensed:
+      declared: WTFPL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team - set declared license

**Details:**
This component is licensed under the WTFPL license

**Resolution:**
Set the declared license

**Affected definitions**:
- [messageformat 0.1.8](https://clearlydefined.io/definitions/npm/npmjs/-/messageformat/0.1.8/0.1.8)