### PR TITLE
Microsoft.ApplicationInsights.Web 2.5.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Web.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Web.yaml
@@ -27,6 +27,9 @@ revisions:
   2.4.1:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: MIT
   2.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.ApplicationInsights.Web 2.5.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Commit dated 2/2018 close to release date:
https://github.com/microsoft/ApplicationInsights-Home/blob/55d87a1b9dd599a554042001cb8b49e039f55157/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.Web 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.Web/2.5.0/2.5.0)