### PR TITLE
Declared for numpy1.18.4

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -51,3 +51,6 @@ revisions:
   1.18.3:
     licensed:
       declared: BSD-3-Clause
+  1.18.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for numpy1.18.4

**Details:**
Pypi metadata is "BSD."  License.txt in package is BSD-3-Clause.

**Resolution:**
Includes other licenses at file level but overall 'declared' license is BSD-3-Clause.

**Affected definitions**:
- [numpy 1.18.4](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.18.4/1.18.4)