### PR TITLE
Adding Declared license

### DIFF
--- a/curations/maven/mavencentral/org.slf4j/jcl104-over-slf4j.yaml
+++ b/curations/maven/mavencentral/org.slf4j/jcl104-over-slf4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jcl104-over-slf4j
+  namespace: org.slf4j
+  provider: mavencentral
+  type: maven
+revisions:
+  1.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
POM - https://repo1.maven.org/maven2/org/slf4j/jcl104-over-slf4j/1.4.1/jcl104-over-slf4j-1.4.1.pom - points to http://www.slf4j.org

**Resolution:**
http://www.slf4j.org/license.html - MIT

**Affected definitions**:
- [jcl104-over-slf4j 1.4.1](https://clearlydefined.io/definitions/maven/mavencentral/org.slf4j/jcl104-over-slf4j/1.4.1/1.4.1)