### PR TITLE
Adding declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -42,3 +42,6 @@ revisions:
   1.18.1:
     licensed:
       declared: BSD-3-Clause
+  1.18.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License contained within license.txt file is BSD 3

**Resolution:**
Pypi.org indicates License: OSI Approved (BSD). License is identified as BSD 3 Clause on GitHub

**Affected definitions**:
- [numpy 1.18.3](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.18.3/1.18.3)