### PR TITLE
bs4	0.0.1

### DIFF
--- a/curations/pypi/pypi/-/bs4.yaml
+++ b/curations/pypi/pypi/-/bs4.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: bs4
+  provider: pypi
+  type: pypi
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bs4	0.0.1

**Details:**
Harvested setup.py file indicates license is MIT

**Resolution:**
Project site also indicates license is MIT

**Affected definitions**:
- [bs4 0.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/bs4/0.0.1/0.0.1)