### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/MSBuild.ILMerge.Task.yaml
+++ b/curations/nuget/nuget/-/MSBuild.ILMerge.Task.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSBuild.ILMerge.Task
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
MIT: License in package states MIT. Latest version points to https://dev.azure.com/Refactorius/_git/MsBuild.ILMerge.Task?path=%2FLicense.txt

**Affected definitions**:
- [MSBuild.ILMerge.Task 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuild.ILMerge.Task/1.0.5/1.0.5)