### PR TITLE
ELD: highcharts v8.0 - Platform Core #12

### DIFF
--- a/curations/git/github/highcharts/highcharts.yaml
+++ b/curations/git/github/highcharts/highcharts.yaml
@@ -45,7 +45,7 @@ revisions:
             Copyright (c) 2015-2018 yWorks GmbH, http://www.yworks.com 2015-2018 Lukas Hollander <lukas.hollaender@yworks.com> ,
             https://github.com/HackbrettXXX 2010-2016 James Hall <james@parall.ax> , https://github.com/MrRio/jsPDF 2010 Aaron Spike,
             https://github.com/acspike 2012 Willow Systems Corporation, willow-systems.com
-        license: CC-BY-SA-4.0 AND GPL-2.0-only AND (MIT )
+        license: CC-BY-SA-4.0 AND GPL-2.0-only OR (MIT )
         path: vendor/jspdf.src.js
       - license: CC-BY-SA-4.0
         path: vendor/moment-2.18.1.js

--- a/curations/git/github/highcharts/highcharts.yaml
+++ b/curations/git/github/highcharts/highcharts.yaml
@@ -6,13 +6,48 @@ coordinates:
 revisions:
   663825404345a074e465c34bdadf97eeb54c9ce9:
     files:
-      - license: CPL-1.0
-        path: tools/google-closure-compiler/compiler.jar
-      - license: ''
-        path: tools/google-closure-compiler/COPYING
+      - license: CC-BY-SA-4.0
+        path: samples/highcharts/studies/appear/demo.js
+      - license: CC-BY-SA-4.0
+        path: samples/highcharts/studies/gpx-height-profile/demo.js
       - attributions:
           - Copyright 2009 The Closure Compiler
-        license: Apache-2.0 AND CPL-1.0
+        license: GPL-2.0-or-later OR MPL-1.1
+        path: tools/google-closure-compiler/compiler.jar
+      - attributions:
+          - Copyright 2009 The Closure Compiler
+        license: GPL-2.0-or-later OR MPL-1.1
         path: tools/google-closure-compiler/README
+      - attributions:
+          - Copyright (c) 2012
+          - Copyright (c) 2017 Aras Abbasi
+          - Copyright (c) 2018 Aras Abbasi
+          - Copyright (c) 2011 Devon Govett
+          - Copyright (c) 2018 Erik Koopmans
+          - Copyright (c) 2014 Steven Spungin
+          - (c) Dean McNamee <dean@gmail.com>
+          - Copyright (c) 2013 Gildas Lormeau.
+          - Copyright (c) 2011 Mozilla Foundation
+          - 'Copyright (c) 2008, Adobe Systems Incorporated'
+          - 'Copyright (c) 2016 Jussi Utunen, u-jussi@suomi24.fi'
+          - 'Copyright (c) 2013 Youssef Beddad, youssef.beddad@gmail.com'
+          - 'Copyright (c) 2014 James Robb, https://github.com/jamesbrobb'
+          - 'Copyright (c) 2016 Alexander Weidt, https://github.com/BiggA94'
+          - 'Copyright (c) 2012 Willow Systems Corporation, willow-systems.com'
+          - 'Copyright (c) 2013 Eduardo Menezes de Morais, eduardo.morais@usp.br'
+          - 'Copyright (c) 1989, 1990, 1991, 1992, 1993, 1997 Adobe Systems Incorporated.'
+          - 'Copyright (c) 2012 Jason Siefken, https://github.com/siefkenj/ 2013 Chris Dowling'
+          - 'Copyright (c) 2012 Willow Systems Corporation, willow-systems.com 2014 Diego Casorran'
+          - >-
+            Copyright (c) 2013 Youssef Beddad, youssef.beddad@gmail.com 2013 Eduardo Menezes de Morais, eduardo.morais@usp.br 2013 Lee Driscoll,
+            https://github.com/lsdriscoll
+          - >-
+            Copyright (c) 2015-2018 yWorks GmbH, http://www.yworks.com 2015-2018 Lukas Hollander <lukas.hollaender@yworks.com> ,
+            https://github.com/HackbrettXXX 2010-2016 James Hall <james@parall.ax> , https://github.com/MrRio/jsPDF 2010 Aaron Spike,
+            https://github.com/acspike 2012 Willow Systems Corporation, willow-systems.com
+        license: CC-BY-SA-4.0 AND GPL-2.0-only AND (MIT )
+        path: vendor/jspdf.src.js
+      - license: CC-BY-SA-4.0
+        path: vendor/moment-2.18.1.js
     licensed:
       declared: CC-BY-NC-3.0 OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: highcharts v8.0 - Platform Core #12

**Details:**
Missing attribution for php.js - line #35

The code following these comments is based on code found at https://github.com/kvz/locutus/blob/master/src/php/url/base64_encode.js and https://github.com/kvz/locutus/blob/master/src/php/url/base64_decode.js. This material was previously part of php.js, wh


**Resolution:**
Note, should be CC and GPL or MIT.  The tool won't let me enter OR MIT.

**Affected definitions**:
- [highcharts 663825404345a074e465c34bdadf97eeb54c9ce9](https://clearlydefined.io/definitions/git/github/highcharts/highcharts/663825404345a074e465c34bdadf97eeb54c9ce9/663825404345a074e465c34bdadf97eeb54c9ce9)