### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -12,6 +12,9 @@ revisions:
   1.5.4:
     licensed:
       declared: BSD-2-Clause
+  1.6.0:
+    licensed:
+      declared: BSD-2-Clause
   1.6.1:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License link on Nuget page indicates BSD-2

**Resolution:**
License file in repository is also BSD-2

**Affected definitions**:
- [NLog.Extensions.Logging 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.6.0/1.6.0)