### PR TITLE
Microsoft.ApplicationInsights.JavaScript 0.21.5-build00175

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
@@ -9,6 +9,9 @@ revisions:
   0.15.0-build58334:
     licensed:
       declared: MIT
+  0.21.5-build00175:
+    licensed:
+      declared: MIT
   0.22.9-build00167:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.JavaScript 0.21.5-build00175

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.JavaScript 0.21.5-build00175](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript/0.21.5-build00175/0.21.5-build00175)