### PR TITLE
ELD: popper-core v2.4.0

### DIFF
--- a/curations/git/github/popperjs/popper-core.yaml
+++ b/curations/git/github/popperjs/popper-core.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: popper-core
+  namespace: popperjs
+  provider: github
+  type: git
+revisions:
+  5b740298263c83a578780371a034c3db8ba86f12:
+    files:
+      - license: CC-BY-SA-3.0
+        path: src/utils/orderModifiers.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: popper-core v2.4.0

**Details:**
File: /popper-core-2.4.0/src/utils/orderModifiers.js
Line: #5
Contains reference from stack overflow website

**Resolution:**
Update License for file.  While Stackoverflow postings are currently licensed under the Creative Commons Attribution-Sharealike 4.0 International License, this was posted prior to May 2, 2018 and after March 7, 2011, and is therefore licensed under the Creative Commons Attribution-ShareAlike 3.0 Unp

**Affected definitions**:
- [popper-core 5b740298263c83a578780371a034c3db8ba86f12](https://clearlydefined.io/definitions/git/github/popperjs/popper-core/5b740298263c83a578780371a034c3db8ba86f12/5b740298263c83a578780371a034c3db8ba86f12)