### PR TITLE
CsQuery 1.3.4

### DIFF
--- a/curations/nuget/nuget/-/CsQuery.yaml
+++ b/curations/nuget/nuget/-/CsQuery.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CsQuery
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
CsQuery 1.3.4

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to project site master license which is MIT, no tagged version. History shows license added in 2012.

Commit on release date: 
https://github.com/jamietre/CsQuery/blob/390ce8464de6fb8632f64fc4ee97777814149e3d/LICENSE.txt

**Affected definitions**:
- [CsQuery 1.3.4](https://clearlydefined.io/definitions/nuget/nuget/-/CsQuery/1.3.4/1.3.4)