### PR TITLE
JetBrains.ReSharper.CommandLineTools 2020.1.0

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: JetBrains.ReSharper.CommandLineTools
+  provider: nuget
+  type: nuget
+revisions:
+  2020.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
JetBrains.ReSharper.CommandLineTools 2020.1.0

**Details:**
Declaring Other for JetBrains free proprietary license

**Resolution:**
NuGet metadata: https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

Project site license: https://www.jetbrains.com/resharper/buy/resharper_clt_license.html

ClearlyDefined license files would be the discovered licenses.

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2020.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2020.1.0/2020.1.0)