### PR TITLE
Missing license for M2MqttDotnetCore/1.0.8

### DIFF
--- a/curations/nuget/nuget/-/m2mqttdotnetcore.yaml
+++ b/curations/nuget/nuget/-/m2mqttdotnetcore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: m2mqttdotnetcore
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.8:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for M2MqttDotnetCore/1.0.8

**Details:**
Adding license

**Resolution:**
Source:
https://github.com/mohaqeq/paho.mqtt.m2mqtt

License:
https://github.com/mohaqeq/paho.mqtt.m2mqtt/blob/master/LICENSE

**Affected definitions**:
- [m2mqttdotnetcore 1.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/m2mqttdotnetcore/1.0.8/1.0.8)