### PR TITLE
ltcdr	2.2.1

### DIFF
--- a/curations/npm/npmjs/-/ltcdr.yaml
+++ b/curations/npm/npmjs/-/ltcdr.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ltcdr
+  provider: npmjs
+  type: npm
+revisions:
+  2.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ltcdr	2.2.1

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [ltcdr 2.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/ltcdr/2.2.1/2.2.1)