### PR TITLE
Declared for Confluent.Kafka/1.4.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -39,3 +39,6 @@ revisions:
   1.0.0-rc4:
     licensed:
       declared: Apache-2.0
+  1.4.0:
+    licensed:
+      declared: Apache-2.0 AND BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Confluent.Kafka/1.4.0

**Details:**
LICENSE file says this package is Apache but derived from a BSD-2-Clause project.

**Resolution:**
So, curating Apache-2.0 AND BSD-2-Clause

**Affected definitions**:
- [Confluent.Kafka 1.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.4.0/1.4.0)