### PR TITLE
ELD: WebViewHook v0.7.0

### DIFF
--- a/curations/git/github/willnode/webviewhook.yaml
+++ b/curations/git/github/willnode/webviewhook.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: webviewhook
+  namespace: willnode
+  provider: github
+  type: git
+revisions:
+  6603cc1d329b21f49edfc549317718b19befb437:
+    files:
+      - attributions:
+          - Copyright (c) 2010-2020 sta.blockhead
+        license: MIT
+        path: Assets/Editor/Plugins/websocket-sharp.dll
+      - attributions:
+          - Copyright (c) 2010-2020 sta.blockhead
+        license: MIT
+        path: Assets/Editor/Plugins/websocket-sharp.dll.meta
+      - attributions:
+          - Copyright (c) 2010-2020 sta.blockhead
+        license: MIT
+        path: Assets/Editor/Plugins/websocket-sharp.xml
+      - attributions:
+          - Copyright (c) 2010-2020 sta.blockhead
+        license: MIT
+        path: Assets/Editor/Plugins/websocket-sharp.xml.meta


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: WebViewHook v0.7.0

**Details:**
Proj: WebViewHook v0.7.0
Comp: WebViewHook v0.7.0
Files: 
/WebViewHook-0.7.0/Assets/Editor/Plugins/websocket-sharp.dll
/WebViewHook-0.7.0/Assets/Editor/Plugins/websocket-sharp.dll.meta
/WebViewHook-0.7.0/Assets/Editor/Plugins/websocket-sharp.xml
/WebViewHook-0.7.0/Assets/Editor/Plugins/websocket-sha

**Resolution:**
Add license and copyright attribution.  Files originating with, or related to, websocket-sharp, a "C# implementation of the WebSocket protocol client and server." See https://github.com/sta/websocket-sharp. This material is licensed under the MIT License (see https://github.com/sta/websocket-sharp/b

**Affected definitions**:
- [webviewhook 6603cc1d329b21f49edfc549317718b19befb437](https://clearlydefined.io/definitions/git/github/willnode/webviewhook/6603cc1d329b21f49edfc549317718b19befb437/6603cc1d329b21f49edfc549317718b19befb437)