### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.agentproxy.jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.agentproxy.jsch.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsch.agentproxy.jsch
+  namespace: com.jcraft
+  provider: mavencentral
+  type: maven
+revisions:
+  0.0.6:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found here (http://www.jcraft.com/jsch-agent-proxy/LICENSE.txt)

**Resolution:**
matches NVM repository high level license but not in pom file

**Affected definitions**:
- [jsch.agentproxy.jsch 0.0.6](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch.agentproxy.jsch/0.0.6/0.0.6)