### PR TITLE
Add MIT License 11.0.0

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.Annotations.yaml
+++ b/curations/nuget/nuget/-/JetBrains.Annotations.yaml
@@ -15,6 +15,9 @@ revisions:
   10.4.0:
     licensed:
       declared: MIT
+  11.0.0:
+    licensed:
+      declared: MIT
   11.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 11.0.0

**Details:**
Package info indicates MIT. Confirmed MIT in meta data. 

**Resolution:**
https://raw.githubusercontent.com/JetBrains/ExternalAnnotations/master/LICENSE.md

**Affected definitions**:
- [JetBrains.Annotations 11.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.Annotations/11.0.0/11.0.0)