### PR TITLE
Add MS-PL and Apache 2.0 license

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -6,6 +6,9 @@ revisions:
   12.1.2:
     licensed:
       declared: Apache-2.0 AND MS-PL
+  12.2.1:
+    licensed:
+      declared: MS-PL
   2.16.3:
     licensed:
       declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MS-PL and Apache 2.0 license

**Details:**
No info in package files. No info in meta data. Found github, which indicated multiple  licenses. 

**Resolution:**
MS-PL and Apache 2.0 in source repo - https://github.com/JoshClose/CsvHelper/blob/12.2.1/LICENSE.txt


**Affected definitions**:
- [CsvHelper 12.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/12.2.1/12.2.1)