### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.0:
     licensed:
       declared: MIT
+  1.1.0:
+    licensed:
+      declared: MIT
   2.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE)

**Resolution:**
Matches project site

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/1.1.0/1.1.0)