### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -9,3 +9,6 @@ revisions:
   5.11.1:
     licensed:
       declared: Apache-2.0
+  5.11.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License link on Nuget site indicates license is Apache 2.0 and license URL in Nuspec file indicates same

**Affected definitions**:
- [Unity.Container 5.11.5](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.11.5/5.11.5)