### PR TITLE
Source Location for Decorator 4.4.2

### DIFF
--- a/curations/pypi/pypi/-/decorator.yaml
+++ b/curations/pypi/pypi/-/decorator.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: decorator
+  provider: pypi
+  type: pypi
+revisions:
+  4.4.2:
+    described:
+      sourceLocation:
+        name: decorator
+        namespace: micheles
+        provider: github
+        revision: 55a68b5ef1951614c5c37a6d201b1f3b804dbce6
+        type: git
+        url: 'https://github.com/micheles/decorator/commit/55a68b5ef1951614c5c37a6d201b1f3b804dbce6'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source Location for Decorator 4.4.2

**Details:**
The github source for Decorator 4.4.2 was missing

**Resolution:**
Added source url and tag/hash for decorator 4.4.2

**Affected definitions**:
- [decorator 4.4.2](https://clearlydefined.io/definitions/pypi/pypi/-/decorator/4.4.2/4.4.2)