### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.AsyncLayoutInflater.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.AsyncLayoutInflater.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Support.AsyncLayoutInflater
+  provider: nuget
+  type: nuget
+revisions:
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Source repo and meta data confirm MIT

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.AsyncLayoutInflater 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.AsyncLayoutInflater/28.0.0.3/28.0.0.3)