### PR TITLE
Adding declared license

### DIFF
--- a/curations/maven/mavencentral/org.scala-sbt/test-interface.yaml
+++ b/curations/maven/mavencentral/org.scala-sbt/test-interface.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: test-interface
+  namespace: org.scala-sbt
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
.pom file indicates license is BSD

**Resolution:**
License URL in .pom file goes to license labeled as "BSD," which upon review is actually BSD-3

**Affected definitions**:
- [test-interface 1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-sbt/test-interface/1.0/1.0)