### PR TITLE
Add BSD 3 Clause License

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -12,3 +12,6 @@ revisions:
   0.4.2:
     licensed:
       declared: BSD-3-Clause
+  0.5.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add BSD 3 Clause License

**Details:**
No info in package files. Meta data point to BSD 3 Clause. 

**Resolution:**
https://github.com/pytorch/vision/blob/v0.5.0/LICENSE

**Affected definitions**:
- [torchvision 0.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.5.0/0.5.0)