### PR TITLE
Declare BSD-3-Clause

### DIFF
--- a/curations/git/github/pytorch/pytorch.yaml
+++ b/curations/git/github/pytorch/pytorch.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  4ff3872a2099993bf7e8c588f7182f3df777205b:
+    licensed:
+      declared: BSD-3-Clause
   8554416a199c4cec01c60c7015d8301d2bb39b64:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause

**Details:**
Declare BSD-3-Clause found under Files here https://github.com/pytorch/pytorch/blob/4ff3872a2099993bf7e8c588f7182f3df777205b/LICENSE)

**Resolution:**
Matches source

**Affected definitions**:
- [pytorch 4ff3872a2099993bf7e8c588f7182f3df777205b](https://clearlydefined.io/definitions/git/github/pytorch/pytorch/4ff3872a2099993bf7e8c588f7182f3df777205b/4ff3872a2099993bf7e8c588f7182f3df777205b)