### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net40.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net40.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETFramework.ReferenceAssemblies.net40
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-preview.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package files. Meta data confirms MIT.

**Resolution:**
Meta data confirms MIT: https://github.com/Microsoft/dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net40 1.0.0-preview.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net40/1.0.0-preview.2/1.0.0-preview.2)