### PR TITLE
Add MIT License

### DIFF
--- a/curations/pypi/pypi/-/opt-einsum.yaml
+++ b/curations/pypi/pypi/-/opt-einsum.yaml
@@ -9,3 +9,6 @@ revisions:
   3.2.0:
     licensed:
       declared: MIT
+  3.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files indicate MIT. Meta data confirms. 

**Resolution:**
https://github.com/dgasmith/opt_einsum/blob/v3.2.1/LICENSE

**Affected definitions**:
- [opt-einsum 3.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/opt-einsum/3.2.1/3.2.1)