### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Moment.js.yaml
+++ b/curations/nuget/nuget/-/Moment.js.yaml
@@ -9,4 +9,6 @@ revisions:
   2.19.3:
     licensed:
       declared: MIT
-      
+  2.24.0:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Moment.js.yaml
+++ b/curations/nuget/nuget/-/Moment.js.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: MIT
   2.24.0:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget site is not labeled, but upon review it is MIT

**Resolution:**
Repository also list MIT

**Affected definitions**:
- [Moment.js 2.24.0](https://clearlydefined.io/definitions/nuget/nuget/-/Moment.js/2.24.0/2.24.0)