### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/MediatR.yaml
+++ b/curations/nuget/nuget/-/MediatR.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MediatR
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License listed on Nuget site is Apache 2.0

**Resolution:**
License URL in Nuspec file also indicates Apache 2.0

**Affected definitions**:
- [MediatR 7.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MediatR/7.0.0/7.0.0)