### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -86,6 +86,9 @@ revisions:
   2.1.4:
     licensed:
       declared: MIT
+  2.2.0:
+    licensed:
+      declared: MIT
   2.2.3:
     files:
       - license: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files had no license information. Meta Data pointed to jquery website that said MIT and source repo confirmed. 

**Resolution:**
Source repo confirms MIT: https://github.com/jquery/jquery/blob/master/LICENSE.txt

**Affected definitions**:
- [jQuery 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/2.2.0/2.2.0)