### PR TITLE
ELD: smali v2.3.4

### DIFF
--- a/curations/git/github/jesusfreke/smali.yaml
+++ b/curations/git/github/jesusfreke/smali.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: smali
+  namespace: jesusfreke
+  provider: github
+  type: git
+revisions:
+  bf65e575a0fd7f03c41aa56d7a49bf0cda1da06a:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: smali v2.3.4

**Details:**
Proj: xplat android
Comp: smali v2.3.4

This material is licensed under the BSD License (see https://github.com/JesusFreke/smali/blob/v2.3.4/NOTICE and file /smali-2.3.4/NOTICE).

**Resolution:**
Set the overall declared license to BSD.

**Affected definitions**:
- [smali bf65e575a0fd7f03c41aa56d7a49bf0cda1da06a](https://clearlydefined.io/definitions/git/github/jesusfreke/smali/bf65e575a0fd7f03c41aa56d7a49bf0cda1da06a/bf65e575a0fd7f03c41aa56d7a49bf0cda1da06a)