### PR TITLE
Add BSD 3-Clause License

### DIFF
--- a/curations/nuget/nuget/-/Thinktecture.IdentityModel.yaml
+++ b/curations/nuget/nuget/-/Thinktecture.IdentityModel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Thinktecture.IdentityModel
+  provider: nuget
+  type: nuget
+revisions:
+  3.6.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3-Clause License

**Details:**
Component is deprecated, but source repo indicates BSD 3-Clause License. Package files and meta data had no license info. 

**Resolution:**
Source repo: https://github.com/IdentityModel/Thinktecture.IdentityModel/blob/master/LICENSE

**Affected definitions**:
- [Thinktecture.IdentityModel 3.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/Thinktecture.IdentityModel/3.6.1/3.6.1)