### PR TITLE
Correcting jszip.min.js 

### DIFF
--- a/curations/git/github/jannisx11/blockbench.yaml
+++ b/curations/git/github/jannisx11/blockbench.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: blockbench
+  namespace: jannisx11
+  provider: github
+  type: git
+revisions:
+  b2cd316ae77a415c78584433b1a7df190cf22d13:
+    files:
+      - attributions:
+          - (c) 2009-2016 Stuart Knightley <stuart at stuartk.com>
+        license: GPL-3.0-only OR MIT
+        path: lib/jszip.min.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correcting jszip.min.js 

**Details:**
Changing AND to OR - https://raw.githubusercontent.com/Stuk/jszip/master/LICENSE.markdown

**Resolution:**
GPL-3.0-only OR MIT

**Affected definitions**:
- [blockbench b2cd316ae77a415c78584433b1a7df190cf22d13](https://clearlydefined.io/definitions/git/github/jannisx11/blockbench/b2cd316ae77a415c78584433b1a7df190cf22d13/b2cd316ae77a415c78584433b1a7df190cf22d13)