### PR TITLE
Aspose.Pdf17.12.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Pdf.yaml
+++ b/curations/nuget/nuget/-/Aspose.Pdf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Aspose.Pdf
+  provider: nuget
+  type: nuget
+revisions:
+  17.12.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Pdf17.12.0

**Details:**
NuGet license link goes to a EULA -https://company.aspose.com/legal/eula

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Aspose.Pdf 17.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Pdf/17.12.0/17.12.0)