### PR TITLE
Add MIT License 1.1.10

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.5:
     licensed:
       declared: MIT
+  1.1.10:
+    licensed:
+      declared: MIT
   1.1.13:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 1.1.10

**Details:**
Meta data points to MIT, confirmed with source repo. 

**Resolution:**
https://github.com/Azure/azure-data-lake-store-net/blob/1.1.10/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DataLake.Store 1.1.10](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DataLake.Store/1.1.10/1.1.10)