### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Visual-StyleCop.MSBuild.yaml
+++ b/curations/nuget/nuget/-/Visual-StyleCop.MSBuild.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Visual-StyleCop.MSBuild
+  provider: nuget
+  type: nuget
+revisions:
+  4.7.59:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget indicates license is MS-PL

**Resolution:**
License URL in Nuspec is also MS-PL

**Affected definitions**:
- [Visual-StyleCop.MSBuild 4.7.59](https://clearlydefined.io/definitions/nuget/nuget/-/Visual-StyleCop.MSBuild/4.7.59/4.7.59)