### PR TITLE
opt-einsum 3.2.0

### DIFF
--- a/curations/pypi/pypi/-/opt-einsum.yaml
+++ b/curations/pypi/pypi/-/opt-einsum.yaml
@@ -6,3 +6,6 @@ revisions:
   3.1.0:
     licensed:
       declared: MIT
+  3.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
opt-einsum 3.2.0

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Files: License is MIT

PyPI metadata: MIT

https://pypi.org/project/opt-einsum/3.2.0/

Project home: 
https://github.com/dgasmith/opt_einsum/blob/v3.2.0/LICENSE

**Affected definitions**:
- [opt-einsum 3.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/opt-einsum/3.2.0/3.2.0)