### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.Platforms.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.Platforms.yaml
@@ -48,6 +48,9 @@ revisions:
   2.2.3:
     licensed:
       declared: MIT
+  2.2.4:
+    licensed:
+      declared: MIT
   3.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Looks like dotnet Core was deprecated and now under dotnet runtime? Package files indicate MIT License. Could not confirm in metadata or repository

**Resolution:**
This is where the redirect sent us and I fould MIT. https://github.com/dotnet/runtime/blob/master/LICENSE.TXT

However, this is what directed me there. https://github.com/dotnet/corefx/blob/archive/README.md

**Affected definitions**:
- [Microsoft.NETCore.Platforms 2.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.Platforms/2.2.4/2.2.4)