### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Mono.Options.yaml
+++ b/curations/nuget/nuget/-/Mono.Options.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.0:
+    licensed:
+      declared: MIT
   5.3.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
No license file in ClearlyDefined or NuGet.

Found MIT for newer version: https://github.com/xamarin/XamarinComponents/blob/Mono.Options-6.6.0.161/XPlat/Mono.Options/License.md

**Affected definitions**:
- [Mono.Options 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Mono.Options/4.4.0/4.4.0)