### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/FakeItEasy.yaml
+++ b/curations/nuget/nuget/-/FakeItEasy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FakeItEasy
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files show no license info. Meta data and source repo confirm MIT License. 

**Resolution:**
https://github.com/FakeItEasy/FakeItEasy/blob/3.2.0/License.txt

**Affected definitions**:
- [FakeItEasy 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/FakeItEasy/3.2.0/3.2.0)