### PR TITLE
Google.Protobuf 3.11.1 - declared

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -9,6 +9,9 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.11.2:
+    licensed:
+      declared: BSD-3-Clause
   3.3.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Google.Protobuf 3.11.1 - declared

**Details:**
Adding BSD-3-Clause

**Resolution:**
ClearlyDefined Files: BSD-3-Clause license at master GitHub

https://github.com/protocolbuffers/protobuf/blob/master/LICENSE

https://github.com/protocolbuffers/protobuf/blob/v3.11.2/LICENSE

**Affected definitions**:
- [Google.Protobuf 3.11.2](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.11.2/3.11.2)