### PR TITLE
Declare Python-2.0

### DIFF
--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -11,7 +11,10 @@ revisions:
       declared: Python-2.0
   2020.2.20:
     licensed:
-      declared: Python-2.0  
+      declared: Python-2.0
   2020.4.4:
+    licensed:
+      declared: Python-2.0
+  2020.6.8:
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare Python-2.0

**Details:**
Declare Python-2.0 found in the metadata of the Download files here (https://pypi.org/project/regex/2020.6.8/)

**Resolution:**
Matches project description

**Affected definitions**:
- [regex 2020.6.8](https://clearlydefined.io/definitions/pypi/pypi/-/regex/2020.6.8/2020.6.8)