### PR TITLE
Declared

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
@@ -9,6 +9,9 @@ revisions:
   6.16.0:
     licensed:
       declared: MIT
+  6.17.0:
+    licensed:
+      declared: MIT
   7.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
Nothing in “Files” section of ClearlyDefined
No source link
NuGet “license Info” link goes to MIT


**Resolution:**
https://raw.githubusercontent.com/OData/odata.net/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.OData.Edm 6.17.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Edm/6.17.0/6.17.0)