### PR TITLE
Declared License

### DIFF
--- a/curations/maven/mavencentral/net.sf.kxml/kxml2.yaml
+++ b/curations/maven/mavencentral/net.sf.kxml/kxml2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kxml2
+  namespace: net.sf.kxml
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Declared License

**Details:**
The package POM says the org.kxml2 package is under a "BSD style" license. The sources jar header files are all MIT.  The repo is also MIT (https://github.com/stefanhaustein/kxml2/blob/master/license.txt) Curated MIT.

**Resolution:**
https://repo1.maven.org/maven2/net/sf/kxml/kxml2/2.3.0/kxml2-2.3.0.pom

**Affected definitions**:
- [kxml2 2.3.0](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.kxml/kxml2/2.3.0/2.3.0)