### PR TITLE
Declared for vswhere 2.3.7

### DIFF
--- a/curations/nuget/nuget/-/vswhere.yaml
+++ b/curations/nuget/nuget/-/vswhere.yaml
@@ -12,6 +12,9 @@ revisions:
   2.3.2:
     licensed:
       declared: MIT
+  2.3.7:
+    licensed:
+      declared: MIT
   2.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for vswhere 2.3.7

**Details:**
Source link, NuGet License info link, and LICENSE.txt in package - all MIT

**Resolution:**
MIT

**Affected definitions**:
- [vswhere 2.3.7](https://clearlydefined.io/definitions/nuget/nuget/-/vswhere/2.3.7/2.3.7)