### PR TITLE
spdx-expression-parse1.0.2

### DIFF
--- a/curations/npm/npmjs/-/spdx-expression-parse.yaml
+++ b/curations/npm/npmjs/-/spdx-expression-parse.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: spdx-expression-parse
-  namespace: null
   provider: npmjs
   type: npm
 revisions:
+  1.0.2:
+    licensed:
+      declared: MIT
   3.0.0:
     described:
       releaseDate: '2018-02-26'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
spdx-expression-parse1.0.2

**Details:**
Changing "Declared" to just MIT

**Resolution:**
MIT

**Affected definitions**:
- [spdx-expression-parse 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/spdx-expression-parse/1.0.2/1.0.2)