### PR TITLE
StyleCop	5.0.0

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.yaml
+++ b/curations/nuget/nuget/-/StyleCop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StyleCop
+  provider: nuget
+  type: nuget
+revisions:
+  5.0.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StyleCop	5.0.0

**Details:**
License link on Nuget site indicates license is MS-PL

**Resolution:**
License file on project site also indicates license is MS-PL

**Affected definitions**:
- [StyleCop 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop/5.0.0/5.0.0)