### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -42,6 +42,9 @@ revisions:
         url: 'https://github.com/microsoft/perfview/commit/6ccbcb4c3d762a03facee49afd04087fc080ceed'
     licensed:
       declared: MIT
+  2.0.45:
+    licensed:
+      declared: MIT
   2.0.49:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License link on Nuget page indicates MIT

**Resolution:**
License file on repository is MIT and license URL in Nuspec file is also MIT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.45](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.45/2.0.45)