### PR TITLE
Add multiple licenses

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.81:
     licensed:
       declared: GPL-2.0-only
+  2.0.267:
+    licensed:
+      declared: MIT AND GPL-2.0-only AND Zlib AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add multiple licenses

**Details:**
Package files seems to have convoluted info. Meta data points to multiple licenses, MIT, Zlib, GPL, , but has a BSD that does not align with any SPDX licenses. 

**Resolution:**
https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 2.0.267](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/2.0.267/2.0.267)