### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/EnterpriseLibrary.TransientFaultHandling.Core.yaml
+++ b/curations/nuget/nuget/-/EnterpriseLibrary.TransientFaultHandling.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: EnterpriseLibrary.TransientFaultHandling.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget indicates license is MIT

**Resolution:**
License URL in Nuspec is also MIT

**Affected definitions**:
- [EnterpriseLibrary.TransientFaultHandling.Core 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/EnterpriseLibrary.TransientFaultHandling.Core/1.2.0/1.2.0)