### PR TITLE
lz4net	1.0.9.93

### DIFF
--- a/curations/nuget/nuget/-/lz4net.yaml
+++ b/curations/nuget/nuget/-/lz4net.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.15.93:
     licensed:
       declared: BSD-2-Clause
+  1.0.9.93:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
lz4net	1.0.9.93

**Details:**
License link on Nuget site indicates license is BSD-2

**Resolution:**
License history indicates license was BSD-2 when released

**Affected definitions**:
- [lz4net 1.0.9.93](https://clearlydefined.io/definitions/nuget/nuget/-/lz4net/1.0.9.93/1.0.9.93)