### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/mkl-random.yaml
+++ b/curations/pypi/pypi/-/mkl-random.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mkl-random
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
The package metadata says: Other/Proprietary License (Proprietary - Intel).  However, downloading the package files, the LICENSE.txt is BSD-3-Clause

**Resolution:**
Curating based on LICENSE.txt file

**Affected definitions**:
- [mkl-random 1.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/mkl-random/1.0.1)