### PR TITLE
Add MIT License 1.1.1.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.LiveData.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.LiveData.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Arch.Lifecycle.LiveData
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 1.1.1.3

**Details:**
No package file info. Meta data indicate MIT License. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Lifecycle.LiveData 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.LiveData/1.1.1.3/1.1.1.3)