### PR TITLE
Swashbuckle.AspNetCore.Newtonsoft 5.5.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
@@ -6,3 +6,6 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.Newtonsoft 5.5.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.5.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Newtonsoft 5.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft/5.5.0/5.5.0)