### PR TITLE
HtmlAgilityPack.CssSelectors	1.0.2

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.CssSelectors.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.CssSelectors.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: HtmlAgilityPack.CssSelectors
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack.CssSelectors	1.0.2

**Details:**
No license link on Nuget site

**Resolution:**
No license listed on project site, no license listed in readme file and no license URL in Nuspec file

**Affected definitions**:
- [HtmlAgilityPack.CssSelectors 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack.CssSelectors/1.0.2/1.0.2)