### PR TITLE
Microsoft.OData.Edm	7.6.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
@@ -48,6 +48,9 @@ revisions:
   7.6.2:
     licensed:
       declared: MIT
+  7.6.3:
+    licensed:
+      declared: MIT
   7.6.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.OData.Edm	7.6.3

**Details:**
License link from Nuget site indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [Microsoft.OData.Edm 7.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Edm/7.6.3/7.6.3)