### PR TITLE
Microsoft.Owin.Security.Facebook	4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.Facebook.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.Facebook.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Security.Facebook
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Owin.Security.Facebook	4.1.0

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License file from project site also indicates license is Apache 2.0

**Affected definitions**:
- [Microsoft.Owin.Security.Facebook 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.Facebook/4.1.0/4.1.0)