### PR TITLE
Added license for mstest.testadapter/2.1.2

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.1:
     licensed:
       declared: MIT
+  2.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added license for mstest.testadapter/2.1.2

**Details:**
Added license details for mstest.testadapter/2.1.2.

**Resolution:**
https://github.com/microsoft/testfx/blob/efebd7f29dd2ca4dd481c17e73758ed28de06a4f/LICENSE.txt

**Affected definitions**:
- [MSTest.TestAdapter 2.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestAdapter/2.1.2/2.1.2)