### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.jmock/jmock-legacy.yaml
+++ b/curations/maven/mavencentral/org.jmock/jmock-legacy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jmock-legacy
+  namespace: org.jmock
+  provider: mavencentral
+  type: maven
+revisions:
+  2.8.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found here (http://jmock.org/license.html)

**Resolution:**
matches NVM Repository license at top but not in the pom file

**Affected definitions**:
- [jmock-legacy 2.8.3](https://clearlydefined.io/definitions/maven/mavencentral/org.jmock/jmock-legacy/2.8.3/2.8.3)