### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Xrm.Client.2015.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Xrm.Client.2015.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Xrm.Client.2015
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Other: Package description states, "This package contains the Microsoft.Xrm.Client dll for Microsoft Dynamics CRM 2015. License available inside SDK download". Link to download SDK is at microsoft.com/en-us/download/details.aspx?id=44567, which contains a MS EULA.

**Affected definitions**:
- [Microsoft.Xrm.Client.2015 7.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Xrm.Client.2015/7.0.1/7.0.1)