### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.WebApi.Versioning.ApiExplorer.yaml
@@ -6,3 +6,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget indicates license is MIT

**Resolution:**
License URL in Nuspec file is also MIT

**Affected definitions**:
- [Microsoft.AspNet.WebApi.Versioning.ApiExplorer 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.WebApi.Versioning.ApiExplorer/1.2.1/1.2.1)