### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Unity.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Unity.Abstractions.yaml
@@ -15,3 +15,6 @@ revisions:
   5.11.1:
     licensed:
       declared: Apache-2.0
+  5.11.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Package files points to Apache 2.0, but meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/unitycontainer/abstractions/blob/v5.11.2/LICENSE

**Affected definitions**:
- [Unity.Abstractions 5.11.2](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Abstractions/5.11.2/5.11.2)