### PR TITLE
source added for Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.CosmosDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.CosmosDB.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: Microsoft.Azure.WebJobs.Extensions.CosmosDB
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.5:
+    described:
+      sourceLocation:
+        name: azure-webjobs-sdk-extensions
+        namespace: azure
+        provider: github
+        revision: 7160d758c40551b5a283dbc24011ffa89c9ffa6b
+        type: git
+        url: 'https://github.com/azure/azure-webjobs-sdk-extensions/commit/7160d758c40551b5a283dbc24011ffa89c9ffa6b'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
source added for Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.5

**Details:**
source added for Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.5

**Resolution:**
adds the source for Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.5

**Affected definitions**:
- [Microsoft.Azure.WebJobs.Extensions.CosmosDB 3.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.CosmosDB/3.0.5/3.0.5)