### PR TITLE
Changed from LGPL-3.0 to LGPL-2.1 or later

### DIFF
--- a/curations/pypi/pypi/-/pymssql.yaml
+++ b/curations/pypi/pypi/-/pymssql.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pymssql
+  provider: pypi
+  type: pypi
+revisions:
+  2.1.4:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changed from LGPL-3.0 to LGPL-2.1 or later

**Details:**
Changed from LGPL-3.0 to LGPL-2.1 or later found here at the tag (https://github.com/pymssql/pymssql/blob/v2.1.4.dev1/LICENSE)

**Resolution:**
This had the wrong license from the scan.

**Affected definitions**:
- [pymssql 2.1.4](https://clearlydefined.io/definitions/pypi/pypi/-/pymssql/2.1.4/2.1.4)