### PR TITLE
Add Apache 2.0 License - missing package (microcosm-propertygraph) license data

### DIFF
--- a/curations/pypi/pypi/-/microcosm-propertygraph.yaml
+++ b/curations/pypi/pypi/-/microcosm-propertygraph.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: microcosm-propertygraph
+  provider: pypi
+  type: pypi
+revisions:
+  1.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing package license data

**Details:**
this package version is missing the license info

**Resolution:**
I manually checked the license for this package and it is Apache-2.0
https://github.com/globality-corp/microcosm/blob/develop/LICENSE

**Affected definitions**:
- [microcosm-propertygraph 1.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/microcosm-propertygraph/1.1.0)