### PR TITLE
Add MIT License 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.Core.Utils.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 28.0.0.3

**Details:**
No info in package files. Meta data points to MIT, as does source repo. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Core.Utils 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Core.Utils/28.0.0.3/28.0.0.3)