### PR TITLE
itsjafer/jupyterlab-sparkmonitorfcf25b4d38b7e1

### DIFF
--- a/curations/git/github/itsjafer/jupyterlab-sparkmonitor.yaml
+++ b/curations/git/github/itsjafer/jupyterlab-sparkmonitor.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jupyterlab-sparkmonitor
+  namespace: itsjafer
+  provider: github
+  type: git
+revisions:
+  fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
itsjafer/jupyterlab-sparkmonitorfcf25b4d38b7e1

**Details:**
I think the declared license is only Apache-2.0

**Resolution:**
Deleting LGPL.2.1 from "Declared" field.

**Affected definitions**:
- [jupyterlab-sparkmonitor fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb](https://clearlydefined.io/definitions/git/github/itsjafer/jupyterlab-sparkmonitor/fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb/fcf25b4d38b7e1a103ebfd5657fd4feabd85acbb)