### PR TITLE
JetBrains.ReSharper.CommandLineTools 2020.1.2

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -5,7 +5,10 @@ coordinates:
 revisions:
   2020.1.0:
     licensed:
-      declared: OTHER  
+      declared: OTHER
   2020.1.1:
+    licensed:
+      declared: OTHER
+  2020.1.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2020.1.2

**Details:**
Package files are unclear. Meta data contains a specific user agreement that has its own license grant. 

**Resolution:**
https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2020.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2020.1.2/2020.1.2)