### PR TITLE
Missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -31,6 +31,9 @@ revisions:
   4.5.11:
     licensed:
       declared: MIT
+  4.5.6:
+    licensed:
+      declared: MIT
   5.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing declared license

**Details:**
License link points to CodePlex, which points to GitHub.

**Resolution:**
https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md

**Affected definitions**:
- [Newtonsoft.Json 4.5.6](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.5.6/4.5.6)