### PR TITLE
Missing license for mstest.testadapter/2.1.0

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: MIT
+  2.1.0:
+    licensed:
+      declared: MIT
   2.1.0-beta2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license for mstest.testadapter/2.1.0

**Details:**
Adding source and license. 

**Resolution:**
https://www.nuget.org/packages/MSTest.TestAdapter/2.1.0
Source:
https://github.com/microsoft/testfx/tree/cdb43cce6811d3a74510c75cb21b4c50a0636c05
MIT License:
https://github.com/microsoft/testfx/blob/cdb43cce6811d3a74510c75cb21b4c50a0636c05/LICENSE.txt

**Affected definitions**:
- [MSTest.TestAdapter 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestAdapter/2.1.0/2.1.0)