### PR TITLE
NUnit.Runners 2.6.3 - declared

### DIFF
--- a/curations/nuget/nuget/-/NUnit.Runners.yaml
+++ b/curations/nuget/nuget/-/NUnit.Runners.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.6.3:
+    licensed:
+      declared: Nunit
   2.6.4:
     licensed:
       declared: Zlib


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NUnit.Runners 2.6.3 - declared

**Details:**
Adding NUnit license

**Resolution:**
https://nunit.org/nuget/license.html


**Affected definitions**:
- [NUnit.Runners 2.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/NUnit.Runners/2.6.3/2.6.3)