### PR TITLE
Xamarin.Android.Support.VersionedParcelable 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.VersionedParcelable.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.VersionedParcelable.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Support.VersionedParcelable
+  provider: nuget
+  type: nuget
+revisions:
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.VersionedParcelable 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata and Project license are the same:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

Master license in repo is also MIT

**Affected definitions**:
- [Xamarin.Android.Support.VersionedParcelable 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.VersionedParcelable/28.0.0.3/28.0.0.3)