### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Packaging.yaml
+++ b/curations/nuget/nuget/-/System.IO.Packaging.yaml
@@ -9,6 +9,9 @@ revisions:
         path: LICENSE.TXT
     licensed:
       declared: MIT
+  4.4.1:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
The discovered licenses were multiple, but the package files indicate MIT license. No meta data. I googled to find the github, but it didn't show a license. 

**Resolution:**
https://clearlydefined.io/file/d7a68596ab69b06f51ca278a6545148e4269a9381c26d597c13df5d88e08cf5b

**Affected definitions**:
- [System.IO.Packaging 4.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Packaging/4.4.1/4.4.1)