### PR TITLE
Fixing cjson 7db005e0281b....

### DIFF
--- a/curations/git/github/davegamble/cjson.yaml
+++ b/curations/git/github/davegamble/cjson.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cjson
+  namespace: davegamble
+  provider: github
+  type: git
+revisions:
+  7db005e0281b140a13c93c9aeda4f1ee1bd8e740:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing cjson 7db005e0281b....

**Details:**
Looks like just "MIT" to me and not "MIT AND Apache-2.0"?

**Resolution:**
https://github.com/DaveGamble/cJSON/blob/7db005e0281b140a13c93c9aeda4f1ee1bd8e740/LICENSE

**Affected definitions**:
- [cjson 7db005e0281b140a13c93c9aeda4f1ee1bd8e740](https://clearlydefined.io/definitions/git/github/davegamble/cjson/7db005e0281b140a13c93c9aeda4f1ee1bd8e740/7db005e0281b140a13c93c9aeda4f1ee1bd8e740)