### PR TITLE
Microsoft.WindowsDesktop.App.Ref 3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WindowsDesktop.App.Ref.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WindowsDesktop.App.Ref.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WindowsDesktop.App.Ref
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.WindowsDesktop.App.Ref 3.0.0

**Details:**
LICENSE file is MIT, "License Info" link goes to MIT

**Resolution:**
MIT

**Affected definitions**:
- [Microsoft.WindowsDesktop.App.Ref 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WindowsDesktop.App.Ref/3.0.0/3.0.0)