### PR TITLE
arm.Microsoft.Net.UWPCoreRuntime.Sdk 2.2.9

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk.yaml
@@ -9,3 +9,6 @@ revisions:
   2.2.8:
     licensed:
       declared: OTHER
+  2.2.9:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
arm.Microsoft.Net.UWPCoreRuntime.Sdk 2.2.9

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
DotNet is licensed under MIT, however, this component in the repo has it's own Microsoft EULA. Latest version in repo is 2.2.

NuGet metadata: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT


**Affected definitions**:
- [runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk 2.2.9](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk/2.2.9/2.2.9)