### PR TITLE
FluentResults 1.1.0

### DIFF
--- a/curations/nuget/nuget/-/FluentResults.yaml
+++ b/curations/nuget/nuget/-/FluentResults.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FluentResults
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentResults 1.1.0

**Details:**
No info in package files. No links in meta data. Found source repo and confirms MIT License. 

**Resolution:**
https://github.com/altmann/FluentResults/blob/master/LICENSE

**Affected definitions**:
- [FluentResults 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/FluentResults/1.1.0/1.1.0)