### PR TITLE
Microsoft.NETFramework.ReferenceAssemblies.net 4621.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net462.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net462.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETFramework.ReferenceAssemblies.net462
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.NETFramework.ReferenceAssemblies.net 4621.0.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license, no tagged version or commit license:

https://github.com/Microsoft/dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net462 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net462/1.0.0/1.0.0)