### PR TITLE
CairoSVG 2.4.2

### DIFF
--- a/curations/pypi/pypi/-/CairoSVG.yaml
+++ b/curations/pypi/pypi/-/CairoSVG.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CairoSVG
+  provider: pypi
+  type: pypi
+revisions:
+  2.4.2:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
CairoSVG 2.4.2

**Details:**
Fixing Declared License to "LGPL 3.0 or later".

(I see no mention of GPLv3.0 and the license does not limit to LGPL 3.0 only)

**Resolution:**
PyPi metadata: https://pypi.org/project/CairoSVG/2.4.2/

https://github.com/Kozea/CairoSVG/blob/2.4.2/LICENSE

**Affected definitions**:
- [CairoSVG 2.4.2](https://clearlydefined.io/definitions/pypi/pypi/-/CairoSVG/2.4.2/2.4.2)