### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/MSBuildTasks.yaml
+++ b/curations/nuget/nuget/-/MSBuildTasks.yaml
@@ -6,6 +6,9 @@ revisions:
   1.4.0.88:
     licensed:
       declared: BSD-2-Clause
+  1.5.0.196:
+    licensed:
+      declared: BSD-2-Clause
   1.5.0.214:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Nuget site indicates license is BSD-2-Clause

**Resolution:**
License URL in Nuspec file is also BSD-2

**Affected definitions**:
- [MSBuildTasks 1.5.0.196](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuildTasks/1.5.0.196/1.5.0.196)