### PR TITLE
ELD: regenerator runtime v0.13.5

### DIFF
--- a/curations/git/github/facebook/regenerator.yaml
+++ b/curations/git/github/facebook/regenerator.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: regenerator
+  namespace: facebook
+  provider: github
+  type: git
+revisions:
+  4889b5c0a0281adfbf20d70311d5f4e4f398c566:
+    files:
+      - attributions:
+          - ' * Copyright (c) 2014 Brian Donovan'
+        license: Apache-2.0
+        path: lib/util.js


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: regenerator runtime v0.13.5

**Details:**
File: /regenerator-regenerator-runtime-0.13.5/lib/util.js
Line: #9
Text: Files with a section of code prefaced by the following notice: 

// Inspired by the isReference function from ast-util:
// https://github.com/eventualbuddha/ast-util/blob/9bf91c5ce8/lib/index.js#L466-L506


**Resolution:**
The code referenced is licensed under Apache 2.  The code following this comment closely follows code from ast-util, providing "[u]tilities for AST transformers." See https://github.com/eventualbuddha/ast-util (see specifically https://github.com/eventualbuddha/ast-util/blob/9bf91c5ce8/lib/index.js#

**Affected definitions**:
- [regenerator 4889b5c0a0281adfbf20d70311d5f4e4f398c566](https://clearlydefined.io/definitions/git/github/facebook/regenerator/4889b5c0a0281adfbf20d70311d5f4e4f398c566/4889b5c0a0281adfbf20d70311d5f4e4f398c566)