### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -6,3 +6,6 @@ revisions:
   4.5.3:
     licensed:
       declared: MIT
+  4.6.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files indicate MIT, as does meta data and source repo.

**Resolution:**
Source repo confirms MIT License: https://github.com/microsoft/botbuilder-dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder 4.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/4.6.3/4.6.3)