### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.5:
     licensed:
       declared: MIT
+  1.1.10:
+    licensed:
+      declared: MIT
   1.1.13:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files have no info. Meta data indicates MIT and confirmed in source repo. 

**Resolution:**
https://raw.githubusercontent.com/Azure/azure-data-lake-store-net/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DataLake.Store 1.1.10](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DataLake.Store/1.1.10/1.1.10)