### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -33,3 +33,6 @@ revisions:
   1.17.4:
     licensed:
       declared: BSD-3-Clause
+  1.18.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing declared license

**Resolution:**
BSD 3 Claues: https://github.com/numpy/numpy/blob/master/LICENSE.txt

**Affected definitions**:
- [numpy 1.18.0](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.18.0/1.18.0)