### PR TITLE
Microsoft.ApplicationInsights.PerfCounterCollector 2.6.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.PerfCounterCollector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.PerfCounterCollector.yaml
@@ -60,6 +60,9 @@ revisions:
   2.5.1:
     licensed:
       declared: MIT
+  2.6.1:
+    licensed:
+      declared: MIT
   2.6.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.PerfCounterCollector 2.6.1

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.PerfCounterCollector 2.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.PerfCounterCollector/2.6.1/2.6.1)