### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/System.Net.Http.Extensions.Compression.Client.yaml
+++ b/curations/nuget/nuget/-/System.Net.Http.Extensions.Compression.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Net.Http.Extensions.Compression.Client
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding Apache 2.0

**Resolution:**
NuGet metadata: "Apache 2.0", broken link

Project license: https://github.com/azzlack/Microsoft.AspNet.WebApi.MessageHandlers.Compression/blob/develop/LICENSE

**Affected definitions**:
- [System.Net.Http.Extensions.Compression.Client 2.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/System.Net.Http.Extensions.Compression.Client/2.0.5/2.0.5)