### PR TITLE
structuremap 4.5.0

### DIFF
--- a/curations/nuget/nuget/-/StructureMap.yaml
+++ b/curations/nuget/nuget/-/StructureMap.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StructureMap
+  provider: nuget
+  type: nuget
+revisions:
+  4.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
structuremap 4.5.0

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/structuremap/structuremap/master/LICENSE.TXT

**Affected definitions**:
- [StructureMap 4.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/StructureMap/4.5.0/4.5.0)