### PR TITLE
Missing information for System.Linq.Dynamic.Core/1.0.19

### DIFF
--- a/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
+++ b/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: System.Linq.Dynamic.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.19:
+    described:
+      sourceLocation:
+        name: system.linq.dynamic.core
+        namespace: stefh
+        provider: github
+        revision: 759172668f5789e87ed4da50ac838c3164572788
+        type: git
+        url: 'https://github.com/stefh/system.linq.dynamic.core/commit/759172668f5789e87ed4da50ac838c3164572788'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for System.Linq.Dynamic.Core/1.0.19

**Details:**
Adding source and license

**Resolution:**
Source:
https://github.com/StefH/System.Linq.Dynamic.Core/tree/759172668f5789e87ed4da50ac838c3164572788

License:
https://github.com/StefH/System.Linq.Dynamic.Core/blob/759172668f5789e87ed4da50ac838c3164572788/LICENSE

**Affected definitions**:
- [System.Linq.Dynamic.Core 1.0.19](https://clearlydefined.io/definitions/nuget/nuget/-/System.Linq.Dynamic.Core/1.0.19)