### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0.124:
+    licensed:
+      declared: MS-PL
   2.1.0.174:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding MS-PL

**Resolution:**
NuGet license and package license link are broken. 

Version before and after have MS-PL in the GitHub repo:

https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v2.0.0.98/License.txt

https://github.com/tathamoddie/System.IO.Abstractions/blob/master/

Newer versions are under MIT.

**Affected definitions**:
- [System.IO.Abstractions 2.0.0.124](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/2.0.0.124/2.0.0.124)