### PR TITLE
Swashbuckle.AspNetCore.SwaggerGen 5.5.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -42,3 +42,6 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.SwaggerGen 5.5.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.5.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 5.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/5.5.0/5.5.0)