### PR TITLE
Declared for Microsoft.Azure.RemoteRendering.Cpp0.1.32

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.RemoteRendering.Cpp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.RemoteRendering.Cpp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.RemoteRendering.Cpp
+  provider: nuget
+  type: nuget
+revisions:
+  0.1.32:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared for Microsoft.Azure.RemoteRendering.Cpp0.1.32

**Details:**
"License info" link: https://www.nuget.org/packages/Microsoft.Azure.RemoteRendering.Cpp/0.1.32/License

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Microsoft.Azure.RemoteRendering.Cpp 0.1.32](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.RemoteRendering.Cpp/0.1.32/0.1.32)