### PR TITLE
Microsoft.Bot.Configuration 4.6.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
@@ -6,6 +6,9 @@ revisions:
   4.5.3:
     licensed:
       declared: MIT
+  4.6.3:
+    licensed:
+      declared: MIT
   4.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Configuration 4.6.3

**Details:**
Declaring MIT

**Resolution:**

NuGet metadata goes to GitHub master license: MIT

Project license: https://github.com/microsoft/botbuilder-dotnet/blob/4.6/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Configuration 4.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Configuration/4.6.3/4.6.3)