### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.WebPages.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.WebPages.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.WebPages
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
Nothing in “Files” section of ClearlyDefined
No source link
NuGet “license” link says “Apache-2.0 License” and goes to CodePlex archive
Navigate to GitHub, version is Apache v2 - https://github.com/OData/WebApi/blob/v3.1/License.txt


**Resolution:**
The license today is MIT, but for this version, it is Apache-2.0 and copyright MS Open Tech

**Affected definitions**:
- [Microsoft.AspNet.WebPages 3.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.WebPages/3.1.0/3.1.0)