### PR TITLE
NUnit3.DotNetNew.Template 1.8.1

### DIFF
--- a/curations/nuget/nuget/-/NUnit3.DotNetNew.Template.yaml
+++ b/curations/nuget/nuget/-/NUnit3.DotNetNew.Template.yaml
@@ -27,3 +27,6 @@ revisions:
   1.8.0:
     licensed:
       declared: MIT
+  1.8.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NUnit3.DotNetNew.Template 1.8.1

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Files: License "MIT"

NuGet metadata goes to GitHub master, tagged version is MIT

https://github.com/nunit/dotnet-new-nunit/blob/v1.8.1/LICENSE

**Affected definitions**:
- [NUnit3.DotNetNew.Template 1.8.1](https://clearlydefined.io/definitions/nuget/nuget/-/NUnit3.DotNetNew.Template/1.8.1/1.8.1)