### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.Logging.Log4net.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.Logging.Log4net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Extensions.Logging.Log4net
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.3:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Dual-licensed, Apache 2.0 or MS-PL

**Resolution:**
NuGet license: https://raw.githubusercontent.com/ninject/ninject.extensions.logging/master/LICENSE.txt

Source license:
https://github.com/ninject/Ninject/blob/3.2.3/LICENSE.txt

**Affected definitions**:
- [Ninject.Extensions.Logging.Log4net 3.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.Logging.Log4net/3.2.3/3.2.3)