### PR TITLE
Unidecode 1.1.1

### DIFF
--- a/curations/pypi/pypi/-/Unidecode.yaml
+++ b/curations/pypi/pypi/-/Unidecode.yaml
@@ -19,3 +19,6 @@ revisions:
         path: Unidecode-1.0.23/ChangeLog
     licensed:
       declared: GPL-2.0-or-later
+  1.1.1:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Unidecode 1.1.1

**Details:**
Fixing the Declared license to GPLv2 or later

**Resolution:**
PyPI metadata: License: GNU General Public License v2 or later (GPLv2+) (GPL)

GPLv2 license file also included in the package download.

**Affected definitions**:
- [Unidecode 1.1.1](https://clearlydefined.io/definitions/pypi/pypi/-/Unidecode/1.1.1/1.1.1)