### PR TITLE
BuildBundlerMinifier2.9.406

### DIFF
--- a/curations/nuget/nuget/-/BuildBundlerMinifier.yaml
+++ b/curations/nuget/nuget/-/BuildBundlerMinifier.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.9.406:
+    licensed:
+      declared: Apache-2.0
   3.2.435:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
BuildBundlerMinifier2.9.406

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master

License from commit for v2.9:

https://github.com/madskristensen/BundlerMinifier/blob/620549a5d7af66b4c5b45e82c6e00399d5e22874/LICENSE

**Affected definitions**:
- [BuildBundlerMinifier 2.9.406](https://clearlydefined.io/definitions/nuget/nuget/-/BuildBundlerMinifier/2.9.406/2.9.406)