### PR TITLE
Xamarin.Kotlin.StdLib.Common 1.3.50.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Kotlin.StdLib.Common.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Kotlin.StdLib.Common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Kotlin.StdLib.Common
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.50.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Kotlin.StdLib.Common 1.3.50.1

**Details:**
Declaring MIT

**Resolution:**
NuGet meta goes to GitHub master repo license

Tagged version: https://github.com/xamarin/XamarinComponents/blob/Kotlin-1.3.50.1/Android/Kotlin/LICENSE.md

**Affected definitions**:
- [Xamarin.Kotlin.StdLib.Common 1.3.50.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Kotlin.StdLib.Common/1.3.50.1)