### PR TITLE
Declared CDDL-1.0

### DIFF
--- a/curations/maven/mavencentral/org.mortbay.jetty/servlet-api-2.5.yaml
+++ b/curations/maven/mavencentral/org.mortbay.jetty/servlet-api-2.5.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: servlet-api-2.5
+  namespace: org.mortbay.jetty
+  provider: mavencentral
+  type: maven
+revisions:
+  6.1.14:
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared CDDL-1.0

**Details:**
Declared CDDL-1.0 found here (https://repo1.maven.org/maven2/org/mortbay/jetty/servlet-api-2.5/6.1.14/servlet-api-2.5-6.1.14.pom)

**Resolution:**
Matched MVN Repository 

**Affected definitions**:
- [servlet-api-2.5 6.1.14](https://clearlydefined.io/definitions/maven/mavencentral/org.mortbay.jetty/servlet-api-2.5/6.1.14/6.1.14)