### PR TITLE
NJsonSchema 10.1.4

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -12,6 +12,9 @@ revisions:
   10.0.27:
     licensed:
       declared: MIT
+  10.1.4:
+    licensed:
+      declared: MIT
   10.1.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NJsonSchema 10.1.4

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Project site v10.1.4 license: https://github.com/RicoSuter/NJsonSchema/blob/cf300189b1d1e671ee8687d966c0ea4f46aac9ba/LICENSE.md

**Affected definitions**:
- [NJsonSchema 10.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/NJsonSchema/10.1.4/10.1.4)