### PR TITLE
jupyterlab-git 0.5.0

### DIFF
--- a/curations/pypi/pypi/-/jupyterlab-git.yaml
+++ b/curations/pypi/pypi/-/jupyterlab-git.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jupyterlab-git
+  provider: pypi
+  type: pypi
+revisions:
+  0.5.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jupyterlab-git 0.5.0

**Details:**
Declaring BSD-3-Clause 

**Resolution:**
Didn't find license information on PyPi

ClearlyDefined Files ReadMe has link to GitHub repo. Located license in GitHub repo: https://github.com/jupyterlab/jupyterlab-git/blob/v0.5.0/LICENSE

**Affected definitions**:
- [jupyterlab-git 0.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/jupyterlab-git/0.5.0/0.5.0)