### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/vswhere.yaml
+++ b/curations/nuget/nuget/-/vswhere.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.58:
+    licensed:
+      declared: MIT
   2.2.11:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License.txt file identifies license as MIT

**Resolution:**
Metadata on Nuget.org  and License.txt file on GitHub also indicate MIT

**Affected definitions**:
- [vswhere 1.0.58](https://clearlydefined.io/definitions/nuget/nuget/-/vswhere/1.0.58/1.0.58)