### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MediatR.Extensions.Microsoft.DependencyInjection
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files have no license info. Meta data and source repo confirm MIT License. 

**Resolution:**
Source repo confirms MIT: https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/blob/master/LICENSE

**Affected definitions**:
- [MediatR.Extensions.Microsoft.DependencyInjection 7.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection/7.0.0/7.0.0)