### PR TITLE
NuGet.CommandLine 4.7.1

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -27,6 +27,9 @@ revisions:
   4.6.2:
     licensed:
       declared: Apache-2.0
+  4.7.1:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.CommandLine 4.7.1

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.CommandLine 4.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.7.1/4.7.1)