### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.0:
     licensed:
       declared: MIT
+  1.1.0:
+    licensed:
+      declared: MIT
   2.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files do not show license info. Meta data and source repo confirm MIT License. 

**Resolution:**
https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v1.1.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/1.1.0/1.1.0)