### PR TITLE
Declared for Confluent.Kafka.StrongName/0.11.3

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.StrongName.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.StrongName.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: Apache-2.0 AND BSD-2-Clause
   0.11.4:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause

--- a/curations/nuget/nuget/-/Confluent.Kafka.StrongName.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.StrongName.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   0.11.3:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared for Confluent.Kafka.StrongName/0.11.3

**Details:**
I think this would be "...AND BSD-2-Clause" because of the bottom of the LICENSE file https://github.com/confluentinc/confluent-kafka-dotnet/blob/45790d9af1fea47555f58ff611c103388a2d2d92/LICENSE

**Resolution:**
The overall package license is both the project this one was derived from and this version's license.

**Affected definitions**:
- [Confluent.Kafka.StrongName 0.11.3](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka.StrongName/0.11.3/0.11.3)