### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/SendGrid.SmtpApi.yaml
+++ b/curations/nuget/nuget/-/SendGrid.SmtpApi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SendGrid.SmtpApi
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here in project site (https://github.com/sendgrid/smtpapi-csharp/blob/master/LICENSE.md)

**Resolution:**
link at license info broken


**Affected definitions**:
- [SendGrid.SmtpApi 1.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/SendGrid.SmtpApi/1.3.1/1.3.1)