### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License link on Nuget site indicates Apache 2.0

**Resolution:**
License file in repository is also Apache 2.0

**Affected definitions**:
- [NuGet.Frameworks 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Frameworks/3.5.0/3.5.0)