### PR TITLE
Missing license for microsoft.azure.devices/1.19.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
@@ -6,6 +6,17 @@ revisions:
   1.17.1:
     licensed:
       declared: MIT
+  1.19.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: da20ff83c5aeb3ce0a736520b86283a6192cdaec
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/da20ff83c5aeb3ce0a736520b86283a6192cdaec'
+    licensed:
+      declared: MIT
   1.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for microsoft.azure.devices/1.19.0

**Details:**
Adding source and license. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Azure.Devices/1.19.0
Source:
https://github.com/Azure/azure-iot-sdk-csharp/tree/da20ff83c5aeb3ce0a736520b86283a6192cdaec
MIT License:
https://github.com/Azure/azure-iot-sdk-csharp/blob/da20ff83c5aeb3ce0a736520b86283a6192cdaec/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices 1.19.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices/1.19.0/1.19.0)