### PR TITLE
Docker - /distribution-2.7.1/vendor/gopkg.in/yaml.v2/yaml.go - set license

### DIFF
--- a/curations/git/github/docker/distribution.yaml
+++ b/curations/git/github/docker/distribution.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: distribution
+  namespace: docker
+  provider: github
+  type: git
+revisions:
+  2461543d988979529609e8cb6fca9ca190dc48da:
+    files:
+      - attributions:
+          - Copyright (c) 2019 Docker Distribution contributors
+        license: Apache-2.0
+        path: LICENSE
+      - attributions:
+          - Copyright (c) 2010-2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
+        license: BSD-3-Clause
+        path: vendor/gopkg.in/yaml.v2/yaml.go

--- a/curations/git/github/docker/distribution.yaml
+++ b/curations/git/github/docker/distribution.yaml
@@ -12,5 +12,5 @@ revisions:
         path: LICENSE
       - attributions:
           - Copyright (c) 2010-2013 - Gustavo Niemeyer <gustavo@niemeyer.net>
-        license: BSD-3-Clause
+        license: BSD-2-Clause
         path: vendor/gopkg.in/yaml.v2/yaml.go


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Docker - /distribution-2.7.1/vendor/gopkg.in/yaml.v2/yaml.go - set license

**Details:**
Docker as part of the Azure stack scan.

File containing a section of code prefaced by the following notice:

// The code in this section was copied from mgo/bson.


**Resolution:**
The code that follows this notice originates with mgo, "[t]he MongoDB driver for Go." See https://github.com/go-mgo/mgo (see specifically https://github.com/go-mgo/mgo/blob/v2-unstable/bson/bson.go). This material is licensed under the BSD License (see https://github.com/go-mgo/mgo/blob/v2-unstable/

**Affected definitions**:
- [distribution 2461543d988979529609e8cb6fca9ca190dc48da](https://clearlydefined.io/definitions/git/github/docker/distribution/2461543d988979529609e8cb6fca9ca190dc48da/2461543d988979529609e8cb6fca9ca190dc48da)