### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Loader.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Loader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Support.Loader
+  provider: nuget
+  type: nuget
+revisions:
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package file info. Source repo and meta data confirm MIT Licence. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Loader 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Loader/28.0.0.3/28.0.0.3)