### PR TITLE
Microsoft.Azure.EventHubs.Processor	3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.EventHubs.Processor.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.EventHubs.Processor.yaml
@@ -15,3 +15,6 @@ revisions:
   2.2.1:
     licensed:
       declared: MIT
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.EventHubs.Processor	3.0.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License history on project site indicates license at time of release was MIT

**Affected definitions**:
- [Microsoft.Azure.EventHubs.Processor 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.EventHubs.Processor/3.0.0/3.0.0)