### PR TITLE
Microsoft.IdentityModel.Clients.ActiveDirectory	2.18.206251556

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -5,45 +5,45 @@ coordinates:
 revisions:
   2.14.201151115:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.16.204221202:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.18.206251556:
     licensed:
       declared: Apache-2.0
   2.19.208020213:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.21.301221612:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.22.302111727:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.23.302261847:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.24.304111323:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.26.305102204:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.28.1:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.28.2:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.28.3:
     described:
       releaseDate: '2016-11-18'
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.28.4:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.29.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -9,6 +9,9 @@ revisions:
   2.16.204221202:
     licensed:
       declared: MIT
+  2.18.206251556:
+    licensed:
+      declared: Apache-2.0
   2.19.208020213:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Clients.ActiveDirectory	2.18.206251556

**Details:**
License when package was released was Apache 2.0

**Resolution:**
License history on project site indicates license at time of release was Apache 2.0, prior to change to MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 2.18.206251556](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/2.18.206251556/2.18.206251556)