### PR TITLE
Renci.SshNet.Async 1.4.0

### DIFF
--- a/curations/nuget/nuget/-/Renci.SshNet.Async.yaml
+++ b/curations/nuget/nuget/-/Renci.SshNet.Async.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Renci.SshNet.Async
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Renci.SshNet.Async 1.4.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Tagged version in Project repo: https://github.com/JohnTheGr8/Renci.SshNet.Async/blob/v1.4.0/License

**Affected definitions**:
- [Renci.SshNet.Async 1.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Renci.SshNet.Async/1.4.0/1.4.0)