### PR TITLE
Update License Attribution

### DIFF
--- a/curations/git/github/microsoft/onnxruntime.yaml
+++ b/curations/git/github/microsoft/onnxruntime.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: onnxruntime
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  c33dab394f4984ab28a370d96c373f0fca84d826:
+    files:
+      - attributions:
+          - Copyright (c) Microsoft Corporation.
+          - 'CMake - Cross Platform Makefile Generator Copyright 2000-2019 Kitware, Inc. and Contributors All rights reserved.'
+        license: BSD-3-Clause
+        path: cmake/CMakeLists.txt
+      - attributions:
+          - Copyright (c) Microsoft Corporation.
+          - Copyright (c) 2018 The gRPC Authors
+        license: Apache-2.0
+        path: cmake/onnxruntime_server.cmake


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update License Attribution

**Details:**
Proj: S Converged Core
Comp: onnxruntime v1.1.0
File: https://github.com/microsoft/onnxruntime/blob/c33dab394f4984ab28a370d96c373f0fca84d826/cmake/CMakeLists.txt 
Line: 606
Reference to cmake material which is licensed under BSD.


**Resolution:**
Updates license attribution to include reference to cmake; see https://gitlab.kitware.com/cmake/cmake/blob/master/Copyright.txt

**Affected definitions**:
- [onnxruntime c33dab394f4984ab28a370d96c373f0fca84d826](https://clearlydefined.io/definitions/git/github/microsoft/onnxruntime/c33dab394f4984ab28a370d96c373f0fca84d826/c33dab394f4984ab28a370d96c373f0fca84d826)