### PR TITLE
Declaring license

### DIFF
--- a/curations/nuget/nuget/-/OmniSharp.Roslyn.yaml
+++ b/curations/nuget/nuget/-/OmniSharp.Roslyn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OmniSharp.Roslyn
+  provider: nuget
+  type: nuget
+revisions:
+  1.33.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declaring license

**Details:**
More recent package says MIT

**Resolution:**
License at "Source" link is MIT

**Affected definitions**:
- [OmniSharp.Roslyn 1.33.0](https://clearlydefined.io/definitions/nuget/nuget/-/OmniSharp.Roslyn/1.33.0/1.33.0)