### PR TITLE
Xamarin.Android.Arch.Lifecycle.Runtime 1.1.1.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Runtime.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Runtime.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Arch.Lifecycle.Runtime.nuspec
     licensed:
       declared: MIT
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Arch.Lifecycle.Runtime 1.1.1.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license, no tagged version:
https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md


Project site (close commit):
https://github.com/xamarin/AndroidSupportComponents/blob/4b8e4b28c88b1c0fa0fc3b5a8673542fcd378363/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Lifecycle.Runtime 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Runtime/1.1.1.3/1.1.1.3)