### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/OmniSharp.Abstractions.yaml
+++ b/curations/nuget/nuget/-/OmniSharp.Abstractions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OmniSharp.Abstractions
+  provider: nuget
+  type: nuget
+revisions:
+  1.33.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
A more recent package has the license specified as MIT

**Resolution:**
Matches repo

**Affected definitions**:
- [OmniSharp.Abstractions 1.33.0](https://clearlydefined.io/definitions/nuget/nuget/-/OmniSharp.Abstractions/1.33.0/1.33.0)