### PR TITLE
Declared OTHER - under Microsoft EULA

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.6.10:
+    licensed:
+      declared: OTHER
   1.6.6:
     licensed:
       declared: ''

--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: OTHER
   1.6.6:
     licensed:
-      declared: ''
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared OTHER - under Microsoft EULA

**Details:**
Declared OTHER - under Microsoft EULA found here at the License (https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Fabric.MSBuild/1.6.10/License)

**Resolution:**
Declared OTHER - under Microsoft EULA found here at the License (https://www.nuget.org/packages/Microsoft.VisualStudio.Azure.Fabric.MSBuild/1.6.10/License)

**Affected definitions**:
- [Microsoft.VisualStudio.Azure.Fabric.MSBuild 1.6.10](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild/1.6.10/1.6.10)