### PR TITLE
Declared for fleximap1.0.0

### DIFF
--- a/curations/npm/npmjs/-/fleximap.yaml
+++ b/curations/npm/npmjs/-/fleximap.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fleximap
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for fleximap1.0.0

**Details:**
I do not see any license info for this package or in the repo.

**Resolution:**
See: https://github.com/SocketCluster/fleximap/issues/2

**Affected definitions**:
- [fleximap 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/fleximap/1.0.0/1.0.0)