### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -33,6 +33,9 @@ revisions:
   1.0.6:
     licensed:
       declared: MIT
+  3.0.1:
+    licensed:
+      declared: MIT
   3.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files indicate MIT License. Meta data and source repository confirm. 

**Resolution:**
Source repository confirms here: https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.1/3.0.1)