### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -12,6 +12,9 @@ revisions:
   1.0.19:
     licensed:
       declared: MIT
+  1.0.22:
+    licensed:
+      declared: MIT
   1.0.24:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget site is MIT

**Resolution:**
License URL in Nuspec file is also MIT

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.22](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.22/1.0.22)