### PR TITLE
Xamarin.Android.Arch.Core.Runtime 1.1.1.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Core.Runtime.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Core.Runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Arch.Core.Runtime
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Arch.Core.Runtime 1.1.1.3

**Details:**
Declaring MIT

**Resolution:**
NuGet and Project license both are the same: https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md

Close commit:
https://github.com/xamarin/AndroidSupportComponents/blob/c5a83e07c6a1ea0ac4ee63af667e70903fd3f567/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Core.Runtime 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Core.Runtime/1.1.1.3/1.1.1.3)