### PR TITLE
NuGet.Packaging	4.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.yaml
@@ -12,6 +12,9 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging	4.2.0

**Details:**
License link on Nuget page indicates Apache 2.0

**Resolution:**
Project site indicates license is Apache 2.0 and license URL in Nuspec file also indicates Apache 2.0

**Affected definitions**:
- [NuGet.Packaging 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging/4.2.0/4.2.0)