### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Cryptography.OpenSsl.yaml
+++ b/curations/nuget/nuget/-/System.Security.Cryptography.OpenSsl.yaml
@@ -6,3 +6,6 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Updating NOASSERTION to MIT

**Resolution:**
MIT license link and license in package: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- [System.Security.Cryptography.OpenSsl 4.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Cryptography.OpenSsl/4.5.1/4.5.1)