### PR TITLE
Missing information for Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.6

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -184,3 +184,14 @@ revisions:
   5.2.5:
     licensed:
       declared: MIT
+  5.2.6:
+    described:
+      sourceLocation:
+        name: azure-activedirectory-library-for-dotnet
+        namespace: azuread
+        provider: github
+        revision: 7879e4efa5d817c7d0c41116bb3a4af88e7d39c8
+        type: git
+        url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/7879e4efa5d817c7d0c41116bb3a4af88e7d39c8'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.6

**Details:**
Adding source and license.

**Resolution:**
Source:
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/tree/7879e4efa5d817c7d0c41116bb3a4af88e7d39c8 
MIT License:
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/7879e4efa5d817c7d0c41116bb3a4af88e7d39c8/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.6/5.2.6)