### PR TITLE
Microsoft.OData.Edm	7.6.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
@@ -42,3 +42,6 @@ revisions:
   7.6.1:
     licensed:
       declared: MIT
+  7.6.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.OData.Edm	7.6.2

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site indicates license is MIT and license URL in Nuspec file indicates same

**Affected definitions**:
- [Microsoft.OData.Edm 7.6.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Edm/7.6.2/7.6.2)