### PR TITLE
net-dns 0.8.0

### DIFF
--- a/curations/gem/rubygems/-/net-dns.yaml
+++ b/curations/gem/rubygems/-/net-dns.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: net-dns
+  provider: rubygems
+  type: gem
+revisions:
+  0.8.0:
+    licensed:
+      declared: Ruby

--- a/curations/gem/rubygems/-/net-dns.yaml
+++ b/curations/gem/rubygems/-/net-dns.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.8.0:
     licensed:
-      declared: Ruby
+      declared: BSD-2-Clause or Ruby


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
net-dns 0.8.0

**Details:**
Declaring Ruby

**Resolution:**
ClearlyDefined Files: README.md states Ruby

https://github.com/bluemonk/net-dns/tree/v0.8.0

**Affected definitions**:
- [net-dns 0.8.0](https://clearlydefined.io/definitions/gem/rubygems/-/net-dns/0.8.0/0.8.0)