### PR TITLE
Declared for typing-extensions - Python-2.0

### DIFF
--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -12,3 +12,6 @@ revisions:
   3.7.4.1:
     licensed:
       declared: Python-2.0
+  3.7.4.2:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for typing-extensions - Python-2.0

**Details:**
Python-2.0 found in metadata in download files - Doesn't specifically note 2.0 but was advised to list that if not specified

**Resolution:**
Matches Project homepage

**Affected definitions**:
- [typing-extensions 3.7.4.2](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/3.7.4.2/3.7.4.2)