### PR TITLE
Microsoft.Bot.Connector 4.7.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -12,6 +12,9 @@ revisions:
   4.7.0:
     licensed:
       declared: MIT
+  4.7.2:
+    licensed:
+      declared: MIT
   4.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Connector 4.7.2

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license: MIT

Project license, tagged version:
https://github.com/microsoft/botbuilder-dotnet/blob/v4.7.0/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 4.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.7.2/4.7.2)