### PR TITLE
Declared License Added

### DIFF
--- a/curations/nuget/nuget/-/murmurhash.yaml
+++ b/curations/nuget/nuget/-/murmurhash.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: murmurhash
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Added

**Details:**
Nuget license link goes to Apache 2.0

**Resolution:**
Source repo has been Apache 2.0 since 2012

**Affected definitions**:
- [murmurhash 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/murmurhash/1.0.0/1.0.0)