### PR TITLE
Correct ring expression

### DIFF
--- a/curations/crate/cratesio/-/ring.yaml
+++ b/curations/crate/cratesio/-/ring.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ring
+  provider: cratesio
+  type: crate
+revisions:
+  0.16.11:
+    licensed:
+      declared: ISC AND OpenSSL AND MIT


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Correct ring expression

**Details:**
The ring project has very complicated licensing due to its ancestry, but it is clearly stated in the LICENSE file in the project itself

**Resolution:**
This PR applies my understanding of the licensing terms spelled out in the top of the LICENSE file into the (I believe) correct top-level SPDX expression for the project

**Affected definitions**:
- [ring 0.16.11](https://clearlydefined.io/definitions/crate/cratesio/-/ring/0.16.11)