### PR TITLE
VsWhere	2.8.4

### DIFF
--- a/curations/nuget/nuget/-/vswhere.yaml
+++ b/curations/nuget/nuget/-/vswhere.yaml
@@ -21,3 +21,6 @@ revisions:
   2.6.7:
     licensed:
       declared: MIT
+  2.8.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VsWhere	2.8.4

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
Project site indicates license is MIT and license URL in Nuspec file indicates same

**Affected definitions**:
- [vswhere 2.8.4](https://clearlydefined.io/definitions/nuget/nuget/-/vswhere/2.8.4/2.8.4)