### PR TITLE
Declared license 

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -18,6 +18,9 @@ revisions:
   3.11.3:
     licensed:
       declared: BSD-3-Clause
+  3.6.0:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license 

**Details:**
Setup.py says  license='3-Clause BSD License',

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [protobuf 3.6.0](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.6.0)