### PR TITLE
itextsharp.xmlworker5.5.11

### DIFF
--- a/curations/nuget/nuget/-/itextsharp.xmlworker.yaml
+++ b/curations/nuget/nuget/-/itextsharp.xmlworker.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: itextsharp.xmlworker
+  provider: nuget
+  type: nuget
+revisions:
+  5.5.11:
+    licensed:
+      declared: AGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
itextsharp.xmlworker5.5.11

**Details:**
License file under "Files" and license at NuGet license link is AGPL 3.0

**Resolution:**
AGPL 3.0

**Affected definitions**:
- [itextsharp.xmlworker 5.5.11](https://clearlydefined.io/definitions/nuget/nuget/-/itextsharp.xmlworker/5.5.11/5.5.11)