### PR TITLE
Add Other License

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform.yaml
@@ -9,3 +9,6 @@ revisions:
   6.2.8:
     licensed:
       declared: OTHER
+  6.2.9:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Other License

**Details:**
Package files and meta data contain unrecognized MSFT license. License not found in SPDX. Curated as other. 

**Resolution:**
https://github.com/Microsoft/dotnet/blob/master/releases/UWP/LICENSE.TXT

**Affected definitions**:
- [runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform 6.2.9](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform/6.2.9/6.2.9)