### PR TITLE
Add BSD 3 Clause License

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.yaml
@@ -7,3 +7,6 @@ revisions:
   0.1.42:
     licensed:
       declared: BSD-3-Clause
+  0.1.54:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3 Clause License

**Details:**
No info in package files. Links to meta data were not functional. Found repo and checked pom file, states BSD and language confirms 3 Clause. https://mvnrepository.com/artifact/com.jcraft/jsch/0.1.54

**Resolution:**
http://www.jcraft.com/jsch/LICENSE.txt

**Affected definitions**:
- [jsch 0.1.54](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch/0.1.54/0.1.54)