### PR TITLE
Update stax-ex licensing

### DIFF
--- a/curations/maven/mavencentral/org.jvnet.staxex/stax-ex.yaml
+++ b/curations/maven/mavencentral/org.jvnet.staxex/stax-ex.yaml
@@ -7,3 +7,14 @@ revisions:
   1.7.7:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-WITH-Classpath-exception-2.0
+  1.8.2:
+    described:
+      sourceLocation:
+        name: jaxb-stax-ex
+        namespace: eclipse-ee4j
+        provider: github
+        revision: 5f18204b3666efa4c6f3514cd6a4eb63c3661c1e
+        type: git
+        url: 'https://github.com/eclipse-ee4j/jaxb-stax-ex/commit/5f18204b3666efa4c6f3514cd6a4eb63c3661c1e'
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/sourcearchive/mavencentral/org.jvnet.staxex/stax-ex.yaml
+++ b/curations/sourcearchive/mavencentral/org.jvnet.staxex/stax-ex.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: stax-ex
+  namespace: org.jvnet.staxex
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.8.3:
+    described:
+      sourceLocation:
+        name: jaxb-stax-ex
+        namespace: eclipse-ee4j
+        provider: github
+        revision: eb4e2c15e3520c0b81b010923c1a94d484ff76aa
+        type: git
+        url: 'https://github.com/eclipse-ee4j/jaxb-stax-ex/commit/eb4e2c15e3520c0b81b010923c1a94d484ff76aa'
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update stax-ex licensing

**Details:**
This project has moved to the Eclipse Foundation.

**Resolution:**
The declared license is captured in the repository.

**Affected definitions**:
- [stax-ex 1.8.2](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet.staxex/stax-ex/1.8.2),- [stax-ex 1.8.3](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.jvnet.staxex/stax-ex/1.8.3)