### PR TITLE
Microsoft.VisualStudio.SlowCheetah 3.2.26

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.SlowCheetah.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.SlowCheetah.yaml
@@ -18,3 +18,6 @@ revisions:
   3.2.20:
     licensed:
       declared: MIT
+  3.2.26:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.SlowCheetah 3.2.26

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/Microsoft/slow-cheetah/master/LICENSE

**Affected definitions**:
- [Microsoft.VisualStudio.SlowCheetah 3.2.26](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.SlowCheetah/3.2.26/3.2.26)