### PR TITLE
Fixing previous curation to Apache 2.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.assert.yaml
+++ b/curations/nuget/nuget/-/xunit.assert.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: Apache-2.0
   2.1.0:
     described:
       releaseDate: '2015-09-27'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing previous curation to Apache 2.0

**Details:**
https://raw.githubusercontent.com/xunit/xunit/master/license.txt

**Resolution:**
https://raw.githubusercontent.com/xunit/xunit/master/license.txt

**Affected definitions**:
- [xunit.assert 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.assert/2.0.0/2.0.0)