### PR TITLE
Xamarin.Android.Support.Vector.Drawable 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Vector.Drawable.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Vector.Drawable.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.Vector.Drawable.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.Vector.Drawable 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata and Project site license are same:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

Master repo license also MIT

**Affected definitions**:
- [Xamarin.Android.Support.Vector.Drawable 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Vector.Drawable/28.0.0.3/28.0.0.3)