### PR TITLE
Newtonsoft.Json.Schema	2.0.7

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: AGPL-3.0-only OR OTHER
   2.0.7:
     licensed:
-      declared: AGPL-3.0-only
+      declared: AGPL-3.0-only OR OTHER
   2.0.8:
     licensed:
       declared: AGPL-3.0-only OR OTHER

--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -9,6 +9,9 @@ revisions:
   2.0.2:
     licensed:
       declared: AGPL-3.0-only OR OTHER
+  2.0.7:
+    licensed:
+      declared: AGPL-3.0-only
   2.0.8:
     licensed:
       declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json.Schema	2.0.7

**Details:**
License link on Nuget site indicates license is AGPL 3.0

**Resolution:**
Project site also indicates license is AGPL 3.0

**Affected definitions**:
- [Newtonsoft.Json.Schema 2.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json.Schema/2.0.7/2.0.7)