### PR TITLE
Declared

### DIFF
--- a/curations/maven/mavencentral/org.antlr/stringtemplate.yaml
+++ b/curations/maven/mavencentral/org.antlr/stringtemplate.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: stringtemplate
+  namespace: org.antlr
+  provider: mavencentral
+  type: maven
+revisions:
+  3.2.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
No license info in the “Files” section of ClearlyDefined
No working source link
Navigate to POM – says BSD and links here - https://www.antlr.org/license.html
Download source jar and files say BSD-3-Clause as well


**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [stringtemplate 3.2.1](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/stringtemplate/3.2.1/3.2.1)