### PR TITLE
Microsoft.NETCore.App 2.1.19

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
@@ -18,6 +18,9 @@ revisions:
         path: LICENSE.TXT
     licensed:
       declared: MIT
+  2.1.19:
+    licensed:
+      declared: MIT
   2.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETCore.App 2.1.19

**Details:**
Package files indicate MIT and meta data confirms. 

**Resolution:**
https://github.com/dotnet/core-setup/blob/v2.1.19/LICENSE.TXT

**Affected definitions**:
- [Microsoft.NETCore.App 2.1.19](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App/2.1.19/2.1.19)