### PR TITLE
@babel/parser	7.10.0

### DIFF
--- a/curations/npm/npmjs/@babel/parser.yaml
+++ b/curations/npm/npmjs/@babel/parser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: parser
+  namespace: '@babel'
+  provider: npmjs
+  type: npm
+revisions:
+  7.10.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@babel/parser	7.10.0

**Details:**
Harvested license file is MIT

**Resolution:**
Harvested json file also indicates license is MIT

**Affected definitions**:
- [parser 7.10.0](https://clearlydefined.io/definitions/npm/npmjs/@babel/parser/7.10.0/7.10.0)