### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Accord.Math.yaml
+++ b/curations/nuget/nuget/-/Accord.Math.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Accord.Math
+  provider: nuget
+  type: nuget
+revisions:
+  3.8.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget.org lists license as LGPL 2.1 or later

**Resolution:**
License URL in Nuspec file lists same license

**Affected definitions**:
- [Accord.Math 3.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Accord.Math/3.8.0/3.8.0)