### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -18,3 +18,6 @@ revisions:
   1.8.20.1:
     licensed:
       declared: MIT
+  1.8.24:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No indication in package files. Looked to metadata, but did not find anything explicit. Appears to indicate jQuery files are MIT. 

**Resolution:**
Followed NuGet link to jquery link. (https://www.nuget.org/packages/jQuery.UI.Combined/1.8.24#show-github-usage) (https://jquery.org/license/)

**Affected definitions**:
- [jQuery.UI.Combined 1.8.24](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.8.24/1.8.24)