### PR TITLE
jQuery3.5.1

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -223,3 +223,6 @@ revisions:
         path: Tools/uninstall.ps1
     licensed:
       declared: MIT
+  3.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jQuery3.5.1

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined License file: "MIT"

NuGet metadata: https://jquery.org/license/

**Affected definitions**:
- [jQuery 3.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/3.5.1/3.5.1)