### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/OpenCover.yaml
+++ b/curations/nuget/nuget/-/OpenCover.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OpenCover
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.519:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files point to MIT, but confirmed in meta data and source repo. 

**Resolution:**
https://github.com/OpenCover/opencover/blob/4.6.519/License.md

**Affected definitions**:
- [OpenCover 4.6.519](https://clearlydefined.io/definitions/nuget/nuget/-/OpenCover/4.6.519/4.6.519)