### PR TITLE
Swashbuckle.AspNetCore.Filters 4.5.5

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Filters.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Filters.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle.AspNetCore.Filters
+  provider: nuget
+  type: nuget
+revisions:
+  4.5.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.Filters 4.5.5

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata points to GitHub master license

Tagged version: https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/blob/4.5.5/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Filters 4.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Filters/4.5.5/4.5.5)