### PR TITLE
Missing info for microsoft.azure.devices/1.21.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
@@ -17,6 +17,17 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/da20ff83c5aeb3ce0a736520b86283a6192cdaec'
     licensed:
       declared: MIT
+  1.21.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: a50dbdd017153c05c1492135a51ea064169e61ee
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/a50dbdd017153c05c1492135a51ea064169e61ee'
+    licensed:
+      declared: MIT
   1.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing info for microsoft.azure.devices/1.21.0

**Details:**
Added source location and license info.

**Resolution:**
https://github.com/Azure/azure-iot-sdk-csharp/blob/a50dbdd017153c05c1492135a51ea064169e61ee/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices 1.21.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices/1.21.0/1.21.0)