### PR TITLE
ELD: A_StackSolnDeploy Mar102020

### DIFF
--- a/curations/git/github/agracio/edge-js.yaml
+++ b/curations/git/github/agracio/edge-js.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: edge-js
+  namespace: agracio
+  provider: github
+  type: git
+revisions:
+  9706906b0229d9fd0039b04450a5a4a89c2919c7:
+    files:
+      - attributions:
+          - 'Copyright (c) 2013 Max Hauser '
+        license: MIT
+        path: src/double/Edge.js/dotnetcore/semversion.cs


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: A_StackSolnDeploy Mar102020

**Details:**
Comp: edge-js #9706906b0229d9fd0039b04450a5a4a89c2919c7
File: /edge-js-9706906b0229d9fd0039b04450a5a4a89c2919c7/src/double/Edge.js/dotnetcore/semversion.cs
Line: #1
Snippet: // From https://github.com/maxhauser/semver

**Resolution:**
The code that follows this notice originates with semver, a "semver implementation in .Net based on the v2.0.0 of the spec found at http://semver.org/." See https://github.com/maxhauser/semver. This material is licensed under the MIT License (see https://github.com/maxhauser/semver/blob/master/Licen

**Affected definitions**:
- [edge-js 9706906b0229d9fd0039b04450a5a4a89c2919c7](https://clearlydefined.io/definitions/git/github/agracio/edge-js/9706906b0229d9fd0039b04450a5a4a89c2919c7/9706906b0229d9fd0039b04450a5a4a89c2919c7)