### PR TITLE
VS.QualityTools.UnitTestFramework	15.0.27323.2

### DIFF
--- a/curations/nuget/nuget/-/VS.QualityTools.UnitTestFramework.yaml
+++ b/curations/nuget/nuget/-/VS.QualityTools.UnitTestFramework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VS.QualityTools.UnitTestFramework
+  provider: nuget
+  type: nuget
+revisions:
+  15.0.27323.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VS.QualityTools.UnitTestFramework	15.0.27323.2

**Details:**
No license link on Nuget site

**Resolution:**
There is no project site identified on Nuget site. No references to a license in the package

**Affected definitions**:
- [VS.QualityTools.UnitTestFramework 15.0.27323.2](https://clearlydefined.io/definitions/nuget/nuget/-/VS.QualityTools.UnitTestFramework/15.0.27323.2/15.0.27323.2)