### PR TITLE
Declared for cloudnative.cloudevents.aspnetcore - 1.3.80

### DIFF
--- a/curations/nuget/nuget/-/CloudNative.CloudEvents.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/CloudNative.CloudEvents.AspNetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CloudNative.CloudEvents.AspNetCore
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.80:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for cloudnative.cloudevents.aspnetcore - 1.3.80

**Details:**
No "License Info" link on NuGet page.  Link to source. https://github.com/cloudevents/sdk-csharp/tree/v1.3 is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [CloudNative.CloudEvents.AspNetCore 1.3.80](https://clearlydefined.io/definitions/nuget/nuget/-/CloudNative.CloudEvents.AspNetCore/1.3.80/1.3.80)