### PR TITLE
uglify-js 1.3.5

### DIFF
--- a/curations/npm/npmjs/-/uglify-js.yaml
+++ b/curations/npm/npmjs/-/uglify-js.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.3.5:
+    licensed:
+      declared: BSD-2-Clause
   2.2.5:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
uglify-js 1.3.5

**Details:**
Declaring BSD-2-Clause

**Resolution:**
NPM points to GitHub repo.

License on this page for v1.3.5 - 

https://github.com/mishoo/UglifyJS-old/tree/ef660f1bd021b2c1154472d705db25f69f007abd

**Affected definitions**:
- [uglify-js 1.3.5](https://clearlydefined.io/definitions/npm/npmjs/-/uglify-js/1.3.5/1.3.5)