### PR TITLE
Nito.Cancellation	1.0.5

### DIFF
--- a/curations/nuget/nuget/-/Nito.Cancellation.yaml
+++ b/curations/nuget/nuget/-/Nito.Cancellation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Nito.Cancellation
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nito.Cancellation	1.0.5

**Details:**
License link from Nuget site indicates license is MIT

**Resolution:**
License file in source repository also indicates license is MIT

**Affected definitions**:
- [Nito.Cancellation 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.Cancellation/1.0.5/1.0.5)