### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -15,6 +15,9 @@ revisions:
   4.0.1:
     licensed:
       declared: MIT
+  5.0.0:
+    licensed:
+      declared: MIT
   5.0.0-rc2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -15,6 +15,9 @@ revisions:
   4.0.1:
     licensed:
       declared: MIT
+  5.0.0:
+    licensed:
+      declared: MIT
   5.0.0-rc2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -15,6 +15,9 @@ revisions:
   4.0.1:
     licensed:
       declared: MIT
+  5.0.0:
+    licensed:
+      declared: MIT
   5.0.0-rc2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Correcting license

**Resolution:**
MIT: All point to https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.0.0),- [Swashbuckle.AspNetCore.SwaggerGen 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/5.0.0),- [Swashbuckle.AspNetCore.SwaggerUI 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.0.0)