### PR TITLE
LICENSE file - NOASSERTION

### DIFF
--- a/curations/gem/rubygems/-/calabash-cucumber.yaml
+++ b/curations/gem/rubygems/-/calabash-cucumber.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: calabash-cucumber
+  provider: rubygems
+  type: gem
+revisions:
+  0.21.4:
+    files:
+      - attributions:
+          - Copyright (c) Karl Krukow.
+        license: EPL-1.0
+        path: LICENSE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LICENSE file - NOASSERTION

**Details:**
Clearing NOASSERTION on LICENSE file

**Resolution:**
EPL-1.0

**Affected definitions**:
- [calabash-cucumber 0.21.4](https://clearlydefined.io/definitions/gem/rubygems/-/calabash-cucumber/0.21.4/0.21.4)