### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/System.Security.AccessControl.yaml
+++ b/curations/nuget/nuget/-/System.Security.AccessControl.yaml
@@ -9,6 +9,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview1-26216-02:
+    licensed:
+      declared: MIT
   4.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
ClearlyDefined Files license.txt:
https://clearlydefined.io/file/d7a68596ab69b06f51ca278a6545148e4269a9381c26d597c13df5d88e08cf5b

NuGet license points to https://github.com/dotnet/corefx, which moved to .NET Runtime repo: 

https://github.com/dotnet/runtime/blob/master/LICENSE.TXT

**Affected definitions**:
- [System.Security.AccessControl 4.5.0-preview1-26216-02](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.AccessControl/4.5.0-preview1-26216-02/4.5.0-preview1-26216-02)