### PR TITLE
Xamarin.Android.Support.v7.MediaRouter 28.0.0.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.v7.MediaRouter.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.v7.MediaRouter.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: Xamarin.Android.Support.v7.MediaRouter
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
   27.0.2:
+    licensed:
+      declared: MIT
+  28.0.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.v7.MediaRouter 28.0.0.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license

Tagged version:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.3/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.v7.MediaRouter 28.0.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.v7.MediaRouter/28.0.0.3)