### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/Unity.yaml
+++ b/curations/nuget/nuget/-/Unity.yaml
@@ -42,6 +42,9 @@ revisions:
   5.11.4:
     licensed:
       declared: Apache-2.0
+  5.11.6:
+    licensed:
+      declared: Apache-2.0
   5.2.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
Apache 2.0 indicated in package files and confirmed in meta data. 

**Resolution:**
https://github.com/unitycontainer/unity/blob/5.11.6.966/LICENSE

**Affected definitions**:
- [Unity 5.11.6](https://clearlydefined.io/definitions/nuget/nuget/-/Unity/5.11.6/5.11.6)