### PR TITLE
Xamarin.Jetbrains.Annotations 13.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Jetbrains.Annotations.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Jetbrains.Annotations.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Jetbrains.Annotations
+  provider: nuget
+  type: nuget
+revisions:
+  13.0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Jetbrains.Annotations 13.0.0.1

**Details:**
Declaring MIT

**Resolution:**
NuGet meta goes to GitHub master repo license

Commit close to release date:
https://github.com/xamarin/XamarinComponents/blob/14706014ad73bcfb467722430bbfbd2850f297aa/LICENSE

**Affected definitions**:
- [Xamarin.Jetbrains.Annotations 13.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Jetbrains.Annotations/13.0.0.1)