### PR TITLE
Fix declared

### DIFF
--- a/curations/crate/cratesio/-/syn.yaml
+++ b/curations/crate/cratesio/-/syn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: syn
+  provider: cratesio
+  type: crate
+revisions:
+  1.0.14:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fix declared

**Details:**
The declared SPDX expression should be `OR`, not `AND`.

**Resolution:**
The declared expression should primarily come from the license field in the Cargo.toml for Rust crates.

https://github.com/dtolnay/syn/blame/master/Cargo.toml#L5

**Affected definitions**:
- [syn 1.0.14](https://clearlydefined.io/definitions/crate/cratesio/-/syn/1.0.14)