### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/DotNetOpenAuth.Core.yaml
+++ b/curations/nuget/nuget/-/DotNetOpenAuth.Core.yaml
@@ -6,6 +6,9 @@ revisions:
   4.0.3.12153:
     licensed:
       declared: MS-PL
+  4.1.4.12333:
+    licensed:
+      declared: MS-PL
   4.3.4.13329:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
Nothing in "Files" section, no "Source" link.  NuGet "license" link goes to https://opensource.org/licenses/ms-pl.html

**Resolution:**
MS-PL

**Affected definitions**:
- [DotNetOpenAuth.Core 4.1.4.12333](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetOpenAuth.Core/4.1.4.12333/4.1.4.12333)