### PR TITLE
Declared for microsoft.diagnostics.tracing.traceevent/2.0.56

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -48,3 +48,6 @@ revisions:
   2.0.49:
     licensed:
       declared: MIT
+  2.0.56:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for microsoft.diagnostics.tracing.traceevent/2.0.56

**Details:**
License Info link - MIT, tagged version in repo MIT - https://github.com/microsoft/perfview/blob/T2.0.56/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.56](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.56/2.0.56)