### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -12,6 +12,9 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0
   4.7.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Package files had no license info. Meta data confirms Apache 2.0. 

**Resolution:**
Meta data confirms Apache 2.0:https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Frameworks 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Frameworks/4.2.0/4.2.0)