### PR TITLE
Missing information for microsoft.azure.amqp

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
@@ -36,3 +36,6 @@ revisions:
   2.4.2:
     licensed:
       declared: MIT
+  2.4.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for microsoft.azure.amqp

**Details:**
Added missing license details.

**Resolution:**
https://github.com/Azure/azure-amqp/blob/dba345285d0c299b412308cb98aad5e41fcf0f1c/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.Amqp 2.4.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Amqp/2.4.4/2.4.4)