### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/wxpython.yaml
+++ b/curations/pypi/pypi/-/wxpython.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wxpython
+  provider: pypi
+  type: pypi
+revisions:
+  4.0.7.post2:
+    licensed:
+      declared: LGPL-2.0-or-later

--- a/curations/pypi/pypi/-/wxpython.yaml
+++ b/curations/pypi/pypi/-/wxpython.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.0.7.post2:
     licensed:
-      declared: LGPL-2.0-or-later
+      declared: LGPL-2.0-or-later WITH WxWindows-exception-3.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
Package metadat: Meta
License: OSI Approved (wxWindows Library License (https://opensource.org/licenses/wxwindows.php))

**Resolution:**
"wxWindows" is a deprecated SPDX identifier. The current SPDX format would be "LGPL-2.0.-or-later WITH WxWindows-exception-3.1."

**Affected definitions**:
- [wxpython 4.0.7.post2](https://clearlydefined.io/definitions/pypi/pypi/-/wxpython/4.0.7.post2/4.0.7.post2)