### PR TITLE
itsjafer/jupyterlab-sparkmonitorfcf25b4d38b

### DIFF
--- a/curations/git/github/itsjafer/jupyterlab-sparkmonitor.yaml
+++ b/curations/git/github/itsjafer/jupyterlab-sparkmonitor.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jupyterlab-sparkmonitor
+  namespace: itsjafer
+  provider: github
+  type: git
+revisions:
+  fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
itsjafer/jupyterlab-sparkmonitorfcf25b4d38b

**Details:**
It looks to me like this commit is Apache-2.0.  There is a package.json file that references LGPL.  But the source at this commit looks like Apache. 

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jupyterlab-sparkmonitor fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb](https://clearlydefined.io/definitions/git/github/itsjafer/jupyterlab-sparkmonitor/fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb/fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb)