### PR TITLE
Declared for msal-extensions0.1.3

### DIFF
--- a/curations/pypi/pypi/-/msal-extensions.yaml
+++ b/curations/pypi/pypi/-/msal-extensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: msal-extensions
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for msal-extensions0.1.3

**Details:**
License fine inside package is MIT

**Resolution:**
    MIT License

    Copyright (c) Microsoft Corporation. All rights reserved.

**Affected definitions**:
- [msal-extensions 0.1.3](https://clearlydefined.io/definitions/pypi/pypi/-/msal-extensions/0.1.3/0.1.3)