### PR TITLE
Correcting Declared for debugpy/1.0.0b7

### DIFF
--- a/curations/pypi/pypi/-/debugpy.yaml
+++ b/curations/pypi/pypi/-/debugpy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: debugpy
+  provider: pypi
+  type: pypi
+revisions:
+  1.0.0b7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting Declared for debugpy/1.0.0b7

**Details:**
LICENSE file in package and METADATA in package both are MIT.  EPL 1.0 is on the ThirdPartyNotices file and would be in the "discovered" licenses. 

**Resolution:**
MIT

**Affected definitions**:
- [debugpy 1.0.0b7](https://clearlydefined.io/definitions/pypi/pypi/-/debugpy/1.0.0b7/1.0.0b7)