### PR TITLE
NLog.Extensions.Logging 1.6.2

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -18,3 +18,6 @@ revisions:
   1.6.1:
     licensed:
       declared: BSD-2-Clause
+  1.6.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NLog.Extensions.Logging 1.6.2

**Details:**
Declaring BSD-2-Clause

**Resolution:**


NuGet metadata goes to GitHub master repo license (BSD-2-Clause). License for tagged version:
https://github.com/NLog/NLog.Extensions.Logging/blob/v1.6.2/LICENSE

**Affected definitions**:
- [NLog.Extensions.Logging 1.6.2](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.6.2/1.6.2)