### PR TITLE
protobuf-net 2.3.2

### DIFF
--- a/curations/nuget/nuget/-/protobuf-net.yaml
+++ b/curations/nuget/nuget/-/protobuf-net.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.0:
     licensed:
       declared: Apache-2.0 AND BSD-3-Clause
+  2.3.2:
+    licensed:
+      declared: BSD-3-Clause AND Apache-2.0
   2.4.0:
     licensed:
       declared: Apache-2.0 AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
protobuf-net 2.3.2

**Details:**
Declaring BSD-3-Clause and Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master repo license, same as tagged version:
https://github.com/protobuf-net/protobuf-net/blob/2.3.2/Licence.txt

**Affected definitions**:
- [protobuf-net 2.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/protobuf-net/2.3.2/2.3.2)