### PR TITLE
CsvHelper 2.13.2

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -9,6 +9,9 @@ revisions:
   12.2.1:
     licensed:
       declared: MS-PL
+  2.13.2:
+    licensed:
+      declared: MS-PL
   2.16.3:
     licensed:
       declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CsvHelper 2.13.2

**Details:**
No info in package files. Meta data confirms MS-PL. 

**Resolution:**
https://raw.githubusercontent.com/JoshClose/CsvHelper/master/LICENSE.txt

**Affected definitions**:
- [CsvHelper 2.13.2](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/2.13.2/2.13.2)