### PR TITLE
Missing license for microsoft.net.sdk.functions/3.0.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -24,3 +24,6 @@ revisions:
   1.0.29:
     licensed:
       declared: MIT
+  3.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for microsoft.net.sdk.functions/3.0.3

**Details:**
Adding license. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.NET.Sdk.Functions/3.0.3
MIT License:
https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.3/3.0.3)