### PR TITLE
Add Other License

### DIFF
--- a/curations/nuget/nuget/-/BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/BouncyCastle.yaml
@@ -12,6 +12,9 @@ revisions:
   1.8.2:
     licensed:
       declared: MIT
+  1.8.3.1:
+    licensed:
+      declared: OTHER
   1.8.4:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/BouncyCastle.yaml
@@ -14,7 +14,7 @@ revisions:
       declared: MIT
   1.8.3.1:
     licensed:
-      declared: OTHER
+      declared: MIT
   1.8.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Other License

**Details:**
No info in package files. Meta data points to Bouncy Castle License. Curated as Other. 

**Resolution:**
http://www.bouncycastle.org/licence.html

**Affected definitions**:
- [BouncyCastle 1.8.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/BouncyCastle/1.8.3.1/1.8.3.1)