### PR TITLE
prometheus-net.AspNetCore 2.1.3

### DIFF
--- a/curations/nuget/nuget/-/prometheus-net.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/prometheus-net.AspNetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: prometheus-net.AspNetCore
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
prometheus-net.AspNetCore 2.1.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/prometheus-net/prometheus-net/master/LICENSE

Project license, tagged version: 
https://github.com/prometheus-net/prometheus-net/blob/v2.1.3/LICENSE

**Affected definitions**:
- [prometheus-net.AspNetCore 2.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/prometheus-net.AspNetCore/2.1.3/2.1.3)