### PR TITLE
Verifying declared license

### DIFF
--- a/curations/maven/mavencentral/xerces/xercesImpl.yaml
+++ b/curations/maven/mavencentral/xerces/xercesImpl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xercesImpl
+  namespace: xerces
+  provider: mavencentral
+  type: maven
+revisions:
+  2.9.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Verifying declared license

**Details:**
Declared license was listed as Apache 2.0

**Resolution:**
Harvested license file lists license as Apache http://xerces.apache.org/xerces2-j/ also states license is Apache 2.0

**Affected definitions**:
- [xercesImpl 2.9.1](https://clearlydefined.io/definitions/maven/mavencentral/xerces/xercesImpl/2.9.1/2.9.1)