### PR TITLE
pywin32	228

### DIFF
--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -15,3 +15,6 @@ revisions:
   '227':
     licensed:
       declared: Python-2.0
+  '228':
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -17,4 +17,4 @@ revisions:
       declared: Python-2.0
   '228':
     licensed:
-      declared: BSD-3-Clause
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pywin32	228

**Details:**
License file in package indicates license is BSD-3

**Resolution:**
While the PyPi site indicates the license is Python Software Foundation License, the actual license file in the package is BSD-3

**Affected definitions**:
- [pywin32 228](https://clearlydefined.io/definitions/pypi/pypi/-/pywin32/228/228)