### PR TITLE
Declared License

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   2.22.2:
     licensed:
-      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.25.1:
     licensed:
-      declared: CDDL-1.1 OR GPL v2.0 only WITH Classpath exception 2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
@@ -7,3 +7,6 @@ revisions:
   2.22.2:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1
+  2.25.1:
+    licensed:
+      declared: CDDL-1.1 OR GPL v2.0 only WITH Classpath exception 2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding CDDL 1.1 or GPLv2.0 only WITH Classpath exception 2.0

**Resolution:**
ClearlyDefined manifest.mf and https://repo1.maven.org/maven2/org/glassfish/jersey/core/jersey-server/2.25.1/jersey-server-2.25.1.pom

**Affected definitions**:
- [jersey-server 2.25.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.core/jersey-server/2.25.1/2.25.1)