### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -24,6 +24,9 @@ revisions:
   1.11.3:
     licensed:
       declared: MIT
+  1.11.7:
+    licensed:
+      declared: MIT
   1.4.6:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo confirm MIT License. 

**Resolution:**
https://github.com/zzzprojects/html-agility-pack/blob/v1.11.7/LICENSE

**Affected definitions**:
- [HtmlAgilityPack 1.11.7](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.7/1.11.7)