### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualBasic.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualBasic.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualBasic
+  provider: nuget
+  type: nuget
+revisions:
+  10.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
ClearlyDefined License File: MIT

NuGet license metadata has broken link.

New repo for .NET Team w/ license: https://github.com/dotnet/runtime/blob/master/LICENSE.TXT

**Affected definitions**:
- [Microsoft.VisualBasic 10.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualBasic/10.3.0/10.3.0)