### PR TITLE
Correct reuse-tool

### DIFF
--- a/curations/pypi/pypi/-/reuse.yaml
+++ b/curations/pypi/pypi/-/reuse.yaml
@@ -1,0 +1,21 @@
+coordinates:
+  name: reuse
+  provider: pypi
+  type: pypi
+revisions:
+  0.8.0:
+    described:
+      facets:
+        doc:
+          - docs/
+        tests:
+          - tests/
+      sourceLocation:
+        name: reuse-tool
+        namespace: fsfe
+        provider: github
+        revision: 204c3457655a3b39b486905179ffffd810b2ec15
+        type: git
+        url: 'https://github.com/fsfe/reuse-tool/commit/204c3457655a3b39b486905179ffffd810b2ec15'
+    licensed:
+      declared: GPL-3.0-or-later AND Apache-2.0 AND CC0-1.0 AND CC-BY-SA-4.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correct reuse-tool

**Details:**
Kind of ironically, reuse scores incredibly low on ClearlyDefined, even though it's one of the most thoroughly defined projects. This PR fixes a handful of things:

- The harvester was unable to find the source location.
- The overall license was incorrectly identified
- Copyright not identified

**Resolution:**
This PR simply fixes the things that are incorrect.

It can't fix the copyright holders not being identified. `SPDX-FileCopyrightText` is used, but the harvester doesn't recognise this.

**Affected definitions**:
- [reuse 0.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/reuse/0.8.0)