### PR TITLE
Declared license

### DIFF
--- a/curations/nuget/nuget/-/OPCFoundation.NetStandard.Opc.Ua.yaml
+++ b/curations/nuget/nuget/-/OPCFoundation.NetStandard.Opc.Ua.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OPCFoundation.NetStandard.Opc.Ua
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.359.31:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license

**Details:**
NuGet License link goes to a EULA type license

**Resolution:**
https://opcfoundation.org/license/redistributables/1.3/

**Affected definitions**:
- [OPCFoundation.NetStandard.Opc.Ua 1.4.359.31](https://clearlydefined.io/definitions/nuget/nuget/-/OPCFoundation.NetStandard.Opc.Ua/1.4.359.31/1.4.359.31)