### PR TITLE
Microsoft.Bot.Builder	4.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -9,3 +9,6 @@ revisions:
   4.6.3:
     licensed:
       declared: MIT
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder	4.8.0

**Details:**
Harvested license file is MIT

**Resolution:**
License link on Nuget site is MIT, license on project is MIT, license URL in Nuspec is also MIT

**Affected definitions**:
- [Microsoft.Bot.Builder 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/4.8.0/4.8.0)