### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/SendGrid.CSharp.HTTP.Client.yaml
+++ b/curations/nuget/nuget/-/SendGrid.CSharp.HTTP.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SendGrid.CSharp.HTTP.Client
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data link seems broken. Source repo indicates MIT. 

**Resolution:**
https://github.com/sendgrid/csharp-http-client/blob/v3.0.0/LICENSE.txt

**Affected definitions**:
- [SendGrid.CSharp.HTTP.Client 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/SendGrid.CSharp.HTTP.Client/3.0.0/3.0.0)