### PR TITLE
Add Other License

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -21,3 +21,6 @@ revisions:
   3.0.13:
     licensed:
       declared: AGPL-3.0-only AND OTHER
+  3.0.5:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -5,22 +5,22 @@ coordinates:
 revisions:
   2.0.10:
     licensed:
-      declared: AGPL-3.0-or-later OR OTHER
+      declared: AGPL-3.0-only OR OTHER
   2.0.2:
     licensed:
-      declared: AGPL-3.0-or-later OR OTHER
+      declared: AGPL-3.0-only OR OTHER
   3.0.10:
     licensed:
-      declared: AGPL-3.0-or-later OR OTHER
+      declared: AGPL-3.0-only OR OTHER
   3.0.11:
     files:
-      - license: AGPL-3.0-or-later OR OTHER
+      - license: AGPL-3.0-only OR OTHER
         path: LICENSE.md
     licensed:
-      declared: AGPL-3.0-or-later OR OTHER
+      declared: AGPL-3.0-only OR OTHER
   3.0.13:
     licensed:
-      declared: AGPL-3.0-only AND OTHER
+      declared: AGPL-3.0-only OR OTHER
   3.0.5:
     licensed:
-      declared: OTHER
+      declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Other License

**Details:**
No info in package files. Meta data pointed to GNU "Affero" General Public License. They changed it to "Affero" and I opted for Other, despite most, if not all of the license language aligning. 

**Resolution:**
https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md

**Affected definitions**:
- [Newtonsoft.Json.Schema 3.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json.Schema/3.0.5/3.0.5)