### PR TITLE
Missing license for System.Security.Cryptography.OpenSsl/4.5.1

### DIFF
--- a/curations/nuget/nuget/-/system.security.cryptography.openssl.yaml
+++ b/curations/nuget/nuget/-/system.security.cryptography.openssl.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: system.security.cryptography.openssl
+  provider: nuget
+  type: nuget
+revisions:
+  4.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for System.Security.Cryptography.OpenSsl/4.5.1

**Details:**
Adding license

**Resolution:**
Source:
https://github.com/dotnet/runtime

License:
https://github.com/dotnet/runtime/blob/master/LICENSE.TXT

**Affected definitions**:
- [system.security.cryptography.openssl 4.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/system.security.cryptography.openssl/4.5.1/4.5.1)