### PR TITLE
Microsoft.Owin.Cors 4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Cors.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Cors.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.1:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Owin.Cors 4.1.0

**Details:**
Declaring Apache 2.0

**Resolution:**
ClearlyDefined Files: LICENSE is Apache 2.0

NuGet metadata: https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt

Project license, tagged version:
https://github.com/aspnet/AspNetKatana/blob/v4.1.0/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Cors 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Cors/4.1.0/4.1.0)