### PR TITLE
Add MIT License 

### DIFF
--- a/curations/nuget/nuget/-/AutoMapper.yaml
+++ b/curations/nuget/nuget/-/AutoMapper.yaml
@@ -102,6 +102,9 @@ revisions:
   8.0.0:
     licensed:
       declared: MIT
+  8.1.0:
+    licensed:
+      declared: MIT
   8.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License 

**Details:**
No info in package files. Meta data points to MIT License.

**Resolution:**
https://github.com/AutoMapper/AutoMapper/blob/v8.1.0/LICENSE.txt

**Affected definitions**:
- [AutoMapper 8.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/AutoMapper/8.1.0/8.1.0)