### PR TITLE
StackExchange.Redis.StrongName 1.0.450

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -14,6 +14,9 @@ revisions:
         path: StackExchange.Redis.StrongName.nuspec
     licensed:
       declared: MIT
+  1.0.450:
+    licensed:
+      declared: MIT
   1.0.481:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis.StrongName 1.0.450

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/StackExchange/StackExchange.Redis/master/LICENSE

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.0.450](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.0.450/1.0.450)