### PR TITLE
sigmund 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/sigmund.yaml
+++ b/curations/npm/npmjs/-/sigmund.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sigmund
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
sigmund 1.0.0

**Details:**
Declaring BSD-2-Clause

**Resolution:**
ClearlyDefined Files: License is BSD-2-Clause

Tagged version in project repo:

https://github.com/isaacs/sigmund/blob/v1.0.0/LICENSE

**Affected definitions**:
- [sigmund 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/sigmund/1.0.0/1.0.0)