### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -15,6 +15,9 @@ revisions:
   4.0.1:
     licensed:
       declared: MIT
+  5.0.0:
+    licensed:
+      declared: MIT
   5.0.0-rc2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Incorrect license

**Resolution:**
MIT: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.0.0/5.0.0)