### PR TITLE
protobuf 3.12.0

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -18,6 +18,9 @@ revisions:
   3.11.3:
     licensed:
       declared: BSD-3-Clause
+  3.12.0:
+    licensed:
+      declared: BSD-3-Clause
   3.6.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
protobuf 3.12.0

**Details:**
Declaring BSD-3-Clause

**Resolution:**
PyPi metadata: BSD-3-Clause

Project homepage: https://github.com/protocolbuffers/protobuf/blob/v3.12.0/LICENSE

**Affected definitions**:
- [protobuf 3.12.0](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.12.0/3.12.0)