### PR TITLE
Declared for ag-grid-enterprise20.2.0

### DIFF
--- a/curations/npm/npmjs/-/ag-grid-enterprise.yaml
+++ b/curations/npm/npmjs/-/ag-grid-enterprise.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: OTHER
   19.1.4:
     licensed:
-      declared: NOASSERTION
+      declared: OTHER
   20.2.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/-/ag-grid-enterprise.yaml
+++ b/curations/npm/npmjs/-/ag-grid-enterprise.yaml
@@ -9,3 +9,6 @@ revisions:
   19.1.4:
     licensed:
       declared: NOASSERTION
+  20.2.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for ag-grid-enterprise20.2.0

**Details:**
ReadMe states: The following packages are Commercial licensed:
+ ag-grid-enterprise

**Resolution:**
OTHER for Commercial 

**Affected definitions**:
- [ag-grid-enterprise 20.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/ag-grid-enterprise/20.2.0/20.2.0)