### PR TITLE
Add LGPL 3.0 License

### DIFF
--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: EPPlus
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: LGPL-3.0-only

--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.1.0:
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add LGPL 3.0 License

**Details:**
No info in package files. Meta data indicated LGPL 2.1. No info in source repo, but a closed issue where author indicates LGPL 3.0. 

**Resolution:**
Issue from source repo is here: https://github.com/JanKallman/EPPlus/issues/311

**Affected definitions**:
- [EPPlus 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/EPPlus/4.1.0/4.1.0)