### PR TITLE
Pillow 7.1.2

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -27,3 +27,6 @@ revisions:
   7.1.1:
     licensed:
       declared: HPND
+  7.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -29,4 +29,4 @@ revisions:
       declared: HPND
   7.1.2:
     licensed:
-      declared: OTHER
+      declared: HPND


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Pillow 7.1.2

**Details:**
Declaring Other for Python Imaging Library License (PIL). 

**Resolution:**
I don't think there is an SPDX identifier for this license.

https://pillow.readthedocs.io/en/stable/about.html#license

https://github.com/python-pillow/Pillow/blob/7.1.2/LICENSE

**Affected definitions**:
- [Pillow 7.1.2](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/7.1.2/7.1.2)