### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Xml.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Xml.yaml
@@ -6,6 +6,9 @@ revisions:
   5.2.0:
     licensed:
       declared: MIT
+  5.2.2:
+    licensed:
+      declared: MIT
   5.2.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget.org is listed as MIT

**Resolution:**
License URL in Nuspec file is also MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Xml 5.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Xml/5.2.2/5.2.2)