### PR TITLE
Microsoft.Azure.Cosmos	3.9.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.Cosmos
+  provider: nuget
+  type: nuget
+revisions:
+  3.9.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.Azure.Cosmos	3.9.1

**Details:**
Declared license was listed at Other, but project site indicates license is MIT

**Resolution:**
History of license on project site indicates initial license was MIT and has not changed

**Affected definitions**:
- [Microsoft.Azure.Cosmos 3.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos/3.9.1/3.9.1)