### PR TITLE
Xamarin.Android.Support.Compat 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Compat.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Compat.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.Compat.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.Compat 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata and Project license are the same:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

Master license in repo is also MIT

**Affected definitions**:
- [Xamarin.Android.Support.Compat 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Compat/28.0.0.3/28.0.0.3)