### PR TITLE
Tech Team - set declared license

### DIFF
--- a/curations/git/github/python/cpython.yaml
+++ b/curations/git/github/python/cpython.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cpython
+  namespace: python
+  provider: github
+  type: git
+revisions:
+  5fd33b5926eb8c9352bf5718369b4a8d72c4bb44:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team - set declared license

**Details:**
Per the license text this is licensed under Python 2.0 terms.

**Resolution:**
Update the declared licensed to Python 2.0

**Affected definitions**:
- [cpython 5fd33b5926eb8c9352bf5718369b4a8d72c4bb44](https://clearlydefined.io/definitions/git/github/python/cpython/5fd33b5926eb8c9352bf5718369b4a8d72c4bb44/5fd33b5926eb8c9352bf5718369b4a8d72c4bb44)