### PR TITLE
Added missing license and source details for portable.bouncycastle/1.8.6.7.

### DIFF
--- a/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
@@ -23,3 +23,14 @@ revisions:
         url: 'https://github.com/novotnyllc/bc-csharp/commit/ba47c16e72bf21dd7a223220a5bd38a05034add9'
     licensed:
       declared: MIT
+  1.8.6.7:
+    described:
+      sourceLocation:
+        name: bc-csharp
+        namespace: bcgit
+        provider: github
+        revision: 2f8db0669637e2217fd749ed987377f6ae71e192
+        type: git
+        url: 'https://github.com/bcgit/bc-csharp/commit/2f8db0669637e2217fd749ed987377f6ae71e192'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added missing license and source details for portable.bouncycastle/1.8.6.7.

**Details:**
Added missing license and source details.

**Resolution:**
https://github.com/bcgit/bc-csharp/tree/2f8db0669637e2217fd749ed987377f6ae71e192

**Affected definitions**:
- [Portable.BouncyCastle 1.8.6.7](https://clearlydefined.io/definitions/nuget/nuget/-/Portable.BouncyCastle/1.8.6.7/1.8.6.7)