### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/System.Threading.Channels.yaml
+++ b/curations/nuget/nuget/-/System.Threading.Channels.yaml
@@ -6,3 +6,6 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/dotnet/runtime/blob/master/LICENSE.TXT)

**Resolution:**
Redirected from Project site to here (https://github.com/dotnet/runtime) - broken link in License info

**Affected definitions**:
- [System.Threading.Channels 4.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Threading.Channels/4.6.0/4.6.0)