### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Unity.yaml
+++ b/curations/nuget/nuget/-/Unity.yaml
@@ -39,6 +39,9 @@ revisions:
   5.11.3:
     licensed:
       declared: Apache-2.0
+  5.11.4:
+    licensed:
+      declared: Apache-2.0
   5.2.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Harvested License file indicates Apache 2.0

**Resolution:**
Nuget site indicates Apache 2.0 and license URL in Nuspec file is also Apache 2.0

**Affected definitions**:
- [Unity 5.11.4](https://clearlydefined.io/definitions/nuget/nuget/-/Unity/5.11.4/5.11.4)