### PR TITLE
Declared for Confluent.Kafka/0.11.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   0.11.0:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   0.11.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared for Confluent.Kafka/0.11.0

**Details:**
LICENSE file says this package is Apache but derived from a BSD-2-Clause project.

**Resolution:**
So, curating Apache-2.0 AND BSD-2-Clause

**Affected definitions**:
- [Confluent.Kafka 0.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/0.11.0/0.11.0)