### PR TITLE
Clearing NOASSERT on LICENSE.txt

### DIFF
--- a/curations/nuget/nuget/-/runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform.yaml
+++ b/curations/nuget/nuget/-/runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform.yaml
@@ -9,3 +9,7 @@ revisions:
   6.2.8:
     licensed:
       declared: OTHER
+  6.2.9:
+    files:
+      - license: OTHER
+        path: LICENSE.TXT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Clearing NOASSERT on LICENSE.txt

**Details:**
LICENSE.txt updating to OTHER

**Resolution:**
EULA = OTHER

**Affected definitions**:
- [runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform 6.2.9](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win10-x64-aot.Microsoft.NETCore.UniversalWindowsPlatform/6.2.9/6.2.9)