### PR TITLE
Add BSD 3 Clause License

### DIFF
--- a/curations/nuget/nuget/-/NLog.Web.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/NLog.Web.AspNetCore.yaml
@@ -36,3 +36,6 @@ revisions:
   4.8.1:
     licensed:
       declared: BSD-3-Clause
+  4.9.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3 Clause License

**Details:**
Package files had no license info. Meta data and source repo confirm BSD 3-Clause License. 

**Resolution:**
Source repo confirms BSD 3-Clause: https://github.com/NLog/NLog.Web/blob/master/LICENSE

**Affected definitions**:
- [NLog.Web.AspNetCore 4.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Web.AspNetCore/4.9.0/4.9.0)