### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/JSLintNet.MSBuild.yaml
+++ b/curations/nuget/nuget/-/JSLintNet.MSBuild.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: JSLintNet.MSBuild
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget site is Apache 2.0

**Resolution:**
License URL in Nuspec file is also Apache 2.0

**Affected definitions**:
- [JSLintNet.MSBuild 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/JSLintNet.MSBuild/2.3.0/2.3.0)