### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -27,3 +27,6 @@ revisions:
   5.3.1:
     licensed:
       declared: MIT
+  5.3.3:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -29,4 +29,4 @@ revisions:
       declared: MIT
   5.3.3:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License file on ClearlyDefined lists MIT license

**Resolution:**
Nuget site also list MIT and license URL in Nuspec is also MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 5.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.3.3/5.3.3)