### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/Crc32C.NET.yaml
+++ b/curations/nuget/nuget/-/Crc32C.NET.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Crc32C.NET
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: BSD-3-Clause AND Zlib


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding BSD-3-Clause and Zlib

**Resolution:**
NuGet license and package license link: https://opensource.org/licenses/BSD-3-Clause
https://github.com/robertvazan/crc32c-hw/blob/master/LICENSE

Sources are available from GitHub and Bitbucket. .NET code is distributed under BSD license. Underlying C++ code is distributed under zlib license.

**Affected definitions**:
- [Crc32C.NET 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Crc32C.NET/1.0.5/1.0.5)