### PR TITLE
Microsoft.PowerShell.CoreCLR.Eventing 6.2.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.CoreCLR.Eventing
+  provider: nuget
+  type: nuget
+revisions:
+  6.2.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.PowerShell.CoreCLR.Eventing 6.2.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license: MIT

Tagged version: https://github.com/PowerShell/PowerShell/blob/v6.2.3/LICENSE.txt

**Affected definitions**:
- [Microsoft.PowerShell.CoreCLR.Eventing 6.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing/6.2.3/6.2.3)