### PR TITLE
Declared for adjust/ios_sdkd746f7189ca...

### DIFF
--- a/curations/git/github/adjust/ios_sdk.yaml
+++ b/curations/git/github/adjust/ios_sdk.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ios_sdk
+  namespace: adjust
+  provider: github
+  type: git
+revisions:
+  d746f7189ca767323d53f34a64a51ddecd7a84ab:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for adjust/ios_sdkd746f7189ca...

**Details:**
MIT-LICENSE file under "Files" and in repo at "Source" link.  Includes some Apache files, but overall "Declared" license is MIT

**Resolution:**
https://github.com/adjust/ios_sdk/blob/d746f7189ca767323d53f34a64a51ddecd7a84ab/MIT-LICENSE

**Affected definitions**:
- [ios_sdk d746f7189ca767323d53f34a64a51ddecd7a84ab](https://clearlydefined.io/definitions/git/github/adjust/ios_sdk/d746f7189ca767323d53f34a64a51ddecd7a84ab/d746f7189ca767323d53f34a64a51ddecd7a84ab)