### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Common.yaml
+++ b/curations/nuget/nuget/-/NuGet.Common.yaml
@@ -12,6 +12,9 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No package file information. Meta data and source repo confirm Apache 2.0. Ironically, they just linked to Apache license, but did not include the actual license text. Intention was clear though. 

**Resolution:**
Source repo confirms: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Common 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Common/4.2.0/4.2.0)