### PR TITLE
Add MIT License

### DIFF
--- a/curations/npm/npmjs/-/qs.yaml
+++ b/curations/npm/npmjs/-/qs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.5.6:
+    licensed:
+      declared: MIT
   0.6.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
While discovered licenses were multiple, the language in the package files only had a MIT License. This was confirmed in metadata.

**Resolution:**
Confirmed MIT License on NPM site metadata under the 0.5.6 version: https://www.npmjs.com/package/qs/v/0.5.6

**Affected definitions**:
- [qs 0.5.6](https://clearlydefined.io/definitions/npm/npmjs/-/qs/0.5.6/0.5.6)