### PR TITLE
murmurhash 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/murmurhash.yaml
+++ b/curations/nuget/nuget/-/murmurhash.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0:
     licensed:
       declared: Apache-2.0
+  1.0.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
murmurhash 1.0.3

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master license which is Apache 2.0, no tagged versions.

Closest commit license file also Apache 2.0: https://github.com/darrenkopp/murmurhash-net/blob/1d9e8bbd8f67729c44ff02a1ef528bd9331da9a6/LICENSE.md

**Affected definitions**:
- [murmurhash 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/murmurhash/1.0.3/1.0.3)