### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/ILMerge.yaml
+++ b/curations/nuget/nuget/-/ILMerge.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.13.307:
+    licensed:
+      declared: MIT
   3.0.18:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
Package license link points to a Microsoft Research profile, but doesn't contain any license information. Newest version license point to https://github.com/dotnet/ILMerge/blob/master/LICENSE.

**Affected definitions**:
- [ILMerge 2.13.307](https://clearlydefined.io/definitions/nuget/nuget/-/ILMerge/2.13.307/2.13.307)