### PR TITLE
Tech Team Scan - Electron v6.0.3

### DIFF
--- a/curations/git/github/electron/electron.yaml
+++ b/curations/git/github/electron/electron.yaml
@@ -1,0 +1,26 @@
+coordinates:
+  name: electron
+  namespace: electron
+  provider: github
+  type: git
+revisions:
+  fb379c3b6a56ab1d4c6590a1c06e66d413b15148:
+    files:
+      - attributions:
+          - Copyright (c) 2015 Ryan McShane <rmcshane@bandwidth.com> and Brandon Smith <bsmith@bandwidth.com>
+          - Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon <jason.poon@microsoft.com>
+        license: MIT
+        path: atom/browser/notifications/win/windows_toast_notification.cc
+      - attributions:
+          - Copyright (c) 2015 Ryan McShane <rmcshane@bandwidth.com> and Brandon Smith <bsmith@bandwidth.com>
+          - Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon <jason.poon@microsoft.com>
+        license: MIT
+        path: atom/browser/notifications/win/windows_toast_notification.h
+      - attributions:
+          - '// Copyright Joyent, Inc. and other Node contributors.'
+        license: MIT
+        path: atom/renderer/atom_sandboxed_renderer_client.cc
+      - attributions:
+          - ' // Copyright (c) 2014 The Chromium Authors. All rights reserved.'
+        license: BSD-3-Clause
+        path: lib/renderer/extensions/i18n.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team Scan - Electron v6.0.3

**Details:**
Files containing a section of code prefaced by the following notice:

// Copyright (c) 2015 Felix Rieseberg <feriese@microsoft.com> and Jason Poon
// <jason.poon@microsoft.com>. All rights reserved.
// Copyright (c) 2015 Ryan McShane <rmcshane@bandwidth.com> and Brandon Smith
// <bsmith@bandwidth.co

**Resolution:**
This material is licensed under the MIT License

**Affected definitions**:
- [electron fb379c3b6a56ab1d4c6590a1c06e66d413b15148](https://clearlydefined.io/definitions/git/github/electron/electron/fb379c3b6a56ab1d4c6590a1c06e66d413b15148/fb379c3b6a56ab1d4c6590a1c06e66d413b15148)