### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -36,6 +36,9 @@ revisions:
   5.2.1:
     licensed:
       declared: MIT
+  5.3.1:
+    licensed:
+      declared: MIT
   5.3.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package info indicates MIT License. Meta data confirms. 

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.3.1/5.3.1)