### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -9,6 +9,9 @@ revisions:
   4.5.3:
     licensed:
       declared: MIT
+  4.7.0:
+    licensed:
+      declared: NOASSERTION
   4.7.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec is also MIT

**Affected definitions**:
- [Microsoft.Bot.Schema 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.7.0/4.7.0)