### PR TITLE
Missing license for microsoft.azure.devices.shared/1.18.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: MIT   
+      declared: MIT
   1.15.1:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -6,6 +6,9 @@ revisions:
   1.1.1:
     licensed:
       declared: MIT
+  1.5.0:	
+    licensed:	
+      declared: MIT    
   1.15.1:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -6,9 +6,6 @@ revisions:
   1.1.1:
     licensed:
       declared: MIT
-  1.5.0:
-    licensed:
-      declared: MIT
   1.15.1:
     licensed:
       declared: MIT
@@ -23,6 +20,20 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/b1041109d4daded8f5dbf64a438497de1660cc16'
     licensed:
       declared: MIT
+  1.18.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: da20ff83c5aeb3ce0a736520b86283a6192cdaec
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/da20ff83c5aeb3ce0a736520b86283a6192cdaec'
+    licensed:
+      declared: MIT
   1.3.0:
+    licensed:
+      declared: MIT
+  1.5.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -5,10 +5,7 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: MIT
-  1.5.0:	
-    licensed:	
-      declared: MIT    
+      declared: MIT   
   1.15.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for microsoft.azure.devices.shared/1.18.0

**Details:**
Adding source and license. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Azure.Devices.Shared/1.18.0
Source:
https://github.com/Azure/azure-iot-sdk-csharp/tree/da20ff83c5aeb3ce0a736520b86283a6192cdaec
MIT License:
https://github.com/Azure/azure-iot-sdk-csharp/blob/da20ff83c5aeb3ce0a736520b86283a6192cdaec/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices.Shared 1.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices.Shared/1.18.0/1.18.0)