### PR TITLE
protobuf-net 2.3.4

### DIFF
--- a/curations/nuget/nuget/-/protobuf-net.yaml
+++ b/curations/nuget/nuget/-/protobuf-net.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.0:
     licensed:
       declared: Apache-2.0 AND BSD-3-Clause
+  2.3.4:
+    licensed:
+      declared: BSD-3-Clause AND Apache-2.0
   2.4.0:
     licensed:
       declared: Apache-2.0 AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
protobuf-net 2.3.4

**Details:**
Declaring BSD-3-Clause and Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master license, which is same as tagged version in GitHub repo: https://github.com/protobuf-net/protobuf-net/blob/2.3.4/Licence.txt

**Affected definitions**:
- [protobuf-net 2.3.4](https://clearlydefined.io/definitions/nuget/nuget/-/protobuf-net/2.3.4/2.3.4)