### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/text.yaml
+++ b/curations/npm/npmjs/-/text.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: text
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
The project does not mention any license in the package.json (package metadata) as a delcared license. BSD3-Claus and MIT were discovered.

**Resolution:**
The project states a BSD-3-Clause license in the README by putting in the license text there.

**Affected definitions**:
- [text 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/text/0.1.0/0.1.0)