### PR TITLE
Tech Team - correct the declared license

### DIFF
--- a/curations/git/github/howeyc/gopass.yaml
+++ b/curations/git/github/howeyc/gopass.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: gopass
+  namespace: howeyc
+  provider: github
+  type: git
+revisions:
+  bf9dde6d0d2c004a008c27aaee91170c786f6db8:
+    licensed:
+      declared: ISC AND CDDL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech Team - correct the declared license

**Details:**
This component is licensed under CDDL AND ISC.

**Resolution:**
Update the declared license

**Affected definitions**:
- [gopass bf9dde6d0d2c004a008c27aaee91170c786f6db8](https://clearlydefined.io/definitions/git/github/howeyc/gopass/bf9dde6d0d2c004a008c27aaee91170c786f6db8/bf9dde6d0d2c004a008c27aaee91170c786f6db8)