### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.MockingKernel.Moq
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.2:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License link on Nuget site indicates user can license under Apache 2.0 or MS-PL

**Resolution:**
License URL in Nuspec file also indicates Apached 2.0 or MS-PL

**Affected definitions**:
- [Ninject.MockingKernel.Moq 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MockingKernel.Moq/3.2.2/3.2.2)