### PR TITLE
Declared Other

### DIFF
--- a/curations/nuget/nuget/-/PowerThreading.yaml
+++ b/curations/nuget/nuget/-/PowerThreading.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PowerThreading
+  provider: nuget
+  type: nuget
+revisions:
+  20120420.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Other

**Details:**
Declared Other found here (https://github.com/Wintellect/PowerThreading/blob/4e41e0ec397d1fcb9b8523990a70c83614c1b614/Power%20Threading%20License.docx)

**Resolution:**
Is this license WINTELLECT POWER THREADING SOFTWARE LICENSE 

**Affected definitions**:
- [PowerThreading 20120420.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/PowerThreading/20120420.0.0/20120420.0.0)