### PR TITLE
Add BSD 3-Clause License

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -78,6 +78,9 @@ revisions:
         url: 'https://github.com/moq/moq4/commit/b776fc2216a591427f4ffe9d3453eeebf9581b3d'
     licensed:
       declared: BSD-3-Clause
+  4.7.10:
+    licensed:
+      declared: BSD-3-Clause
   4.7.137:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3-Clause License

**Details:**
No info in Package Files. Meta Data points to BSD 3-Clause and confirmed in Source repository

**Resolution:**
Confirmed in source repository here: https://github.com/moq/moq4/blob/master/License.txt 

**Affected definitions**:
- [Moq 4.7.10](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.7.10/4.7.10)