### PR TITLE
Missing Declared license

### DIFF
--- a/curations/nuget/nuget/-/Sln.yaml
+++ b/curations/nuget/nuget/-/Sln.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Sln
+  provider: nuget
+  type: nuget
+revisions:
+  0.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing Declared license

**Details:**
No "license" link on NuGet page, but source repo link with LICENSE file

**Resolution:**
https://github.com/enricosada/sln/blob/master/LICENSE

**Affected definitions**:
- [Sln 0.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Sln/0.3.0/0.3.0)