### PR TITLE
.NET for Apache Spark

### DIFF
--- a/curations/git/github/dotnet/spark.yaml
+++ b/curations/git/github/dotnet/spark.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: spark
+  namespace: dotnet
+  provider: github
+  type: git
+revisions:
+  8719e44d5eac08ecfb7f742e4b17160a255a5866:
+    files:
+      - attributions:
+          - '* Copyright (c) 2015 Databricks Inc.'
+        license: Apache-2.0
+        path: benchmark/csharp/Tpch/TpchSqlQueries.cs


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
.NET for Apache Spark

**Details:**
File: /spark/benchmark/csharp/Tpch/TpchSqlQueries.cs

File prefaced by the following notice (emphasis added):

/**
  * The queries are based off of the original SparkSQL TPC-H queries from:
  * https://github.com/databricks/spark-sql-perf/tree/master/src/main/resources/tpch/queries


**Resolution:**
spark-sql-perf is "a performance testing framework for Spark SQL in Apache Spark 2.2+." See https://github.com/databricks/spark-sql-perf. This material is licensed under the Apache Software License v2.0 (see https://github.com/databricks/spark-sql-perf/blob/master/LICENSE

**Affected definitions**:
- [spark 8719e44d5eac08ecfb7f742e4b17160a255a5866](https://clearlydefined.io/definitions/git/github/dotnet/spark/8719e44d5eac08ecfb7f742e4b17160a255a5866/8719e44d5eac08ecfb7f742e4b17160a255a5866)