### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/System.Resources.Extensions.yaml
+++ b/curations/nuget/nuget/-/System.Resources.Extensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Resources.Extensions
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data and source repo point to MIT License. 

**Resolution:**
https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- [System.Resources.Extensions 4.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Resources.Extensions/4.6.0/4.6.0)