### PR TITLE
Declare Other under MSFT EULA

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.TeamFoundation.DistributedTask.Common.Contracts.yaml
+++ b/curations/nuget/nuget/-/Microsoft.TeamFoundation.DistributedTask.Common.Contracts.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.TeamFoundation.DistributedTask.Common.Contracts
+  provider: nuget
+  type: nuget
+revisions:
+  16.153.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Other under MSFT EULA

**Details:**
Declare Other under MSFT EULA found here (https://www.nuget.org/packages/Microsoft.TeamFoundation.DistributedTask.Common.Contracts/16.153.0/License)

**Resolution:**
Matches project site

**Affected definitions**:
- [Microsoft.TeamFoundation.DistributedTask.Common.Contracts 16.153.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.TeamFoundation.DistributedTask.Common.Contracts/16.153.0)