### PR TITLE
caseless	0.10.0

### DIFF
--- a/curations/npm/npmjs/-/caseless.yaml
+++ b/curations/npm/npmjs/-/caseless.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.10.0:
+    licensed:
+      declared: Apache-2.0
   0.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
caseless	0.10.0

**Details:**
Package.json file in repository indicates license is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apache 2.0

**Affected definitions**:
- [caseless 0.10.0](https://clearlydefined.io/definitions/npm/npmjs/-/caseless/0.10.0/0.10.0)