### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/log4net.yaml
+++ b/curations/nuget/nuget/-/log4net.yaml
@@ -15,6 +15,9 @@ revisions:
   2.0.5:
     licensed:
       declared: Apache-2.0
+  2.0.6:
+    licensed:
+      declared: Apache-2.0
   2.0.7:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Meta data confirms discovered license, Apache 2.0. 

**Resolution:**
http://logging.apache.org/log4net/license.html

**Affected definitions**:
- [log4net 2.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/log4net/2.0.6/2.0.6)