### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.yaml
@@ -15,3 +15,6 @@ revisions:
   4.8.1:
     licensed:
       declared: MIT
+  4.9.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
NuGet and project license: https://numerics.mathdotnet.com/License.html

Source master and tagged version licenses are the same:
https://github.com/mathnet/mathnet-numerics/blob/v4.9.0/LICENSE.md

**Affected definitions**:
- [MathNet.Numerics 4.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics/4.9.0/4.9.0)