### PR TITLE
JetBrains.Annotations10.1.4

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.Annotations.yaml
+++ b/curations/nuget/nuget/-/JetBrains.Annotations.yaml
@@ -6,6 +6,9 @@ revisions:
   10.0.0:
     licensed:
       declared: OTHER
+  10.1.4:
+    licensed:
+      declared: MIT
   10.1.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.Annotations10.1.4

**Details:**
Earlier versions linked to commercial terms.  This version is MIT

**Resolution:**
MIT at the file level and MIT "License info" link.

**Affected definitions**:
- [JetBrains.Annotations 10.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.Annotations/10.1.4/10.1.4)