### PR TITLE
Declared for typed-ast 1.4.1

### DIFF
--- a/curations/pypi/pypi/-/typed-ast.yaml
+++ b/curations/pypi/pypi/-/typed-ast.yaml
@@ -6,3 +6,6 @@ revisions:
   1.4.0:
     licensed:
       declared: Apache-2.0 AND Python-2.0
+  1.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Declared for typed-ast 1.4.1

**Details:**
Hard to tell "declared" from "discovered" on the license file. 
 Based on the metadata here - https://pypi.org/project/typed-ast/1.4.1/ - going to put Apache-2.0 as "declared" and leave Python and MIT as discovered.

**Resolution:**
https://pypi.org/project/typed-ast/1.4.1/

**Affected definitions**:
- [typed-ast 1.4.1](https://clearlydefined.io/definitions/pypi/pypi/-/typed-ast/1.4.1/1.4.1)