### PR TITLE
ELD: highcharts v8.0 - Platform Core

### DIFF
--- a/curations/git/github/highcharts/highcharts.yaml
+++ b/curations/git/github/highcharts/highcharts.yaml
@@ -6,8 +6,11 @@ coordinates:
 revisions:
   663825404345a074e465c34bdadf97eeb54c9ce9:
     files:
-      - license: CPL-1.0
-        path: tools/google-closure-compiler/compiler.jar
+      - attributions:
+          - 'Copyright 2011, John Resig'
+          - 'Copyright 2011, The Dojo Foundation'
+        license: MIT OR GPL-2.0-only
+        path: vendor/jquery-1.6.4.js
       - license: ''
         path: tools/google-closure-compiler/COPYING
       - attributions:


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ELD: highcharts v8.0 - Platform Core

**Details:**
Update attribution for older jquery files. 

older versions of jQuery are dual-licensed under the GPL v2 or MIT License (see e.g. https://github.com/jquery/jquery/blob/1.7.2/GPL-LICENSE.txt and https://github.com/jquery/jquery/blob/1.7.2/MIT-LICENSE.txt)

**Resolution:**
Update license data.

**Affected definitions**:
- [highcharts 663825404345a074e465c34bdadf97eeb54c9ce9](https://clearlydefined.io/definitions/git/github/highcharts/highcharts/663825404345a074e465c34bdadf97eeb54c9ce9/663825404345a074e465c34bdadf97eeb54c9ce9)