### PR TITLE
electron-to-chromium	1.3.452

### DIFF
--- a/curations/npm/npmjs/-/electron-to-chromium.yaml
+++ b/curations/npm/npmjs/-/electron-to-chromium.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: electron-to-chromium
+  provider: npmjs
+  type: npm
+revisions:
+  1.3.452:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
electron-to-chromium	1.3.452

**Details:**
Harvested license file is ISC

**Resolution:**
Json file on GitHub commit also indicates license is ISC

**Affected definitions**:
- [electron-to-chromium 1.3.452](https://clearlydefined.io/definitions/npm/npmjs/-/electron-to-chromium/1.3.452/1.3.452)