### PR TITLE
Updating NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.Cookies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.Cookies.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.OpenIdConnect.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.OpenIdConnect.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating NOASSERTION

**Details:**
Incorrect license

**Resolution:**
Apache-2.0: Both point to https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Security.Cookies 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.Cookies/4.1.0),- [Microsoft.Owin.Security.OpenIdConnect 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.OpenIdConnect/4.1.0)