### PR TITLE
reflect	0.1.3

### DIFF
--- a/curations/npm/npmjs/-/reflect.yaml
+++ b/curations/npm/npmjs/-/reflect.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: reflect
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
reflect	0.1.3

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
Source repository also indicates license is MIT

**Affected definitions**:
- [reflect 0.1.3](https://clearlydefined.io/definitions/npm/npmjs/-/reflect/0.1.3/0.1.3)