### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -33,3 +33,6 @@ revisions:
   3.0.3:
     licensed:
       declared: MIT
+  3.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package files. Checked metadata and source repository, looks like MIT.

**Resolution:**
Github appear to point toward MIT: https://github.com/Azure/azure-functions-vs-build-sdk

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.5/3.0.5)