### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-compiler.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-compiler.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.11.0:
+    licensed:
+      declared: Apache-2.0
   2.11.12:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Links in Clearly Defined are inoperable. Found Maven repo. Pom file indicates Apache 2.0. https://mvnrepository.com/artifact/org.scala-lang/scala-compiler/2.11.0

**Resolution:**
https://www.scala-lang.org/license/

**Affected definitions**:
- [scala-compiler 2.11.0](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-compiler/2.11.0/2.11.0)