### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/MSBuildTasks.yaml
+++ b/curations/nuget/nuget/-/MSBuildTasks.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.4.0.88:
+    licensed:
+      declared: BSD-2-Clause
   1.5.0.214:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding BSD-2-Clause

**Resolution:**
NuGet license: "BSD-2-Clause"

https://github.com/loresoft/msbuildtasks/blob/1.4.0.88/LICENSE

Source license: https://github.com/loresoft/msbuildtasks/blob/214ec5e8e176c02d98b7e18027b769e707f73eec/LICENSE

**Affected definitions**:
- [MSBuildTasks 1.4.0.88](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuildTasks/1.4.0.88/1.4.0.88)