### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -12,6 +12,9 @@ revisions:
   2.8.1:
     licensed:
       declared: MIT
+  2.9.0:
+    licensed:
+      declared: MIT
   2.9.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta Data points to MIT. 

**Resolution:**
https://github.com/OfficeDev/Open-XML-SDK/blob/master/LICENSE

**Affected definitions**:
- [DocumentFormat.OpenXml 2.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/DocumentFormat.OpenXml/2.9.0/2.9.0)