### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/System.Drawing.Common.yaml
+++ b/curations/nuget/nuget/-/System.Drawing.Common.yaml
@@ -6,6 +6,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview2-26406-04:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- [System.Drawing.Common 4.5.0-preview2-26406-04](https://clearlydefined.io/definitions/nuget/nuget/-/System.Drawing.Common/4.5.0-preview2-26406-04/4.5.0-preview2-26406-04)