### PR TITLE
Add MIT License 

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.Host.win-x64.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.Host.win-x64.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.2:
     licensed:
       declared: MIT
+  3.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 

**Details:**
No info in package files. Meta data and source repo confirms MIT license. 

**Resolution:**
https://github.com/dotnet/core-setup/blob/v3.0.3/LICENSE.TXT

**Affected definitions**:
- [Microsoft.NETCore.App.Host.win-x64 3.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App.Host.win-x64/3.0.3/3.0.3)