### PR TITLE
Declared for highcharts 7.1.3

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -15,6 +15,9 @@ revisions:
   7.1.2:
     licensed:
       declared: OTHER
+  7.1.3:
+    licensed:
+      declared: OTHER
   7.2.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for highcharts 7.1.3

**Details:**
ReadMe points to https://shop.highsoft.com/media/highsoft/Standard-License-Agreement-12.0.pdf

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [highcharts 7.1.3](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/7.1.3/7.1.3)