### PR TITLE
Bond.Runtime.CSharp	9.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
@@ -73,3 +73,6 @@ revisions:
   8.2.0:
     licensed:
       declared: MIT
+  9.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Runtime.CSharp	9.0.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Repository also indicates license is MIT

**Affected definitions**:
- [Bond.Runtime.CSharp 9.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Runtime.CSharp/9.0.0/9.0.0)