### PR TITLE
Add Declared and curate LICENSE.txt

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
@@ -12,6 +12,12 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.16:
+    files:
+      - license: MIT
+        path: LICENSE.TXT
+    licensed:
+      declared: MIT
   2.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Declared and curate LICENSE.txt

**Details:**
LICENSE.txt in “Files” section – MIT
Source link goes to MIT
NuGet “License Info” link – MIT


**Resolution:**
https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT

**Affected definitions**:
- [Microsoft.NETCore.App 2.1.16](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App/2.1.16/2.1.16)