### PR TITLE
PowerShell	1.0.0

### DIFF
--- a/curations/nuget/nuget/-/PowerShell.yaml
+++ b/curations/nuget/nuget/-/PowerShell.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PowerShell
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PowerShell	1.0.0

**Details:**
There is no license link on the Nuget site

**Resolution:**
There is no license link in the Nuspec file and the Nuget site indicates the package has been unlisted

**Affected definitions**:
- [PowerShell 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/PowerShell/1.0.0/1.0.0)