### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/RazorGenerator.MsBuild.yaml
+++ b/curations/nuget/nuget/-/RazorGenerator.MsBuild.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RazorGenerator.MsBuild
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No package files, meta data indicates Apache, but source repo moved to github, and github indicates Apache 2.0. 

**Resolution:**
Github shows Apache 2.0: https://github.com/RazorGenerator/RazorGenerator/blob/master/LICENSE.txt

**Affected definitions**:
- [RazorGenerator.MsBuild 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/RazorGenerator.MsBuild/2.4.1/2.4.1)