### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
@@ -12,6 +12,9 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Component is deprecated, but meta data and source repo confirms Apache 2.0

**Resolution:**
Source repo confirms: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Packaging.Core 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core/4.2.0/4.2.0)