### PR TITLE
Correcting Declared license

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: LGPL-2.1-only
   2.7.1:
     licensed:
-      declared: LGPL-2.0-or-later
+      declared: LGPL-2.1-or-later

--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -6,3 +6,6 @@ revisions:
   2.6.0:
     licensed:
       declared: LGPL-2.1-only
+  2.7.1:
+    licensed:
+      declared: LGPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting Declared license

**Details:**
The package metadata says "GNU Library or Lesser General Public License (LGPL) (LGPL)," so LGPL-2.0 or 2.1.•	The setup.py says LGPL-2.1 or later https://github.com/paramiko/paramiko/blob/690d142321f53ae82f49a57b7f6716fb947d5687/setup.py.

**Resolution:**
So, I opted for LGPL-2.0-or later.

**Affected definitions**:
- [paramiko 2.7.1](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.7.1/2.7.1)