### PR TITLE
Prism.Core	6.3.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.Core.yaml
+++ b/curations/nuget/nuget/-/Prism.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Prism.Core
+  provider: nuget
+  type: nuget
+revisions:
+  6.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Core	6.3.0

**Details:**
License link from Nuget site indicates license was Apache 2.0 when package was released

**Resolution:**
License file from project site also indicates license was Apache 2.0

**Affected definitions**:
- [Prism.Core 6.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Core/6.3.0/6.3.0)