### PR TITLE
Missing information for various Microsoft.Owin.* components

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Diagnostics.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Diagnostics.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.FileSystems.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.FileSystems.yaml
@@ -9,3 +9,6 @@ revisions:
         path: Microsoft.Owin.FileSystems.nuspec
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.ActiveDirectory.yaml
@@ -9,3 +9,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.Jwt.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.Jwt.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Microsoft.Owin.Security.Jwt.nuspec
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.OAuth.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.OAuth.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Microsoft.Owin.Security.OAuth.nuspec
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Microsoft.Owin.Security.nuspec
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.SelfHost.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.SelfHost.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.Owin.StaticFiles.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.StaticFiles.yaml
@@ -11,3 +11,6 @@ revisions:
         path: Microsoft.Owin.StaticFiles.nuspec
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for various Microsoft.Owin.* components

**Details:**
Update declared license to Apache-2.0

**Resolution:**
License can be found here: https://github.com/aspnet/AspNetKatana/blob/9e9c44d0b0027cb58a3252a10ea93f25ccab32af/LICENSE.txt . All components in this curation have the same source and thus are all subject to this license.

**Affected definitions**:
- [Microsoft.Owin.Diagnostics 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Diagnostics/4.1.0),- [Microsoft.Owin.FileSystems 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.FileSystems/4.1.0),- [Microsoft.Owin.Security 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security/4.1.0),- [Microsoft.Owin.Security.ActiveDirectory 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.ActiveDirectory/4.1.0),- [Microsoft.Owin.Security.Jwt 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.Jwt/4.1.0),- [Microsoft.Owin.Security.OAuth 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.OAuth/4.1.0),- [Microsoft.Owin.SelfHost 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.SelfHost/4.1.0),- [Microsoft.Owin.StaticFiles 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.StaticFiles/4.1.0)