### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -12,3 +12,6 @@ revisions:
   5.11.5:
     licensed:
       declared: Apache-2.0
+  5.8.11:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. meta data points to Apache 2.0. 

**Resolution:**
https://github.com/unitycontainer/unity/blob/master/LICENSE

**Affected definitions**:
- [Unity.Container 5.8.11](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.8.11/5.8.11)