### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/matplotlib.yaml
+++ b/curations/pypi/pypi/-/matplotlib.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  3.0.0:
+    licensed:
+      declared: OTHER
   3.0.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
The license metadata says PSF (BSD).  It is a custom license - https://matplotlib.org/users/license.html

**Resolution:**
Curated OTHER

**Affected definitions**:
- [matplotlib 3.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/matplotlib/3.0.0)