### PR TITLE
ELD: cordova-android v8.1.0

### DIFF
--- a/curations/git/github/apache/cordova-android.yaml
+++ b/curations/git/github/apache/cordova-android.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: cordova-android
+  namespace: apache
+  provider: github
+  type: git
+revisions:
+  f1f472297af7d3985a5769edd7272222bfd42416:
+    files:
+      - license: EPL-1.0
+        path: framework/.settings/org.eclipse.jdt.core.prefs


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: cordova-android v8.1.0

**Details:**
Missing attribution for this preferences file from the Eclipse IDE.  

**Resolution:**
Add attribution for this file.  Eclipse is licensed under the terms of the Eclipse Public License (EPL) v1.0 (see http://www.eclipse.org/legal/epl-v10.html).

**Affected definitions**:
- [cordova-android f1f472297af7d3985a5769edd7272222bfd42416](https://clearlydefined.io/definitions/git/github/apache/cordova-android/f1f472297af7d3985a5769edd7272222bfd42416/f1f472297af7d3985a5769edd7272222bfd42416)