### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Nito.Collections.Deque.yaml
+++ b/curations/nuget/nuget/-/Nito.Collections.Deque.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Nito.Collections.Deque
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.4:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Nito.Collections.Deque.yaml
+++ b/curations/nuget/nuget/-/Nito.Collections.Deque.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.4:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget.org identifies license as MIT

**Resolution:**
License.txt on GitHub also identifies license as MIT

**Affected definitions**:
- [Nito.Collections.Deque 1.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.Collections.Deque/1.0.4/1.0.4)