### PR TITLE
License is MIT

### DIFF
--- a/curations/npm/npmjs/@octokit/plugin-request-log.yaml
+++ b/curations/npm/npmjs/@octokit/plugin-request-log.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: plugin-request-log
+  namespace: '@octokit'
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    files:
+      - license: MIT
+        path: package/LICENSE
+      - license: MIT
+        path: package/README.md


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License is MIT

**Details:**
The license is indicated as, AFAICT, MIT in both the README and LICENSE files.

**Resolution:**
Update license information.

**Affected definitions**:
- [plugin-request-log 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/@octokit/plugin-request-log/1.0.0/1.0.0)