### PR TITLE
Declared license

### DIFF
--- a/curations/pypi/pypi/-/wincertstore.yaml
+++ b/curations/pypi/pypi/-/wincertstore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wincertstore
+  provider: pypi
+  type: pypi
+revisions:
+  '0.2':
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
Downloaded the files and found: # Copyright (c) 2013 by Christian Heimes <christian@python.org>
# Licensed to PSF under a Contributor Agreement.
# See http://www.python.org/psf/license for licensing details.

**Resolution:**
That link goes to a history page that aligns with Python-2.0

**Affected definitions**:
- [wincertstore 0.2](https://clearlydefined.io/definitions/pypi/pypi/-/wincertstore/0.2)