### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -30,6 +30,9 @@ revisions:
   1.0.31:
     licensed:
       declared: MIT
+  1.0.34:
+    licensed:
+      declared: MIT
   1.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Harvested License file indicates license is MIT

**Resolution:**
Nuget site and repository also list license as MIT

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.34](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.34/1.0.34)