### PR TITLE
Adding declared license

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -36,6 +36,9 @@ revisions:
   1.17.4:
     licensed:
       declared: BSD-3-Clause
+  1.17.5:
+    licensed:
+      declared: BSD-3-Clause
   1.18.0:
     licensed:
       declared: BSD-3-Clause
@@ -44,7 +47,7 @@ revisions:
       declared: BSD-3-Clause
   1.18.2:
     licensed:
-      declared: BSD-3-Clause  
+      declared: BSD-3-Clause
   1.18.3:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding declared license

**Details:**
Metadata on Pypi site indicates BSD license

**Resolution:**
Project site and GitHub indicate license is BSD-3

**Affected definitions**:
- [numpy 1.17.5](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.17.5/1.17.5)