### PR TITLE
Add BSD 3 Clause License

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -12,6 +12,9 @@ revisions:
   3.11.2:
     licensed:
       declared: BSD-3-Clause
+  3.11.3:
+    licensed:
+      declared: BSD-3-Clause
   3.3.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3 Clause License

**Details:**
No info in package files. Meta data points to BSD 3 Clause License. 

**Resolution:**
https://github.com/protocolbuffers/protobuf/blob/master/LICENSE

**Affected definitions**:
- [Google.Protobuf 3.11.3](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.11.3/3.11.3)