### PR TITLE
caseless 0.6.0

### DIFF
--- a/curations/npm/npmjs/-/caseless.yaml
+++ b/curations/npm/npmjs/-/caseless.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: BSD-3-Clause
   0.8.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSD-3-Clause
   0.9.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSD-3-Clause

--- a/curations/npm/npmjs/-/caseless.yaml
+++ b/curations/npm/npmjs/-/caseless.yaml
@@ -6,6 +6,9 @@ revisions:
   0.10.0:
     licensed:
       declared: Apache-2.0
+  0.6.0:
+    licensed:
+      declared: BSD-3-Clause
   0.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
caseless 0.6.0

**Details:**
Declaring BSD-3-Clause for "BSD"

**Resolution:**
v0.6.0 package.json says "BSD". License was changed 5 years ago to Apache 2.0

https://github.com/request/caseless/blob/876663a70e7ebe77e0314f5335437e727db73442/package.json

https://github.com/request/caseless/commit/bd0fcfb3399fb230ac23b153007665075dcf87c0#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

**Affected definitions**:
- [caseless 0.6.0](https://clearlydefined.io/definitions/npm/npmjs/-/caseless/0.6.0/0.6.0)