### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.MicrosoftAccount.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.MicrosoftAccount.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Security.MicrosoftAccount
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Package files indicate Apache 2.0. Meta data and source repo confirm Apache 2.0. 

**Resolution:**
Meta data confirm Apache 2.0: https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Security.MicrosoftAccount 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.MicrosoftAccount/4.1.0/4.1.0)