### PR TITLE
Add MS-PL Locense

### DIFF
--- a/curations/nuget/nuget/-/CommonServiceLocator.yaml
+++ b/curations/nuget/nuget/-/CommonServiceLocator.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.0:
     licensed:
       declared: MS-PL
+  1.2.0:
+    licensed:
+      declared: MS-PL
   1.3.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MS-PL Locense

**Details:**
No info in package files. Meta data says package was relocated to github. Github shows MS-PL. 

**Resolution:**
https://github.com/unitycontainer/commonservicelocator/blob/master/LICENSE

**Affected definitions**:
- [CommonServiceLocator 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommonServiceLocator/1.2.0/1.2.0)