### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
@@ -12,3 +12,6 @@ revisions:
   0.22.9-build00167:
     licensed:
       declared: MIT
+  1.0.0-build00159:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data points to MIT and source repo confirms. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.JavaScript 1.0.0-build00159](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript/1.0.0-build00159/1.0.0-build00159)