### PR TITLE
Microsoft.Bot.Configuration 4.5.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.5.3:
+    licensed:
+      declared: MIT
   4.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Configuration 4.5.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license (MIT): https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

Project license/ tagged version: https://github.com/microsoft/botbuilder-dotnet/blob/4.5.3/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Configuration 4.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Configuration/4.5.3/4.5.3)