### PR TITLE
Microsoft.Win32.SystemEvents4.5.0-preview 2-26406-04

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Win32.SystemEvents.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Win32.SystemEvents.yaml
@@ -6,6 +6,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview2-26406-04:
+    licensed:
+      declared: MIT
   4.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Win32.SystemEvents4.5.0-preview 2-26406-04

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license which is MIT (per history the license has been MIT since 2017)

**Affected definitions**:
- [Microsoft.Win32.SystemEvents 4.5.0-preview2-26406-04](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Win32.SystemEvents/4.5.0-preview2-26406-04/4.5.0-preview2-26406-04)