### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -6,3 +6,6 @@ revisions:
   5.10.3:
     licensed:
       declared: Apache-2.0
+  5.11.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/unitycontainer/unity/blob/master/LICENSE)

**Resolution:**
matches project site

**Affected definitions**:
- [Unity.Container 5.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.11.1/5.11.1)