### PR TITLE
Clarify declared license

### DIFF
--- a/curations/crate/cratesio/-/webpki.yaml
+++ b/curations/crate/cratesio/-/webpki.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: webpki
+  provider: cratesio
+  type: crate
+revisions:
+  0.21.2:
+    licensed:
+      declared: ISC AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Clarify declared license

**Details:**
This project uses an ISC license for the main code, as well as BSD-3-Clause for some third party chromium code, both were discovered correctly, but the package itself didn't state the expression which left the crate in an ambiguous state.

**Resolution:**
Combined the ISC and BSD-3-Clause with `AND` to indicate the crate is licensed under both of these terms.

**Affected definitions**:
- [webpki 0.21.2](https://clearlydefined.io/definitions/crate/cratesio/-/webpki/0.21.2)