### PR TITLE
Sendgrid 9.10.0

### DIFF
--- a/curations/nuget/nuget/-/Sendgrid.yaml
+++ b/curations/nuget/nuget/-/Sendgrid.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  9.10.0:
+    licensed:
+      declared: MIT
   9.11.0:
     licensed:
-      declared: MIT  
+      declared: MIT
   9.12.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Sendgrid 9.10.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata license broken.

Project license: https://github.com/sendgrid/sendgrid-csharp/blob/v9.10.0/LICENSE.txt

**Affected definitions**:
- [Sendgrid 9.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Sendgrid/9.10.0/9.10.0)