### PR TITLE
Add LGPL 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -5,13 +5,13 @@ coordinates:
 revisions:
   1.0.129:
     licensed:
-      declared: GPL-2.0-only
+      declared: GPL-2.0-only WITH OTHER
   1.0.81:
     licensed:
-      declared: GPL-2.0-only
+      declared: GPL-2.0-only WITH OTHER
   2.0.267:
     licensed:
       declared: GPL-2.0-only WITH OTHER
   2.0.289:
     licensed:
-      declared: LGPL-2.0-only
+      declared: GPL-2.0-only WITH OTHER

--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -12,3 +12,6 @@ revisions:
   2.0.267:
     licensed:
       declared: GPL-2.0-only WITH OTHER
+  2.0.289:
+    licensed:
+      declared: LGPL-2.0-only


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Add GPL 2.0 License

**Details:**
Conflicting license info in package files. Meta data points to LGPL 2.0.  

**Resolution:**
https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 2.0.289](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/2.0.289/2.0.289)