### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -15,6 +15,9 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0
   4.9.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License on Nuget site is Apache 2.0

**Resolution:**
License on repository is also Apache 2.0 and license URL in Nuspec file is also Apache 2.0

**Affected definitions**:
- [NuGet.Versioning 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/4.2.0/4.2.0)