### PR TITLE
Microsoft Flow - azure-activedirectory-identitymodel-extensions-for-dotnet v5.5.0

### DIFF
--- a/curations/git/github/azuread/azure-activedirectory-identitymodel-extensions-for-dotnet.yaml
+++ b/curations/git/github/azuread/azure-activedirectory-identitymodel-extensions-for-dotnet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: azure-activedirectory-identitymodel-extensions-for-dotnet
+  namespace: azuread
+  provider: github
+  type: git
+revisions:
+  5810cd81dd3d7a802f111005f42990dc8ebb0aa7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft Flow - azure-activedirectory-identitymodel-extensions-for-dotnet v5.5.0

**Details:**
Correct the overall license to MIT.

Files originating with, or related to, azure-activedirectory-identitymodel-extensions-for-dotnet v5.5.0, "IdentityModel extensions for .Net." See https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet. 

**Resolution:**
Set license to MIT - This material is licensed under the MIT License (see file /azure-activedirectory-identitymodel-extensions-for-dotnet-5.5.0/LICENSE.txt).

**Affected definitions**:
- [azure-activedirectory-identitymodel-extensions-for-dotnet 5810cd81dd3d7a802f111005f42990dc8ebb0aa7](https://clearlydefined.io/definitions/git/github/azuread/azure-activedirectory-identitymodel-extensions-for-dotnet/5810cd81dd3d7a802f111005f42990dc8ebb0aa7/5810cd81dd3d7a802f111005f42990dc8ebb0aa7)