### PR TITLE
org.scala-lang/scalap/2.11.0

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scalap.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scalap.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: scalap
+  namespace: org.scala-lang
+  provider: mavencentral
+  type: maven
+revisions:
+  2.11.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scalap/2.11.0

**Details:**
.pom file indicates license is BSD-3

**Resolution:**
License URL in pom file indicates versions distributed prior to December 2018 were distributed under BSD-3

**Affected definitions**:
- [scalap 2.11.0](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scalap/2.11.0/2.11.0)