### PR TITLE
CommonMark.NET 0.15.1

### DIFF
--- a/curations/nuget/nuget/-/CommonMark.NET.yaml
+++ b/curations/nuget/nuget/-/CommonMark.NET.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CommonMark.NET
+  provider: nuget
+  type: nuget
+revisions:
+  0.15.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
CommonMark.NET 0.15.1

**Details:**
Declaring BSD-3-Clause

**Resolution:**
ClearlyDefined Files: License.md is BSD-3-Clause

NuGet metadata: https://raw.githubusercontent.com/Knagis/CommonMark.NET/master/LICENSE.md

Project license, tagged version:
https://github.com/Knagis/CommonMark.NET/blob/v0.15.1/LICENSE.md


**Affected definitions**:
- [CommonMark.NET 0.15.1](https://clearlydefined.io/definitions/nuget/nuget/-/CommonMark.NET/0.15.1/0.15.1)