### PR TITLE
RequireJS 2.1.17

### DIFF
--- a/curations/nuget/nuget/-/RequireJS.yaml
+++ b/curations/nuget/nuget/-/RequireJS.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.17:
+    licensed:
+      declared: BSD-3-Clause OR MIT
   2.1.18:
     licensed:
       declared: BSD-3-Clause and MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RequireJS 2.1.17

**Details:**
Declaring BSD-3-Clause or MIT. Licensee can pick which license best suits their needs.

**Resolution:**
https://github.com/requirejs/requirejs/blob/2.1.17/LICENSE

Note: master license in repo is MIT only for later releases.

**Affected definitions**:
- [RequireJS 2.1.17](https://clearlydefined.io/definitions/nuget/nuget/-/RequireJS/2.1.17/2.1.17)