### PR TITLE
LICENSE file

### DIFF
--- a/curations/pypi/pypi/-/paho-mqtt.yaml
+++ b/curations/pypi/pypi/-/paho-mqtt.yaml
@@ -5,5 +5,5 @@ coordinates:
 revisions:
   1.5.0:
     files:
-      - license: EPL-1.0 AND BSD-3-Clause
+      - license: EPL-1.0 OR BSD-3-Clause
         path: paho-mqtt-1.5.0/LICENSE.txt

--- a/curations/pypi/pypi/-/paho-mqtt.yaml
+++ b/curations/pypi/pypi/-/paho-mqtt.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: paho-mqtt
+  provider: pypi
+  type: pypi
+revisions:
+  1.5.0:
+    files:
+      - license: EPL-1.0 AND BSD-3-Clause
+        path: paho-mqtt-1.5.0/LICENSE.txt


### PR DESCRIPTION
**Type:** Missing

**Summary:**
LICENSE file

**Details:**
Curating license file - https://clearlydefined.io/file/76f13729e84e9222e543303df00f87d1b2c0995b6a505cd859a285667e44babb

**Resolution:**
Dual-licensed is customarily understood to mean "or" - so, it would be "EPL-1.0 OR BSD-3-Clause"

**Affected definitions**:
- [paho-mqtt 1.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/paho-mqtt/1.5.0/1.5.0)