### PR TITLE
Add BSD 3-Clause License

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-compiler.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-compiler.yaml
@@ -7,3 +7,6 @@ revisions:
   2.11.12:
     licensed:
       declared: BSD-3-Clause
+  2.11.8:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3-Clause License

**Details:**
No package files, but found Scala Compiler on Maven and the pom file indicates BSD 3-Clause. 

**Resolution:**
Pom file here shows BSD 3-Clause: https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.11.8/scala-compiler-2.11.8.pom

**Affected definitions**:
- [scala-compiler 2.11.8](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-compiler/2.11.8/2.11.8)