### PR TITLE
Xamarin.Android.Support.CursorAdapter 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.CursorAdapter.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.CursorAdapter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Support.CursorAdapter
+  provider: nuget
+  type: nuget
+revisions:
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.CursorAdapter 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata and Project license are the same:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

Master repo license is also MIT

**Affected definitions**:
- [Xamarin.Android.Support.CursorAdapter 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.CursorAdapter/28.0.0.3/28.0.0.3)