### PR TITLE
Microsoft.Management.Infrastructure.Runtime.Win2.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Management.Infrastructure.Runtime.Win.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Management.Infrastructure.Runtime.Win.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Management.Infrastructure.Runtime.Win
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Management.Infrastructure.Runtime.Win2.0.0

**Details:**
Declaring Other for NuGet package under Microsoft EULA

**Resolution:**
NuGet metadata: 
https://www.nuget.org/packages/Microsoft.Management.Infrastructure.Runtime.Win/2.0.0/License

Note: Project license goes to GitHub master license (MIT), no tagged version.

**Affected definitions**:
- [Microsoft.Management.Infrastructure.Runtime.Win 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Management.Infrastructure.Runtime.Win/2.0.0/2.0.0)