### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -61,6 +61,9 @@ revisions:
   7.0.1:
     licensed:
       declared: MIT
+  8.0.1:
+    licensed:
+      declared: MIT
   8.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package files with license information. Reviewed metadata at NuGet, indicated MIT license. 

**Resolution:**
Confirmed MIT License in source repository: https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md


**Affected definitions**:
- [Newtonsoft.Json 8.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/8.0.1/8.0.1)