### PR TITLE
Google.Protobuf	3.10.1

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -9,6 +9,9 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.10.1:
+    licensed:
+      declared: BSD-3-Clause
   3.11.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf	3.10.1

**Details:**
Harvested license file indicates license is BSD-3

**Resolution:**
License file on project site also indicates license is BSD-3

**Affected definitions**:
- [Google.Protobuf 3.10.1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.10.1/3.10.1)