### PR TITLE
Google.Protobuf	3.11.4

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -15,6 +15,9 @@ revisions:
   3.11.3:
     licensed:
       declared: BSD-3-Clause
+  3.11.4:
+    licensed:
+      declared: BSD-3-Clause
   3.3.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf	3.11.4

**Details:**
Harvested license file indicates license is BSD-3

**Resolution:**
Project site also indicates license is BSD-3

**Affected definitions**:
- [Google.Protobuf 3.11.4](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.11.4/3.11.4)