### PR TITLE
Microsoft.Exchange.WebServices 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Exchange.WebServices.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Exchange.WebServices.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Exchange.WebServices
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Exchange.WebServices 2.2.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master; MIT

https://github.com/OfficeDev/ews-managed-api/blob/master/license.txt

Closest commit:
https://github.com/OfficeDev/ews-managed-api/blob/b0e8021d51c1547df7aa907d9a3335ed0b9ddf6e/license.txt

**Affected definitions**:
- [Microsoft.Exchange.WebServices 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Exchange.WebServices/2.2.0/2.2.0)