### PR TITLE
arm.Microsoft.Net.Native.SharedLibrary 2.2.7-rel-27913-00

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.Native.SharedLibrary.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.Native.SharedLibrary.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.3:
     licensed:
       declared: OTHER
+  2.2.7-rel-27913-00:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
arm.Microsoft.Net.Native.SharedLibrary 2.2.7-rel-27913-00

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
Dotnet is MIT, however, this component in the repo has its own Microsoft EULA

https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

Version 2.2 is the latest version in repo.

**Affected definitions**:
- [runtime.win10-arm.Microsoft.Net.Native.SharedLibrary 2.2.7-rel-27913-00](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.Native.SharedLibrary/2.2.7-rel-27913-00/2.2.7-rel-27913-00)