### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: azureml-train-restclients-hyperdrive
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.60:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Other for Microsoft Online Subscription Agreement

**Resolution:**
License file in package is same as PyPI meta: https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.0.60](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.0.60/1.0.60)