### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/nuget/nuget/-/Ben.Demystifier.yaml
+++ b/curations/nuget/nuget/-/Ben.Demystifier.yaml
@@ -6,6 +6,9 @@ revisions:
   0.1.2:
     licensed:
       declared: Apache-2.0
+  0.1.3:
+    licensed:
+      declared: Apache-2.0
   0.1.6:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found here (https://github.com/benaadams/Ben.Demystifier/blob/master/LICENSE)

**Resolution:**
Matches project site

**Affected definitions**:
- [Ben.Demystifier 0.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Ben.Demystifier/0.1.3/0.1.3)