### PR TITLE
Curating Declared and LICENSE file

### DIFF
--- a/curations/maven/mavencentral/javax.transaction/jta.yaml
+++ b/curations/maven/mavencentral/javax.transaction/jta.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: jta
+  namespace: javax.transaction
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    files:
+      - license: CDDL-1.0
+        path: META-INF/LICENSE.txt
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Curating Declared and LICENSE file

**Details:**
Curating CDDL-1.0 per the LICENSE file in the Files content area

**Resolution:**
https://clearlydefined.io/file/92bb38fc5b1d81a9e82258b05cfc92b13cc5d1a099555f1f60387ab8e9718d0d

**Affected definitions**:
- [jta 1.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.transaction/jta/1.1/1.1)