### PR TITLE
Declared for kxml2-min/2.3.0

### DIFF
--- a/curations/maven/mavencentral/net.sf.kxml/kxml2-min.yaml
+++ b/curations/maven/mavencentral/net.sf.kxml/kxml2-min.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kxml2-min
+  namespace: net.sf.kxml
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.0:
+    licensed:
+      declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for kxml2-min/2.3.0

**Details:**
POM references BSD, but the actual LICENSE file is MIT - https://github.com/stefanhaustein/kxml2/blob/master/license.txt.  OTHER is for the public domain for the xmlpull API  that is pulled into the binary package (https://repo1.maven.org/maven2/net/sf/kxml/kxml2-min/2.3.0/kxml2-min-2.3.0.jar.sha1).

**Resolution:**
"MIT AND OTHER"  where OTHER is for public domain

**Affected definitions**:
- [kxml2-min 2.3.0](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.kxml/kxml2-min/2.3.0/2.3.0)