### PR TITLE
Microsoft.Azure.DocumentDB Changed from OTHER to MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.DocumentDB
+  provider: nuget
+  type: nuget
+revisions:
+  2.10.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.Azure.DocumentDB Changed from OTHER to MIT

**Details:**
MIT found here (https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/LICENSE)

**Resolution:**
No tags and license link is broken - no other indication the license would be anything but MIT

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.10.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.10.3/2.10.3)