### PR TITLE
Microsoft.Extensions.Configuration.AzureAppConfiguration	3.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.0:
     licensed:
       declared: OTHER
+  3.0.1:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: OTHER
   3.0.1:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Extensions.Configuration.AzureAppConfiguration	3.0.1

**Details:**
Project site indicates license is MIT

**Resolution:**
License history indicates MIT was license at initial commit and hasn't changed

**Affected definitions**:
- [Microsoft.Extensions.Configuration.AzureAppConfiguration 3.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration/3.0.1/3.0.1)