### PR TITLE
Declared Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/razorengine.yaml
+++ b/curations/nuget/nuget/-/razorengine.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: razorengine
+  provider: nuget
+  type: nuget
+revisions:
+  3.7.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Apache-2.0

**Details:**
Declared Apache-2.0 found here (https://github.com/Antaris/RazorEngine/blob/master/LICENSE.md)

**Resolution:**
matched project site

**Affected definitions**:
- [razorengine 3.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/razorengine/3.7.2/3.7.2)