### PR TITLE
Xamarin.Android.Support.v 428.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.v4.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.v4.yaml
@@ -14,3 +14,6 @@ revisions:
         path: Xamarin.Android.Support.v4.nuspec
     licensed:
       declared: MIT
+  28.0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.v 428.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet meta goes to GitHub master repo license

Tagged version:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md


**Affected definitions**:
- [Xamarin.Android.Support.v4 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.v4/28.0.0.3)