### PR TITLE
Adding Declared license

### DIFF
--- a/curations/maven/mavencentral/javolution/javolution.yaml
+++ b/curations/maven/mavencentral/javolution/javolution.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javolution
+  namespace: javolution
+  provider: mavencentral
+  type: maven
+revisions:
+  5.5.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
POM https://repo1.maven.org/maven2/javolution/javolution/5.5.1/javolution-5.5.1.pom points to http://javolution.org/LICENSE.txt

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [javolution 5.5.1](https://clearlydefined.io/definitions/maven/mavencentral/javolution/javolution/5.5.1/5.5.1)