### PR TITLE
CefSharp v75.1.142 Declared License

### DIFF
--- a/curations/git/github/cefsharp/cefsharp.yaml
+++ b/curations/git/github/cefsharp/cefsharp.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cefsharp
+  namespace: cefsharp
+  provider: github
+  type: git
+revisions:
+  9d6e5de858a79deff109d28e459218d4e24f47d7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
CefSharp v75.1.142 Declared License

**Details:**
CEFSharp as part of Power BI DT scan. 

Files originating with, or related to, CefSharp v75.1.142, which "lets you embed Chromium in .NET apps. It is a lightweight .NET wrapper around the Chromium Embedded Framework (CEF)." See https://github.com/cefsharp/CefSharp.

**Resolution:**
Sets declared license.
This material is licensed under the BSD License (see https://github.com/cefsharp/CefSharp/blob/v75.1.142/LICENSE and file /CefSharp-75.1.142/LICENSE).

**Affected definitions**:
- [cefsharp 9d6e5de858a79deff109d28e459218d4e24f47d7](https://clearlydefined.io/definitions/git/github/cefsharp/cefsharp/9d6e5de858a79deff109d28e459218d4e24f47d7/9d6e5de858a79deff109d28e459218d4e24f47d7)