### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.WsFederation.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.WsFederation.yaml
@@ -9,6 +9,9 @@ revisions:
   5.2.2:
     licensed:
       declared: MIT
+  5.2.4:
+    licensed:
+      declared: MIT
   5.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. meta data and source repo point to MIT License. 

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/rel/5.2.4/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.Protocols.WsFederation 5.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocols.WsFederation/5.2.4/5.2.4)