### PR TITLE
Missing information for Portable.BouncyCastle/1.8.5.2

### DIFF
--- a/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
@@ -9,3 +9,14 @@ revisions:
   1.8.5:
     licensed:
       declared: MIT
+  1.8.5.2:
+    described:
+      sourceLocation:
+        name: bc-csharp
+        namespace: novotnyllc
+        provider: github
+        revision: ba47c16e72bf21dd7a223220a5bd38a05034add9
+        type: git
+        url: 'https://github.com/novotnyllc/bc-csharp/commit/ba47c16e72bf21dd7a223220a5bd38a05034add9'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Portable.BouncyCastle/1.8.5.2

**Details:**
Adding source and license.

**Resolution:**
Source:
https://github.com/novotnyllc/bc-csharp/tree/ba47c16e72bf21dd7a223220a5bd38a05034add9
Bouncy Castle License:
https://github.com/novotnyllc/bc-csharp/blob/ba47c16e72bf21dd7a223220a5bd38a05034add9/License.html
Note that the license is based on the MIT license.

**Affected definitions**:
- [Portable.BouncyCastle 1.8.5.2](https://clearlydefined.io/definitions/nuget/nuget/-/Portable.BouncyCastle/1.8.5.2/1.8.5.2)