### PR TITLE
ELD: highcharts v8.0 - Platform Core

### DIFF
--- a/curations/git/github/highcharts/highcharts.yaml
+++ b/curations/git/github/highcharts/highcharts.yaml
@@ -6,13 +6,26 @@ coordinates:
 revisions:
   663825404345a074e465c34bdadf97eeb54c9ce9:
     files:
-      - license: CPL-1.0
-        path: tools/google-closure-compiler/compiler.jar
-      - license: ''
-        path: tools/google-closure-compiler/COPYING
       - attributions:
-          - Copyright 2009 The Closure Compiler
-        license: Apache-2.0 AND CPL-1.0
-        path: tools/google-closure-compiler/README
+          - Copyright (c) 2009 John Resig
+          - 'Copyright 2009, The Dojo Foundation'
+        license: MIT OR GPL-2.0-only
+        path: vendor/jquery-1.3.2.js
+      - attributions:
+          - 'Copyright 2010, John Resig'
+          - 'Copyright 2010, The Dojo Foundation'
+          - 'Copyright 2009, The Dojo Foundation'
+        license: MIT OR GPL-2.0-only
+        path: vendor/jquery-1.4.4.js
+      - attributions:
+          - 'Copyright 2011, John Resig'
+          - 'Copyright 2011, The Dojo Foundation'
+        license: MIT OR GPL-2.0-only
+        path: vendor/jquery-1.5.2.js
+      - attributions:
+          - 'Copyright 2011, John Resig'
+          - 'Copyright 2011, The Dojo Foundation'
+        license: MIT OR GPL-2.0-only
+        path: vendor/jquery-1.6.4.js
     licensed:
       declared: CC-BY-NC-3.0 OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: highcharts v8.0 - Platform Core

**Details:**
Updating Instances of jQuery v1.2.6, v1.3.2, v1.4.4, v1.5.2, v1.6.4, and v1.7.2

**Resolution:**
these older versions of jQuery are dual-licensed under the GPL v2 or MIT License (see e.g. https://github.com/jquery/jquery/blob/1.7.2/GPL-LICENSE.txt and https://github.com/jquery/jquery/blob/1.7.2/MIT-LICENSE.txt).

**Affected definitions**:
- [highcharts 663825404345a074e465c34bdadf97eeb54c9ce9](https://clearlydefined.io/definitions/git/github/highcharts/highcharts/663825404345a074e465c34bdadf97eeb54c9ce9/663825404345a074e465c34bdadf97eeb54c9ce9)