### PR TITLE
IPNetwork 22.4.0.114

### DIFF
--- a/curations/nuget/nuget/-/IPNetwork2.yaml
+++ b/curations/nuget/nuget/-/IPNetwork2.yaml
@@ -24,3 +24,6 @@ revisions:
   2.3.0.97:
     licensed:
       declared: BSD-2-Clause
+  2.4.0.114:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
IPNetwork 22.4.0.114

**Details:**
Declaring BSD-2-Clause

**Resolution:**
ClearlyDefined License File: BSD-2-Clause

https://github.com/lduchosal/ipnetwork/blob/branch-2.4/LICENSE


**Affected definitions**:
- [IPNetwork2 2.4.0.114](https://clearlydefined.io/definitions/nuget/nuget/-/IPNetwork2/2.4.0.114/2.4.0.114)