### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.17.0:
+    licensed:
+      declared: MIT
   0.7.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files did not have info on license. Meta data confirms MIT. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights 0.17.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights/0.17.0/0.17.0)