### PR TITLE
Microsoft.Owin.Security.Twitter 4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.Twitter.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.Twitter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Security.Twitter
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Owin.Security.Twitter 4.1.0

**Details:**
Package files indicate Apache 2.0 and meta data confirms. 

**Resolution:**
https://raw.githubusercontent.com/aspnet/AspNetKatana/v4.0.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.Owin.Security.Twitter 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.Twitter/4.1.0/4.1.0)