### PR TITLE
pandas/1.0.4

### DIFF
--- a/curations/pypi/pypi/-/pandas.yaml
+++ b/curations/pypi/pypi/-/pandas.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.3:
     licensed:
       declared: BSD-3-Clause
+  1.0.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pandas/1.0.4

**Details:**
Downloaded package - BSD-3-Clause file, metadata says "BSD" and source is same license.

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [pandas 1.0.4](https://clearlydefined.io/definitions/pypi/pypi/-/pandas/1.0.4/1.0.4)