### PR TITLE
Microsoft.TestApi	0.6.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.TestApi.yaml
+++ b/curations/nuget/nuget/-/Microsoft.TestApi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.TestApi
+  provider: nuget
+  type: nuget
+revisions:
+  0.6.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.TestApi	0.6.0

**Details:**
Nuget site indicates license is MS-PL

**Resolution:**
No other license information was found

**Affected definitions**:
- [Microsoft.TestApi 0.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.TestApi/0.6.0/0.6.0)