### PR TITLE
caniuse-lite	1.0.30001066

### DIFF
--- a/curations/npm/npmjs/-/caniuse-lite.yaml
+++ b/curations/npm/npmjs/-/caniuse-lite.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: caniuse-lite
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.30001066:
+    licensed:
+      declared: CC-BY-4.0


### PR DESCRIPTION

**Type:** Other

**Summary:**
caniuse-lite	1.0.30001066

**Details:**
Harvested license file is CC By 4.0

**Resolution:**
NPM site also indicates license is CC by 4.0

**Affected definitions**:
- [caniuse-lite 1.0.30001066](https://clearlydefined.io/definitions/npm/npmjs/-/caniuse-lite/1.0.30001066/1.0.30001066)