### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -9,6 +9,9 @@ revisions:
   4.7.0:
     licensed:
       declared: MIT
+  4.7.2:
+    licensed:
+      declared: MIT
   4.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.7.2/4.7.2)