### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
@@ -9,3 +9,6 @@ revisions:
   4.7.2:
     licensed:
       declared: MIT
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo confirm MIT.

**Resolution:**
https://github.com/microsoft/botbuilder-dotnet/blob/4.8/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Configuration 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Configuration/4.8.0/4.8.0)