### PR TITLE
rubyzip1.3.0

### DIFF
--- a/curations/gem/rubygems/-/rubyzip.yaml
+++ b/curations/gem/rubygems/-/rubyzip.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rubyzip
+  provider: rubygems
+  type: gem
+revisions:
+  1.3.0:
+    licensed:
+      declared: BSD-2-Clause OR Ruby


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rubyzip1.3.0

**Details:**
README says License is MIT, but I think that only applies to the path_traversal samples.  If you follow the Source link, it says the license for rubyzip is BSD-2-Clause or the Ruby license

**Resolution:**
BSD-2-Clause OR Ruby

**Affected definitions**:
- [rubyzip 1.3.0](https://clearlydefined.io/definitions/gem/rubygems/-/rubyzip/1.3.0/1.3.0)