### PR TITLE
Swashbuckle.AspNetCore.Filters 5.1.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Filters.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Filters.yaml
@@ -6,3 +6,6 @@ revisions:
   4.5.5:
     licensed:
       declared: MIT
+  5.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.Filters 5.1.1

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/blob/v5.1.1/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Filters 5.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Filters/5.1.1/5.1.1)