### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/Ben.Demystifier.yaml
+++ b/curations/nuget/nuget/-/Ben.Demystifier.yaml
@@ -9,6 +9,9 @@ revisions:
   0.1.3:
     licensed:
       declared: Apache-2.0
+  0.1.4:
+    licensed:
+      declared: Apache-2.0
   0.1.6:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License link on Nuget site indicates Apache 2.0

**Resolution:**
Repository indicates license is Apache 2.0 and license URL link in Nuspec file also indicates Apache 2.0

**Affected definitions**:
- [Ben.Demystifier 0.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/Ben.Demystifier/0.1.4/0.1.4)