### PR TITLE
Changed to MIT from OTHER

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.Cosmos
+  provider: nuget
+  type: nuget
+revisions:
+  3.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Changed to MIT from OTHER

**Details:**
MIT found at Project Site here (https://github.com/Azure/azure-cosmos-dotnet-v3/blob/3.8.0/LICENSE)

**Resolution:**
MIT found at Project Site here (https://github.com/Azure/azure-cosmos-dotnet-v3/blob/3.8.0/LICENSE)

**Affected definitions**:
- [Microsoft.Azure.Cosmos 3.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos/3.8.0/3.8.0)