### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.DocumentDB
+  provider: nuget
+  type: nuget
+revisions:
+  2.11.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info package files. Meta data link did not work. Source repo points to MIT. 

**Resolution:**
https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.11.0/2.11.0)