### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.Ref.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.Ref.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETCore.App.Ref
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files, meta data, and source repository all reflect MIT License. 

**Resolution:**
See link to confirm MIT License. https://github.com/dotnet/core-setup/blob/7d57652f33493fa022125b7f63aad0d70c52d810/LICENSE.TXT

**Affected definitions**:
- [Microsoft.NETCore.App.Ref 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App.Ref/3.0.0/3.0.0)