### PR TITLE
Declared License

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.10.4:
+    licensed:
+      declared: BSD-3-Clause
   2.11.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding BSD-3-Clause

**Resolution:**
Maven release date is March 18, 2014. 
POM file says BSD-like -https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.10.4/scala-reflect-2.10.4.pom
License for Scala prior to December 2018 under BSD-3-Clause and later versions were switched to Apache 2.0 -
https://www.scala-lang.org/license/


**Affected definitions**:
- [scala-reflect 2.10.4](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.10.4/2.10.4)