### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -6,6 +6,9 @@ revisions:
   1.14.5:
     licensed:
       declared: BSD-3-Clause
+  1.15.2:
+    licensed:
+      declared: BSD-3-Clause
   1.16.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
LICENSE.txt in downloaded files in BSD-3-Clause

**Resolution:**
Matches package metadata on https://pypi.org/

**Affected definitions**:
- [numpy 1.15.2](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.15.2)