### PR TITLE
runtime.win10-x86.Microsoft.Net.Native.Compiler2.2.8-rel-28605-00

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-x86.Microsoft.Net.Native.Compiler.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-x86.Microsoft.Net.Native.Compiler.yaml
@@ -9,3 +9,6 @@ revisions:
   2.2.7-rel-27913-00:
     licensed:
       declared: OTHER
+  2.2.8-rel-28605-00:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
runtime.win10-x86.Microsoft.Net.Native.Compiler2.2.8-rel-28605-00

**Details:**
NuGet license link: https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [runtime.win10-x86.Microsoft.Net.Native.Compiler 2.2.8-rel-28605-00](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-x86.Microsoft.Net.Native.Compiler/2.2.8-rel-28605-00/2.2.8-rel-28605-00)