### PR TITLE
Fixing declared license for microsoft/appcenter-sdk-androidbc91ca822...

### DIFF
--- a/curations/git/github/microsoft/appcenter-sdk-android.yaml
+++ b/curations/git/github/microsoft/appcenter-sdk-android.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: appcenter-sdk-android
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  bc91ca8224dab0a7d2e9e8391e0d2a02da9a5706:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing declared license for microsoft/appcenter-sdk-androidbc91ca822...

**Details:**
I think this is just MIT for declared: https://github.com/microsoft/appcenter-sdk-android/blob/bc91ca8224dab0a7d2e9e8391e0d2a02da9a5706/license.txt

**Resolution:**
MIT

**Affected definitions**:
- [appcenter-sdk-android bc91ca8224dab0a7d2e9e8391e0d2a02da9a5706](https://clearlydefined.io/definitions/git/github/microsoft/appcenter-sdk-android/bc91ca8224dab0a7d2e9e8391e0d2a02da9a5706/bc91ca8224dab0a7d2e9e8391e0d2a02da9a5706)