### PR TITLE
Tech Team Scan electron v6.0.3

### DIFF
--- a/curations/git/github/electron/electron.yaml
+++ b/curations/git/github/electron/electron.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: electron
+  namespace: electron
+  provider: github
+  type: git
+revisions:
+  fb379c3b6a56ab1d4c6590a1c06e66d413b15148:
+    files:
+      - attributions:
+          - '// Copyright Joyent, Inc. and other Node contributors.'
+        license: MIT
+        path: atom/renderer/atom_sandboxed_renderer_client.cc
+      - attributions:
+          - ' // Copyright (c) 2014 The Chromium Authors. All rights reserved.'
+        license: BSD-3-Clause
+        path: lib/renderer/extensions/i18n.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Tech Team Scan electron v6.0.3

**Details:**
File containing a section of code prefaced by the following notice:

// adapted from node.cc


**Resolution:**
The code that follows this notice is "adapted from" nodejs, a "JavaScript runtime built on Chrome's V8 JavaScript engine." See https://github.com/nodejs/node (see specifically https://github.com/nodejs/node/blob/master/src/node.cc). This material is licensed under the MIT License (see https://github

**Affected definitions**:
- [electron fb379c3b6a56ab1d4c6590a1c06e66d413b15148](https://clearlydefined.io/definitions/git/github/electron/electron/fb379c3b6a56ab1d4c6590a1c06e66d413b15148/fb379c3b6a56ab1d4c6590a1c06e66d413b15148)