### PR TITLE
ServiceFabric.Mocks 3.4.17

### DIFF
--- a/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
+++ b/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ServiceFabric.Mocks
+  provider: nuget
+  type: nuget
+revisions:
+  3.4.17:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ServiceFabric.Mocks 3.4.17

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license:
https://github.com/loekd/ServiceFabric.Mocks/blob/master/LICENSE.md

Closest commit in repo:

https://github.com/loekd/ServiceFabric.Mocks/blob/0cf07e0457c0a3ed15c4ad196dc2290352beacaf/LICENSE.md

**Affected definitions**:
- [ServiceFabric.Mocks 3.4.17](https://clearlydefined.io/definitions/nuget/nuget/-/ServiceFabric.Mocks/3.4.17/3.4.17)