### PR TITLE
Declared for highcharts-react-official3.0.0

### DIFF
--- a/curations/npm/npmjs/-/highcharts-react-official.yaml
+++ b/curations/npm/npmjs/-/highcharts-react-official.yaml
@@ -9,3 +9,6 @@ revisions:
   2.2.2:
     licensed:
       declared: MIT AND OTHER
+  3.0.0:
+    licensed:
+      declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for highcharts-react-official3.0.0

**Details:**
Did MIT AND OTHER where OTHER is referring to this extra language: The software in Highcharts React repository is free and open source, 
but as highcharts-react relies on Highcharts.js, it requires a valid 
Highcharts license for commercial use.

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [highcharts-react-official 3.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-react-official/3.0.0/3.0.0)