### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -6,3 +6,6 @@ revisions:
   4.5.3:
     licensed:
       declared: MIT
+  4.6.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files show MIT. Meta data and course repo confirm MIT. 

**Resolution:**
Source Repo confirms: https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 4.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.6.3/4.6.3)