### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.jmock/jmock-junit4.yaml
+++ b/curations/maven/mavencentral/org.jmock/jmock-junit4.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jmock-junit4
+  namespace: org.jmock
+  provider: mavencentral
+  type: maven
+revisions:
+  2.8.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found here (http://jmock.org/license.html)

**Resolution:**
matches NVM repository at top license but not in pom file

**Affected definitions**:
- [jmock-junit4 2.8.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jmock/jmock-junit4/2.8.4/2.8.4)