### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Shouldly.yaml
+++ b/curations/nuget/nuget/-/Shouldly.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Shouldly
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Metadata from Nuget site indicates license is BSD, which upon review is BSD-3

**Resolution:**
Repository indicates license is BSD-3 and license URL in Nuspec indicates same

**Affected definitions**:
- [Shouldly 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Shouldly/3.0.2/3.0.2)