### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -12,6 +12,9 @@ revisions:
   3.5.0:
     licensed:
       declared: Apache-2.0
+  4.3.0:
+    licensed:
+      declared: Apache-2.0
   4.4.1:
     licensed:
       declared: Apache-2.0
@@ -20,4 +23,4 @@ revisions:
       declared: Apache-2.0
   4.9.4:
     licensed:
-      declared: Apache-2.0      
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt0

**Resolution:**
Matches Project Site

**Affected definitions**:
- [NuGet.CommandLine 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.3.0/4.3.0)