### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.yaml
@@ -66,3 +66,6 @@ revisions:
   0.26.0-preview-0080:
     licensed:
       declared: MIT
+  0.26.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://raw.githubusercontent.com/libgit2/libgit2sharp/9a87d4c3d81da4a84223e0eb463f3f62867f8ef0/LICENSE.md

**Affected definitions**:
- [LibGit2Sharp 0.26.2](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp/0.26.2/0.26.2)