### PR TITLE
Declared for M2MqttDotnetCore1.1.0

### DIFF
--- a/curations/nuget/nuget/-/M2MqttDotnetCore.yaml
+++ b/curations/nuget/nuget/-/M2MqttDotnetCore.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.8:
     licensed:
       declared: EPL-1.0
+  1.1.0:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for M2MqttDotnetCore1.1.0

**Details:**
License link goes to EPL-1.0.  No tagged versions in repo.

**Resolution:**
https://github.com/mohaqeq/paho.mqtt.m2mqtt/blob/master/LICENSE

**Affected definitions**:
- [M2MqttDotnetCore 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/M2MqttDotnetCore/1.1.0/1.1.0)