### PR TITLE
scikit-learn 0.22.2

### DIFF
--- a/curations/pypi/pypi/-/scikit-learn.yaml
+++ b/curations/pypi/pypi/-/scikit-learn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: scikit-learn
+  provider: pypi
+  type: pypi
+revisions:
+  0.22.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
scikit-learn 0.22.2

**Details:**
Declaring BSD-3-Clause

**Resolution:**
PyPi metadata: new BSD

Source license: https://github.com/scikit-learn/scikit-learn/blob/0.22.X/COPYING

https://scikit-learn.org/0.22/

**Affected definitions**:
- [scikit-learn 0.22.2](https://clearlydefined.io/definitions/pypi/pypi/-/scikit-learn/0.22.2/0.22.2)