### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/structuremap.yaml
+++ b/curations/nuget/nuget/-/structuremap.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: structuremap
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.5.154:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Package files had no license info. Meta data and source repo confirm Apache 2.0.

**Resolution:**
Source repo confirms: https://github.com/structuremap/structuremap/blob/master/LICENSE.TXT

**Affected definitions**:
- [structuremap 3.1.5.154](https://clearlydefined.io/definitions/nuget/nuget/-/structuremap/3.1.5.154/3.1.5.154)