### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/MaxMind.Db.yaml
+++ b/curations/nuget/nuget/-/MaxMind.Db.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MaxMind.Db
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/maxmind/MaxMind-DB-Reader-dotnet/blob/v2.2.0/LICENSE

**Affected definitions**:
- [MaxMind.Db 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/MaxMind.Db/2.2.0/2.2.0)