### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Builder.Integration.AspNet.Core
+  provider: nuget
+  type: nuget
+revisions:
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo confirm MIT License. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE


**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.8.0/4.8.0)