### PR TITLE
NLog 4.7.2

### DIFF
--- a/curations/nuget/nuget/-/NLog.yaml
+++ b/curations/nuget/nuget/-/NLog.yaml
@@ -185,6 +185,9 @@ revisions:
   4.7.0:
     licensed:
       declared: BSD-3-Clause
+  4.7.2:
+    licensed:
+      declared: BSD-3-Clause
   5.0.0-beta05:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NLog 4.7.2

**Details:**
Declaring BSD-3-Clause

**Resolution:**
NuGet metadata goes to GitHub master license (BSD-3-Clause), tagged version:

https://github.com/NLog/NLog/blob/v4.7.2/LICENSE.txt

https://nlog-project.org/

**Affected definitions**:
- [NLog 4.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/NLog/4.7.2/4.7.2)