### PR TITLE
ZXing.Net.Mobile2.4.1

### DIFF
--- a/curations/nuget/nuget/-/ZXing.Net.Mobile.yaml
+++ b/curations/nuget/nuget/-/ZXing.Net.Mobile.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.4.1:
     licensed:
-      declared: Apache-2.0
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ZXing.Net.Mobile2.4.1

**Details:**
NuGet "license info" link gets a 404:https://raw.githubusercontent.com/Redth/ZXing.Net.Mobile/master/License.md.  Newer packages specify "MIT."

**Resolution:**
Author confirmed they intend the older packages with 404 license link to be under MIT: https://github.com/chromaui/chromatic-cli/issues/154#issuecomment-652792169

**Affected definitions**:
- [ZXing.Net.Mobile 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/ZXing.Net.Mobile/2.4.1/2.4.1)