### PR TITLE
Xamarin.Auth 1.7.0

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Auth.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Auth.yaml
@@ -9,3 +9,6 @@ revisions:
   1.6.0.2:
     licensed:
       declared: Apache-2.0
+  1.7.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Auth 1.7.0

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet meta goes to GitHub master repo license

Tagged version: https://github.com/xamarin/Xamarin.Auth/blob/1.7.0.0/License.md

**Affected definitions**:
- [Xamarin.Auth 1.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Auth/1.7.0)