### PR TITLE
boost 1.68.0

### DIFF
--- a/curations/nuget/nuget/-/boost.yaml
+++ b/curations/nuget/nuget/-/boost.yaml
@@ -9,3 +9,6 @@ revisions:
   1.67.0:
     licensed:
       declared: BSL-1.0
+  1.68.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost 1.68.0

**Details:**
No info in package files. Meta data confirms Apache 2.0 License. 

**Resolution:**
https://github.com/sergey-shandar/getboost/blob/master/LICENSE

**Affected definitions**:
- [boost 1.68.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost/1.68.0/1.68.0)