### PR TITLE
Declared license

### DIFF
--- a/curations/npm/npmjs/-/log-prefix.yaml
+++ b/curations/npm/npmjs/-/log-prefix.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: log-prefix
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
Didn't see license info in the registry.  Repo "Source" link README says MIT.

**Resolution:**
MIT

**Affected definitions**:
- [log-prefix 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/log-prefix/0.1.1/0.1.1)