### PR TITLE
ReadMe "NOASSERTION" for luffa2.0.0

### DIFF
--- a/curations/gem/rubygems/-/luffa.yaml
+++ b/curations/gem/rubygems/-/luffa.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: luffa
+  provider: rubygems
+  type: gem
+revisions:
+  2.0.0:
+    files:
+      - license: EPL-1.0
+        path: README.md


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ReadMe "NOASSERTION" for luffa2.0.0

**Details:**
ReadMe file had "NOASSERTION."  The license identified in the ReadMe is EPL-1.0

**Resolution:**
EPL-1.0

**Affected definitions**:
- [luffa 2.0.0](https://clearlydefined.io/definitions/gem/rubygems/-/luffa/2.0.0/2.0.0)