### PR TITLE
Microsoft.AspNetCore.OData	7.2.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: MIT
   7.2.2:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   7.3.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -6,6 +6,9 @@ revisions:
   7.1.0:
     licensed:
       declared: MIT
+  7.2.2:
+    licensed:
+      declared: NOASSERTION
   7.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNetCore.OData	7.2.2

**Details:**
License link on Nuget site indicates code is licensed under MIT and documentation is licensed under Creative Commons 3.0

**Resolution:**
License URL in Nuspec file indicates License link on Nuget site indicates code is licensed under MIT and documentation is licensed under Creative Commons 3.0

**Affected definitions**:
- [Microsoft.AspNetCore.OData 7.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.OData/7.2.2/7.2.2)