### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Jil.yaml
+++ b/curations/nuget/nuget/-/Jil.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Jil
+  provider: nuget
+  type: nuget
+revisions:
+  2.16.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
No license found on NuGet page or in package. GitHub repo latest version is MIT (https://github.com/kevin-montrose/Jil/blob/2.15.4/LICENSE). Curating MIT for v2.16.0.

**Affected definitions**:
- [Jil 2.16.0](https://clearlydefined.io/definitions/nuget/nuget/-/Jil/2.16.0/2.16.0)