### PR TITLE
Microsoft.Bot.Streaming	4.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -9,3 +9,6 @@ revisions:
   4.7.0:
     licensed:
       declared: MIT
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Streaming	4.8.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site indicates license is MIT and project site indicates same

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.8.0/4.8.0)