### PR TITLE
backport-util-concurrent:backport-util-concurrent	3.1

### DIFF
--- a/curations/maven/mavencentral/backport-util-concurrent/backport-util-concurrent.yaml
+++ b/curations/maven/mavencentral/backport-util-concurrent/backport-util-concurrent.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: backport-util-concurrent
+  namespace: backport-util-concurrent
+  provider: mavencentral
+  type: maven
+revisions:
+  '3.1':
+    licensed:
+      declared: CC-PDDC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
backport-util-concurrent:backport-util-concurrent	3.1

**Details:**
License link in .pom file indicates license is CC-PDDC

**Resolution:**
Project site also indicates license is CC-PDDC

**Affected definitions**:
- [backport-util-concurrent 3.1](https://clearlydefined.io/definitions/maven/mavencentral/backport-util-concurrent/backport-util-concurrent/3.1/3.1)