### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -15,6 +15,9 @@ revisions:
   1.11.12:
     licensed:
       declared: MIT
+  1.11.16:
+    licensed:
+      declared: MIT
   1.11.17:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo confirm MIT License. 

**Resolution:**
https://github.com/zzzprojects/html-agility-pack/blob/v1.11.16/LICENSE

**Affected definitions**:
- [HtmlAgilityPack 1.11.16](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.16/1.11.16)