### PR TITLE
org.junit.platform/junit-platform-engine 1.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-platform-engine
+  namespace: org.junit.platform
+  provider: mavencentral
+  type: maven
+revisions:
+  1.5.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.junit.platform/junit-platform-engine 1.5.2

**Details:**
Declaring EPL 2.0

**Resolution:**
ClearlyDefined Files: License.md is EPL v2.0

Maven POM file: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.5.2/junit-platform-engine-1.5.2.pom

**Affected definitions**:
- [junit-platform-engine 1.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-engine/1.5.2/1.5.2)