### PR TITLE
Declared for Git commit 6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2

### DIFF
--- a/curations/git/github/open-source-parsers/jsoncpp.yaml
+++ b/curations/git/github/open-source-parsers/jsoncpp.yaml
@@ -7,3 +7,12 @@ revisions:
   645250b6690785be60ab6780ce4b58698d884d11:
     licensed:
       declared: MIT OR Other
+  6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2:
+    files:
+      - attributions:
+          - Copyright (c) 2007-2010 Baptiste Lepilleur and The JsonCpp Authors
+          - Copyright (c) 2007-2010 by Baptiste Lepilleur and The JsonCpp Authors
+        license: MIT OR OTHER
+        path: LICENSE
+    licensed:
+      declared: MIT OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Git commit 6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2

**Details:**
Per the LICENSE file, putting MIT OR OTHER, where OTHER is for the public domain. 

**Resolution:**
https://github.com/open-source-parsers/jsoncpp/blob/6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2/LICENSE

**Affected definitions**:
- [jsoncpp 6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2](https://clearlydefined.io/definitions/git/github/open-source-parsers/jsoncpp/6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2/6aba23f4a8628d599a9ef7fa4811c4ff6e4070e2)