### PR TITLE
Add BSD 3 Clause License

### DIFF
--- a/curations/nuget/nuget/-/redis-64.yaml
+++ b/curations/nuget/nuget/-/redis-64.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: redis-64
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.503:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3 Clause License

**Details:**
No info in package files. Meta data suggests BSD 3 Clause. The language is BSD 3 Clause, but it does not cite it as BSD 3 clause. 

**Resolution:**
https://github.com/microsoftarchive/redis/blob/win-3.0.503/license.txt

**Affected definitions**:
- [redis-64 3.0.503](https://clearlydefined.io/definitions/nuget/nuget/-/redis-64/3.0.503/3.0.503)