### PR TITLE
Adding declared license

### DIFF
--- a/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
+++ b/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.10.6:
+    licensed:
+      declared: BSD-3-Clause
   0.10.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Project site, www.py4j.org, indicates license is BSD - 3

**Resolution:**
File is also available from Pypi, license file on that site also indicates BSD-3

**Affected definitions**:
- [py4j 0.10.6](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.py4j/py4j/0.10.6/0.10.6)