### PR TITLE
Xamarin.Android.Support.CustomTabs 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.CustomTabs.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.CustomTabs.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.CustomTabs.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.CustomTabs 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license (MIT). Tagged version:

https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.CustomTabs 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.CustomTabs/28.0.0.3/28.0.0.3)