### PR TITLE
ELD: apktool v2.4.1

### DIFF
--- a/curations/git/github/ibotpeaches/apktool.yaml
+++ b/curations/git/github/ibotpeaches/apktool.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: apktool
+  namespace: ibotpeaches
+  provider: github
+  type: git
+revisions:
+  511718ef3aeadf6a96bc167bdfb04d6dda2091e6:
+    files:
+      - license: CC-BY-NC-2.0
+        path: brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/drawable-ldpi/data.jpg

--- a/curations/git/github/ibotpeaches/apktool.yaml
+++ b/curations/git/github/ibotpeaches/apktool.yaml
@@ -6,5 +6,5 @@ coordinates:
 revisions:
   511718ef3aeadf6a96bc167bdfb04d6dda2091e6:
     files:
-      - license: CC-BY-NC-2.0
+      - license: CC-BY-NC-SA-2.0
         path: brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/drawable-ldpi/data.jpg


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: apktool v2.4.1

**Details:**
Proj: xplat android
Comp: apktool v2.4.1
File: /Apktool-2.4.1/brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/drawable-ldpi/data.jpg

Image file containing EXIF data with the following:

  | WebStatement = http://creativecommons.org/licenses/by-nc-sa/2.0/
  | Rights = Romain Guy


**Resolution:**
This material is licensed under the Creative Commons Attribution-NonCommercial-ShareAlike 2.0 Generic License, per the notice in the file, adding attribution.

**Affected definitions**:
- [apktool 511718ef3aeadf6a96bc167bdfb04d6dda2091e6](https://clearlydefined.io/definitions/git/github/ibotpeaches/apktool/511718ef3aeadf6a96bc167bdfb04d6dda2091e6/511718ef3aeadf6a96bc167bdfb04d6dda2091e6)