### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/Chutzpah.yaml
+++ b/curations/nuget/nuget/-/Chutzpah.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Chutzpah
+  provider: nuget
+  type: nuget
+revisions:
+  4.2.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
a. license.txt is Apache-2.0
b. license link on NuGet goes to Apache-2.0
c. Source link goes to Apache-2.0

**Resolution:**
There is also a Service Stack BSD license but as that only applies to a portion of the project, it would be a discovered license.

**Affected definitions**:
- [Chutzpah 4.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Chutzpah/4.2.3/4.2.3)