### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/DotNetZip.yaml
+++ b/curations/nuget/nuget/-/DotNetZip.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.10.1:
+    licensed:
+      declared: MS-PL
   1.11.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget.org states "Original intellectual property in DotNetZip is provided under the Ms-PL"

**Resolution:**
License on GitHub states "Original intellectual property in DotNetZip is provided under the Ms-PL"  and history indicates no changes since 2014

**Affected definitions**:
- [DotNetZip 1.10.1](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetZip/1.10.1/1.10.1)