### PR TITLE
Missing license

### DIFF
--- a/curations/npm/npmjs/-/wellknown.yaml
+++ b/curations/npm/npmjs/-/wellknown.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wellknown
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.0:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license

**Details:**
Missing license here, but declared in GitHub.

**Resolution:**
https://github.com/mapbox/wellknown/blob/master/LICENSE

**Affected definitions**:
- [wellknown 0.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/wellknown/0.5.0/0.5.0)