### PR TITLE
Ninject.Web.Common 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Web.Common.yaml
+++ b/curations/nuget/nuget/-/Ninject.Web.Common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Web.Common
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Web.Common 3.2.0

**Details:**
No info in package files. Meta data confirms an Apache 2.0 or MS-PL Licenses. 

**Resolution:**
https://raw.githubusercontent.com/ninject/ninject.extensions.wcf/master/LICENSE.txt

**Affected definitions**:
- [Ninject.Web.Common 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Web.Common/3.2.0/3.2.0)