### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/NLog.Web.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/NLog.Web.AspNetCore.yaml
@@ -36,3 +36,6 @@ revisions:
   4.8.1:
     licensed:
       declared: BSD-3-Clause
+  4.8.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget site indicates license is BSD-3

**Resolution:**
License URL in Nuspec file is BSD-3

**Affected definitions**:
- [NLog.Web.AspNetCore 4.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Web.AspNetCore/4.8.5/4.8.5)