### PR TITLE
Add license to eslint-config

### DIFF
--- a/curations/git/github/landscapehub/eslint-config.yaml
+++ b/curations/git/github/landscapehub/eslint-config.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: eslint-config
+  namespace: landscapehub
+  provider: github
+  type: git
+revisions:
+  70380698f997c0097d9fbd67993c80318b61cefa:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add license to eslint-config

**Details:**
License was missing. So it was added.

**Resolution:**
The license is listed as MIT in the package.json files.

**Affected definitions**:
- [eslint-config 70380698f997c0097d9fbd67993c80318b61cefa](https://clearlydefined.io/definitions/git/github/landscapehub/eslint-config/70380698f997c0097d9fbd67993c80318b61cefa)