### PR TITLE
MarkdownLog 0.9.64

### DIFF
--- a/curations/nuget/nuget/-/MarkdownLog.yaml
+++ b/curations/nuget/nuget/-/MarkdownLog.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MarkdownLog
+  provider: nuget
+  type: nuget
+revisions:
+  0.9.64:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
MarkdownLog 0.9.64

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Commit matching version release date:

https://github.com/Wheelies/MarkdownLog/blob/783459d28a6ca189f6ff33040a4bc6771943c9b2/LICENSE

**Affected definitions**:
- [MarkdownLog 0.9.64](https://clearlydefined.io/definitions/nuget/nuget/-/MarkdownLog/0.9.64/0.9.64)