### PR TITLE
ELD: regenerator runtime v0.13.5

### DIFF
--- a/curations/git/github/facebook/regenerator.yaml
+++ b/curations/git/github/facebook/regenerator.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: regenerator
+  namespace: facebook
+  provider: github
+  type: git
+revisions:
+  4889b5c0a0281adfbf20d70311d5f4e4f398c566:
+    files:
+      - attributions:
+          - 'Copyright (c) 2014-present, Facebook, Inc.'
+        license: MIT
+        path: LICENSE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: regenerator runtime v0.13.5

**Details:**
Provide missing copyright as party of license

**Resolution:**
Add copyright information

**Affected definitions**:
- [regenerator 4889b5c0a0281adfbf20d70311d5f4e4f398c566](https://clearlydefined.io/definitions/git/github/facebook/regenerator/4889b5c0a0281adfbf20d70311d5f4e4f398c566/4889b5c0a0281adfbf20d70311d5f4e4f398c566)