### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Client.yaml
+++ b/curations/nuget/nuget/-/NuGet.Client.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data indicates Apache 2.0 License. 

**Resolution:**
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Client 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Client/4.2.0/4.2.0)