### PR TITLE
Polly-Signed	5.3.1

### DIFF
--- a/curations/nuget/nuget/-/Polly-Signed.yaml
+++ b/curations/nuget/nuget/-/Polly-Signed.yaml
@@ -6,6 +6,9 @@ revisions:
   4.3.0:
     licensed:
       declared: BSD-3-Clause
+  5.3.1:
+    licensed:
+      declared: BSD-3-Clause
   5.8.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Polly-Signed	5.3.1

**Details:**
Nuget site indicates license is BSD-3

**Resolution:**
Project site and license URL from Nuspec file also indicate BSD-3

**Affected definitions**:
- [Polly-Signed 5.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/Polly-Signed/5.3.1/5.3.1)