### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net461.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net461.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETFramework.ReferenceAssemblies.net461
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-preview.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files had no license info. meta data confirms MIT license. 

**Resolution:**
meta data confirms: https://github.com/Microsoft/dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net461 1.0.0-preview.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net461/1.0.0-preview.2/1.0.0-preview.2)