### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Core.Common.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Core.Common.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Arch.Core.Common.nuspec
     licensed:
       declared: MIT
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data points to MIT. Source repo seems to just have master.

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Core.Common 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Core.Common/1.1.1.3/1.1.1.3)