### PR TITLE
Unity.Container	5.11.4

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -9,6 +9,9 @@ revisions:
   5.11.1:
     licensed:
       declared: Apache-2.0
+  5.11.4:
+    licensed:
+      declared: Apache-2.0
   5.11.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Container	5.11.4

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License file on project site indicates license is Apache 2.0

**Affected definitions**:
- [Unity.Container 5.11.4](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.11.4/5.11.4)