### PR TITLE
Declared Swashbuckle.AspNetCore/5.4.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -39,3 +39,6 @@ revisions:
   5.3.3:
     licensed:
       declared: MIT
+  5.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared Swashbuckle.AspNetCore/5.4.1

**Details:**
LICENSE file is MIT, "License Info" MIT

**Resolution:**
MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.4.1/5.4.1)