### PR TITLE
Add Apache 2.0 License

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -26,6 +26,9 @@ revisions:
   106.6.10:
     licensed:
       declared: Apache-2.0
+  106.6.7:
+    licensed:
+      declared: Apache-2.0
   106.6.9:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add Apache 2.0 License

**Details:**
No info in package files. Meta data link inoperable. Source repo confirms Apache 2.0. 

**Resolution:**
https://github.com/restsharp/RestSharp/blob/106.6.7/LICENSE.txt

**Affected definitions**:
- [RestSharp 106.6.7](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/106.6.7/106.6.7)