### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
@@ -6,3 +6,6 @@ revisions:
   2.0.0:
     licensed:
       declared: MIT
+  2.1.0-beta2:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/MSTest.TestFramework.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestFramework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSTest.TestFramework
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.0-beta2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Adding license

**Resolution:**
MIT license:

https://www.nuget.org/packages/MSTest.TestAdapter/2.1.0-beta2/License
https://www.nuget.org/packages/MSTest.TestFramework/2.1.0-beta2/License

**Affected definitions**:
- [MSTest.TestAdapter 2.1.0-beta2](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestAdapter/2.1.0-beta2),- [MSTest.TestFramework 2.1.0-beta2](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestFramework/2.1.0-beta2)