### PR TITLE
em-websocket 0.5.1 - declared

### DIFF
--- a/curations/gem/rubygems/-/em-websocket.yaml
+++ b/curations/gem/rubygems/-/em-websocket.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: em-websocket
+  provider: rubygems
+  type: gem
+revisions:
+  0.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
em-websocket 0.5.1 - declared

**Details:**
Adding MIT

**Resolution:**
ClearlyDefined Files: README.md "MIT"

https://github.com/igrigorik/em-websocket/blob/master/LICENCE

**Affected definitions**:
- [em-websocket 0.5.1](https://clearlydefined.io/definitions/gem/rubygems/-/em-websocket/0.5.1/0.5.1)