### PR TITLE
Add Other License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.SqlServer.Management.SqlParser.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.Management.SqlParser.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.SqlServer.Management.SqlParser
+  provider: nuget
+  type: nuget
+revisions:
+  150.37051.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Other License

**Details:**
Package files are inconclusive. Meta data contains unrecognized MSFT license that is not present in SPDX list. Curated as Other. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.SqlServer.Management.SqlParser/150.37051.0/License

**Affected definitions**:
- [Microsoft.SqlServer.Management.SqlParser 150.37051.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.SqlServer.Management.SqlParser/150.37051.0/150.37051.0)