### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.console.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.console.yaml
@@ -15,6 +15,9 @@ revisions:
         url: 'https://github.com/xunit/xunit'
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0
   2.3.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/xunit/xunit/master/license.txt

**Affected definitions**:
- [xunit.runner.console 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.console/2.2.0/2.2.0)