### PR TITLE
node-bitmap	0.0.1

### DIFF
--- a/curations/npm/npmjs/-/node-bitmap.yaml
+++ b/curations/npm/npmjs/-/node-bitmap.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: node-bitmap
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
node-bitmap	0.0.1

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
NPM site also indicates license is MIT

**Affected definitions**:
- [node-bitmap 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/node-bitmap/0.0.1/0.0.1)