### PR TITLE
Bond.Core.CSharp 7.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
@@ -29,6 +29,9 @@ revisions:
   6.0.0:
     licensed:
       declared: MIT
+  7.0.0:
+    licensed:
+      declared: MIT
   7.0.1:
     described:
       releaseDate: '2017-10-26'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Core.CSharp 7.0.0

**Details:**
No info in package files. Meta data confirms  MIT License. 

**Resolution:**
https://github.com/microsoft/bond/blob/7.0.0/LICENSE

**Affected definitions**:
- [Bond.Core.CSharp 7.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Core.CSharp/7.0.0/7.0.0)