### PR TITLE
Microsoft.NET.Sdk.Functions 1.0.8

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -39,6 +39,9 @@ revisions:
   1.0.6:
     licensed:
       declared: MIT
+  1.0.8:
+    licensed:
+      declared: MIT
   3.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.NET.Sdk.Functions 1.0.8

**Details:**
Declaring MIT

**Resolution:**
NuGet points to GitHub master license

Tagged version:

https://github.com/Azure/azure-functions-vs-build-sdk/blob/1.0.8/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.8/1.0.8)