### PR TITLE
Declared for Microsoft.Office.Interop.Outlook15.0.4797.1003

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Office.Interop.Outlook.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Office.Interop.Outlook.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Office.Interop.Outlook
+  provider: nuget
+  type: nuget
+revisions:
+  15.0.4797.1003:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Microsoft.Office.Interop.Outlook15.0.4797.1003

**Details:**
I do not see any license info for this NuGet

**Resolution:**
NONE

**Affected definitions**:
- [Microsoft.Office.Interop.Outlook 15.0.4797.1003](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Office.Interop.Outlook/15.0.4797.1003/15.0.4797.1003)