### PR TITLE
Microsoft.NET.Sdk.Functions	3.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -42,6 +42,9 @@ revisions:
   3.0.1:
     licensed:
       declared: MIT
+  3.0.2:
+    licensed:
+      declared: MIT
   3.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NET.Sdk.Functions	3.0.2

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Nuget site indicates license is MIT and project site also indicates license is MIT

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.2/3.0.2)