### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/CredentialManagement.yaml
+++ b/curations/nuget/nuget/-/CredentialManagement.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CredentialManagement
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
License file in Codeplex package is Apache 2.0, and NuGet package license directs to the CodePlex project site.

**Affected definitions**:
- [CredentialManagement 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/CredentialManagement/1.0.2/1.0.2)