### PR TITLE
License is Apache-2.0

### DIFF
--- a/curations/npm/npmjs/-/spdx-correct.yaml
+++ b/curations/npm/npmjs/-/spdx-correct.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: spdx-correct
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.0:
+    files:
+      - license: Apache-2.0
+        path: package/index.js
+      - license: NONE
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is Apache-2.0

**Details:**
The content refers to multiple licenses, but only as function. The actual license declarations are Apache-2.0 

**Resolution:**
Change the license.

**Affected definitions**:
- [spdx-correct 3.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/spdx-correct/3.1.0/3.1.0)