### PR TITLE
Missing information for M2MqttDotnetCore/1.0.8

### DIFF
--- a/curations/nuget/nuget/-/M2MqttDotnetCore.yaml
+++ b/curations/nuget/nuget/-/M2MqttDotnetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: M2MqttDotnetCore
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.8:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for M2MqttDotnetCore/1.0.8

**Details:**
Adding license

**Resolution:**
License:
https://github.com/mohaqeq/paho.mqtt.m2mqtt/blob/master/LICENSE

**Affected definitions**:
- [M2MqttDotnetCore 1.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/M2MqttDotnetCore/1.0.8)