### PR TITLE
Fix declared licenses for Hamcrest 1.3 to be BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.hamcrest/hamcrest-core.yaml
+++ b/curations/maven/mavencentral/org.hamcrest/hamcrest-core.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.3':
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause

--- a/curations/sourcearchive/mavencentral/org.hamcrest/hamcrest-core.yaml
+++ b/curations/sourcearchive/mavencentral/org.hamcrest/hamcrest-core.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.3':
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause


### PR DESCRIPTION
hamcrest-core inherits from hamcrest-parent [1] which declares
"New BSD License" [2] aka BSB-3-Clause. Also the license text at [3] is a
BSD-3-Clause one despite the third clause being wrapped into the second
clause. Finally, making this a BSD-3-Clause curation resolves the
inconsistency with the existing curations for hamcrest-all and
hamcrest-library which already declare BSD-3-Clause.

[1] https://github.com/hamcrest/JavaHamcrest/blob/hamcrest-java-1.3/pom/hamcrest-core.pom#L8
[2] https://github.com/hamcrest/JavaHamcrest/blob/hamcrest-java-1.3/pom/hamcrest-parent.pom#L17
[3] https://github.com/hamcrest/JavaHamcrest/blob/hamcrest-java-1.3/LICENSE.txt#L10-L12