### PR TITLE
Correcting Declared

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: HPND
   5.4.1:
     licensed:
-      declared: OTHER
+      declared: HPND
   6.1.0:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting Declared

**Details:**
Correcting from OTHER to HPND

**Resolution:**
The PIL license is the HPND

**Affected definitions**:
- [Pillow 5.4.1](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/5.4.1/5.4.1)