### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/CommandLineArgumentsParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineArgumentsParser.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.13:
     licensed:
       declared: MIT
+  3.0.20:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://raw.githubusercontent.com/j-maly/CommandLineParser/master/LICENCE.md

**Affected definitions**:
- [CommandLineArgumentsParser 3.0.20](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineArgumentsParser/3.0.20/3.0.20)