### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/vswhere.yaml
+++ b/curations/nuget/nuget/-/vswhere.yaml
@@ -9,6 +9,9 @@ revisions:
   2.3.2:
     licensed:
       declared: MIT
+  2.4.1:
+    licensed:
+      declared: MIT
   2.5.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
a.	LICENSE.txt in the “Files” section
b.	Source link - MIT “LICENSE.txt”
c.	“License” link on NuGet page - MIT "LICENSE.txt"

**Resolution:**
MIT

**Affected definitions**:
- [vswhere 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/vswhere/2.4.1/2.4.1)