### PR TITLE
Microsoft.AspNetCore.OData	7.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -12,3 +12,6 @@ revisions:
   7.3.0:
     licensed:
       declared: MIT
+  7.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNetCore.OData	7.4.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Static license link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.AspNetCore.OData 7.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.OData/7.4.0/7.4.0)