### PR TITLE
Accord.Statistics	3.8.0

### DIFF
--- a/curations/nuget/nuget/-/Accord.Statistics.yaml
+++ b/curations/nuget/nuget/-/Accord.Statistics.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Accord.Statistics
+  provider: nuget
+  type: nuget
+revisions:
+  3.8.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Accord.Statistics	3.8.0

**Details:**
License link on Nuget site indicates license is LGPL 2.1 or later

**Resolution:**
License URL in Nuspec file also indicates license is LGPL 2.1 or later

**Affected definitions**:
- [Accord.Statistics 3.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Accord.Statistics/3.8.0/3.8.0)