### PR TITLE
Correcting Declared and LICENSE file

### DIFF
--- a/curations/git/github/jquery/sizzle.yaml
+++ b/curations/git/github/jquery/sizzle.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: sizzle
+  namespace: jquery
+  provider: github
+  type: git
+revisions:
+  112ff172e06c92fa87c3362baad13153302f7359:
+    files:
+      - attributions:
+          - Copyright (c) 2009 John Resig
+          - 'Copyright (c) 2009, John Resig'
+          - copyrighted by the Free Software Foundation
+          - 'Copyright (c) 1989, 1991 Free Software Foundation, Inc.'
+        license: BSD-3-Clause OR MIT OR GPL-2.0-only
+        path: LICENSE
+    licensed:
+      declared: BSD-3-Clause OR (GPL-2.0-only OR MIT)

--- a/curations/git/github/jquery/sizzle.yaml
+++ b/curations/git/github/jquery/sizzle.yaml
@@ -11,7 +11,7 @@ revisions:
           - 'Copyright (c) 2009, John Resig'
           - copyrighted by the Free Software Foundation
           - 'Copyright (c) 1989, 1991 Free Software Foundation, Inc.'
-        license: BSD-3-Clause OR MIT OR GPL-2.0-only
+        license: MIT OR BSD-3-Clause OR GPL-2.0-only
         path: LICENSE
     licensed:
-      declared: BSD-3-Clause OR (GPL-2.0-only OR MIT)
+      declared: MIT OR BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting Declared and LICENSE file

**Details:**
Updating Declared and LICENSE file per LICENSE file: "Sizzle is released under three licenses: MIT, BSD, and GPL. You may pick the license that best suits your development needs. The text of all three licenses are provided below."

**Resolution:**
MIT OR BSD-3-Clause OR GPL-2.0-only

**Affected definitions**:
- [sizzle 112ff172e06c92fa87c3362baad13153302f7359](https://clearlydefined.io/definitions/git/github/jquery/sizzle/112ff172e06c92fa87c3362baad13153302f7359/112ff172e06c92fa87c3362baad13153302f7359)