### PR TITLE
Changelog describes a change of license

### DIFF
--- a/curations/npm/npmjs/-/genfun.yaml
+++ b/curations/npm/npmjs/-/genfun.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: genfun
+  provider: npmjs
+  type: npm
+revisions:
+  5.0.0:
+    files:
+      - license: MIT
+        path: package/CHANGELOG.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changelog describes a change of license

**Details:**
The Changlog describes a change of license in the package; it is not an assertion of license.

**Resolution:**
From the statement of license change, I believe that we can assume that the content is under MIT.

**Affected definitions**:
- [genfun 5.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/genfun/5.0.0/5.0.0)