### PR TITLE
Xamarin.Android.Arch.Lifecycle.LiveData.Core 1.1.1.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.LiveData.Core.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.LiveData.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Arch.Lifecycle.LiveData.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Arch.Lifecycle.LiveData.Core 1.1.1.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license

Close commit to release date:
https://github.com/xamarin/AndroidSupportComponents/blob/c5a83e07c6a1ea0ac4ee63af667e70903fd3f567/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Lifecycle.LiveData.Core 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.LiveData.Core/1.1.1.3)