### PR TITLE
Adding missing license

### DIFF
--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -6,3 +6,6 @@ revisions:
   2019.11.1:
     licensed:
       declared: Python-2.0
+  2020.1.8:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing license

**Details:**
Pypi site indicates license is Python

**Resolution:**
Setup file in repository also indicates license is Python

**Affected definitions**:
- [regex 2020.1.8](https://clearlydefined.io/definitions/pypi/pypi/-/regex/2020.1.8/2020.1.8)