### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/log4net.yaml
+++ b/curations/nuget/nuget/-/log4net.yaml
@@ -12,6 +12,9 @@ revisions:
   2.0.5:
     licensed:
       declared: Apache-2.0
+  2.0.7:
+    licensed:
+      declared: Apache-2.0
   2.0.8:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (http://logging.apache.org/log4net/license.html)

**Resolution:**
matches project site

**Affected definitions**:
- [log4net 2.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/log4net/2.0.7/2.0.7)