### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -6,6 +6,9 @@ revisions:
   3.1.0:
     licensed:
       declared: BSD-3-Clause
+  3.10.0:
+    licensed:
+      declared: BSD-3-Clause
   3.4.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding BSD-3-Clause

**Resolution:**
NuGet license points to GitHub repo Master license

https://github.com/protocolbuffers/protobuf/blob/v3.10.0/LICENSE

**Affected definitions**:
- [Google.Protobuf 3.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.10.0/3.10.0)