### PR TITLE
Add MIT License 

### DIFF
--- a/curations/nuget/nuget/-/EnterpriseLibrary.TransientFaultHandling.Core.yaml
+++ b/curations/nuget/nuget/-/EnterpriseLibrary.TransientFaultHandling.Core.yaml
@@ -6,3 +6,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/Dixin/EnterpriseLibrary.TransientFaultHandling.Core/blob/master/LICENSE

**Affected definitions**:
- [EnterpriseLibrary.TransientFaultHandling.Core 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/EnterpriseLibrary.TransientFaultHandling.Core/2.0.0/2.0.0)