### PR TITLE
Add Declared License

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: azureml-train-automl-client
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.85:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Other for Microsoft online services terms

**Resolution:**
Package license and PyPi meta are the same -https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-train-automl-client 1.0.85](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.0.85/1.0.85)