### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -12,6 +12,9 @@ revisions:
   3.11.1:
     licensed:
       declared: BSD-3-Clause
+  3.11.2:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
No declared license

**Resolution:**
BSD 3 Clause: https://pypi.org/project/protobuf/3.11.2/
https://github.com/protocolbuffers/protobuf/blob/master/LICENSE

**Affected definitions**:
- [protobuf 3.11.2](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.11.2/3.11.2)