### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/mkl-fft.yaml
+++ b/curations/pypi/pypi/-/mkl-fft.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mkl-fft
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.6:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
The download page says  Other/Proprietary License (Proprietary - Intel).  However, the actual LICENSE.txt in the downloaded package files is BSD-3-Clause

**Resolution:**
Curating BSD-3-Clause per package LICENSE.txt.  

**Affected definitions**:
- [mkl-fft 1.0.6](https://clearlydefined.io/definitions/pypi/pypi/-/mkl-fft/1.0.6)