### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.488:
     licensed:
       declared: MIT
+  1.1.603:
+    licensed:
+      declared: MIT
   1.1.608:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget.org identifies license as MIT

**Resolution:**
License link in Nuspec file also indicates MIT 

**Affected definitions**:
- [StackExchange.Redis 1.1.603](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/1.1.603/1.1.603)