### PR TITLE
Add Declared License

### DIFF
--- a/curations/npm/npmjs/-/testpackage.yaml
+++ b/curations/npm/npmjs/-/testpackage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: testpackage
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding BSD-3-Clause

**Resolution:**
Couldn't see contents of .tgz file. Curating BSD-3-Clause, however, only found "BSD" in the following places -

ClearlyDefined license: BSD

NPM: BSD (http://registry.npmjs.com/testpackage)

**Affected definitions**:
- [testpackage 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/testpackage/1.0.0/1.0.0)