### PR TITLE
Declared and LICENSE file

### DIFF
--- a/curations/git/github/fmtlib/fmt.yaml
+++ b/curations/git/github/fmtlib/fmt.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: fmt
+  namespace: fmtlib
+  provider: github
+  type: git
+revisions:
+  9bdd1596cef1b57b9556f8bef32dc4a32322ef3e:
+    files:
+      - attributions:
+          - 'Copyright (c) 2012 - present, Victor Zverovich'
+        license: MIT OR OTHER
+        path: LICENSE.rst
+    licensed:
+      declared: MIT OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared and LICENSE file

**Details:**
Setting as MIT OR OTHER due to "Optional exception to the license ."

**Resolution:**
Went with "OR" due to the exception to the license being optional.

**Affected definitions**:
- [fmt 9bdd1596cef1b57b9556f8bef32dc4a32322ef3e](https://clearlydefined.io/definitions/git/github/fmtlib/fmt/9bdd1596cef1b57b9556f8bef32dc4a32322ef3e/9bdd1596cef1b57b9556f8bef32dc4a32322ef3e)