### PR TITLE
ClosedXML.Signed 0.94.2

### DIFF
--- a/curations/nuget/nuget/-/ClosedXML.Signed.yaml
+++ b/curations/nuget/nuget/-/ClosedXML.Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ClosedXML.Signed
+  provider: nuget
+  type: nuget
+revisions:
+  0.94.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ClosedXML.Signed 0.94.2

**Details:**
Declaring MIT

**Resolution:**
NuGet goes to GitHub master repo license: MIT

Tagged version: https://github.com/ClosedXML/ClosedXML/blob/0.94.2/LICENSE

**Affected definitions**:
- [ClosedXML.Signed 0.94.2](https://clearlydefined.io/definitions/nuget/nuget/-/ClosedXML.Signed/0.94.2/0.94.2)