### PR TITLE
Microsoft.NETCore.DotNetHostResolver 2.1.19

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.19:
+    licensed:
+      declared: MIT
   2.1.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETCore.DotNetHostResolver 2.1.19

**Details:**
Info in package files is unclear. Meta data confirms MIT. 

**Resolution:**
https://github.com/dotnet/core-setup/blob/master/LICENSE.TXT

**Affected definitions**:
- [Microsoft.NETCore.DotNetHostResolver 2.1.19](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver/2.1.19/2.1.19)