### PR TITLE
Declare OTHER under MSFT EULA

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Services.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Services.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Services.Client
+  provider: nuget
+  type: nuget
+revisions:
+  16.153.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Declare OTHER under MSFT EULA

**Details:**
Declare OTHER under MSFT EULA found here (https://www.nuget.org/packages/Microsoft.VisualStudio.Services.Client/16.153.0/License)

**Resolution:**
Matches project site

**Affected definitions**:
- [Microsoft.VisualStudio.Services.Client 16.153.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Services.Client/16.153.0)