### PR TITLE
Unofficial.Microsoft.WindowsAzure.Diagnostics	2.9.0

### DIFF
--- a/curations/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.Diagnostics.yaml
+++ b/curations/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.Diagnostics.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Unofficial.Microsoft.WindowsAzure.Diagnostics
+  provider: nuget
+  type: nuget
+revisions:
+  2.9.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unofficial.Microsoft.WindowsAzure.Diagnostics	2.9.0

**Details:**
There is no license link on Nuget page

**Resolution:**
There is no license URL in Nuspec file

**Affected definitions**:
- [Unofficial.Microsoft.WindowsAzure.Diagnostics 2.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.Diagnostics/2.9.0/2.9.0)