### PR TITLE
org.codehaus.janino:janino declare BSD-3-Clause

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.janino/janino.yaml
+++ b/curations/maven/mavencentral/org.codehaus.janino/janino.yaml
@@ -7,3 +7,6 @@ revisions:
   3.0.8:
     licensed:
       declared: BSD-3-Clause
+  3.0.9:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.codehaus.janino:janino declare BSD-3-Clause

**Details:**
BSD-3-Clause found here (https://mvnrepository.com/artifact/org.codehaus.janino/janino/3.0.9) under license and in the jar file (https://raw.githubusercontent.com/janino-compiler/janino/master/LICENSE)

**Resolution:**
Matches jar file

**Affected definitions**:
- [janino 3.0.9](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.janino/janino/3.0.9/3.0.9)