### PR TITLE
jose-jwt	2.5.0

### DIFF
--- a/curations/nuget/nuget/-/jose-jwt.yaml
+++ b/curations/nuget/nuget/-/jose-jwt.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: MIT
   2.5.0:
     licensed:
-      declared: NOASSERTION
+      declared: MIT

--- a/curations/nuget/nuget/-/jose-jwt.yaml
+++ b/curations/nuget/nuget/-/jose-jwt.yaml
@@ -9,3 +9,6 @@ revisions:
   2.4.0:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jose-jwt	2.5.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file on source repository also indicates license is MIT

**Affected definitions**:
- [jose-jwt 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/jose-jwt/2.5.0/2.5.0)