### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Validation.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Validation.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  15.0.82:
+    licensed:
+      declared: MIT
   15.3.15:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Looked to meta data, which indicated MIT. 

**Resolution:**
Confirmed in source repository at https://github.com/microsoft/vs-validation/blob/1fc5bdcf81384abd0c7eae4c9b0d577a2e22e6ae/LICENSE

**Affected definitions**:
- [Microsoft.VisualStudio.Validation 15.0.82](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Validation/15.0.82/15.0.82)