### PR TITLE
Swashbuckle.AspNetCore.Swagger 5.2.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -33,6 +33,9 @@ revisions:
   5.1.0:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.3.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Swashbuckle.AspNetCore.Swagger 5.2.1

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined License file: MIT

NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.2.1/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.2.1/5.2.1)