### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MockingKernel.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.MockingKernel
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.2:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License listing on Nuget site is Apache 2.0 or MS-PL

**Resolution:**
License URL in Nuspec file states users can opt for either license

**Affected definitions**:
- [Ninject.MockingKernel 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MockingKernel/3.2.2/3.2.2)