### PR TITLE
Update curations/git/github/nodejs/node.yaml

### DIFF
--- a/curations/git/github/nodejs/node.yaml
+++ b/curations/git/github/nodejs/node.yaml
@@ -19,6 +19,12 @@ revisions:
           - 'Copyright (c) 2007, 2008 gnombat@users.sourceforge.net'
         license: GPL-3.0
         path: doc/sh_main.js
+  64219741218aa87e259cf8257596073b8e747f0a:
+    files:
+      - attributions:
+          - 'Copyright (c) Mathias Bynens <https://mathiasbynens.be/>'
+        license: MIT
+        path: benchmark/misc/punycode.js
   7e463500b2483c084d1dbc016806d6f1092ddabf:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tech Team scan Electron v6 - component = node

**Details:**
Files originating with, or related to, Punycode, a "robust Punycode converter that fully complies to RFC 3492 and RFC 5891." See https://github.com/bestiejs/punycode.js. 

**Resolution:**
This material is licensed under the MIT License (see https://github.com/bestiejs/punycode.js/blob/master/LICENSE-MIT.txt)

**Affected definitions**:
- [node 64219741218aa87e259cf8257596073b8e747f0a](https://clearlydefined.io/definitions/git/github/nodejs/node/64219741218aa87e259cf8257596073b8e747f0a/64219741218aa87e259cf8257596073b8e747f0a)