### PR TITLE
.Net for Apache Spark

### DIFF
--- a/curations/git/github/dotnet/spark.yaml
+++ b/curations/git/github/dotnet/spark.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: spark
+  namespace: dotnet
+  provider: github
+  type: git
+revisions:
+  8719e44d5eac08ecfb7f742e4b17160a255a5866:
+    files:
+      - attributions:
+          - '* Copyright (c) 2015 Databricks Inc.'
+        license: Apache-2.0
+        path: benchmark/csharp/Tpch/TpchSqlQueries.cs
+      - attributions:
+          - 'Copyright (c) 2015 Savvas Savvides, ssavvides@us.ibm.com, savvas@purdue.edu'
+        license: MIT
+        path: benchmark/scala/src/main/scala/com/microsoft/tpch/TpchFunctionalQueries.scala


### PR DESCRIPTION

**Type:** Missing

**Summary:**
.Net for Apache Spark

**Details:**
File: /spark/benchmark/scala/src/main/scala/com/microsoft/tpch/TpchFunctionalQueries.scala

File with a section of code prefaced by the following notice:

/*
 * Note that the queries are taken from: https://github.com/ssavvides/tpch-spark and updated.
 */


**Resolution:**
License is correct (MIT), update copyright.
The code following this notice is based on code from tpch-spark, an implementation of "TPC-H queries in spark SQL using native DataFrames API." See https://github.com/ssavvides/tpch-spark. This material is licensed under the MIT License (see https://github

**Affected definitions**:
- [spark 8719e44d5eac08ecfb7f742e4b17160a255a5866](https://clearlydefined.io/definitions/git/github/dotnet/spark/8719e44d5eac08ecfb7f742e4b17160a255a5866/8719e44d5eac08ecfb7f742e4b17160a255a5866)