### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CodeAnalysis.Elfie.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeAnalysis.Elfie.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CodeAnalysis.Elfie
+  provider: nuget
+  type: nuget
+revisions:
+  0.10.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
NuGet and Project license links are broken.
Project looks like it moved to a new repo: https://github.com/microsoft/elfie-arriba/blob/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.CodeAnalysis.Elfie 0.10.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CodeAnalysis.Elfie/0.10.6/0.10.6)