### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -27,6 +27,9 @@ revisions:
   5.0.0-rc4:
     licensed:
       declared: MIT
+  5.0.0-rc5:
+    licensed:
+      declared: MIT
   5.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Harvested License file indicates license is MIT

**Resolution:**
Nuget site and license URL in Nuspec file also indicate MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 5.0.0-rc5](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/5.0.0-rc5/5.0.0-rc5)