### PR TITLE
Adding Declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -71,6 +71,9 @@ revisions:
   3.17.0:
     licensed:
       declared: MIT
+  3.17.1:
+    licensed:
+      declared: MIT
   3.17.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
NuGet license link is MIT

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/dev/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 3.17.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/3.17.1/3.17.1)