### PR TITLE
Swashbuckle.AspNetCore.SwaggerUi 2.5.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -12,6 +12,9 @@ revisions:
   2.4.0:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: MIT
   3.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.SwaggerUi 2.5.0

**Details:**
No info in package files. Meta data confirms MIT.

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/2.5.0/2.5.0)