### PR TITLE
Declared for MessagePack/1.8.80

### DIFF
--- a/curations/nuget/nuget/-/MessagePack.yaml
+++ b/curations/nuget/nuget/-/MessagePack.yaml
@@ -9,3 +9,6 @@ revisions:
   1.7.3.7:
     licensed:
       declared: MIT
+  1.8.80:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for MessagePack/1.8.80

**Details:**
License file MIT (and BSD for a sub file).  "License Info" same

**Resolution:**
MIT

**Affected definitions**:
- [MessagePack 1.8.80](https://clearlydefined.io/definitions/nuget/nuget/-/MessagePack/1.8.80/1.8.80)