### PR TITLE
Plugin.CurrentActivity 2.1.0.4

### DIFF
--- a/curations/nuget/nuget/-/Plugin.CurrentActivity.yaml
+++ b/curations/nuget/nuget/-/Plugin.CurrentActivity.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: Plugin.CurrentActivity
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
   1.0.1:
+    licensed:
+      declared: MIT
+  2.1.0.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Plugin.CurrentActivity 2.1.0.4

**Details:**
Declaring MIT

**Resolution:**
NuGet meta goes to GitHub master license: MIT

Tagged version: https://github.com/jamesmontemagno/CurrentActivityPlugin/blob/v2.1.0.4/LICENSE

**Affected definitions**:
- [Plugin.CurrentActivity 2.1.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/Plugin.CurrentActivity/2.1.0.4)