### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Libmongocrypt.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Libmongocrypt.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MongoDB.Libmongocrypt
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Harvested License file indicates license is Apache 2.0

**Resolution:**
Nuget site and Mongo site both indicate license is Apache 2.0

**Affected definitions**:
- [MongoDB.Libmongocrypt 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Libmongocrypt/1.0.0/1.0.0)