### PR TITLE
NuGet.ContentModel	4.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.ContentModel.yaml
+++ b/curations/nuget/nuget/-/NuGet.ContentModel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.ContentModel
+  provider: nuget
+  type: nuget
+revisions:
+  4.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.ContentModel	4.2.0

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License URL in Nuspec file also indicates license is Apache 2.0

**Affected definitions**:
- [NuGet.ContentModel 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.ContentModel/4.2.0/4.2.0)