### PR TITLE
Declare Apache-2.0

### DIFF
--- a/curations/git/github/datejs/datejs.yaml
+++ b/curations/git/github/datejs/datejs.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: datejs
+  namespace: datejs
+  provider: github
+  type: git
+revisions:
+  77b907f9d21b944dc5ce0ddd20934d8c3af68610:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Apache-2.0

**Details:**
Declare Apache-2.0 found in Files license section here (https://github.com/datejs/datejs/blob/77b907f9d21b944dc5ce0ddd20934d8c3af68610/LICENSE)

**Resolution:**
Matches source site found here (https://github.com/datejs/Datejs/blob/77b907f9d21b944dc5ce0ddd20934d8c3af68610/LICENSE

**Affected definitions**:
- [datejs 77b907f9d21b944dc5ce0ddd20934d8c3af68610](https://clearlydefined.io/definitions/git/github/datejs/datejs/77b907f9d21b944dc5ce0ddd20934d8c3af68610/77b907f9d21b944dc5ce0ddd20934d8c3af68610)