### PR TITLE
Declare dual licensed under MPL-2.0 or EPL-1.0

### DIFF
--- a/curations/maven/mavencentral/com.h2database/h2.yaml
+++ b/curations/maven/mavencentral/com.h2database/h2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: h2
+  namespace: com.h2database
+  provider: mavencentral
+  type: maven
+revisions:
+  1.4.193:
+    licensed:
+      declared: MPL-2.0 OR EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare dual licensed under MPL-2.0 or EPL-1.0

**Details:**
Declare dual licensed under MPL-2.0 or EPL-1.0 found here (https://repo1.maven.org/maven2/com/h2database/h2/1.4.195/h2-1.4.195.pom)

**Resolution:**
Matches MVN Repository

**Affected definitions**:
- [h2 1.4.193](https://clearlydefined.io/definitions/maven/mavencentral/com.h2database/h2/1.4.193/1.4.193)