### PR TITLE
Swashbuckle.AspNetCore	5.3.3

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -36,3 +36,6 @@ revisions:
   5.3.1:
     licensed:
       declared: MIT
+  5.3.3:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -38,4 +38,4 @@ revisions:
       declared: MIT
   5.3.3:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore	5.3.3

**Details:**
Harvested License file indicates MIT

**Resolution:**
License link on Nuget site is MIT, license file on project site is also MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.3.3/5.3.3)