### PR TITLE
SoCreate.Extensions.Caching.ServiceF 2.0.1

### DIFF
--- a/curations/nuget/nuget/-/SoCreate.Extensions.Caching.ServiceFabric.yaml
+++ b/curations/nuget/nuget/-/SoCreate.Extensions.Caching.ServiceFabric.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SoCreate.Extensions.Caching.ServiceFabric
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SoCreate.Extensions.Caching.ServiceF 2.0.1

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Files: License.txt is MIT

NuGet metadata: https://raw.githubusercontent.com/SoCreate/service-fabric-distributed-cache/master/LICENSE

**Affected definitions**:
- [SoCreate.Extensions.Caching.ServiceFabric 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/SoCreate.Extensions.Caching.ServiceFabric/2.0.1/2.0.1)