### PR TITLE
SystemWrapper.Wrappers 0.23.0.168

### DIFF
--- a/curations/nuget/nuget/-/SystemWrapper.Wrappers.yaml
+++ b/curations/nuget/nuget/-/SystemWrapper.Wrappers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SystemWrapper.Wrappers
+  provider: nuget
+  type: nuget
+revisions:
+  0.23.0.168:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SystemWrapper.Wrappers 0.23.0.168

**Details:**
No info in package files. Meta data confirms MS-PL License. 

**Resolution:**
https://github.com/jozefizso/SystemWrapper/blob/v0.23.0/LICENSE.txt

**Affected definitions**:
- [SystemWrapper.Wrappers 0.23.0.168](https://clearlydefined.io/definitions/nuget/nuget/-/SystemWrapper.Wrappers/0.23.0.168/0.23.0.168)