### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Streaming
+  provider: nuget
+  type: nuget
+revisions:
+  4.7.0:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.7.0:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates MIT

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.7.0/4.7.0)