### PR TITLE
Adding Declared license

### DIFF
--- a/curations/maven/mavencentral/ant/ant-junit.yaml
+++ b/curations/maven/mavencentral/ant/ant-junit.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ant-junit
+  namespace: ant
+  provider: mavencentral
+  type: maven
+revisions:
+  1.6.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
Package 1.6.5 doesn't have license info on the POM or a sources jar.  https://mvnrepository.com/artifact/ant/ant-junit/1.6.5

**Resolution:**
Newer version has a POM with license info - https://repo1.maven.org/maven2/org/apache/ant/ant-junit/1.7.0/ant-junit-1.7.0.pom

**Affected definitions**:
- [ant-junit 1.6.5](https://clearlydefined.io/definitions/maven/mavencentral/ant/ant-junit/1.6.5/1.6.5)