### PR TITLE
Fixing Declared License

### DIFF
--- a/curations/pypi/pypi/-/pexpect.yaml
+++ b/curations/pypi/pypi/-/pexpect.yaml
@@ -6,3 +6,6 @@ revisions:
   4.7.0:
     licensed:
       declared: ISC
+  4.8.0:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing Declared License

**Details:**
The ISC LICENSE e mentions "GPL" and tooling incorrectly included GPL in curation.  I downloaded the package and the license is just ISC.

**Resolution:**
PEXPECT LICENSE::

    http://opensource.org/licenses/isc-license.txt

    Copyright (c) 2013-2016, Pexpect development team
    Copyright (c) 2012, Noah Spurrier <noah@noah.org>

    PERMISSION TO USE, COPY, MODIFY, AND/OR DISTRIBUTE THIS SOFTWARE FOR ANY
    PURPOSE WITH OR WITHOUT FEE IS HEREBY..

**Affected definitions**:
- [pexpect 4.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/pexpect/4.8.0/4.8.0)