### PR TITLE
Declared for bitstadium/hockeysdk-ios 055f2e980

### DIFF
--- a/curations/git/github/bitstadium/hockeysdk-ios.yaml
+++ b/curations/git/github/bitstadium/hockeysdk-ios.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  055f2e9804b351812c7eb25f48f538d5cf1d9970:
+    licensed:
+      declared: MIT
   dabf7f9f66b27a4dca089ad6dbbece04bae7d7dd:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for bitstadium/hockeysdk-ios 055f2e980

**Details:**
Per the LICENSE file, the 'declared' license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [hockeysdk-ios 055f2e9804b351812c7eb25f48f538d5cf1d9970](https://clearlydefined.io/definitions/git/github/bitstadium/hockeysdk-ios/055f2e9804b351812c7eb25f48f538d5cf1d9970/055f2e9804b351812c7eb25f48f538d5cf1d9970)