### PR TITLE
Missing information for Microsoft.Owin/4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.yaml
@@ -9,3 +9,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Owin/4.1.0

**Details:**
Adding license

**Resolution:**
Apache 2.0 License:
https://github.com/aspnet/AspNetKatana/blob/9e9c44d0b0027cb58a3252a10ea93f25ccab32af/LICENSE.txt


**Affected definitions**:
- [Microsoft.Owin 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin/4.1.0/4.1.0)