### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -12,3 +12,6 @@ revisions:
   4.7.2:
     licensed:
       declared: MIT
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files, meta data, and source repo all confirm MIT. 

**Resolution:**
MIT confirmed here: https://github.com/microsoft/botbuilder-dotnet/blob/master/LICENSE


**Affected definitions**:
- [Microsoft.Bot.Schema 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.8.0/4.8.0)