### PR TITLE
Adding Declared license

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
@@ -12,3 +12,6 @@ revisions:
   2.1.0-beta2:
     licensed:
       declared: MIT
+  2.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding Declared license

**Details:**
LICENSE.txt in the "Files" section.

**Resolution:**
That matches the "License" link on NuGet and the source repo (https://github.com/microsoft/testfx/blob/3c76ad3a64800643727502a85e34e242868f41b8/LICENSE.txt)

**Affected definitions**:
- [MSTest.TestAdapter 2.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestAdapter/2.1.1/2.1.1)