### PR TITLE
added source location for dotnetproject/wpfToolkit

### DIFF
--- a/curations/nuget/nuget/-/DotNetProjects.WpfToolkit.Input.yaml
+++ b/curations/nuget/nuget/-/DotNetProjects.WpfToolkit.Input.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: DotNetProjects.WpfToolkit.Input
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.79:
+    described:
+      sourceLocation:
+        name: wpftoolkit
+        namespace: dotnetprojects
+        provider: github
+        revision: 307774892d67a190ce6b696b43cfad4eb5a4e3d7
+        type: git
+        url: 'https://github.com/dotnetprojects/wpftoolkit/commit/307774892d67a190ce6b696b43cfad4eb5a4e3d7'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
added source location for dotnetproject/wpfToolkit

**Details:**
added source location for dotnetproject/wpfToolkit

**Resolution:**
add source location for more details

**Affected definitions**:
- [DotNetProjects.WpfToolkit.Input 6.0.79](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetProjects.WpfToolkit.Input/6.0.79/6.0.79)