### PR TITLE
bootstrap 3.3.2

### DIFF
--- a/curations/nuget/nuget/-/bootstrap.yaml
+++ b/curations/nuget/nuget/-/bootstrap.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: Apache-2.0
+  3.3.2:
+    licensed:
+      declared: MIT
   3.3.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bootstrap 3.3.2

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/twbs/bootstrap/blob/v3.3.2/LICENSE

**Affected definitions**:
- [bootstrap 3.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/bootstrap/3.3.2/3.3.2)