### PR TITLE
Declared NONE

### DIFF
--- a/curations/nuget/nuget/-/microsoft.windowsazure.sdk.yaml
+++ b/curations/nuget/nuget/-/microsoft.windowsazure.sdk.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: microsoft.windowsazure.sdk
+  provider: nuget
+  type: nuget
+revisions:
+  2.9.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared NONE

**Details:**
Declared None - couldn't find a license 

**Resolution:**
Declared None - couldn't find a license

**Affected definitions**:
- [microsoft.windowsazure.sdk 2.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/microsoft.windowsazure.sdk/2.9.0/2.9.0)