### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -20,6 +20,9 @@ revisions:
   106.3.1:
     licensed:
       declared: Apache-2.0
+  106.5.4:
+    licensed:
+      declared: Apache-2.0
   106.6.10:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Package files had no license info. Meta data and source repo confirm Apache 2.0

**Resolution:**
Source repo confirms Apache 2.0: https://github.com/restsharp/RestSharp/blob/master/LICENSE.txt

**Affected definitions**:
- [RestSharp 106.5.4](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/106.5.4/106.5.4)