### PR TITLE
Declared for facebook/zstdb 706286adbb...

### DIFF
--- a/curations/git/github/facebook/zstd.yaml
+++ b/curations/git/github/facebook/zstd.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: zstd
+  namespace: facebook
+  provider: github
+  type: git
+revisions:
+  b706286adbba780006a47ef92df0ad7a785666b6:
+    licensed:
+      declared: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for facebook/zstdb 706286adbb...

**Details:**
Read me says: Zstandard is dual-licensed under BSD and GPLv2.

**Resolution:**
https://github.com/facebook/zstd/blob/b706286adbba780006a47ef92df0ad7a785666b6/LICENSE is BSD-3-Clause

**Affected definitions**:
- [zstd b706286adbba780006a47ef92df0ad7a785666b6](https://clearlydefined.io/definitions/git/github/facebook/zstd/b706286adbba780006a47ef92df0ad7a785666b6/b706286adbba780006a47ef92df0ad7a785666b6)