### PR TITLE
Declared for log4j/log4j1.2.17

### DIFF
--- a/curations/maven/mavencentral/log4j/log4j.yaml
+++ b/curations/maven/mavencentral/log4j/log4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: log4j
+  namespace: log4j
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for log4j/log4j1.2.17

**Details:**
Apache-2.0 on metadata - https://repo1.maven.org/maven2/log4j/log4j/1.2.17/log4j-1.2.17.pom

**Resolution:**
And in source package -  .java file headers say Apache-2.0

**Affected definitions**:
- [log4j 1.2.17](https://clearlydefined.io/definitions/maven/mavencentral/log4j/log4j/1.2.17/1.2.17)