### PR TITLE
jakarta.activation:jakarta.activation-api	1.2.1

### DIFF
--- a/curations/maven/mavencentral/jakarta.activation/jakarta.activation-api.yaml
+++ b/curations/maven/mavencentral/jakarta.activation/jakarta.activation-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jakarta.activation-api
+  namespace: jakarta.activation
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jakarta.activation:jakarta.activation-api	1.2.1

**Details:**
License file in sources.jar indicates license is BSD-3

**Resolution:**
Pom file also indicates license is BSD-3

**Affected definitions**:
- [jakarta.activation-api 1.2.1](https://clearlydefined.io/definitions/maven/mavencentral/jakarta.activation/jakarta.activation-api/1.2.1/1.2.1)