### PR TITLE
Aspose.Words17.4.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Words.yaml
+++ b/curations/nuget/nuget/-/Aspose.Words.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Aspose.Words
+  provider: nuget
+  type: nuget
+revisions:
+  17.4.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Words17.4.0

**Details:**
NuGet license link goes to a EULA - https://company.aspose.com/legal/eula

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Aspose.Words 17.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Words/17.4.0/17.4.0)