### PR TITLE
ansicolors	1.1.8

### DIFF
--- a/curations/pypi/pypi/-/ansicolors.yaml
+++ b/curations/pypi/pypi/-/ansicolors.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ansicolors
+  provider: pypi
+  type: pypi
+revisions:
+  1.1.8:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ansicolors	1.1.8

**Details:**
License file in package has an unlabeled license which is ISC

**Resolution:**
PyPi site indicates license is ISC

**Affected definitions**:
- [ansicolors 1.1.8](https://clearlydefined.io/definitions/pypi/pypi/-/ansicolors/1.1.8/1.1.8)