### PR TITLE
org.jodd:jodd-core	3.5.2

### DIFF
--- a/curations/maven/mavencentral/org.jodd/jodd-core.yaml
+++ b/curations/maven/mavencentral/org.jodd/jodd-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jodd-core
+  namespace: org.jodd
+  provider: mavencentral
+  type: maven
+revisions:
+  3.5.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jodd:jodd-core	3.5.2

**Details:**
Link in .pom file indicates license is BSD-2

**Resolution:**
Source repository also indicates license is BSD-2

**Affected definitions**:
- [jodd-core 3.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.jodd/jodd-core/3.5.2/3.5.2)