### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -12,3 +12,6 @@ revisions:
   5.11.5:
     licensed:
       declared: Apache-2.0
+  5.7.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data points to Apache 2.0, Source repo confirms. 

**Resolution:**
https://github.com/unitycontainer/unity/blob/5.7.0.476/LICENSE

**Affected definitions**:
- [Unity.Container 5.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.7.0/5.7.0)