### PR TITLE
gensim 3.8.3

### DIFF
--- a/curations/pypi/pypi/-/gensim.yaml
+++ b/curations/pypi/pypi/-/gensim.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.8.3:
     licensed:
-      declared: LGPL-2.0-or-later
+      declared: LGPL-2.1-only

--- a/curations/pypi/pypi/-/gensim.yaml
+++ b/curations/pypi/pypi/-/gensim.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: gensim
+  provider: pypi
+  type: pypi
+revisions:
+  3.8.3:
+    licensed:
+      declared: LGPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
gensim 3.8.3

**Details:**
Fixing the Declared license to LGPL 2.0 or later

**Resolution:**
PyPi meta: GNU Lesser General Public License v2 or later (LGPLv2+) (LGPLv2.1)

https://pypi.org/project/gensim/3.8.3/

**Affected definitions**:
- [gensim 3.8.3](https://clearlydefined.io/definitions/pypi/pypi/-/gensim/3.8.3/3.8.3)