### PR TITLE
Adding declared license

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
@@ -22,7 +22,7 @@ revisions:
       declared: Apache-2.0
   1.1.0-beta001:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   1.1.0-beta004:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
@@ -20,6 +20,9 @@ revisions:
         url: 'https://github.com/DotNetAnalyzers/StyleCopAnalyzers/commit/21559d870f78956a08d15e05ad1e52b445f8c2c9'
     licensed:
       declared: Apache-2.0
+  1.1.0-beta001:
+    licensed:
+      declared: MIT
   1.1.0-beta004:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
License file on project site indicates license changed to MIT 3 months ago

**Resolution:**
License link on Nuget site and URL in Nuspec both indicate Apache 2.0, but appear to be out of date based on 

**Affected definitions**:
- [StyleCop.Analyzers 1.1.0-beta001](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.Analyzers/1.1.0-beta001/1.1.0-beta001)