### PR TITLE
Declared license

### DIFF
--- a/curations/maven/mavencentral/org.jvnet.staxex/stax-ex.yaml
+++ b/curations/maven/mavencentral/org.jvnet.staxex/stax-ex.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.7.7:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-WITH-Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.jvnet.staxex/stax-ex.yaml
+++ b/curations/maven/mavencentral/org.jvnet.staxex/stax-ex.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: stax-ex
+  namespace: org.jvnet.staxex
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.7:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
https://repo1.maven.org/maven2/org/jvnet/staxex/stax-ex/1.7.7/stax-ex-1.7.7.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-WITH-Classpath-exception-2.0

**Affected definitions**:
- [stax-ex 1.7.7](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet.staxex/stax-ex/1.7.7/1.7.7)