### PR TITLE
morelinq	3.2.0

### DIFF
--- a/curations/nuget/nuget/-/morelinq.yaml
+++ b/curations/nuget/nuget/-/morelinq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: morelinq
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 AND MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
morelinq	3.2.0

**Details:**
Harvested Copying file indicates licenses are Apache 2.0 and MIT

**Resolution:**
License link from Nuget site also indicates Apache 2.0 and MIT, Nuspec file indicates Copying file is the license file

**Affected definitions**:
- [morelinq 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/morelinq/3.2.0/3.2.0)