### PR TITLE
Copyright from NOTICE file

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents/httpclient.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents/httpclient.yaml
@@ -7,3 +7,9 @@ revisions:
   4.3.3:
     licensed:
       declared: Apache-2.0
+  4.5.11:
+    files:
+      - attributions:
+          - Copyright 1999-2020 The Apache Software Foundation
+        license: ''
+        path: META-INF/NOTICE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Copyright from NOTICE file

**Details:**
The attribution for the component was not harvested from the NOTICE file, even given it is present there.

**Resolution:**
Take over the attribution from the NOTICE file to the Copyrights of the NOTICE file.

**Affected definitions**:
- [httpclient 4.5.11](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.httpcomponents/httpclient/4.5.11/4.5.11)