### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/BuildBundlerMinifier.yaml
+++ b/curations/nuget/nuget/-/BuildBundlerMinifier.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: BuildBundlerMinifier
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.435:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data points to Apache 2.0.

**Resolution:**
https://github.com/madskristensen/BundlerMinifier/blob/master/LICENSE

**Affected definitions**:
- [BuildBundlerMinifier 3.2.435](https://clearlydefined.io/definitions/nuget/nuget/-/BuildBundlerMinifier/3.2.435/3.2.435)