### PR TITLE
Add BSD 3-Clause License

### DIFF
--- a/curations/pypi/pypi/-/pandas.yaml
+++ b/curations/pypi/pypi/-/pandas.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.1:
     licensed:
       declared: BSD-3-Clause
+  1.0.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3-Clause License

**Details:**
No package files. Went to metadata, but was still unclear. Repository showed BSD 3-Clause, but MIT license also showed in github master branch.

**Resolution:**
License on github showed BSD 3-clause: https://github.com/pandas-dev/pandas/blob/master/LICENSE

However, MIT License showed up on master branch on github too: https://github.com/pandas-dev/pandas/tree/master 

**Affected definitions**:
- [pandas 1.0.3](https://clearlydefined.io/definitions/pypi/pypi/-/pandas/1.0.3/1.0.3)