### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/RazorEngine.yaml
+++ b/curations/nuget/nuget/-/RazorEngine.yaml
@@ -3,12 +3,15 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
-  3.7.2:
-    licensed:
-      declared: Apache-2.0
   3.10.0:
     files:
       - license: Apache-2.0
         path: LICENSE.md
+    licensed:
+      declared: Apache-2.0
+  3.7.2:
+    licensed:
+      declared: Apache-2.0
+  3.9.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/Antaris/RazorEngine/blob/master/LICENSE.md)

**Resolution:**
matches project site 

**Affected definitions**:
- [RazorEngine 3.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/RazorEngine/3.9.0/3.9.0)