### PR TITLE
FluentAssertions.Json5.3.0

### DIFF
--- a/curations/nuget/nuget/-/FluentAssertions.Json.yaml
+++ b/curations/nuget/nuget/-/FluentAssertions.Json.yaml
@@ -12,3 +12,6 @@ revisions:
   5.0.0:
     licensed:
       declared: Apache-2.0
+  5.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
FluentAssertions.Json5.3.0

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet meta goes to GitHub master license

License for tagged version:
https://github.com/fluentassertions/fluentassertions.json/blob/5.3.0/LICENSE

Project site: https://fluentassertions.com/

**Affected definitions**:
- [FluentAssertions.Json 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/FluentAssertions.Json/5.3.0/5.3.0)