### PR TITLE
websocket-driver	0.7.4

### DIFF
--- a/curations/npm/npmjs/-/websocket-driver.yaml
+++ b/curations/npm/npmjs/-/websocket-driver.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: websocket-driver
+  provider: npmjs
+  type: npm
+revisions:
+  0.7.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Other

**Summary:**
websocket-driver	0.7.4

**Details:**
Harvested license and json files indicate license is Apache 2.0

**Resolution:**
License link on source also indicates license is Apache 2.0

**Affected definitions**:
- [websocket-driver 0.7.4](https://clearlydefined.io/definitions/npm/npmjs/-/websocket-driver/0.7.4/0.7.4)