### PR TITLE
Declared License

### DIFF
--- a/curations/nuget/nuget/-/TimeZoneConverter.yaml
+++ b/curations/nuget/nuget/-/TimeZoneConverter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TimeZoneConverter
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared License

**Details:**
Adding MIT

**Resolution:**
NuGet license: https://raw.githubusercontent.com/mj1856/TimeZoneConverter/master/LICENSE.txt

Project master and tagged version licences are same: MIT

https://github.com/mj1856/TimeZoneConverter/blob/2.4.1/LICENSE.txt

**Affected definitions**:
- [TimeZoneConverter 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/TimeZoneConverter/2.4.1/2.4.1)