### PR TITLE
tar	1.0.3

### DIFF
--- a/curations/npm/npmjs/-/tar.yaml
+++ b/curations/npm/npmjs/-/tar.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: tar
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.3:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tar	1.0.3

**Details:**
Harvested .json file indicates license is BSD-2

**Resolution:**
Harvested license file also indicates license is BSD-2

**Affected definitions**:
- [tar 1.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/tar/1.0.3/1.0.3)