### PR TITLE
Pyphen 0.9.5

### DIFF
--- a/curations/pypi/pypi/-/Pyphen.yaml
+++ b/curations/pypi/pypi/-/Pyphen.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.9.5:
     licensed:
-      declared: (GPL-2.0-or-later OR LGPL-2.1-or-later) AND (MPL-1.1 )
+      declared: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1

--- a/curations/pypi/pypi/-/Pyphen.yaml
+++ b/curations/pypi/pypi/-/Pyphen.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Pyphen
+  provider: pypi
+  type: pypi
+revisions:
+  0.9.5:
+    licensed:
+      declared: (GPL-2.0-or-later OR LGPL-2.1-or-later) AND (MPL-1.1 )


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pyphen 0.9.5

**Details:**
Fixing the Declared License to 
GPL v2.0 or later OR LGPL v2.1 or later OR MPL 1.1

**Resolution:**
PyPI metadata:
 GNU General Public License v2 or later (GPLv2+), GNU Lesser General Public License v2 or later (LGPLv2+), Mozilla Public License 1.1 (MPL 1.1)


and 

https://github.com/Kozea/Pyphen/blob/0.9.5/COPYING

**Affected definitions**:
- [Pyphen 0.9.5](https://clearlydefined.io/definitions/pypi/pypi/-/Pyphen/0.9.5/0.9.5)