### PR TITLE
javax.activation:javax.activation-api	1.2.0

### DIFF
--- a/curations/maven/mavencentral/javax.activation/javax.activation-api.yaml
+++ b/curations/maven/mavencentral/javax.activation/javax.activation-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.activation-api
+  namespace: javax.activation
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.0:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.activation:javax.activation-api	1.2.0

**Details:**
Harvested license file indicates CDDL 1.1 or GPL - 2.0

**Resolution:**
.pom file indicates license is either GPL - 2.0 or CDDL as listed in license file

**Affected definitions**:
- [javax.activation-api 1.2.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.activation/javax.activation-api/1.2.0/1.2.0)