### PR TITLE
Microsoft.ApplicationInsights.Log4NetAppender 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Log4NetAppender.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Log4NetAppender.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.Log4NetAppender 2.2.0

**Details:**
No info in package files. Meta data confirms MIT License.

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.Log4NetAppender 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.Log4NetAppender/2.2.0/2.2.0)