### PR TITLE
LightGBM	2.2.3

### DIFF
--- a/curations/nuget/nuget/-/LightGBM.yaml
+++ b/curations/nuget/nuget/-/LightGBM.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.2.3:
     licensed:
-      declared: NOASSERTION
+      declared: MIT

--- a/curations/nuget/nuget/-/LightGBM.yaml
+++ b/curations/nuget/nuget/-/LightGBM.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: LightGBM
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.3:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LightGBM	2.2.3

**Details:**
License link on Nuget page indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [LightGBM 2.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/LightGBM/2.2.3/2.2.3)