### PR TITLE
Add MIT License

### DIFF
--- a/curations/npm/npmjs/-/storybook-chromatic.yaml
+++ b/curations/npm/npmjs/-/storybook-chromatic.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: storybook-chromatic
+  provider: npmjs
+  type: npm
+revisions:
+  2.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
Package files have no info. Meta data points to MIT. 

**Resolution:**
https://github.com/chromaui/chromatic-cli/blob/next/LICENSE

**Affected definitions**:
- [storybook-chromatic 2.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/storybook-chromatic/2.2.2/2.2.2)