### PR TITLE
System.Reactive.Core	4.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.Core.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.Core.yaml
@@ -10,12 +10,14 @@ revisions:
     described:
       releaseDate: '2016-11-21'
       sourceLocation:
+        name: Rx.NET
+        namespace: Reactive-Extensions
         provider: github
         revision: e0b6af3e204feb8aa13841a8a873d78ae6c43467
         type: git
-        url: >-
-          https://github.com/Reactive-Extensions/Rx.NET/commit/e0b6af3e204feb8aa13841a8a873d78ae6c43467
-        name: Rx.NET
-        namespace: Reactive-Extensions
+        url: 'https://github.com/Reactive-Extensions/Rx.NET/commit/e0b6af3e204feb8aa13841a8a873d78ae6c43467'
+    licensed:
+      declared: Apache-2.0
+  4.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Reactive.Core	4.0.0

**Details:**
License history on repository indicates license was Apache 2.0 until March 2020

**Resolution:**
This package was released in 2018 prior to license change to MIT

**Affected definitions**:
- [System.Reactive.Core 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive.Core/4.0.0/4.0.0)