### PR TITLE
Declare BSD-3-Clause org.scala-lang:scala-library

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.11.12:
+    licensed:
+      declared: BSD-3-Clause
   2.11.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare BSD-3-Clause org.scala-lang:scala-library

**Details:**
Found here (https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.12/scala-library-2.11.12.pom) 

**Resolution:**
Matches Project Site and Project site explaining change of license here (https://www.scala-lang.org/license/)

**Affected definitions**:
- [scala-library 2.11.12](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-library/2.11.12/2.11.12)