### PR TITLE
Xamarin.Android.Arch.Lifecycle.Common 1.1.1.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Common.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Common.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Arch.Lifecycle.Common.nuspec
     licensed:
       declared: MIT
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Arch.Lifecycle.Common 1.1.1.3

**Details:**
Declaring MIT

**Resolution:**
Both NuGet metadata and Project license are the same going to the Master repo license which is MIT.

There's no tagged version. Commit license close to release date:
https://github.com/xamarin/AndroidSupportComponents/blob/c5a83e07c6a1ea0ac4ee63af667e70903fd3f567/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Lifecycle.Common 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Common/1.1.1.3/1.1.1.3)