### PR TITLE
SonarAnalyzer.CSharp 8.4.0.15306

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SonarAnalyzer.CSharp
+  provider: nuget
+  type: nuget
+revisions:
+  8.4.0.15306:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SonarAnalyzer.CSharp 8.4.0.15306

**Details:**
No info in package files. Meta data confirms LGPL 3.0. 

**Resolution:**
https://www.nuget.org/packages/SonarAnalyzer.CSharp/8.4.0.15306/License

**Affected definitions**:
- [SonarAnalyzer.CSharp 8.4.0.15306](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/8.4.0.15306/8.4.0.15306)