### PR TITLE
runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk2.2.10

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.2.10:
+    licensed:
+      declared: OTHER
   2.2.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk2.2.10

**Details:**
NuGet license link: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk 2.2.10](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-arm.Microsoft.Net.UWPCoreRuntimeSdk/2.2.10/2.2.10)