### PR TITLE
x86 Microsoft.Net.UWPCoreRuntime Sd 2.2.9

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-x86.Microsoft.Net.UWPCoreRuntimeSdk.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-x86.Microsoft.Net.UWPCoreRuntimeSdk.yaml
@@ -9,3 +9,6 @@ revisions:
   2.2.8:
     licensed:
       declared: OTHER
+  2.2.9:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
x86 Microsoft.Net.UWPCoreRuntime Sd 2.2.9

**Details:**
Adding Other for Microsoft EULA

**Resolution:**
ClearlyDefined License.txt and NuGet metadata 

https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Affected definitions**:
- [runtime.win10-x86.Microsoft.Net.UWPCoreRuntimeSdk 2.2.9](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-x86.Microsoft.Net.UWPCoreRuntimeSdk/2.2.9/2.2.9)