### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -9,6 +9,9 @@ revisions:
   1.1.2:
     licensed:
       declared: MIT
+  1.1.9:
+    licensed:
+      declared: MIT
   2.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
No license file for v1.1.9. Later versions on NuGet point to master in repo:

https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT

https://github.com/dotnet/core-setup/blob/release/2.0.0/LICENSE.TXT

**Affected definitions**:
- [Microsoft.DotNet.PlatformAbstractions 1.1.9](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions/1.1.9/1.1.9)