### PR TITLE
Added license details for mstest.testframework/2.1.2

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestFramework.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestFramework.yaml
@@ -17,3 +17,6 @@ revisions:
   2.1.0-beta2:
     licensed:
       declared: MIT
+  2.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added license details for mstest.testframework/2.1.2

**Details:**
Added missing license details.

**Resolution:**
https://github.com/microsoft/testfx/blob/efebd7f29dd2ca4dd481c17e73758ed28de06a4f/LICENSE.txt

**Affected definitions**:
- [MSTest.TestFramework 2.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestFramework/2.1.2/2.1.2)