### PR TITLE
Swashbuckle.AspNetCore.Swagger 5.4.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -36,3 +36,6 @@ revisions:
   5.3.3:
     licensed:
       declared: MIT
+  5.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.Swagger 5.4.1

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.4.1/LICENSE

Master license in repo also MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.4.1/5.4.1)