### PR TITLE
log4net 2.0.4

### DIFF
--- a/curations/nuget/nuget/-/log4net.yaml
+++ b/curations/nuget/nuget/-/log4net.yaml
@@ -12,6 +12,9 @@ revisions:
   2.0.3:
     licensed:
       declared: Apache-2.0
+  2.0.4:
+    licensed:
+      declared: Apache-2.0
   2.0.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
log4net 2.0.4

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata: http://logging.apache.org/log4net/license.html

http://logging.apache.org/log4net/

**Affected definitions**:
- [log4net 2.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/log4net/2.0.4/2.0.4)