### PR TITLE
Adding Declared

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.SharePoint.Client.dll.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SharePoint.Client.dll.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.SharePoint.Client.dll
+  provider: nuget
+  type: nuget
+revisions:
+  15.0.4420.1017:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared

**Details:**
Not sure if NONE or OTHER. There are no license terms, but the download page would indicate that perhaps, the NuGet is under the Microsoft SharePoint 2013 license terms.

**Resolution:**
Curated NONE, as no express link to any license terms or copy of a license.  Curious what others think.

**Affected definitions**:
- [Microsoft.SharePoint.Client.dll 15.0.4420.1017](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.SharePoint.Client.dll/15.0.4420.1017/15.0.4420.1017)