### PR TITLE
System.Reflection.DispatchProxy	4.5.1

### DIFF
--- a/curations/nuget/nuget/-/System.Reflection.DispatchProxy.yaml
+++ b/curations/nuget/nuget/-/System.Reflection.DispatchProxy.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: MIT
   4.5.1:
     licensed:
-      declared: NOASSERTION
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Reflection.DispatchProxy.yaml
+++ b/curations/nuget/nuget/-/System.Reflection.DispatchProxy.yaml
@@ -9,3 +9,6 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.1:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Reflection.DispatchProxy	4.5.1

**Details:**
Harvest license file indicates license is MIT

**Resolution:**
License link from Nuget site also indicates license is MIT

**Affected definitions**:
- [System.Reflection.DispatchProxy 4.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reflection.DispatchProxy/4.5.1/4.5.1)