### PR TITLE
Declared for fare/2.1.2

### DIFF
--- a/curations/nuget/nuget/-/Fare.yaml
+++ b/curations/nuget/nuget/-/Fare.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.1:
     licensed:
       declared: MIT
+  2.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for fare/2.1.2

**Details:**
Source URL - MIT
License info URL - MIT

**Resolution:**
MIT

**Affected definitions**:
- [Fare 2.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Fare/2.1.2/2.1.2)