### PR TITLE
Declared for

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Kinect.Sensor.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Kinect.Sensor.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.Kinect.Sensor
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for

**Details:**
Source is MIT, but the NuGet "license info" link goes to a EULA - https://www.nuget.org/packages/Microsoft.Azure.Kinect.Sensor/1.3.0/License

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Microsoft.Azure.Kinect.Sensor 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Kinect.Sensor/1.3.0/1.3.0)