### PR TITLE
NLog	4.6.6

### DIFF
--- a/curations/nuget/nuget/-/NLog.yaml
+++ b/curations/nuget/nuget/-/NLog.yaml
@@ -179,6 +179,9 @@ revisions:
   4.6.5:
     licensed:
       declared: BSD-3-Clause
+  4.6.6:
+    licensed:
+      declared: BSD-3-Clause
   4.6.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog	4.6.6

**Details:**
License link from Nuget site indicates license is BSD-3

**Resolution:**
License file on source repository also indicates license is BSD-3

**Affected definitions**:
- [NLog 4.6.6](https://clearlydefined.io/definitions/nuget/nuget/-/NLog/4.6.6/4.6.6)