### PR TITLE
pillow	7.1.0

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -21,6 +21,9 @@ revisions:
   7.0.0:
     licensed:
       declared: HPND
+  7.1.0:
+    licensed:
+      declared: HPND
   7.1.1:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pillow	7.1.0

**Details:**
PyPi site indicates license is HPND

**Resolution:**
License file in package also indicates license is HPND

**Affected definitions**:
- [Pillow 7.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/7.1.0/7.1.0)