### PR TITLE
bitstadium/hockeysdk-mac6169aec3571b1...

### DIFF
--- a/curations/git/github/bitstadium/hockeysdk-mac.yaml
+++ b/curations/git/github/bitstadium/hockeysdk-mac.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hockeysdk-mac
+  namespace: bitstadium
+  provider: github
+  type: git
+revisions:
+  6169aec3571b1e47aa496e8d42ffecbc6edb602b:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
bitstadium/hockeysdk-mac6169aec3571b1...

**Details:**
I think the 'declared' should just be MIT

**Resolution:**
https://github.com/bitstadium/hockeysdk-mac/blob/6169aec3571b1e47aa496e8d42ffecbc6edb602b/LICENSE.md

**Affected definitions**:
- [hockeysdk-mac 6169aec3571b1e47aa496e8d42ffecbc6edb602b](https://clearlydefined.io/definitions/git/github/bitstadium/hockeysdk-mac/6169aec3571b1e47aa496e8d42ffecbc6edb602b/6169aec3571b1e47aa496e8d42ffecbc6edb602b)