### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/DgmlImage.yaml
+++ b/curations/nuget/nuget/-/DgmlImage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DgmlImage
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://microsoft.mit-license.org/

**Affected definitions**:
- [DgmlImage 1.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/DgmlImage/1.0.0.1/1.0.0.1)