### PR TITLE
Update Licenese information

### DIFF
--- a/curations/git/github/microsoft/onnxruntime.yaml
+++ b/curations/git/github/microsoft/onnxruntime.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: onnxruntime
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  c33dab394f4984ab28a370d96c373f0fca84d826:
+    files:
+      - attributions:
+          - Copyright (c) Microsoft Corporation.
+          - Copyright (c) 2018 The gRPC Authors
+        license: Apache-2.0
+        path: cmake/onnxruntime_server.cmake


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update Licenese information

**Details:**
Proj: Skype Converged Core
Comp: onnxruntime v1.1.0
File: https://github.com/microsoft/onnxruntime/blob/c33dab394f4984ab28a370d96c373f0fca84d826/cmake/onnxruntime_server.cmake
Line: 12
Reference to gRPC material which is licensed under Apache v2.


**Resolution:**
Updates license attributions to include Apache v2 to cover gRPC

**Affected definitions**:
- [onnxruntime c33dab394f4984ab28a370d96c373f0fca84d826](https://clearlydefined.io/definitions/git/github/microsoft/onnxruntime/c33dab394f4984ab28a370d96c373f0fca84d826/c33dab394f4984ab28a370d96c373f0fca84d826)