### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Identity.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Identity.Client.yaml
@@ -12,6 +12,9 @@ revisions:
   1.1.4-preview0002:
     licensed:
       declared: MIT
+  2.7.0:
+    licensed:
+      declared: MIT
   2.7.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License file in repository is MIT

**Resolution:**
License link on Nuget site and license URL in Nuspec file are broken

**Affected definitions**:
- [Microsoft.Identity.Client 2.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Identity.Client/2.7.0/2.7.0)