### PR TITLE
SshNet.Security.Cryptography 1.2.0

### DIFF
--- a/curations/nuget/nuget/-/SshNet.Security.Cryptography.yaml
+++ b/curations/nuget/nuget/-/SshNet.Security.Cryptography.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SshNet.Security.Cryptography
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SshNet.Security.Cryptography 1.2.0

**Details:**
Declaring MIT

**Resolution:**
Repo license for Master and tagged version are MIT:

https://github.com/sshnet/Cryptography/blob/1.2.0/LICENSE

**Affected definitions**:
- [SshNet.Security.Cryptography 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/SshNet.Security.Cryptography/1.2.0/1.2.0)