### PR TITLE
update license in - /node-12.4.0/src/node_crypto.cc

### DIFF
--- a/curations/git/github/nodejs/node.yaml
+++ b/curations/git/github/nodejs/node.yaml
@@ -19,6 +19,12 @@ revisions:
           - 'Copyright (c) 2007, 2008 gnombat@users.sourceforge.net'
         license: GPL-3.0
         path: doc/sh_main.js
+  64219741218aa87e259cf8257596073b8e747f0a:
+    files:
+      - attributions:
+          - ' * Copyright (c) 1998-2018 The OpenSSL Project.  All rights reserved.'
+        license: OpenSSL
+        path: src/node_crypto.cc
   7e463500b2483c084d1dbc016806d6f1092ddabf:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
update license in - /node-12.4.0/src/node_crypto.cc

**Details:**
File with a section of code prefaced by the following notice:

Taken from OpenSSL - edited for style.


**Resolution:**
Update license and copyright to OPENSSL - node v12.4.0 may not be in compliance with the attribution-style OpenSSL License and Original SSLeay License (see https://www.openssl.org/source/license.txt).

**Affected definitions**:
- [node 64219741218aa87e259cf8257596073b8e747f0a](https://clearlydefined.io/definitions/git/github/nodejs/node/64219741218aa87e259cf8257596073b8e747f0a/64219741218aa87e259cf8257596073b8e747f0a)