### PR TITLE
example-gulp-protractor 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/example-gulp-protractor.yaml
+++ b/curations/npm/npmjs/-/example-gulp-protractor.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: example-gulp-protractor
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
example-gulp-protractor 0.0.1

**Details:**
Declaring NONE 

**Resolution:**
None is noted as license on NPM - https://www.npmjs.com/package/example-gulp-protractor/v/0.0.1

This GitHub repo appears to be related with examples listed, but repo starts from v.0.0.2 (MIT).

**Affected definitions**:
- [example-gulp-protractor 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/example-gulp-protractor/0.0.1/0.0.1)