### PR TITLE
Missing information for RichardSzalay.MockHttp/6.0.0

### DIFF
--- a/curations/nuget/nuget/-/RichardSzalay.MockHttp.yaml
+++ b/curations/nuget/nuget/-/RichardSzalay.MockHttp.yaml
@@ -9,3 +9,6 @@ revisions:
   5.0.0:
     licensed:
       declared: MIT
+  6.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for RichardSzalay.MockHttp/6.0.0

**Details:**
Adding license.

**Resolution:**
MIT License:
https://github.com/richardszalay/mockhttp/blob/b7b690058a8cc09fbc6f7cbea9a4809f760a536f/LICENSE

**Affected definitions**:
- [RichardSzalay.MockHttp 6.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/RichardSzalay.MockHttp/6.0.0/6.0.0)