### PR TITLE
Added missing info for moq/4.14.1

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -21,6 +21,9 @@ revisions:
   4.13.1:
     licensed:
       declared: BSD-3-Clause
+  4.14.1:
+    licensed:
+      declared: BSD-3-Clause
   4.2.1402.2112:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added missing info for moq/4.14.1

**Details:**
Added license details.

**Resolution:**
https://github.com/moq/moq4/blob/d5552d5762033764b495cd122d55185f0adddbf8/License.txt

**Affected definitions**:
- [Moq 4.14.1](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.14.1/4.14.1)