### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/xunit.runners.yaml
+++ b/curations/nuget/nuget/-/xunit.runners.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xunit.runners
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No package file info. Meta data points to new location in source repo, but source repo points to Apache 2.0.

**Resolution:**
https://github.com/xunit/xunit/blob/1.9.2/license.txt

**Affected definitions**:
- [xunit.runners 1.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runners/1.9.2/1.9.2)