### PR TITLE
net.jcip/jcip-annotations 1.0

### DIFF
--- a/curations/maven/mavencentral/net.jcip/jcip-annotations.yaml
+++ b/curations/maven/mavencentral/net.jcip/jcip-annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jcip-annotations
+  namespace: net.jcip
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: NONE

--- a/curations/maven/mavencentral/net.jcip/jcip-annotations.yaml
+++ b/curations/maven/mavencentral/net.jcip/jcip-annotations.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.0':
     licensed:
-      declared: NONE
+      declared: CC-BY-2.5


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
net.jcip/jcip-annotations 1.0

**Details:**
Declaring NONE

**Resolution:**
No license found in files. Maven site notes "public" 

https://mvnrepository.com/artifact/net.jcip/jcip-annotations/1.0

http://jcip.net/

**Affected definitions**:
- [jcip-annotations 1.0](https://clearlydefined.io/definitions/maven/mavencentral/net.jcip/jcip-annotations/1.0/1.0)