### PR TITLE
Fixing file

### DIFF
--- a/curations/pypi/pypi/-/reuse.yaml
+++ b/curations/pypi/pypi/-/reuse.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: reuse
+  provider: pypi
+  type: pypi
+revisions:
+  0.8.0:
+    files:
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <https://fsf.org/>'
+        license: GPL-3.0-or-later
+        path: reuse-0.8.0/LICENSES/GPL-3.0-or-later.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing file

**Details:**
Fixing license file from GPL-3.0-only to GPL-3.0-or-later, as indicated by the file name and the metadata

**Resolution:**
https://pypi.org/project/reuse/0.8.0/

**Affected definitions**:
- [reuse 0.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/reuse/0.8.0/0.8.0)