### PR TITLE
Microsoft.IdentityModel.Protocols 2.1.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.4:
     licensed:
       declared: MIT
+  2.1.5:
+    licensed:
+      declared: MIT
   5.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Protocols 2.1.5

**Details:**
No info in package files. No links in meta data. Found what appears to be source repo and it confirms MIT License. 

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/dev/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.Protocols 2.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocols/2.1.5/2.1.5)