### PR TITLE
Polly	5.2.0

### DIFF
--- a/curations/nuget/nuget/-/Polly.yaml
+++ b/curations/nuget/nuget/-/Polly.yaml
@@ -12,6 +12,9 @@ revisions:
   5.1.0:
     licensed:
       declared: BSD-3-Clause
+  5.2.0:
+    licensed:
+      declared: BSD-3-Clause
   5.3.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Polly	5.2.0

**Details:**
License link on Nuget site indicates license is BSD-3

**Resolution:**
License file on source repository also indicates license is BSD-3

**Affected definitions**:
- [Polly 5.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Polly/5.2.0/5.2.0)