### PR TITLE
Microsoft.NET.Sdk.Functions	3.0.6

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -48,6 +48,9 @@ revisions:
   3.0.5:
     licensed:
       declared: MIT
+  3.0.6:
+    licensed:
+      declared: MIT
   3.0.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NET.Sdk.Functions	3.0.6

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
Project site also indicates license is MIT

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.6/3.0.6)