### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Win32.Registry.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Win32.Registry.yaml
@@ -9,6 +9,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview1-26216-02:
+    licensed:
+      declared: MIT
   4.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
ClearlyDefined License File: MIT

NuGet license link broken

.NET repo has moved to GitHub with license:

https://github.com/dotnet/runtime/blob/master/LICENSE.TXT

**Affected definitions**:
- [Microsoft.Win32.Registry 4.5.0-preview1-26216-02](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Win32.Registry/4.5.0-preview1-26216-02/4.5.0-preview1-26216-02)