### PR TITLE
org.javassist/javassist 3.27.0-GA

### DIFF
--- a/curations/maven/mavencentral/org.javassist/javassist.yaml
+++ b/curations/maven/mavencentral/org.javassist/javassist.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javassist
+  namespace: org.javassist
+  provider: mavencentral
+  type: maven
+revisions:
+  3.27.0-GA:
+    licensed:
+      declared: LGPL 2.1 or later or MPL 1.1 or Apache 2.0

--- a/curations/maven/mavencentral/org.javassist/javassist.yaml
+++ b/curations/maven/mavencentral/org.javassist/javassist.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.27.0-GA:
     licensed:
-      declared: LGPL 2.1 or later or MPL 1.1 or Apache 2.0
+      declared: MPL-1.1 OR LGPL-2.1-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.javassist/javassist 3.27.0-GA

**Details:**
Fixing this curation. The component is triple licensed under LGPL v2.1 or later, MPL 1.1 or Apache 2.0

**Resolution:**
Maven meta: http://www.javassist.org/

https://github.com/jboss-javassist/javassist

**Affected definitions**:
- [javassist 3.27.0-GA](https://clearlydefined.io/definitions/maven/mavencentral/org.javassist/javassist/3.27.0-GA/3.27.0-GA)