### PR TITLE
.Extensions.ConfiguratiMicrosofton.AzureAppConfiguration 3.0.0-preview-011100001-1152

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: OTHER
   3.0.0-preview-011100001-1152:
     licensed:
-      declared: MIT
+      declared: OTHER
   3.0.1:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: OTHER
+  3.0.0-preview-011100001-1152:
+    licensed:
+      declared: MIT
   3.0.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
.Extensions.ConfiguratiMicrosofton.AzureAppConfiguration 3.0.0-preview-011100001-1152

**Details:**
No info in package files. Meta data shows Azure terms. Source repo confirms MIT. 

**Resolution:**
https://github.com/Azure/AppConfiguration-DotnetProvider/blob/3.0.0/LICENSE

**Affected definitions**:
- [Microsoft.Extensions.Configuration.AzureAppConfiguration 3.0.0-preview-011100001-1152](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration/3.0.0-preview-011100001-1152/3.0.0-preview-011100001-1152)