### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/git/github/facebook/rocksdb.yaml
+++ b/curations/git/github/facebook/rocksdb.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   27e593fbe10efa5a562ca79b1939ffb69d25163f:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 OR GPL-2.0-only
   641fae60f63619ed5d0c9d9e4c4ea5a0ffa3e253:
     files:
       - attributions:

--- a/curations/git/github/facebook/rocksdb.yaml
+++ b/curations/git/github/facebook/rocksdb.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  27e593fbe10efa5a562ca79b1939ffb69d25163f:
+    licensed:
+      declared: Apache-2.0
   641fae60f63619ed5d0c9d9e4c4ea5a0ffa3e253:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/facebook/rocksdb/blob/27e593fbe10efa5a562ca79b1939ffb69d25163f/LICENSE.Apache)

**Resolution:**
Matches file section in ClearlyDefined

**Affected definitions**:
- [rocksdb 27e593fbe10efa5a562ca79b1939ffb69d25163f](https://clearlydefined.io/definitions/git/github/facebook/rocksdb/27e593fbe10efa5a562ca79b1939ffb69d25163f/27e593fbe10efa5a562ca79b1939ffb69d25163f)