### PR TITLE
Declared for git-for-windows/git 907ab1011d...

### DIFF
--- a/curations/git/github/git-for-windows/git.yaml
+++ b/curations/git/github/git-for-windows/git.yaml
@@ -9,3 +9,6 @@ revisions:
       releaseDate: '2019-02-26'
     licensed:
       declared: GPL-2.0-or-later
+  907ab1011dce9112700498e034b974ba60f8b407:
+    licensed:
+      declared: GPL-2.0-only

--- a/curations/git/github/git-for-windows/git.yaml
+++ b/curations/git/github/git-for-windows/git.yaml
@@ -8,7 +8,7 @@ revisions:
     described:
       releaseDate: '2019-02-26'
     licensed:
-      declared: GPL-2.0-or-later
+      declared: GPL-2.0-only
   907ab1011dce9112700498e034b974ba60f8b407:
     licensed:
       declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared for git-for-windows/git 907ab1011d...

**Details:**
I think the "declared" is only "GPL-2.0-only." The rest are "discovered."

**Resolution:**
https://github.com/git-for-windows/git/blob/907ab1011dce9112700498e034b974ba60f8b407/COPYING

**Affected definitions**:
- [git 907ab1011dce9112700498e034b974ba60f8b407](https://clearlydefined.io/definitions/git/github/git-for-windows/git/907ab1011dce9112700498e034b974ba60f8b407/907ab1011dce9112700498e034b974ba60f8b407)