### PR TITLE
Xamarin.Android.Support.Transition 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Transition.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Transition.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.Transition.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.Transition 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license (MIT). Tagged version:

https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Transition 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Transition/28.0.0.3/28.0.0.3)