### PR TITLE
sacremoses	0.0.38

### DIFF
--- a/curations/pypi/pypi/-/sacremoses.yaml
+++ b/curations/pypi/pypi/-/sacremoses.yaml
@@ -6,6 +6,9 @@ revisions:
   0.0.35:
     licensed:
       declared: LGPL-2.1-or-later
+  0.0.38:
+    licensed:
+      declared: LGPL-2.1-or-later
   0.0.40:
     files:
       - license: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sacremoses	0.0.38

**Details:**
Harvested Readme file indicates license is LGPL 2.1 or later

**Resolution:**
Setup.py file is silent on license

**Affected definitions**:
- [sacremoses 0.0.38](https://clearlydefined.io/definitions/pypi/pypi/-/sacremoses/0.0.38/0.0.38)