### PR TITLE
Merge pull request #3357 from clearlydefined/ariel11_200114_230421.940

### DIFF
--- a/curations/git/github/chriskohlhoff/asio.yaml
+++ b/curations/git/github/chriskohlhoff/asio.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: asio
+  namespace: chriskohlhoff
+  provider: github
+  type: git
+revisions:
+  22afb86087a77037cd296d27134756c9b0d2cb75:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
License info found on http://think-async.com/Asio/

**Resolution:**
License
Asio is released under the Boost Software License.

**Affected definitions**:
- [asio 22afb86087a77037cd296d27134756c9b0d2cb75](https://clearlydefined.io/definitions/git/github/chriskohlhoff/asio/22afb86087a77037cd296d27134756c9b0d2cb75/22afb86087a77037cd296d27134756c9b0d2cb75)