### PR TITLE
iTextSharp5.5.13

### DIFF
--- a/curations/nuget/nuget/-/iTextSharp.yaml
+++ b/curations/nuget/nuget/-/iTextSharp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: iTextSharp
+  provider: nuget
+  type: nuget
+revisions:
+  5.5.13:
+    licensed:
+      declared: AGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
iTextSharp5.5.13

**Details:**
NuGet "License Info" link and AGPL.text in "Files" point to Declared being AGPL-3.0-only

**Resolution:**
 AGPL-3.0-only

**Affected definitions**:
- [iTextSharp 5.5.13](https://clearlydefined.io/definitions/nuget/nuget/-/iTextSharp/5.5.13/5.5.13)