### PR TITLE
zlib 1.2.8.6

### DIFF
--- a/curations/nuget/nuget/-/zlib.yaml
+++ b/curations/nuget/nuget/-/zlib.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: zlib
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.8.6:
+    licensed:
+      declared: Zlib


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
zlib 1.2.8.6

**Details:**
Declaring Zlib license

**Resolution:**
NuGet metadata license is broken. 

Referenced on NuGet page: http://zlib.net/

**Affected definitions**:
- [zlib 1.2.8.6](https://clearlydefined.io/definitions/nuget/nuget/-/zlib/1.2.8.6/1.2.8.6)