### PR TITLE
Crc32.NET 1.2.0

### DIFF
--- a/curations/nuget/nuget/-/Crc32.NET.yaml
+++ b/curations/nuget/nuget/-/Crc32.NET.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Crc32.NET
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Crc32.NET 1.2.0

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/force-net/Crc32.NET/blob/v1.2.0/LICENSE

**Affected definitions**:
- [Crc32.NET 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Crc32.NET/1.2.0/1.2.0)