### PR TITLE
Microsoft.Bot.Builder.Dialogs 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
@@ -6,3 +6,6 @@ revisions:
   4.7.0:
     licensed:
       declared: MIT
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Builder.Dialogs 4.8.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license

Project license (tagged version): https://github.com/microsoft/botbuilder-dotnet/blob/4.8/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Dialogs 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs/4.8.0/4.8.0)