### PR TITLE
NuGet.CommandLine 4.1.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -12,6 +12,9 @@ revisions:
   3.5.0:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0
   4.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NuGet.CommandLine 4.1.0

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

Project site:

https://github.com/NuGet/NuGet.Client/blob/4.1.0-rtm-2427/LICENSE.txt

**Affected definitions**:
- [NuGet.CommandLine 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.1.0/4.1.0)