### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.WsFederation.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.WsFederation.yaml
@@ -6,6 +6,9 @@ revisions:
   5.2.0:
     licensed:
       declared: MIT
+  5.2.2:
+    licensed:
+      declared: MIT
   5.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License at Nuget.org is MIT

**Resolution:**
License URL in Nuspec file is also MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Protocols.WsFederation 5.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocols.WsFederation/5.2.2/5.2.2)