### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -24,6 +24,9 @@ revisions:
   5.0.0-rc4:
     licensed:
       declared: MIT
+  5.0.0-rc5:
+    licensed:
+      declared: MIT
   5.3.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files indicate MIT, as does meta data and source repo. 

**Resolution:**
Source repo confirms: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.0.0-rc5](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.0.0-rc5/5.0.0-rc5)