### PR TITLE
Declared for expirymanager/0.9.3

### DIFF
--- a/curations/npm/npmjs/-/expirymanager.yaml
+++ b/curations/npm/npmjs/-/expirymanager.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: expirymanager
+  provider: npmjs
+  type: npm
+revisions:
+  0.9.3:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for expirymanager/0.9.3

**Details:**
I do not see any license info for this package or in the repo

**Resolution:**
See: https://github.com/SocketCluster/expirymanager/issues/1

**Affected definitions**:
- [expirymanager 0.9.3](https://clearlydefined.io/definitions/npm/npmjs/-/expirymanager/0.9.3/0.9.3)