### PR TITLE
Microsoft.NETFramework.ReferenceAssemblies.net472	1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net472.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net472.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: NOASSERTION
   1.0.0-preview.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net472.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net472.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.0.0:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   1.0.0-preview.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETFramework.ReferenceAssemblies.net472	1.0.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link from Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net472 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net472/1.0.0/1.0.0)