### PR TITLE
vowpalwabbit - set declared license

### DIFF
--- a/curations/git/github/vowpalwabbit/vowpal_wabbit.yaml
+++ b/curations/git/github/vowpalwabbit/vowpal_wabbit.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: vowpal_wabbit
+  namespace: vowpalwabbit
+  provider: github
+  type: git
+revisions:
+  07ac3db2afc30a5f2f90fc02707f978fbd5db61d:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
vowpalwabbit - set declared license

**Details:**
Update declared license to BSD.  

This material is licensed under the BSD License (see file /vowpal_wabbit-07ac3db2afc30a5f2f90fc02707f978fbd5db61d/LICENSE).

**Resolution:**
Set the declared license to BSD.

**Affected definitions**:
- [vowpal_wabbit 07ac3db2afc30a5f2f90fc02707f978fbd5db61d](https://clearlydefined.io/definitions/git/github/vowpalwabbit/vowpal_wabbit/07ac3db2afc30a5f2f90fc02707f978fbd5db61d/07ac3db2afc30a5f2f90fc02707f978fbd5db61d)