### PR TITLE
Need to curate license for BouncyCastle 1.8.6

### DIFF
--- a/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
@@ -23,3 +23,14 @@ revisions:
         url: 'https://github.com/novotnyllc/bc-csharp/commit/ba47c16e72bf21dd7a223220a5bd38a05034add9'
     licensed:
       declared: MIT
+  1.8.6.7:
+    described:
+      sourceLocation:
+        name: bc-csharp
+        namespace: novotnyllc
+        provider: github
+        revision: e72e3a8a96b0cd4e83d51f5b4ae83bc520c4c894
+        type: git
+        url: 'https://github.com/novotnyllc/bc-csharp/commit/e72e3a8a96b0cd4e83d51f5b4ae83bc520c4c894'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Need to curate license for BouncyCastle 1.8.6

**Details:**
Need to curate license for BouncyCastle 1.8.6 - please ignore prior one, I used the wrong link for source.

**Resolution:**
Need to curate license for BouncyCastle 1.8.6 - please ignore prior one, I used the wrong link for source.

**Affected definitions**:
- [Portable.BouncyCastle 1.8.6.7](https://clearlydefined.io/definitions/nuget/nuget/-/Portable.BouncyCastle/1.8.6.7)