### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  5.0.0:
+    licensed:
+      declared: MIT
   5.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Newtonsoft 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft/5.0.0/5.0.0)