### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/RestSharpSigned.yaml
+++ b/curations/nuget/nuget/-/RestSharpSigned.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RestSharpSigned
+  provider: nuget
+  type: nuget
+revisions:
+  105.2.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/restsharp/RestSharp/blob/master/LICENSE.txt)

**Resolution:**
matches project site

**Affected definitions**:
- [RestSharpSigned 105.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharpSigned/105.2.3/105.2.3)