### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Repositories.yaml
+++ b/curations/nuget/nuget/-/NuGet.Repositories.yaml
@@ -9,3 +9,6 @@ revisions:
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data points to Apache 2.0. 

**Resolution:**
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Repositories 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Repositories/4.2.0/4.2.0)