### PR TITLE
org.apache.curator/curator-framework 2.4.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.curator/curator-framework.yaml
+++ b/curations/maven/mavencentral/org.apache.curator/curator-framework.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.4.0:
+    licensed:
+      declared: Apache-2.0
   2.6.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.apache.curator/curator-framework 2.4.0

**Details:**
Declaring Apache 2.0

**Resolution:**
Maven POM file: https://repo1.maven.org/maven2/org/apache/curator/curator-framework/2.4.0/curator-framework-2.4.0.pom

**Affected definitions**:
- [curator-framework 2.4.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.curator/curator-framework/2.4.0/2.4.0)