### PR TITLE
Update combined copyright from LICENSE and package.json

### DIFF
--- a/curations/npm/npmjs/-/absolute-path.yaml
+++ b/curations/npm/npmjs/-/absolute-path.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: absolute-path
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.0:
+    files:
+      - attributions:
+          - Copyright (c) 2014 filearts
+        license: MIT
+        path: package/LICENSE
+      - attributions:
+          - Copyright (c) 2014 Geoff Goodman
+        license: MIT
+        path: package/package.json


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update combined copyright from LICENSE and package.json

**Details:**
The copyright is misleadingly filled with just the date but a missing author.

**Resolution:**
Extracted the copyright in the LICENSE including the author. As the author is different from the package.json, extracted a separate COPYRIGHT for the package.json. The year is the same, verified on github (when the file was created).

**Affected definitions**:
- [absolute-path 0.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/absolute-path/0.0.0/0.0.0)