### PR TITLE
torchvision 0.6.0

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -15,3 +15,6 @@ revisions:
   0.5.0:
     licensed:
       declared: BSD-3-Clause
+  0.6.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision 0.6.0

**Details:**
No package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/pytorch/vision/blob/v0.6.0/LICENSE

**Affected definitions**:
- [torchvision 0.6.0](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.6.0/0.6.0)