### PR TITLE
Bond.Core.CSharp	9.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
@@ -43,3 +43,6 @@ revisions:
   8.2.0:
     licensed:
       declared: MIT
+  9.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Core.CSharp	9.0.0

**Details:**
Harvest license file indicates license is MIT

**Resolution:**
Project site indicates license for 9.0.0 is MIT

**Affected definitions**:
- [Bond.Core.CSharp 9.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Core.CSharp/9.0.0/9.0.0)