### PR TITLE
StackExchange.Redis.StrongName 1.1.605

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -31,6 +31,9 @@ revisions:
         path: StackExchange.Redis.StrongName.nuspec
     licensed:
       declared: MIT
+  1.1.605:
+    licensed:
+      declared: MIT
   1.1.608:
     described:
       releaseDate: '2016-10-06'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis.StrongName 1.1.605

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://raw.githubusercontent.com/StackExchange/StackExchange.Redis/master/LICENSE

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.1.605](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.1.605/1.1.605)