### PR TITLE
Unity.Container 5.8.10

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -15,6 +15,9 @@ revisions:
   5.7.0:
     licensed:
       declared: Apache-2.0
+  5.8.10:
+    licensed:
+      declared: Apache-2.0
   5.8.11:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Unity.Container 5.8.10

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master repo license: Apache 2.0

Tagged versions before and after v5.8.10 also include Apache 2.0 license

https://github.com/unitycontainer/unity/blob/5.8.11.537/LICENSE

**Affected definitions**:
- [Unity.Container 5.8.10](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.8.10/5.8.10)