### PR TITLE
Declared for highcharts 8.1.1

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -18,3 +18,6 @@ revisions:
   7.2.1:
     licensed:
       declared: OTHER
+  8.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for highcharts 8.1.1

**Details:**
Package.json points to https://www.highcharts.com/license

**Resolution:**
OTHER for commercial terms

**Affected definitions**:
- [highcharts 8.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/8.1.1/8.1.1)