### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Bond.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.CSharp.yaml
@@ -72,3 +72,6 @@ revisions:
   8.1.0:
     licensed:
       declared: MIT
+  8.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package file license information. Found and confirmed MIT License in meta data and repository. 

**Resolution:**
Found MIT License here: https://github.com/microsoft/bond/blob/a7025d60bcdc1cb979a6131c3afc2eee7c6c76ae/LICENSE


**Affected definitions**:
- [Bond.CSharp 8.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.CSharp/8.2.0/8.2.0)