### PR TITLE
css-mediaquery 0.1.2

### DIFF
--- a/curations/npm/npmjs/-/css-mediaquery.yaml
+++ b/curations/npm/npmjs/-/css-mediaquery.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: css-mediaquery
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
css-mediaquery 0.1.2

**Details:**
Declaring BSD-3-Clause

**Resolution:**
ClearlyDefined Files License: BSD-3-Clause

NPM page also notes BSD

Project site, tagged version: https://github.com/ericf/css-mediaquery/blob/v0.1.2/LICENSE


**Affected definitions**:
- [css-mediaquery 0.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/css-mediaquery/0.1.2/0.1.2)