### PR TITLE
ELD: android-maps-utils v0.6.2

### DIFF
--- a/curations/git/github/googlemaps/android-maps-utils.yaml
+++ b/curations/git/github/googlemaps/android-maps-utils.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: android-maps-utils
+  namespace: googlemaps
+  provider: github
+  type: git
+revisions:
+  80d9497ed10b9ec92e16376008b1727ff6695eea:
+    files:
+      - attributions:
+          - 'Copyright (c) 2017, Brandon Keepers'
+        license: ISC
+        path: .github/stale.yml


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ELD: android-maps-utils v0.6.2

**Details:**
Proj: S_SpacesAndroid
Comp: android-maps-utils v0.6.2
FIle: /android-maps-utils-0.6.2/build.gradle
Line: #1
File prefaced by the following notice:

# Configuration for probot-stale - https://github.com/probot/stale


**Resolution:**
Adding license attribution and copyright.
The code that follows this notice originates with Stale, a "GitHub [a]pp built with Probot that closes abandoned Issues and [p]ull [r]equests after a period of inactivity." See https://github.com/probot/stale. This material is licensed under the ISC License 

**Affected definitions**:
- [android-maps-utils 80d9497ed10b9ec92e16376008b1727ff6695eea](https://clearlydefined.io/definitions/git/github/googlemaps/android-maps-utils/80d9497ed10b9ec92e16376008b1727ff6695eea/80d9497ed10b9ec92e16376008b1727ff6695eea)