### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Unity.Microsoft.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/Unity.Microsoft.DependencyInjection.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  5.10.2:
+    licensed:
+      declared: Apache-2.0
   5.11.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data indicates Apache 2.0.

**Resolution:**
https://github.com/unitycontainer/microsoft-dependency-injection/blob/master/LICENSE

**Affected definitions**:
- [Unity.Microsoft.DependencyInjection 5.10.2](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Microsoft.DependencyInjection/5.10.2/5.10.2)