### PR TITLE
runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform6.2.10

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  6.2.10:
+    licensed:
+      declared: OTHER
   6.2.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform6.2.10

**Details:**
NuGet license link goes to a EULA: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform 6.2.10](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm.Microsoft.NETCore.UniversalWindowsPlatform/6.2.10/6.2.10)