### PR TITLE
Xamarin.Android.Support.SlidingPaneLayout 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.SlidingPaneLayout.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.SlidingPaneLayout.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.Support.SlidingPaneLayout
+  provider: nuget
+  type: nuget
+revisions:
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.SlidingPaneLayout 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet meta goes to GitHub master repo license

Tagged version:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.SlidingPaneLayout 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.SlidingPaneLayout/28.0.0.3)