### PR TITLE
Microsoft.Bot.Builder.Integration.AspNet.Core 4.5.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.5.3:
+    licensed:
+      declared: MIT
   4.6.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Builder.Integration.AspNet.Core 4.5.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license (MIT), no tagged version

Close commit to release date for this version: https://github.com/microsoft/botframework-sdk/blob/5710d35ee35a69eaded8c8bdbaa962ba76f4cf14/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.5.3/4.5.3)