### PR TITLE
unorm1.4.1

### DIFF
--- a/curations/npm/npmjs/-/unorm.yaml
+++ b/curations/npm/npmjs/-/unorm.yaml
@@ -4,5 +4,16 @@ coordinates:
   type: npm
 revisions:
   1.4.1:
+    files:
+      - attributions:
+          - 'Copyright (c) 2008-2013 Matsuza <matsuza@gmail.com> , Bjarke Walling <bwp@bwp.dk>'
+        license: MIT OR GPL-2.0-only
+        path: package/README.md
+      - license: MIT OR GPL-2.0-only
+        path: package/package.json
+      - attributions:
+          - 'Copyright (c) 2008-2013 Matsuza <matsuza@gmail.com> , Bjarke Walling <bwp@bwp.dk>'
+        license: MIT OR GPL-2.0-only
+        path: package/LICENSE.md
     licensed:
-      declared: MIT AND GPL-2.0-or-later
+      declared: MIT OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
unorm1.4.1

**Details:**
Updating Declared ,LICENSE, README, and package.json to "MIT OR GPL-2.0-only"

**Resolution:**
Dual licensed means OR and package.json says "or."

**Affected definitions**:
- [unorm 1.4.1](https://clearlydefined.io/definitions/npm/npmjs/-/unorm/1.4.1/1.4.1)