### PR TITLE
Fs.Processes 0.1.14

### DIFF
--- a/curations/nuget/nuget/-/Fs.Processes.yaml
+++ b/curations/nuget/nuget/-/Fs.Processes.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Fs.Processes
+  provider: nuget
+  type: nuget
+revisions:
+  0.1.14:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Fs.Processes 0.1.14

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license: https://github.com/williamb1024/fs-processes/blob/master/LICENSE.txt

Commit for this version:
https://github.com/williamb1024/fs-processes/blob/8fb3cfcf82f805547b29590e6296ae87ab15e585/LICENSE.txt

**Affected definitions**:
- [Fs.Processes 0.1.14](https://clearlydefined.io/definitions/nuget/nuget/-/Fs.Processes/0.1.14/0.1.14)