### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Testing.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Testing.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Testing
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data and source repo point to Apache 2.0. 

**Resolution:**
https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Testing 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Testing/4.1.0/4.1.0)