### PR TITLE
x64 Microsoft.Net.Native.Shared Library 2.2.7 rel 27913-00

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-x64.Microsoft.Net.Native.SharedLibrary.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-x64.Microsoft.Net.Native.SharedLibrary.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.3:
     licensed:
       declared: OTHER
+  2.2.7-rel-27913-00:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
x64 Microsoft.Net.Native.Shared Library 2.2.7 rel 27913-00

**Details:**
Adding Other for Microsoft EULA

**Resolution:**
NuGet metadata: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Affected definitions**:
- [runtime.win10-x64.Microsoft.Net.Native.SharedLibrary 2.2.7-rel-27913-00](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-x64.Microsoft.Net.Native.SharedLibrary/2.2.7-rel-27913-00/2.2.7-rel-27913-00)