### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
@@ -40,3 +40,6 @@ revisions:
   8.1.0:
     licensed:
       declared: MIT
+  8.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No information in package files. Raw data shows MIT License, checked meta data and github indicates MIT License, as well 

**Resolution:**
Confirmed on github: https://github.com/microsoft/bond/blob/master/LICENSE

**Affected definitions**:
- [Bond.Core.CSharp 8.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Core.CSharp/8.2.0/8.2.0)