### PR TITLE
Swashbuckle.AspNetCore.SwaggerUI 5.1.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -27,6 +27,9 @@ revisions:
   5.0.0-rc5:
     licensed:
       declared: MIT
+  5.1.0:
+    licensed:
+      declared: MIT
   5.2.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.SwaggerUI 5.1.0

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined License File: MIT

NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project site: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.1.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 5.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.1.0/5.1.0)