### PR TITLE
Fixing

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: OTHER
   6.1.0:
     licensed:
-      declared: OTHER
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing

**Details:**
Updating OTHER to HPND

**Resolution:**
HPND is in the metadata.  The license file is called the PIL Software License, but matches https://spdx.org/licenses/HPND.html#licenseText

**Affected definitions**:
- [Pillow 6.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/6.1.0/6.1.0)