### PR TITLE
Plannier iOS - swiftdate

### DIFF
--- a/curations/git/github/malcommac/swiftdate.yaml
+++ b/curations/git/github/malcommac/swiftdate.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: swiftdate
+  namespace: malcommac
+  provider: github
+  type: git
+revisions:
+  89774a1e28826af1498693bcbdf9ff6037ec646f:
+    files:
+      - attributions:
+          - Copyright (c) 2019 Daniele Margutti.
+          - Copyright (c) 2006–2011 Peter Hosey  All rights reserved.
+        license: BSD-3-Clause
+        path: Sources/SwiftDate/Formatters/ISOParser.swift


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Plannier iOS - swiftdate

**Details:**
file: /SwiftDate-6.0.3/Sources/SwiftDate/Formatters/ISOParser.swift

File with a section of code prefaced by the following notice: 

/// This work is inspired to the original ISO8601DateFormatter class written in ObjC by
/// Peter Hosey (available here https://bitbucket.org/boredzo/iso-8601-parser-u

**Resolution:**
The code that follows this statement originates with ISO 8601 parser/unparser, a date manipulation library. See https://bitbucket.org/boredzo/iso-8601-parser-unparser. This material is licensed under the BSD License (see https://bitbucket.org/boredzo/iso-8601-parser-unparser/src/default/LICENSE.txt)

**Affected definitions**:
- [swiftdate 89774a1e28826af1498693bcbdf9ff6037ec646f](https://clearlydefined.io/definitions/git/github/malcommac/swiftdate/89774a1e28826af1498693bcbdf9ff6037ec646f/89774a1e28826af1498693bcbdf9ff6037ec646f)