### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -24,3 +24,6 @@ revisions:
   3.1.2:
     licensed:
       declared: MIT
+  3.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files are unclear. Meta data confirms MIT license. 

**Resolution:**
Confirms MIT in meta data: https://www.nuget.org/packages/Microsoft.DotNet.PlatformAbstractions/3.1.3/License

**Affected definitions**:
- [Microsoft.DotNet.PlatformAbstractions 3.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions/3.1.3/3.1.3)