### PR TITLE
Microsoft.Azure.Storage.DataMovement	1.2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Storage.DataMovement.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Storage.DataMovement.yaml
@@ -72,3 +72,6 @@ revisions:
   1.1.0:
     licensed:
       declared: MIT
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Storage.DataMovement	1.2.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link from Nuget page indicates license is MIT and license file in repo tag indicates same

**Affected definitions**:
- [Microsoft.Azure.Storage.DataMovement 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Storage.DataMovement/1.2.0/1.2.0)