### PR TITLE
ELD: android-maps-utils v0.6.2

### DIFF
--- a/curations/git/github/googlemaps/android-maps-utils.yaml
+++ b/curations/git/github/googlemaps/android-maps-utils.yaml
@@ -6,5 +6,5 @@ coordinates:
 revisions:
   80d9497ed10b9ec92e16376008b1727ff6695eea:
     files:
-      - license: CC-BY-NC-2.5
+      - license: CC-BY-2.5
         path: build.gradle

--- a/curations/git/github/googlemaps/android-maps-utils.yaml
+++ b/curations/git/github/googlemaps/android-maps-utils.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: android-maps-utils
+  namespace: googlemaps
+  provider: github
+  type: git
+revisions:
+  80d9497ed10b9ec92e16376008b1727ff6695eea:
+    files:
+      - license: CC-BY-NC-2.5
+        path: build.gradle


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ELD: android-maps-utils v0.6.2

**Details:**
Proj: S_SpacesAndroid
Comp: android-maps-utils v0.6.2
File: /android-maps-utils-0.6.2/build.gradle
Line: #40
Issue: file notes this code -  * Improve build server performance by allowing disabling of pre-dexing
 * (see http://tools.android.com/tech-docs/new-build-system/tips#TOC-Improving-Build-Serv

**Resolution:**
Update license attribution & copyright.
The code that follows this notice originates with Android Tools Project Site, "the official IDE for Android app development." See http://tools.android.com and historically https://web.archive.org/web/20160316121128/http://tools.android.com/tech-docs/new-build-

**Affected definitions**:
- [android-maps-utils 80d9497ed10b9ec92e16376008b1727ff6695eea](https://clearlydefined.io/definitions/git/github/googlemaps/android-maps-utils/80d9497ed10b9ec92e16376008b1727ff6695eea/80d9497ed10b9ec92e16376008b1727ff6695eea)