### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Common.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Common.yaml
@@ -14,6 +14,9 @@ revisions:
         path: Xamarin.Android.Arch.Lifecycle.Common.nuspec
     licensed:
       declared: MIT
+  1.1.1.1:
+    licensed:
+      declared: mit
   1.1.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Lifecycle.Common 1.1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.Common/1.1.1.1/1.1.1.1)