### PR TITLE
Microsoft.Owin.Testing 4.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Testing.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Testing.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.0.1:
+    licensed:
+      declared: Apache-2.0
   4.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Owin.Testing 4.0.1

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Testing 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Testing/4.0.1/4.0.1)