### PR TITLE
Missing information for system.linq.dynamic.core/1.0.20

### DIFF
--- a/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
+++ b/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
@@ -14,3 +14,6 @@ revisions:
         url: 'https://github.com/stefh/system.linq.dynamic.core/commit/759172668f5789e87ed4da50ac838c3164572788'
     licensed:
       declared: Apache-2.0
+  1.0.20:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for system.linq.dynamic.core/1.0.20

**Details:**
Adding license.

**Resolution:**
Apache 2.0 License:
https://github.com/StefH/System.Linq.Dynamic.Core/blob/1e9effbf637c18b791d9f4bf5dbd52f92fdab44b/LICENSE

**Affected definitions**:
- [System.Linq.Dynamic.Core 1.0.20](https://clearlydefined.io/definitions/nuget/nuget/-/System.Linq.Dynamic.Core/1.0.20/1.0.20)