### PR TITLE
backport-util-concurrent:backport-util-concurrent	3.1

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.60':
+    licensed:
+      declared: CC0-1.0
   '1.61':
     files:
       - attributions:

--- a/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   '1.60':
     licensed:
-      declared: CC0-1.0
+      declared: MIT
   '1.61':
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
backport-util-concurrent:backport-util-concurrent	3.1

**Details:**
License URL in poms file indicates CC 0-1.0

**Resolution:**
Repository also indicates license is CC0-1.0

**Affected definitions**:
- [bcpkix-jdk15on 1.60](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.60/1.60)