### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.RuntimeModel.yaml
+++ b/curations/nuget/nuget/-/NuGet.RuntimeModel.yaml
@@ -9,3 +9,6 @@ revisions:
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No package file info. Meta data states and links Apache 2.0, but does not literally have text for Apache 2.0. 

**Resolution:**
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.RuntimeModel 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.RuntimeModel/4.2.0/4.2.0)