### PR TITLE
ZXing.Net.Mobile2.4.1

### DIFF
--- a/curations/nuget/nuget/-/ZXing.Net.Mobile.yaml
+++ b/curations/nuget/nuget/-/ZXing.Net.Mobile.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ZXing.Net.Mobile
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ZXing.Net.Mobile2.4.1

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet meta license link not found message 

On project site, commit matching to release date:
https://github.com/Redth/ZXing.Net.Mobile/blob/9d61732478eced2910333c52a5e458e7253f6846/LICENSE.txt

Master license in repo is also Apache 2.0

**Affected definitions**:
- [ZXing.Net.Mobile 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/ZXing.Net.Mobile/2.4.1)