### PR TITLE
runtime.win10-arm64.Microsoft.Net.Native.Compiler 2.2.7-rel-27913-00

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm64.Microsoft.Net.Native.Compiler.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm64.Microsoft.Net.Native.Compiler.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.3:
     licensed:
       declared: OTHER
+  2.2.7-rel-27913-00:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
runtime.win10-arm64.Microsoft.Net.Native.Compiler 2.2.7-rel-27913-00

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
DotNet is MIT, however, this component in the repo has it's own Microsoft EULA.

NuGet Metadata: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Affected definitions**:
- [runtime.win10-arm64.Microsoft.Net.Native.Compiler 2.2.7-rel-27913-00](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm64.Microsoft.Net.Native.Compiler/2.2.7-rel-27913-00/2.2.7-rel-27913-00)