### PR TITLE
Microsoft.ApplicationInsights 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.yaml
@@ -9,6 +9,9 @@ revisions:
   0.7.1:
     licensed:
       declared: MIT
+  1.0.0:
+    licensed:
+      declared: MIT
   1.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights 1.0.0

**Details:**
Looks like some contribution was merged, but no the license. 

No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights/1.0.0/1.0.0)