### PR TITLE
Declared for PowerThreading20101026.0.0

### DIFF
--- a/curations/nuget/nuget/-/PowerThreading.yaml
+++ b/curations/nuget/nuget/-/PowerThreading.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  20101026.0.0:
+    licensed:
+      declared: OTHER
   20120420.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for PowerThreading20101026.0.0

**Details:**
NuGet page says: When you download it, please read the enclosed End User License Agreement (EULA) before using the library in your own projects.


**Resolution:**
OTHER for EULA

**Affected definitions**:
- [PowerThreading 20101026.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/PowerThreading/20101026.0.0)