### PR TITLE
source for Microsoft.CSharp 4.5.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CSharp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CSharp.yaml
@@ -10,6 +10,14 @@ revisions:
     licensed:
       declared: MIT
   4.5.0:
+    described:
+      sourceLocation:
+        name: corefx
+        namespace: dotnet
+        provider: github
+        revision: 65e7ccd1d03987a457c26b2b1afc2ad867e35749
+        type: git
+        url: 'https://github.com/dotnet/corefx/commit/65e7ccd1d03987a457c26b2b1afc2ad867e35749'
     licensed:
       declared: MIT
   4.6.0:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
source for Microsoft.CSharp 4.5.0

**Details:**
missing commit id for the release 4.5.0

**Resolution:**
added the information

**Affected definitions**:
- [Microsoft.CSharp 4.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CSharp/4.5.0/4.5.0)