### PR TITLE
Xamarin.Plugin.FilePicker 2.1.34

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Plugin.FilePicker.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Plugin.FilePicker.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Plugin.FilePicker
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.34:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Plugin.FilePicker 2.1.34

**Details:**
Declaring MIT

**Resolution:**
NuGet meta goes to GitHub master repo license

Close commit to release date:
https://github.com/jfversluis/FilePicker-Plugin-for-Xamarin-and-Windows/blob/9c43bcff9384412c9ab611184a38ab4503afb8b0/LICENSE

**Affected definitions**:
- [Xamarin.Plugin.FilePicker 2.1.34](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Plugin.FilePicker/2.1.34)