### PR TITLE
StackExchange.Redis.StrongName	1.0.333

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.333:
+    licensed:
+      declared: MIT
   1.0.414:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis.StrongName	1.0.333

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file on project site is also MIT and hasn't been changed in 6 years, license URL in Nuspec also indicates MIT

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.0.333](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.0.333/1.0.333)