### PR TITLE
Declared for Confluent.Kafka/1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -5,40 +5,40 @@ coordinates:
 revisions:
   0.11.0:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.2:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.3:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.4:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.5:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.6:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.0.0:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause
   1.0.0-beta2:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.0.0-experimental-9:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.0.0-rc1-ci-900:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.0.0-rc2:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.0.0-rc4:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.1.0:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause

--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -39,3 +39,6 @@ revisions:
   1.0.0-rc4:
     licensed:
       declared: Apache-2.0
+  1.1.0:
+    licensed:
+      declared: Apache-2.0 AND BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Confluent.Kafka/1.1.0

**Details:**
LICENSE file says this package is Apache but derived from a BSD-2-Clause project.

**Resolution:**
So, curating Apache-2.0 AND BSD-2-Clause

**Affected definitions**:
- [Confluent.Kafka 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.1.0/1.1.0)