### PR TITLE
Declared for

### DIFF
--- a/curations/git/github/cocoalumberjack/cocoalumberjack.yaml
+++ b/curations/git/github/cocoalumberjack/cocoalumberjack.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cocoalumberjack
+  namespace: cocoalumberjack
+  provider: github
+  type: git
+revisions:
+  9ed7b2551a3c64b0ddb7c181f5c31332364dd3b4:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/git/github/cocoalumberjack/cocoalumberjack.yaml
+++ b/curations/git/github/cocoalumberjack/cocoalumberjack.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   9ed7b2551a3c64b0ddb7c181f5c31332364dd3b4:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-Source-Code


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for

**Details:**
On ReadMe at commit it says "BSD" license and then has a broken LICENSE link.  The LICENSE in master is BSD-3-Clause

**Resolution:**
https://github.com/cocoalumberjack/cocoalumberjack/tree/9ed7b2551a3c64b0ddb7c181f5c31332364dd3b4

**Affected definitions**:
- [cocoalumberjack 9ed7b2551a3c64b0ddb7c181f5c31332364dd3b4](https://clearlydefined.io/definitions/git/github/cocoalumberjack/cocoalumberjack/9ed7b2551a3c64b0ddb7c181f5c31332364dd3b4/9ed7b2551a3c64b0ddb7c181f5c31332364dd3b4)