### PR TITLE
NLog 4.6.5

### DIFF
--- a/curations/nuget/nuget/-/NLog.yaml
+++ b/curations/nuget/nuget/-/NLog.yaml
@@ -176,6 +176,9 @@ revisions:
   4.6.2:
     licensed:
       declared: BSD-3-Clause
+  4.6.5:
+    licensed:
+      declared: BSD-3-Clause
   4.6.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NLog 4.6.5

**Details:**
Declaring BSD-3-Clause

**Resolution:**
NuGet metadata goes to GitHub master license, same as Project license: BSD-3-Clause

Tagged version:
https://github.com/NLog/NLog/blob/v4.6.5/LICENSE.txt

https://nlog-project.org/

**Affected definitions**:
- [NLog 4.6.5](https://clearlydefined.io/definitions/nuget/nuget/-/NLog/4.6.5/4.6.5)