### PR TITLE
Add BDS-3-Clause License

### DIFF
--- a/curations/pypi/pypi/-/kiwisolver.yaml
+++ b/curations/pypi/pypi/-/kiwisolver.yaml
@@ -9,3 +9,6 @@ revisions:
   1.1.0:
     licensed:
       declared: BSD-3-Clause
+  1.2.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BDS-3-Clause License

**Details:**
No package files. Meta data contained BSD reference. Confirmed with repository information. 

**Resolution:**
Meta data indicates : https://pypi.org/project/kiwisolver/1.2.0/#data
Repository confirms: https://github.com/nucleic/kiwi/blob/d9d1d772b3bd730659d500a582ce143fdf987fd1/LICENSE

**Affected definitions**:
- [kiwisolver 1.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/kiwisolver/1.2.0/1.2.0)