### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net46.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net46.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETFramework.ReferenceAssemblies.net46
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-preview.2:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net46.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net46.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.0-preview.2:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget indicates license is MIT

**Resolution:**
License URL in Nuspec file is also MIT

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net46 1.0.0-preview.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net46/1.0.0-preview.2/1.0.0-preview.2)