### PR TITLE
Microsoft.NETFramework.ReferenceAssemblies.net45 1.0.0-preview.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net45.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net45.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.NETFramework.ReferenceAssemblies.net45
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-preview.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETFramework.ReferenceAssemblies.net45 1.0.0-preview.2

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/Microsoft/dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net45 1.0.0-preview.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net45/1.0.0-preview.2/1.0.0-preview.2)