### PR TITLE
Correcting Declared

### DIFF
--- a/curations/pypi/pypi/-/paho-mqtt.yaml
+++ b/curations/pypi/pypi/-/paho-mqtt.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: paho-mqtt
+  provider: pypi
+  type: pypi
+revisions:
+  1.5.0:
+    files:
+      - license: EPL-1.0 AND BSD-3-Clause
+        path: paho-mqtt-1.5.0/LICENSE.txt
+    licensed:
+      declared: BSD-3-Clause OR EPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting Declared

**Details:**
Customarily "dual-licensed' is understood to mean "or."  So, it would be EPL-1.0 OR BSD-3-Clause.

**Resolution:**
 EPL-1.0 OR BSD-3-Clause

**Affected definitions**:
- [paho-mqtt 1.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/paho-mqtt/1.5.0/1.5.0)