### PR TITLE
Declared

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-client.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-client.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.19':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.9':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception

--- a/curations/maven/mavencentral/com.sun.jersey/jersey-client.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-client.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.9':
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared

**Details:**
POM - https://repo1.maven.org/maven2/com/sun/jersey/jersey-client/1.9/jersey-client-1.9.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-client 1.9](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-client/1.9/1.9)