### PR TITLE
Declared License

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.hk2.external/javax.inject.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2.external/javax.inject.yaml
@@ -7,3 +7,6 @@ revisions:
   2.4.0-b34:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1
+  2.5.0-b32:
+    licensed:
+      declared: CDDL-1.1 OR GPLv2.0 only WITH Classpath exception 2.0

--- a/curations/maven/mavencentral/org.glassfish.hk2.external/javax.inject.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2.external/javax.inject.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   2.4.0-b34:
     licensed:
-      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.5.0-b32:
     licensed:
-      declared: CDDL-1.1 OR GPLv2.0 only WITH Classpath exception 2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding CDDL 1.1 or GPLv2.0 only WITH Classpath exception 2.0

**Resolution:**
ClearlyDefined pom.xml for package:

https://clearlydefined.io/file/b8438a7b38865f6b84de37d8b783bf21c353113b23e1f86ca5a0b28d939ee217

https://repo1.maven.org/maven2/org/glassfish/hk2/external/javax.inject/2.5.0-b32/javax.inject-2.5.0-b32.pom

**Affected definitions**:
- [javax.inject 2.5.0-b32](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.hk2.external/javax.inject/2.5.0-b32/2.5.0-b32)