### PR TITLE
runtime.win10-arm.Microsoft.Net.Native.Compiler 2.2.7-rel-27913-00

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.Native.Compiler.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.Native.Compiler.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.3:
     licensed:
       declared: OTHER
+  2.2.7-rel-27913-00:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
runtime.win10-arm.Microsoft.Net.Native.Compiler 2.2.7-rel-27913-00

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
Dotnet is MIT, however, this component in the repo seems to have it's own Microsoft EULA. Latest version I can find is 2.2 in the repo.

NuGet metadata: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT



**Affected definitions**:
- [runtime.win10-arm.Microsoft.Net.Native.Compiler 2.2.7-rel-27913-00](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.Native.Compiler/2.2.7-rel-27913-00/2.2.7-rel-27913-00)