### PR TITLE
Selenium.WebDriver.ChromeDriver	2.33.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.ChromeDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.ChromeDriver.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.33.0:
+    licensed:
+      declared: Unlicense
   2.37.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.ChromeDriver	2.33.0

**Details:**
License link on Nuget site indicates license is Unlicense

**Resolution:**
License file on project site also indicates license is Unlicense

**Affected definitions**:
- [Selenium.WebDriver.ChromeDriver 2.33.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.ChromeDriver/2.33.0/2.33.0)