### PR TITLE
Missing declared license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -15,6 +15,9 @@ revisions:
   3.11.2:
     licensed:
       declared: BSD-3-Clause
+  3.11.3:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
Missing license

**Resolution:**
PKG-INFO states BSD-3-Clause and the source repo is the same: https://github.com/protocolbuffers/protobuf/blob/master/LICENSE

**Affected definitions**:
- [protobuf 3.11.3](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.11.3/3.11.3)