### PR TITLE
Npm	3.5.2

### DIFF
--- a/curations/nuget/nuget/-/Npm.yaml
+++ b/curations/nuget/nuget/-/Npm.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Npm
+  provider: nuget
+  type: nuget
+revisions:
+  3.5.2:
+    licensed:
+      declared: Artistic-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Npm	3.5.2

**Details:**
License link on Nuget site indicates license is Artistic 2.0

**Resolution:**
License file on source repository also indicates license is Artistic 2.0

**Affected definitions**:
- [Npm 3.5.2](https://clearlydefined.io/definitions/nuget/nuget/-/Npm/3.5.2/3.5.2)