### PR TITLE
System.Security.Cryptography.Pkcs 4.4.0

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Cryptography.Pkcs.yaml
+++ b/curations/nuget/nuget/-/System.Security.Cryptography.Pkcs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.0:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
System.Security.Cryptography.Pkcs 4.4.0

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Files: License txt is MIT

NuGet meta goes to GitHub master repo license. Commit close to release date:
https://github.com/dotnet/corefx/blob/fab6ae579aff17cb9b464b2b167b7dfd8fcea175/LICENSE.TXT

**Affected definitions**:
- [System.Security.Cryptography.Pkcs 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Cryptography.Pkcs/4.4.0/4.4.0)