### PR TITLE
Declared license 

### DIFF
--- a/curations/nuget/nuget/-/Humanizer.Core.ar.yaml
+++ b/curations/nuget/nuget/-/Humanizer.Core.ar.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Humanizer.Core.ar
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license 

**Details:**
NuGet license link goes to https://raw.githubusercontent.com/Humanizr/Humanizer/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Humanizer.Core.ar 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Humanizer.Core.ar/2.2.0/2.2.0)