### PR TITLE
itextsharp.licensekey1.0.4

### DIFF
--- a/curations/nuget/nuget/-/itextsharp.licensekey.yaml
+++ b/curations/nuget/nuget/-/itextsharp.licensekey.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: itextsharp.licensekey
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.4:
+    licensed:
+      declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
itextsharp.licensekey1.0.4

**Details:**
NuGet license link goes to https://itextpdf.com/en/how-buy.  Put AGPL OR OTHER, where OTHER is for the commercial license option.

**Resolution:**
AGPL-3.0-only OR OTHER

**Affected definitions**:
- [itextsharp.licensekey 1.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/itextsharp.licensekey/1.0.4/1.0.4)