### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -9,3 +9,9 @@ revisions:
   6.1.0:
     licensed:
       declared: OTHER
+  6.2.1:
+    licensed:
+      declared: HPND
+  7.0.0:
+    licensed:
+      declared: HPND


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
HPND: Both versions declare HPND in the metadata and contain a HPND license file.

**Affected definitions**:
- [Pillow 6.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/6.2.1)
- [Pillow 7.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/7.0.0)