### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/WebConfigTransformRunner.yaml
+++ b/curations/nuget/nuget/-/WebConfigTransformRunner.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WebConfigTransformRunner
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data confirms Apache 2.0 License. 

**Resolution:**
https://github.com/erichexter/WebConfigTransformRunner/blob/master/License

**Affected definitions**:
- [WebConfigTransformRunner 1.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/WebConfigTransformRunner/1.0.0.1/1.0.0.1)