### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/intel-numpy.yaml
+++ b/curations/pypi/pypi/-/intel-numpy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: intel-numpy
+  provider: pypi
+  type: pypi
+revisions:
+  1.14.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
Meta
License: Other/Proprietary License (Proprietary - Intel)

**Resolution:**
Under the Intel Simplified Software License (Version January 2018)


**Affected definitions**:
- [intel-numpy 1.14.3](https://clearlydefined.io/definitions/pypi/pypi/-/intel-numpy/1.14.3)