### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.22.2:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-media-jaxb
+  namespace: org.glassfish.jersey.media
+  provider: mavencentral
+  type: maven
+revisions:
+  2.22.2:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Updating NOASSERTION to CDDL 1.1 OR GPL-2.0-only WITH classpath-exception

**Resolution:**
https://clearlydefined.io/file/8d0d5235ef1b322a5e700bae918560f41467b98935bd25c9a4da0224f7e9f57a

**Affected definitions**:
- [jersey-media-jaxb 2.22.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb/2.22.2/2.22.2)