### PR TITLE
MIssing info for microsoft.net.sdk.functions/3.0.7

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -48,3 +48,6 @@ revisions:
   3.0.5:
     licensed:
       declared: MIT
+  3.0.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MIssing info for microsoft.net.sdk.functions/3.0.7

**Details:**
Added the license info.

**Resolution:**
https://github.com/Azure/azure-iot-sdk-csharp/blob/a50dbdd017153c05c1492135a51ea064169e61ee/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.7/3.0.7)