### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Design.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Design.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.Design.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo point to MIT License. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Design 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Design/28.0.0.3/28.0.0.3)