### PR TITLE
cppcodec #bd6ddf9

### DIFF
--- a/curations/git/github/tplgy/cppcodec.yaml
+++ b/curations/git/github/tplgy/cppcodec.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: cppcodec
+  namespace: tplgy
+  provider: github
+  type: git
+revisions:
+  bd6ddf95129e769b50ef63e0f558fa21364f3f65:
+    files:
+      - attributions:
+          - Copyright (c) 2015 Topology LP
+          - Copyright (c) 2018 Jakob Petsovits
+        license: CC-BY-SA-4.0
+        path: cppcodec/data/access.hpp


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
cppcodec #bd6ddf9

**Details:**
File containing a section of code prefaced by the following notice:

// For the put() default implementation, we try calling push_back() with either uint8_t or char,
// whichever compiles. Scary-fancy template magic from http://stackoverflow.com/a/1386390.


**Resolution:**
The code following this comment is based on sample code from the cited stackoverflow.com webpage, as found at http://stackoverflow.com/questions/1386183/how-to-call-a-templated-function-if-it-exists-and-something-else-otherwise (see specifically http://stackoverflow.com/a/1386390). Material on this 

**Affected definitions**:
- [cppcodec bd6ddf95129e769b50ef63e0f558fa21364f3f65](https://clearlydefined.io/definitions/git/github/tplgy/cppcodec/bd6ddf95129e769b50ef63e0f558fa21364f3f65/bd6ddf95129e769b50ef63e0f558fa21364f3f65)