### PR TITLE
escodegen 1.1.0

### DIFF
--- a/curations/npm/npmjs/-/escodegen.yaml
+++ b/curations/npm/npmjs/-/escodegen.yaml
@@ -9,6 +9,9 @@ revisions:
   0.0.28:
     licensed:
       declared: BSD-2-Clause
+  1.1.0:
+    licensed:
+      declared: BSD-2-Clause
   1.2.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
escodegen 1.1.0

**Details:**
Declaring top level license as BSD-2-Clause

**Resolution:**
BSD-2-Clause license text on NPM page and also points to GitHub repo

License for tagged version:

https://github.com/estools/escodegen/blob/1.1.0/LICENSE.BSD

**Affected definitions**:
- [escodegen 1.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/escodegen/1.1.0/1.1.0)