### PR TITLE
Declared MIT

### DIFF
--- a/curations/nuget/nuget/-/dotnetty.codecs.mqtt.yaml
+++ b/curations/nuget/nuget/-/dotnetty.codecs.mqtt.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dotnetty.codecs.mqtt
+  provider: nuget
+  type: nuget
+revisions:
+  0.4.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared MIT

**Details:**
Declared MIT found here (https://github.com/Azure/DotNetty/blob/master/LICENSE.txt)

**Resolution:**
Matches Project Site

**Affected definitions**:
- [dotnetty.codecs.mqtt 0.4.6](https://clearlydefined.io/definitions/nuget/nuget/-/dotnetty.codecs.mqtt/0.4.6/0.4.6)