### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.yaml
@@ -51,6 +51,9 @@ revisions:
   0.25.4:
     licensed:
       declared: MIT
+  0.26.0:
+    licensed:
+      declared: MIT
   0.26.0-preview-0027:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files have no information on license. Meta data and source repo confirms MIT. 

**Resolution:**
Source repo confirms MIT: https://github.com/libgit2/libgit2sharp/blob/master/LICENSE.md

**Affected definitions**:
- [LibGit2Sharp 0.26.0](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp/0.26.0/0.26.0)