### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: GPL-2.0-only
   1.0.81:
     licensed:
-      declared: GPL-2.0
+      declared: GPL-2.0-only

--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: LibGit2Sharp.NativeBinaries
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
+  1.0.129:
+    licensed:
+      declared: GPL-2.0-only
   1.0.81:
     licensed:
       declared: GPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget.org identifies license as GPL 2.0

**Resolution:**
Nuspec file contains URL for license. That URL only GPL 2.0 is only valid version

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 1.0.129](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/1.0.129/1.0.129)