### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -27,6 +27,9 @@ revisions:
   5.0.0-rc5:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.3.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE)

**Resolution:**
Matches Project Site

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.2.1/5.2.1)