### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.yaml
@@ -9,6 +9,9 @@ revisions:
   4.5.1:
     licensed:
       declared: MIT
+  4.7.0:
+    licensed:
+      declared: MIT
   4.8.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget site is MIT

**Resolution:**
License on repository is MIT and license URL in Nuspec is also MIT

**Affected definitions**:
- [MathNet.Numerics 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics/4.7.0/4.7.0)