### PR TITLE
Filling in Declared

### DIFF
--- a/curations/nuget/nuget/-/FastText.Native.Windows.yaml
+++ b/curations/nuget/nuget/-/FastText.Native.Windows.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FastText.Native.Windows
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.72:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Filling in Declared

**Details:**
No license or source repo info for this version or other versions

**Resolution:**
NONE

**Affected definitions**:
- [FastText.Native.Windows 1.0.72](https://clearlydefined.io/definitions/nuget/nuget/-/FastText.Native.Windows/1.0.72/1.0.72)