### PR TITLE
Microsoft.Bot.Builder.Testing 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Testing.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Testing.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Builder.Testing
+  provider: nuget
+  type: nuget
+revisions:
+  4.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Builder.Testing 4.8.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Project license (tagged version):
https://github.com/microsoft/botbuilder-dotnet/blob/4.8/LICENSE


**Affected definitions**:
- [Microsoft.Bot.Builder.Testing 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Testing/4.8.0/4.8.0)