### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Builder.Dialogs
+  provider: nuget
+  type: nuget
+revisions:
+  4.7.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files indicate MIT. Meta Data confirms MIT, but source repo contradicts. Based on our call, meta data controls. 

**Resolution:**
meta data - https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs/4.7.0

source repo - https://github.com/microsoft/botbuilder-dotnet/blob/v0.4.7/LICENSE.md

**Affected definitions**:
- [Microsoft.Bot.Builder.Dialogs 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs/4.7.0/4.7.0)