### PR TITLE
Declared for pinterest/pincache569df9390a....

### DIFF
--- a/curations/git/github/pinterest/pincache.yaml
+++ b/curations/git/github/pinterest/pincache.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pincache
+  namespace: pinterest
+  provider: github
+  type: git
+revisions:
+  569df9390a730bf48c0ed589c10cd8de0255e87a:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for pinterest/pincache569df9390a....

**Details:**
LICENSE file in source is Apache

**Resolution:**
https://github.com/pinterest/pincache/blob/569df9390a730bf48c0ed589c10cd8de0255e87a/LICENSE.txt

**Affected definitions**:
- [pincache 569df9390a730bf48c0ed589c10cd8de0255e87a](https://clearlydefined.io/definitions/git/github/pinterest/pincache/569df9390a730bf48c0ed589c10cd8de0255e87a/569df9390a730bf48c0ed589c10cd8de0255e87a)