### PR TITLE
org.scala-lang/scalap2 .11.0

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scalap.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scalap.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: scalap
+  namespace: org.scala-lang
+  provider: mavencentral
+  type: maven
+revisions:
+  2.11.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.scala-lang/scalap2 .11.0

**Details:**
Declaring BSD-3-Clause

**Resolution:**
POM file: https://repo1.maven.org/maven2/org/scala-lang/scalap/2.11.0/scalap-2.11.0.pom


This version was released in 2014 when Scala was using the BSD-3-Clause license

https://www.scala-lang.org/news/2.11.0/

**Affected definitions**:
- [scalap 2.11.0](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scalap/2.11.0/2.11.0)