### PR TITLE
re2j 1.1 - declared

### DIFF
--- a/curations/maven/mavencentral/com.google.re2j/re2j.yaml
+++ b/curations/maven/mavencentral/com.google.re2j/re2j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: re2j
+  namespace: com.google.re2j
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
re2j 1.1 - declared

**Details:**
Adding BSD-3-Clause

**Resolution:**
POM license: https://golang.org/LICENSE

HomePage, master license: https://github.com/google/re2j/blob/master/LICENSE


**Affected definitions**:
- [re2j 1.1](https://clearlydefined.io/definitions/maven/mavencentral/com.google.re2j/re2j/1.1/1.1)