### PR TITLE
vscode-chrome-debug-core 6.8.7

### DIFF
--- a/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
+++ b/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
@@ -18,3 +18,6 @@ revisions:
   6.7.46:
     licensed:
       declared: MIT
+  6.8.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
vscode-chrome-debug-core 6.8.7

**Details:**
Declaring MIT

**Resolution:**
NPM metadata goes to GitHub repo

https://github.com/microsoft/vscode-chrome-debug-core/blob/v6.8.7/LICENSE.txt

**Affected definitions**:
- [vscode-chrome-debug-core 6.8.7](https://clearlydefined.io/definitions/npm/npmjs/-/vscode-chrome-debug-core/6.8.7/6.8.7)