### PR TITLE
Add OTHER as License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CompilerServices.AsyncTargetingPack.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CompilerServices.AsyncTargetingPack.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CompilerServices.AsyncTargetingPack
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add OTHER as License

**Details:**
No info in package files, meta data points to MSFT EULA License.

**Resolution:**
https://www.nuget.org/packages/Microsoft.CompilerServices.AsyncTargetingPack/1.0.0

**Affected definitions**:
- [Microsoft.CompilerServices.AsyncTargetingPack 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CompilerServices.AsyncTargetingPack/1.0.0/1.0.0)