### PR TITLE
Declared license

### DIFF
--- a/curations/npm/npmjs/-/assert.yaml
+++ b/curations/npm/npmjs/-/assert.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: assert
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
I don't see license info on package.json (or at http://registry.npmjs.com/assert/1.0.0)

**Resolution:**
However, a more recent package is MIT, so curating MIT.

**Affected definitions**:
- [assert 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/assert/1.0.0)