### PR TITLE
xunit.assert 2.3.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.assert.yaml
+++ b/curations/nuget/nuget/-/xunit.assert.yaml
@@ -21,6 +21,9 @@ revisions:
   2.2.0:
     licensed:
       declared: Apache-2.0
+  2.3.0:
+    licensed:
+      declared: Apache-2.0
   2.3.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.assert 2.3.0

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/xunit/xunit/master/license.txt

**Affected definitions**:
- [xunit.assert 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.assert/2.3.0/2.3.0)