### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Build.Packaging.yaml
+++ b/curations/nuget/nuget/-/NuGet.Build.Packaging.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: NuGet.Build.Packaging
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
   0.2.0:
+    licensed:
+      declared: Apache-2.0
+  0.2.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data and source repo point to Apache 2.0.

**Resolution:**
https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Build.Packaging/0.2.2


**Affected definitions**:
- [NuGet.Build.Packaging 0.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Build.Packaging/0.2.2/0.2.2)