### PR TITLE
Updating Declared mdn-data1.1.4

### DIFF
--- a/curations/npm/npmjs/-/mdn-data.yaml
+++ b/curations/npm/npmjs/-/mdn-data.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mdn-data
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.4:
+    licensed:
+      declared: MPL-2.0-no-copyleft-exception


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating Declared mdn-data1.1.4

**Details:**
Current versions are CC0, but version 1.1.4 has the MPL-2.0-no-copyleft-exception license, which includes Exhibit B

**Resolution:**
See LICENSE under "Files," or follow "Source" link, or look here: https://cdn.jsdelivr.net/npm/mdn-data@1.1.4/LICENSE

**Affected definitions**:
- [mdn-data 1.1.4](https://clearlydefined.io/definitions/npm/npmjs/-/mdn-data/1.1.4/1.1.4)