### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Cauldron.BasicInterceptors.yaml
+++ b/curations/nuget/nuget/-/Cauldron.BasicInterceptors.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Cauldron.BasicInterceptors
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/Capgemini/Cauldron/master/LICENSE

**Affected definitions**:
- [Cauldron.BasicInterceptors 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Cauldron.BasicInterceptors/3.2.2/3.2.2)