### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: MIT
   2.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package files. Meta data and source repo confirm MIT License. 

**Resolution:**
Source repo confirms MIT: https://github.com/microsoft/aspnet-api-versioning/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer/2.1.0/2.1.0)