### PR TITLE
Swashbuckle.AspNetCore.SwaggerUI 1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.0:
     licensed:
       declared: MIT
+  1.1.0:
+    licensed:
+      declared: MIT
   2.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.SwaggerUI 1.1.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v1.1.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/1.1.0/1.1.0)