### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/RestEase.yaml
+++ b/curations/nuget/nuget/-/RestEase.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.4.7:
+    licensed:
+      declared: MIT
   1.4.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No package file info. Source repo and meta data confirm MIT License. 

**Resolution:**
https://github.com/canton7/RestEase/blob/v1.4.7/LICENSE.txt

**Affected definitions**:
- [RestEase 1.4.7](https://clearlydefined.io/definitions/nuget/nuget/-/RestEase/1.4.7/1.4.7)