### PR TITLE
Xamarin.Android.Arch.Core.Common 1.1.1.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Core.Common.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Core.Common.yaml
@@ -14,6 +14,9 @@ revisions:
         path: Xamarin.Android.Arch.Core.Common.nuspec
     licensed:
       declared: MIT
+  1.1.1.1:
+    licensed:
+      declared: MIT
   1.1.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Arch.Core.Common 1.1.1.1

**Details:**
No info in package files. Meta data confirms. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Core.Common 1.1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Core.Common/1.1.1.1/1.1.1.1)