### PR TITLE
Newtonsoft.Json 4.5.1

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -28,6 +28,9 @@ revisions:
   11.0.2:
     licensed:
       declared: MIT
+  4.5.1:
+    licensed:
+      declared: MIT
   4.5.11:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json 4.5.1

**Details:**
No info in package files. Meta data shows relocation. Source repo shows MIT License on master, but a 404 error on 4.5.1 version. 

**Resolution:**
https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md

**Affected definitions**:
- [Newtonsoft.Json 4.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.5.1/4.5.1)