### PR TITLE
Declared field and files

### DIFF
--- a/curations/pypi/pypi/-/PyInstaller.yaml
+++ b/curations/pypi/pypi/-/PyInstaller.yaml
@@ -25,4 +25,4 @@ revisions:
         license: GPL-2.0-or-later WITH Bootloader-exception
         path: PyInstaller-3.4/setup.py
     licensed:
-      declared: GPL-2.0-or-later
+      declared: GPL-2.0-or-later WITH Bootloader-exception

--- a/curations/pypi/pypi/-/PyInstaller.yaml
+++ b/curations/pypi/pypi/-/PyInstaller.yaml
@@ -1,0 +1,28 @@
+coordinates:
+  name: PyInstaller
+  provider: pypi
+  type: pypi
+revisions:
+  '3.4':
+    files:
+      - attributions:
+          - 'Copyright (c) 2013-2018, PyInstaller Development Team.'
+        license: GPL-2.0-or-later WITH Bootloader-exception
+        path: PyInstaller-3.4/pyinstaller.py
+      - license: GPL-2.0-or-later WITH Bootloader-exception
+        path: PyInstaller-3.4/PKG-INFO
+      - attributions:
+          - 'Copyright (c) 2005-2009, Giovanni Bajo'
+          - copyrighted by the Free Software Foundation
+          - 'copyright (c) 2002 McMillan Enterprises, Inc.'
+          - 'Copyright (c) 2010-2018, PyInstaller Development Team'
+          - 'Copyright (c) 2005-20l5, PyInstaller Development Team.'
+          - 'Copyright (c) 1989, 1991 Free Software Foundation, Inc.'
+        license: GPL-2.0-or-later WITH Bootloader-exception
+        path: PyInstaller-3.4/COPYING.txt
+      - attributions:
+          - 'Copyright (c) 2005-2018, PyInstaller Development Team.'
+        license: GPL-2.0-or-later WITH Bootloader-exception
+        path: PyInstaller-3.4/setup.py
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared field and files

**Details:**
Should be GPL-2.0-or-later WITH Bootloader-exception

**Resolution:**
See all files under "Files" in ClearlyDefined

**Affected definitions**:
- [PyInstaller 3.4](https://clearlydefined.io/definitions/pypi/pypi/-/PyInstaller/3.4/3.4)