### PR TITLE
@microsoft/sp-module-interfaces 1.10.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-module-interfaces.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-module-interfaces.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.10.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@microsoft/sp-module-interfaces 1.10.0

**Details:**
Declaring Other for Microsoft license

**Resolution:**
Project homepage: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

License mentioned at link above:
The SharePoint Framework components are licensed under this Microsoft EULA.

**Affected definitions**:
- [sp-module-interfaces 1.10.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-module-interfaces/1.10.0/1.10.0)