### PR TITLE
azureml-train-automl-client 1.2.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.85:
     licensed:
       declared: OTHER
+  1.2.0:
+    licensed:
+      declared: OTHER
   1.3.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
azureml-train-automl-client 1.2.0

**Details:**
Declaring Other for Microsoft proprietary license

**Resolution:**
PyPi metadata and package license: https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-train-automl-client 1.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.2.0/1.2.0)