### PR TITLE
Add Declared License

### DIFF
--- a/curations/nuget/nuget/-/ExpressionEvaluator.yaml
+++ b/curations/nuget/nuget/-/ExpressionEvaluator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ExpressionEvaluator
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Declared License

**Details:**
Adding Other for proprietary license

**Resolution:**
Package deprecated and project has moved to https://eval-expression.net/ to purchase license.

**Affected definitions**:
- [ExpressionEvaluator 2.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/ExpressionEvaluator/2.0.4/2.0.4)