### PR TITLE
Add multiple licenses 2.0.267

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: GPL-2.0-only
   2.0.267:
     licensed:
-      declared: MIT AND LGPL-2.0-only AND Zlib AND OTHER
+      declared: GPL-2.0-only WITH OTHER

--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.81:
     licensed:
       declared: GPL-2.0-only
+  2.0.267:
+    licensed:
+      declared: MIT AND LGPL-2.0-only AND Zlib AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add multiple licenses 2.0.267

**Details:**
No infor in package files. Found multiple licenses in meta data, including MIT, GPL 2.0, Zlib, and some sort of BSD license that did not align with any SPDX licenses. Source repo shows MIT, but only has Master, no tag for 2.0.267

**Resolution:**
https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING

https://github.com/libgit2/libgit2sharp.nativebinaries/blob/master/LICENSE.md

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 2.0.267](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/2.0.267/2.0.267)