### PR TITLE
Bond.CSharp	9.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.CSharp.yaml
@@ -75,3 +75,6 @@ revisions:
   8.2.0:
     licensed:
       declared: MIT
+  9.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.CSharp	9.0.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget page also indicates license is MIT

**Affected definitions**:
- [Bond.CSharp 9.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.CSharp/9.0.0/9.0.0)