### PR TITLE
Plugin.Permissions 6.0.1

### DIFF
--- a/curations/nuget/nuget/-/Plugin.Permissions.yaml
+++ b/curations/nuget/nuget/-/Plugin.Permissions.yaml
@@ -18,3 +18,6 @@ revisions:
   3.0.0.12:
     licensed:
       declared: MIT
+  6.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Plugin.Permissions 6.0.1

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://github.com/jamesmontemagno/PermissionsPlugin/blob/master/LICENSE

Project and source all go to GitHub repo, no version tag license file for this release

**Affected definitions**:
- [Plugin.Permissions 6.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Plugin.Permissions/6.0.1/6.0.1)