### PR TITLE
axe-android: Add missing MPL-2.0 license decl

### DIFF
--- a/curations/maven/mavencentral/com.deque.android/axe-android.yaml
+++ b/curations/maven/mavencentral/com.deque.android/axe-android.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: axe-android
+  namespace: com.deque.android
+  provider: mavencentral
+  type: maven
+revisions:
+  0.2.0:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
axe-android: Add missing MPL-2.0 license decl

**Details:**
Component is missing license declaration.

**Resolution:**
Updates declared license to MPL-2.0. Sources:

* https://mvnrepository.com/artifact/com.deque.android/axe-android/0.2.0
* https://github.com/dequelabs/axe-android/blob/0.2.0/LICENSE

**Affected definitions**:
- [axe-android 0.2.0](https://clearlydefined.io/definitions/maven/mavencentral/com.deque.android/axe-android/0.2.0)