### PR TITLE
Adding declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -42,3 +42,6 @@ revisions:
   1.18.1:
     licensed:
       declared: BSD-3-Clause
+  1.18.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Pypi.org indicate the license was OSI Approved (BSD)

**Resolution:**
Reviewed license on Homepage and that license was BSD-3

**Affected definitions**:
- [numpy 1.18.2](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.18.2/1.18.2)