### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/jQuery.Validation.yaml
+++ b/curations/nuget/nuget/-/jQuery.Validation.yaml
@@ -18,6 +18,9 @@ revisions:
         path: jQuery.Validation.nuspec
     licensed:
       declared: MIT
+  1.14.0:
+    licensed:
+      declared: MIT
   1.15.1:
     files:
       - license: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files don't show license. Meta data does not have license. Found on Github and confirmed MIT. 

**Resolution:**
Source Repo: https://github.com/jquery-validation/jquery-validation/blob/master/LICENSE.md

**Affected definitions**:
- [jQuery.Validation 1.14.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.Validation/1.14.0/1.14.0)