### PR TITLE
args4j 2.0.16 no license to BDS-2

### DIFF
--- a/curations/maven/mavencentral/args4j/args4j.yaml
+++ b/curations/maven/mavencentral/args4j/args4j.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.12:
     licensed:
       declared: MIT
+  2.0.16:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
args4j 2.0.16 no license to BDS-2

**Details:**
Recent versions are licensed MIT, but this version appears to be licensed BSD-2, per https://github.com/kohsuke/args4j/blob/1420f8692894eb319123b9c613c0e04dd03dacf7/args4j/LICENSE.txt

**Resolution:**
Corrects the missing license for args4j 2.0.16

**Affected definitions**:
- [args4j 2.0.16](https://clearlydefined.io/definitions/maven/mavencentral/args4j/args4j/2.0.16/2.0.16)