### PR TITLE
Fixing Declared

### DIFF
--- a/curations/git/github/libusb/libusb.yaml
+++ b/curations/git/github/libusb/libusb.yaml
@@ -7,3 +7,6 @@ revisions:
   b5991a9e02e59a842a8ea2e0235cf319f2ec6cd1:
     licensed:
       declared: LGPL-2.1-or-later
+  e782eeb2514266f6738e242cdcb18e3ae1ed06fa:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing Declared

**Details:**
README says: libusb is a library for USB device access from Linux, macOS, Windows, OpenBSD/NetBSD and Haiku userspace. It is written in C (Haiku backend in C++) and licensed under the GNU Lesser General Public License version 2.1 or, at your option, any later version (see COPYING).

**Resolution:**
Updating "only" to "or-later."

**Affected definitions**:
- [libusb e782eeb2514266f6738e242cdcb18e3ae1ed06fa](https://clearlydefined.io/definitions/git/github/libusb/libusb/e782eeb2514266f6738e242cdcb18e3ae1ed06fa/e782eeb2514266f6738e242cdcb18e3ae1ed06fa)