### PR TITLE
Missing information for Mono.Posix.NETStandard/1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Mono.Posix.NETStandard.yaml
+++ b/curations/nuget/nuget/-/Mono.Posix.NETStandard.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: MIT AND BSD-3-Clause
   1.0.0-beta2:
     licensed:
       declared: MIT AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Mono.Posix.NETStandard/1.0.0

**Details:**
Adding license

**Resolution:**
Source:
https://github.com/mono/mono
License:
https://github.com/mono/mono/blob/master/LICENSE

**Affected definitions**:
- [Mono.Posix.NETStandard 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Mono.Posix.NETStandard/1.0.0)