### PR TITLE
Add declared license

### DIFF
--- a/curations/npm/npmjs/-/ssh2-streams.yaml
+++ b/curations/npm/npmjs/-/ssh2-streams.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ssh2-streams
+  provider: npmjs
+  type: npm
+revisions:
+  0.4.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add declared license

**Details:**
No assertion for the license was made.

**Resolution:**
Sets the declared license to MIT to match that stated in the package.json.

**Affected definitions**:
- [ssh2-streams 0.4.6](https://clearlydefined.io/definitions/npm/npmjs/-/ssh2-streams/0.4.6)