### PR TITLE
Vue Missing Copyright and some license info

### DIFF
--- a/curations/npm/npmjs/-/vue.yaml
+++ b/curations/npm/npmjs/-/vue.yaml
@@ -1,0 +1,55 @@
+coordinates:
+  name: vue
+  provider: npmjs
+  type: npm
+revisions:
+  3.0.0-alpha.5:
+    files:
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/index.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/package.json
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/README.md
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.cjs.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.cjs.prod.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.d.ts
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.esm-bundler.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.esm.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.esm.prod.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.global.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.global.prod.js
+      - attributions:
+          - 'Copyright (c) 2013-present, Yuxi (Evan) You'
+        license: MIT
+        path: package/dist/vue.runtime.esm-bundler.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Vue Missing Copyright and some license info

**Details:**
Vue Missing Copyright and some license info

**Resolution:**
Added Copyright and license info to vue npm

**Affected definitions**:
- [vue 3.0.0-alpha.5](https://clearlydefined.io/definitions/npm/npmjs/-/vue/3.0.0-alpha.5)