### PR TITLE
 DotNet.Glob 2.0.3

### DIFF
--- a/curations/nuget/nuget/-/DotNet.Glob.yaml
+++ b/curations/nuget/nuget/-/DotNet.Glob.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNet.Glob
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 DotNet.Glob 2.0.3

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/dazinator/DotNet.Glob/blob/2.0.3/LICENSE

**Affected definitions**:
- [DotNet.Glob 2.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/DotNet.Glob/2.0.3/2.0.3)