### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/Node.js.with.uv.pipe.name.fixed.yaml
+++ b/curations/nuget/nuget/-/Node.js.with.uv.pipe.name.fixed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Node.js.with.uv.pipe.name.fixed
+  provider: nuget
+  type: nuget
+revisions:
+  8.9.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
Source link - MIT
NuGet license link - MIT
The license mentions other licenses but those only apply to a subset and are therefore, discovered licenses

**Resolution:**
MIT

**Affected definitions**:
- [Node.js.with.uv.pipe.name.fixed 8.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/Node.js.with.uv.pipe.name.fixed/8.9.4/8.9.4)