### PR TITLE
dotnet-xunit 2.3.1

### DIFF
--- a/curations/nuget/nuget/-/dotnet-xunit.yaml
+++ b/curations/nuget/nuget/-/dotnet-xunit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dotnet-xunit
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
dotnet-xunit 2.3.1

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet meta: https://raw.githubusercontent.com/xunit/xunit/master/license.txt

Project license, tagged version:
https://github.com/xunit/xunit/blob/2.3.1/license.txt

**Affected definitions**:
- [dotnet-xunit 2.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/dotnet-xunit/2.3.1/2.3.1)