### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Experimental.IO.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Experimental.IO.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Experimental.IO
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Incorrect license

**Resolution:**
License link points to https://bcl.codeplex.com/license. CodePlex states the project migrated to https://github.com/MicrosoftArchive/bcl, which is MIT.
https://github.com/microsoftarchive/bcl/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Experimental.IO 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Experimental.IO/1.0.0/1.0.0)