### PR TITLE
Microsoft.Bot.Connector	4.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -14,4 +14,4 @@ revisions:
       declared: MIT
   4.8.0:
     licensed:
-      declared: NOASSERTION
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -12,3 +12,6 @@ revisions:
   4.7.0:
     licensed:
       declared: MIT
+  4.8.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector	4.8.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site indicates license is MIT and project site also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Connector 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.8.0/4.8.0)