### PR TITLE
MessagePack/1.9.11

### DIFF
--- a/curations/nuget/nuget/-/MessagePack.yaml
+++ b/curations/nuget/nuget/-/MessagePack.yaml
@@ -9,3 +9,6 @@ revisions:
   1.7.3.7:
     licensed:
       declared: MIT
+  1.9.11:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MessagePack/1.9.11

**Details:**
Package MIT with one part (lz4net) under BSD-2-Clause.  "Declared" would be MIT.

**Resolution:**
MIT

**Affected definitions**:
- [MessagePack 1.9.11](https://clearlydefined.io/definitions/nuget/nuget/-/MessagePack/1.9.11/1.9.11)