### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Crm.Sdk.Proxy.2015.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Crm.Sdk.Proxy.2015.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Crm.Sdk.Proxy.2015
+  provider: nuget
+  type: nuget
+revisions:
+  7.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
OTHER: Package states, "This package contains the Microsoft.Crm.Sdk.Proxy dll for Microsoft Dynamics CRM 2015. License available inside SDK download". CRM 2015 is under https://www.microsoft.com/en-us/download/details.aspx?id=44567.

**Affected definitions**:
- [Microsoft.Crm.Sdk.Proxy.2015 7.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Crm.Sdk.Proxy.2015/7.1.0/7.1.0)