### PR TITLE
ELD: Proj: A_DevOps Feb72020

### DIFF
--- a/curations/git/github/elastic/elasticsearch-net.yaml
+++ b/curations/git/github/elastic/elasticsearch-net.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: elasticsearch-net
+  namespace: elastic
+  provider: github
+  type: git
+revisions:
+  f550f736fb721e697b398fcd1dbda68796425650:
+    files:
+      - license: CC-BY-SA-4.0
+        path: src/Tests/Tests.Reproduce/JsonNetSerializerConverters.cs


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: Proj: A_DevOps Feb72020

**Details:**
Comp: elasticsearch-net v6.8.3
File: /elasticsearch-net-6.8.3/src/Tests/Tests.Reproduce/JsonNetSerializerConverters.cs
Line: #14
Snippet:  // from https://stackoverflow.com/questions/49224866/elasticsearch-nest-6-storing-enums-as-string

Issue: add attribution for stack overflow reference

**Resolution:**
The code following this comment is based on sample code on the cited stackoverflow.com webpage, as found at https://stackoverflow.com/questions/49224866/elasticsearch-nest-6-storing-enums-as-string (see specifically https://stackoverflow.com/a/49226866).  licensed under CC-BY-SA-4.0

**Affected definitions**:
- [elasticsearch-net f550f736fb721e697b398fcd1dbda68796425650](https://clearlydefined.io/definitions/git/github/elastic/elasticsearch-net/f550f736fb721e697b398fcd1dbda68796425650/f550f736fb721e697b398fcd1dbda68796425650)