### PR TITLE
Missing info for microsoft.azure.devices.shared/1.20.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -31,6 +31,17 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/da20ff83c5aeb3ce0a736520b86283a6192cdaec'
     licensed:
       declared: MIT
+  1.20.1:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: a50dbdd017153c05c1492135a51ea064169e61ee
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/a50dbdd017153c05c1492135a51ea064169e61ee'
+    licensed:
+      declared: MIT
   1.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing info for microsoft.azure.devices.shared/1.20.1

**Details:**
Added license and source location.

**Resolution:**
https://github.com/Azure/azure-iot-sdk-csharp/blob/a50dbdd017153c05c1492135a51ea064169e61ee/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices.Shared 1.20.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices.Shared/1.20.1/1.20.1)