### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Node.js.redist.yaml
+++ b/curations/nuget/nuget/-/Node.js.redist.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Node.js.redist
+  provider: nuget
+  type: nuget
+revisions:
+  10.15.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget isn't labeled, but upon review is MIT

**Resolution:**
License URL in Nuspec indicates license is MIT

**Affected definitions**:
- [Node.js.redist 10.15.0](https://clearlydefined.io/definitions/nuget/nuget/-/Node.js.redist/10.15.0/10.15.0)