### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/GraphQL.yaml
+++ b/curations/nuget/nuget/-/GraphQL.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: GraphQL
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo confirm MIT. 

**Resolution:**
Source repo confirm MIT: https://github.com/graphql-dotnet/graphql-dotnet/blob/master/LICENSE.md

**Affected definitions**:
- [GraphQL 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/GraphQL/2.4.0/2.4.0)