### PR TITLE
Tech Team scan of Electron v6, component = node

### DIFF
--- a/curations/git/github/nodejs/node.yaml
+++ b/curations/git/github/nodejs/node.yaml
@@ -19,6 +19,80 @@ revisions:
           - 'Copyright (c) 2007, 2008 gnombat@users.sourceforge.net'
         license: GPL-3.0
         path: doc/sh_main.js
+  64219741218aa87e259cf8257596073b8e747f0a:
+    files:
+      - attributions:
+          - Copyright (c) 2018 Agoric
+          - copyright Niels Provos. Two
+          - 'Copyright 2008, Google Inc.'
+          - 'Copyright Fedor Indutny, 2018.'
+          - 'Copyright 2014, the V8 project'
+          - Copyright (c) 2009 Google Inc.
+          - Copyright (c) 2011 Google Inc.
+          - Copyright (c) 2014 Matt Warren
+          - Copyright (c) 1999 TaBE Project.
+          - Copyright (c) 2014 Michael Barker
+          - 'Copyright 2006-2011, the V8 project'
+          - copyright Alexander Chemeris. Three
+          - 'copyrighted by Apple Computer, Inc.'
+          - 'Copyright (c) 2014, StrongLoop Inc.'
+          - 'Copyright (c) 2006-2008, Google Inc.'
+          - Copyright (c) 1999 Pai-Hsiang Hsiao.
+          - copyrighted by Sun Microsystems Inc.
+          - Copyright 2016 The Chromium Authors.
+          - Copyright (c) 2009 by the Jinja Team
+          - Copyright (c) 2018 Intel Corporation
+          - 'Copyright (c) 1991-2019 Unicode, Inc.'
+          - Copyright (c) 2017-2018 by Adrian Heine
+          - 'Copyright (c) 2012, 2013, 2014 Gil Tene'
+          - 'Copyright (c) npm, Inc. and Contributors'
+          - 'Copyright (c) 2013, LeRoy Benjamin Sharon'
+          - 'Copyright (c) 2007 - 2018, Daniel Stenberg'
+          - Copyright (c) 1998-2019 The OpenSSL Project.
+          - 'Copyright (c) 2000-2006, The Perl Foundation.'
+          - Copyright (c) 2012-2018 by various contributors
+          - 'copyright the Internet Systems Consortium, Inc.'
+          - Copyright (c) Mathias Pettersson and Brian Hammond
+          - 'Copyright Joyent, Inc. and other Node contributors.'
+          - 'Copyright Mathias Bynens <https://mathiasbynens.be/>'
+          - Copyright (c) 2015-present libuv project contributors.
+          - Copyright (c) 2010 by Armin Ronacher and contributors.
+          - 'Copyright (c) 2012, Ben Noordhuis <info@bnoordhuis.nl>'
+          - Copyright (c) 1995-2017 Jean-loup Gailly and Mark Adler
+          - copyright Google Inc. and Sony Mobile Communications AB.
+          - 'Copyright (c) 2012, 2014, 2015, 2016 Tatsuhiro Tsujikawa'
+          - 'Copyright (c) 2012, 2014, 2015, 2016 nghttp2 contributors'
+          - 'Copyright (c) 2009, 2010, 2013-2016 by the Brotli Authors.'
+          - Copyright 1998 by the Massachusetts Institute of Technology.
+          - 'Copyright (c) Tjarda Koster, https://jelloween.deviantart.com'
+          - Copyright (c) 2014-2016 Sebastian McKenzie <sebmck@gmail.com>
+          - 'Copyright (c) 2013 Brian Eugene Wilson, Robert Martin Campbell.'
+          - 'copyright Berkeley Software Design Inc, Kenneth MacKay and Emergya'
+          - 'Copyright JS Foundation and other contributors, https://js.foundation'
+          - 'Copyright 2000, 2001, 2002, 2003 Nara Institute of Science and Technology.'
+          - Copyright (c) 2013 International Business Machines Corporation and others.
+          - Copyright (c) 2014 International Business Machines Corporation and others.
+          - Copyright (c) 2016 Jean-Philippe Aumasson <jeanphilippe.aumasson@gmail.com>
+          - Copyright (c) 1995-2016 International Business Machines Corporation and others
+          - 'Copyright 1996 Chih-Hao Tsai Beckman Institute, University of Illinois c-tsai4@uiuc.edu'
+          - 'Copyright (c) 1999 Computer Systems and Communication Lab, Institute of Information Science, Academia Sinica.'
+          - Copyright Node.js contributors. All rights reserved.
+        license: MIT
+        path: LICENSE
+      - attributions: []
+        license: Apache-2.0
+        path: deps/uv/docs/src/sphinx-plugins/manpage.py
+      - attributions:
+          - ' * Copyright (c) 1989, 1993'
+        license: BSD-3-Clause
+        path: deps/uv/src/unix/tty.c
+      - attributions:
+          - Copyright (c) 2005 Tom Wu
+          - Copyright (c) 2003-2005 Tom Wu
+          - Copyright 2009 The Closure Library
+          - '(c) // int putchar(int c) // http://pubs.opengroup.org/onlinepubs/000095399/functions/putchar.html'
+        license: Apache-2.0
+        path: deps/v8/test/mjsunit/asm/embenchen/lua_binarytrees.js
   7e463500b2483c084d1dbc016806d6f1092ddabf:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team scan of Electron v6, component = node

**Details:**
File with a section of code prefaced by the following notice:

   * This implementation of cfmakeraw for Solaris and derivatives is taken from
   * http://www.perkin.org.uk/posts/solaris-portability-cfmakeraw.html.



**Resolution:**
The code following this comment is based on sample code on the cited webpage, as found at http://www.perkin.org.uk/posts/solaris-portability-cfmakeraw.html. The relevant section of sample code at the referenced URL is prefaced by the comment "[o]k, so all it’s doing is setting some additional flags 

**Affected definitions**:
- [node 64219741218aa87e259cf8257596073b8e747f0a](https://clearlydefined.io/definitions/git/github/nodejs/node/64219741218aa87e259cf8257596073b8e747f0a/64219741218aa87e259cf8257596073b8e747f0a)