### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.yaml
@@ -12,3 +12,6 @@ revisions:
   6.0.0:
     licensed:
       declared: MIT
+  6.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/aaubry/YamlDotNet/blob/v6.1.1/LICENSE

**Affected definitions**:
- [YamlDotNet 6.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet/6.1.1/6.1.1)