### PR TITLE
jQuery 3.5.0.1

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -226,6 +226,9 @@ revisions:
   3.5.0:
     licensed:
       declared: MIT
+  3.5.0.1:
+    licensed:
+      declared: MIT
   3.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery 3.5.0.1

**Details:**
Package files point toward MIT License. MEta data also points toward MIT. Found source repo and confirmed MIT. 

**Resolution:**
https://github.com/jquery/jquery/blob/3.5.0/LICENSE.txt

**Affected definitions**:
- [jQuery 3.5.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/3.5.0.1/3.5.0.1)