### PR TITLE
RestSharp 106.10.1

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -14,6 +14,9 @@ revisions:
       releaseDate: '2015-08-26'
     licensed:
       declared: Apache-2.0
+  106.10.1:
+    licensed:
+      declared: Apache-2.0
   106.2.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RestSharp 106.10.1

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: broken link

Project site: https://restsharp.dev/ "Apache 2.0 licensed"

https://github.com/restsharp/RestSharp/blob/106.10.1/LICENSE.txt

**Affected definitions**:
- [RestSharp 106.10.1](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/106.10.1/106.10.1)