### PR TITLE
System.Collections.Immutable 1.6.0

### DIFF
--- a/curations/nuget/nuget/-/System.Collections.Immutable.yaml
+++ b/curations/nuget/nuget/-/System.Collections.Immutable.yaml
@@ -9,3 +9,6 @@ revisions:
   1.5.0:
     licensed:
       declared: MIT
+  1.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
System.Collections.Immutable 1.6.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: MIT license file

Project repo: Master license is MIT, commit matching to release date:

https://github.com/dotnet/corefx/blob/23f5ecd6a1231d286257d9cc2efda549efed949b/LICENSE.TXT

**Affected definitions**:
- [System.Collections.Immutable 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Collections.Immutable/1.6.0)