### PR TITLE
Adding Declared

### DIFF
--- a/curations/nuget/nuget/-/AD.System.Web.Helpers.dll.yaml
+++ b/curations/nuget/nuget/-/AD.System.Web.Helpers.dll.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AD.System.Web.Helpers.dll
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared

**Details:**
Not sure if this should be NONE or OTHER.  There is no license info on the NuGet page.  If you download the package, there is a line that says "View license terms," but the link goes to a defunct website - https://acedollar.com/.

**Resolution:**
Decided on NONE, as no findable license terms for this package. 

**Affected definitions**:
- [AD.System.Web.Helpers.dll 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/AD.System.Web.Helpers.dll/2.0.0/2.0.0)