### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/GraphQL-Parser.yaml
+++ b/curations/nuget/nuget/-/GraphQL-Parser.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: GraphQL-Parser
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget site indicates license is MIT

**Resolution:**
Repository and license URL in Nuspec file also indicate MIT

**Affected definitions**:
- [GraphQL-Parser 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/GraphQL-Parser/3.0.0/3.0.0)