### PR TITLE
commander	2.2.0

### DIFF
--- a/curations/npm/npmjs/-/commander.yaml
+++ b/curations/npm/npmjs/-/commander.yaml
@@ -15,6 +15,9 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.2.0:
+    licensed:
+      declared: MIT
   2.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commander	2.2.0

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [commander 2.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/commander/2.2.0/2.2.0)