### PR TITLE
Add MIT License

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -21,6 +21,9 @@ revisions:
   5.0.0:
     licensed:
       declared: MIT
+  5.0.0-beta:
+    licensed:
+      declared: MIT
   5.0.0-rc2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT License

**Details:**
No info in package files. Meta data confirms MIT. 


**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.0.0-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.0.0-beta/5.0.0-beta)