### PR TITLE
Microsoft.Azure.CosmosDB.Table 2.1.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.CosmosDB.Table.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.CosmosDB.Table.yaml
@@ -30,3 +30,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.CosmosDB.Table 2.1.2

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://raw.githubusercontent.com/WindowsAzure/azure-sdk-for-net/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.CosmosDB.Table 2.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.CosmosDB.Table/2.1.2/2.1.2)