### PR TITLE
Add BSD 2-Clause License

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -12,3 +12,6 @@ revisions:
   1.5.4:
     licensed:
       declared: BSD-2-Clause
+  1.6.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 2-Clause License

**Details:**
No info in package files. Meta date and source repo confirm BSD 2-Clause. 

**Resolution:**
Source repo confirms BSD 2-Clause: https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.6.1


**Affected definitions**:
- [NLog.Extensions.Logging 1.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.6.1/1.6.1)