### PR TITLE
Declared License

### DIFF
--- a/curations/npm/npmjs/-/semver-utils.yaml
+++ b/curations/npm/npmjs/-/semver-utils.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.1.1:
+    licensed:
+      declared: Apache-2.0
   1.1.4:
     licensed:
       declared: MIT OR Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
ClearlyDefined Files: "Apache 2.0" and here for closest version: https://git.coolaj86.com/coolaj86/semver-utils.js/src/tag/v1.1.2/package.json

Noting license was updated for later version (1.1.3) to be either MIT or Apache 2.0.

**Affected definitions**:
- [semver-utils 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/semver-utils/1.1.1/1.1.1)