### PR TITLE
Declared

### DIFF
--- a/curations/maven/mavencentral/org.antlr/antlr-runtime.yaml
+++ b/curations/maven/mavencentral/org.antlr/antlr-runtime.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '3.4':
+    licensed:
+      declared: BSD-3-Clause
   3.5.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
No license info in the “Files” section of ClearlyDefined
No working source link
Navigate to POM – points to www.antlr.org
Download source jar and files say BSD-3-Clause as well


**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [antlr-runtime 3.4](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/antlr-runtime/3.4/3.4)