### PR TITLE
Adding declared

### DIFF
--- a/curations/git/github/rust-lang/compiler-builtins.yaml
+++ b/curations/git/github/rust-lang/compiler-builtins.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: compiler-builtins
+  namespace: rust-lang
+  provider: github
+  type: git
+revisions:
+  3e6327aa59214133fa74b3c51743b5ebde39526f:
+    licensed:
+      declared: NCSA OR MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared

**Details:**
The compiler-builtins crate is dual licensed under both the University of

Illinois "BSD-Like" license and the MIT license.  As a user of this code you may

choose to use it under either license.  As a contributor, you agree to allow

your code to be used under both.

**Resolution:**
NCSA or MIT

**Affected definitions**:
- [compiler-builtins 3e6327aa59214133fa74b3c51743b5ebde39526f](https://clearlydefined.io/definitions/git/github/rust-lang/compiler-builtins/3e6327aa59214133fa74b3c51743b5ebde39526f/3e6327aa59214133fa74b3c51743b5ebde39526f)