### PR TITLE
Correcting Declared and License file

### DIFF
--- a/curations/pypi/pypi/-/PyInstaller.yaml
+++ b/curations/pypi/pypi/-/PyInstaller.yaml
@@ -26,3 +26,14 @@ revisions:
         path: PyInstaller-3.4/setup.py
     licensed:
       declared: GPL-2.0-or-later WITH Bootloader-exception
+  '3.6':
+    files:
+      - attributions:
+          - 'Copyright (c) 2005-2009, Giovanni Bajo'
+          - copyrighted by the Free Software Foundation
+          - 'copyright (c) 2002 McMillan Enterprises, Inc.'
+          - 'Copyright (c) 1989, 1991 Free Software Foundation, Inc.'
+        license: GPL-2.0-or-later WITH Bootloader-exception
+        path: PyInstaller-3.6/COPYING.txt
+    licensed:
+      declared: GPL-2.0-or-later

--- a/curations/pypi/pypi/-/PyInstaller.yaml
+++ b/curations/pypi/pypi/-/PyInstaller.yaml
@@ -36,4 +36,4 @@ revisions:
         license: GPL-2.0-or-later WITH Bootloader-exception
         path: PyInstaller-3.6/COPYING.txt
     licensed:
-      declared: GPL-2.0-or-later
+      declared: GPL-2.0-or-later WITH Bootloader-exception


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting Declared and License file

**Details:**

GPL-2.0-or later WITH Bootloader-exception

**Resolution:**
See COPYING file

**Affected definitions**:
- [PyInstaller 3.6](https://clearlydefined.io/definitions/pypi/pypi/-/PyInstaller/3.6/3.6)