### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Unity.AspNet.WebApi.yaml
+++ b/curations/nuget/nuget/-/Unity.AspNet.WebApi.yaml
@@ -6,3 +6,6 @@ revisions:
   5.0.15:
     licensed:
       declared: Apache-2.0
+  5.11.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No infor in package files. Meta data and source repo confirm Apache 2.0. 

**Resolution:**
Source repo confirms Apache 2.0: https://github.com/unitycontainer/aspnet-webapi/blob/master/LICENSE

**Affected definitions**:
- [Unity.AspNet.WebApi 5.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.AspNet.WebApi/5.11.1/5.11.1)