### PR TITLE
BouncyCastle.NetCore	1.8.5

### DIFF
--- a/curations/nuget/nuget/-/BouncyCastle.NetCore.yaml
+++ b/curations/nuget/nuget/-/BouncyCastle.NetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: BouncyCastle.NetCore
+  provider: nuget
+  type: nuget
+revisions:
+  1.8.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BouncyCastle.NetCore	1.8.5

**Details:**
Project site indicates license is MIT

**Resolution:**
http://www.bouncycastle.org/licence.html also indicates license is MIT

**Affected definitions**:
- [BouncyCastle.NetCore 1.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/BouncyCastle.NetCore/1.8.5/1.8.5)