### PR TITLE
Update license information on bundletool 

### DIFF
--- a/curations/git/github/google/bundletool.yaml
+++ b/curations/git/github/google/bundletool.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: bundletool
+  namespace: google
+  provider: github
+  type: git
+revisions:
+  5ac94cb61e949f135c50f6ce52bbb5f00e8e959f:
+    files:
+      - attributions:
+          - Copyright (c) 2018 The Android Open Source Project
+          - 'Copyright (c) 2016, the R8 project authors. All rights reserved.'
+        license: BSD-3-Clause
+        path: src/test/java/com/android/tools/build/bundletool/mergers/D8DexMergerTest.java


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update license information on bundletool 

**Details:**
Proj: Review of Xam.Android.Jul32019 
Comp: bundletool v0.10.0
File: https://github.com/microsoft/onnxruntime/blob/c33dab394f4984ab28a370d96c373f0fca84d826/onnxruntime/core/providers/dml/OperatorAuthorHelper/OperatorHelper.cpp 
Line: 241
Reference to android tool which is licensed under BSD-3-Clau.


**Resolution:**
Updates license information to include BSD-3-Clause for tool referenced.  
Issue #2.

**Affected definitions**:
- [bundletool 5ac94cb61e949f135c50f6ce52bbb5f00e8e959f](https://clearlydefined.io/definitions/git/github/google/bundletool/5ac94cb61e949f135c50f6ce52bbb5f00e8e959f/5ac94cb61e949f135c50f6ce52bbb5f00e8e959f)