### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/OmniSharp.Roslyn.CSharp.yaml
+++ b/curations/nuget/nuget/-/OmniSharp.Roslyn.CSharp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OmniSharp.Roslyn.CSharp
+  provider: nuget
+  type: nuget
+revisions:
+  1.33.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
More recent package is MIT

**Resolution:**
Source link license is MIT

**Affected definitions**:
- [OmniSharp.Roslyn.CSharp 1.33.0](https://clearlydefined.io/definitions/nuget/nuget/-/OmniSharp.Roslyn.CSharp/1.33.0/1.33.0)