### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.7.0:
+    licensed:
+      declared: MIT
   4.7.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files, meta data, and source repo all confirm MIT. 

**Resolution:**
https://github.com/microsoft/botbuilder-dotnet/blob/v4.7.0/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Configuration 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Configuration/4.7.0/4.7.0)