### PR TITLE
Security.Cryptography 1.7.2

### DIFF
--- a/curations/nuget/nuget/-/Security.Cryptography.yaml
+++ b/curations/nuget/nuget/-/Security.Cryptography.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Security.Cryptography
+  provider: nuget
+  type: nuget
+revisions:
+  1.7.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Security.Cryptography 1.7.2

**Details:**
Declaring Other for Microsoft Limited Public License

**Resolution:**
NuGet project link goes to CodePlex (https://archive.codeplex.com/?p=clrsecurity), Downloaded Archive - license file in zip folder is MS-LPL

Project was migrated to GitHub. License was in repo is MIT from 2017.

**Affected definitions**:
- [Security.Cryptography 1.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/Security.Cryptography/1.7.2/1.7.2)