### PR TITLE
Update license attribution

### DIFF
--- a/curations/git/github/google/bundletool.yaml
+++ b/curations/git/github/google/bundletool.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: bundletool
+  namespace: google
+  provider: github
+  type: git
+revisions:
+  2e9ac4e628a690c0fce402548fe90c747c86533c:
+    files:
+      - attributions:
+          - Copyright (C) 2018 The Android Open Source Project
+        license: Apache-2.0
+        path: LICENSE
+      - attributions:
+          - Copyright (c) 2018 The Android Open Source Project
+          - 'Copyright (c) 2016, the R8 project authors. All rights reserved.'
+        license: BSD-3-Clause
+        path: src/test/java/com/android/tools/build/bundletool/mergers/D8DexMergerTest.java


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update license attribution

**Details:**
Proj: Xam.Andriod Jul2019
Comp: bundletool v0.10.2
File: https://github.com/google/bundletool/blob/2e9ac4e628a690c0fce402548fe90c747c86533c/src/test/java/com/android/tools/build/bundletool/mergers/D8DexMergerTest.java
Line: 241

**Resolution:**
Update reference to tool referenced in this file which is licensed under BSD-3-Clause.

**Affected definitions**:
- [bundletool 2e9ac4e628a690c0fce402548fe90c747c86533c](https://clearlydefined.io/definitions/git/github/google/bundletool/2e9ac4e628a690c0fce402548fe90c747c86533c/2e9ac4e628a690c0fce402548fe90c747c86533c)