### PR TITLE
Declared Swashbuckle.AspNetCore.SwaggerGen 5.2.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -33,6 +33,9 @@ revisions:
   5.1.0:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.3.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Swashbuckle.AspNetCore.SwaggerGen 5.2.1

**Details:**
LICENSE file is MIT, "License Info" link goes to MIT

**Resolution:**
MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/5.2.1/5.2.1)