### PR TITLE
Missing declared license 

### DIFF
--- a/curations/pypi/pypi/-/pandas.yaml
+++ b/curations/pypi/pypi/-/pandas.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0:
     licensed:
       declared: BSD-3-Clause
+  1.0.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license 

**Details:**
Missing license

**Resolution:**
BSD-3-Clause: package states "BSD". Source repo is BSD-3-Clause so submitting as that.
https://github.com/pandas-dev/pandas/blob/master/LICENSE

**Affected definitions**:
- [pandas 1.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/pandas/1.0.1/1.0.1)