### PR TITLE
Declared License

### DIFF
--- a/curations/maven/mavencentral/commons-el/commons-el.yaml
+++ b/curations/maven/mavencentral/commons-el/commons-el.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-el
+  namespace: commons-el
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: Apache-1.1


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding Apache 1.1

**Resolution:**
ClearlyDefined Files License.txt: Apache 1.1
No license found in sources.jar. POM file has Apache 2.0 reference.
Found Apache 1.1 license at http://commons.apache.org/dormant/commons-el/javadocs/commons-el-1.0/LICENSE

**Affected definitions**:
- [commons-el 1.0](https://clearlydefined.io/definitions/maven/mavencentral/commons-el/commons-el/1.0/1.0)