### PR TITLE
Swashbuckle.AspNetCore.Newtonsoft 5.4.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle.AspNetCore.Newtonsoft
+  provider: nuget
+  type: nuget
+revisions:
+  5.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.Newtonsoft 5.4.1

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.4.1/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Newtonsoft 5.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft/5.4.1/5.4.1)