### PR TITLE
Google.Protobuf	3.6.0

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -21,6 +21,9 @@ revisions:
   3.5.1:
     licensed:
       declared: BSD-3-Clause
+  3.6.0:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf	3.6.0

**Details:**
License link on Nuget site indicates license is BSD-3

**Resolution:**
License link on project site and license URL in Nuspec file also indicate BSD-3

**Affected definitions**:
- [Google.Protobuf 3.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.6.0/3.6.0)