### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -33,3 +33,6 @@ revisions:
   5.3.3:
     licensed:
       declared: MIT
+  5.4.1:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -35,4 +35,4 @@ revisions:
       declared: MIT
   5.4.1:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Harvested License file is MIT

**Resolution:**
Nuget site shows MIT and License URL in Nuspec file is also MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 5.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/5.4.1/5.4.1)