### PR TITLE
Declared for Microsoft.Azure.Storage.CPP.v1405.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Storage.CPP.v140.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Storage.CPP.v140.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.Storage.CPP.v140
+  provider: nuget
+  type: nuget
+revisions:
+  5.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Microsoft.Azure.Storage.CPP.v1405.0.0

**Details:**
"License info" link goes to: https://go.microsoft.com/fwlink/?LinkId=235170

**Resolution:**
Other for EULA

**Affected definitions**:
- [Microsoft.Azure.Storage.CPP.v140 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Storage.CPP.v140/5.0.0/5.0.0)