### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CSharp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CSharp.yaml
@@ -15,3 +15,6 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview3.19128.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found in the "Files" LICENSE.TXT

**Resolution:**
Matches project site redirected per README.md (https://github.com/dotnet/runtime/blob/master/LICENSE.TXT)

**Affected definitions**:
- [Microsoft.CSharp 4.6.0-preview3.19128.7](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CSharp/4.6.0-preview3.19128.7/4.6.0-preview3.19128.7)