### PR TITLE
Add Declared License

### DIFF
--- a/curations/npm/npmjs/-/stringify-object.yaml
+++ b/curations/npm/npmjs/-/stringify-object.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: stringify-object
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding BSD-2-Clause

**Resolution:**
ClearlyDefined located MIT license file in package. That was confirmed as an error per GitHub repo Issue: https://github.com/yeoman/stringify-object/issues/23


http://registry.npmjs.com/stringify-object/1.0.1

https://github.com/yeoman/stringify-object/tree/0.1.0

**Affected definitions**:
- [stringify-object 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/stringify-object/1.0.1/1.0.1)