### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/bootstrap.yaml
+++ b/curations/nuget/nuget/-/bootstrap.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: Apache-2.0
+  3.3.4:
+    licensed:
+      declared: MIT
   3.3.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License

**Details:**
a.	No LICENSE file in “Files” – N/A
b.	Source link filled in – MIT LICENSE.txt
c.	License” link on NuGet page – find MIT LICENSE (note: the license link says “Apache-2.0 License” but clicks through to the MIT LICENSE 

**Resolution:**
Curate MIT

**Affected definitions**:
- [bootstrap 3.3.4](https://clearlydefined.io/definitions/nuget/nuget/-/bootstrap/3.3.4/3.3.4)