### PR TITLE
 Added missing info for Microsoft.Spatial/7.5.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Spatial.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Spatial.yaml
@@ -9,6 +9,9 @@ revisions:
   7.2.0:
     licensed:
       declared: MIT
+  7.5.0:
+    licensed:
+      declared: MIT
   7.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Added missing info for Microsoft.Spatial/7.5.0

**Details:**
Added license details.

**Resolution:**
https://raw.githubusercontent.com/OData/odata.net/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.Spatial 7.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Spatial/7.5.0/7.5.0)