### PR TITLE
Declared for Aspose.Email5.8.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Email.yaml
+++ b/curations/nuget/nuget/-/Aspose.Email.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Aspose.Email
+  provider: nuget
+  type: nuget
+revisions:
+  5.8.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Aspose.Email5.8.0

**Details:**
License Info link goes to EULA - https://company.aspose.com/legal/eula

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Aspose.Email 5.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Email/5.8.0/5.8.0)