### PR TITLE
Microsoft.ApplicationInsights.ServiceFabric.Native 2.2.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.ServiceFabric.Native.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.ServiceFabric.Native.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ApplicationInsights.ServiceFabric.Native
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.ServiceFabric.Native 2.2.2

**Details:**
No info in package files. Meta data confirms MIT License. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.ServiceFabric.Native 2.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.ServiceFabric.Native/2.2.2/2.2.2)