### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -24,6 +24,9 @@ revisions:
   5.0.0-rc4:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.3.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE)

**Resolution:**
matches project site

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.2.1/5.2.1)