### PR TITLE
Declared OTHER under MSFT EULA

### DIFF
--- a/curations/nuget/nuget/-/System.Windows.Interactivity.WPF.yaml
+++ b/curations/nuget/nuget/-/System.Windows.Interactivity.WPF.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Windows.Interactivity.WPF
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.20525:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared OTHER under MSFT EULA

**Details:**
Declared OTHER under MSFT EULA found when I downloaded the component

**Resolution:**
Declared OTHER under MSFT EULA found when I downloaded the component

**Affected definitions**:
- [System.Windows.Interactivity.WPF 2.0.20525](https://clearlydefined.io/definitions/nuget/nuget/-/System.Windows.Interactivity.WPF/2.0.20525)