### PR TITLE
Set declared license for ssh2

### DIFF
--- a/curations/npm/npmjs/-/ssh2.yaml
+++ b/curations/npm/npmjs/-/ssh2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ssh2
+  provider: npmjs
+  type: npm
+revisions:
+  0.8.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Set declared license for ssh2

**Details:**
No declared license was set.

**Resolution:**
Sets the declared license to MIT to match that stated in the package.json.

**Affected definitions**:
- [ssh2 0.8.5](https://clearlydefined.io/definitions/npm/npmjs/-/ssh2/0.8.5)