### PR TITLE
Bond.CSharp	4.0.1

### DIFF
--- a/curations/nuget/nuget/-/Bond.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.CSharp.yaml
@@ -35,6 +35,9 @@ revisions:
       releaseDate: '2015-07-30'
     licensed:
       declared: MIT
+  4.0.1:
+    licensed:
+      declared: MIT
   4.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.CSharp	4.0.1

**Details:**
License link from Nuget site indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [Bond.CSharp 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.CSharp/4.0.1/4.0.1)