### PR TITLE
Xamarin.Android.Support.Annotations 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Annotations.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Annotations.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.Annotations.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.Annotations 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata and Project license are the same:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

Master repo license is also MIT

**Affected definitions**:
- [Xamarin.Android.Support.Annotations 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Annotations/28.0.0.3/28.0.0.3)