### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Accord.yaml
+++ b/curations/nuget/nuget/-/Accord.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Accord
+  provider: nuget
+  type: nuget
+revisions:
+  3.8.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget site indicates licenses is LGPL 2.1 or later

**Resolution:**
License URL in Nuspec file also indicates licenses is LGPL 2.1 or later

**Affected definitions**:
- [Accord 3.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Accord/3.8.0/3.8.0)