### PR TITLE
Microsoft.Win32.SystemEvents 4.6.0-preview6.19303.8

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Win32.SystemEvents.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Win32.SystemEvents.yaml
@@ -12,6 +12,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview6.19303.8:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Win32.SystemEvents 4.6.0-preview6.19303.8

**Details:**
Package files indicates MIT and meta data confirms. 

**Resolution:**
https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- [Microsoft.Win32.SystemEvents 4.6.0-preview6.19303.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Win32.SystemEvents/4.6.0-preview6.19303.8/4.6.0-preview6.19303.8)