### PR TITLE
Nito.AsyncEx	5.0.0

### DIFF
--- a/curations/nuget/nuget/-/Nito.AsyncEx.yaml
+++ b/curations/nuget/nuget/-/Nito.AsyncEx.yaml
@@ -9,3 +9,6 @@ revisions:
   4.0.1:
     licensed:
       declared: MIT
+  5.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nito.AsyncEx	5.0.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [Nito.AsyncEx 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.AsyncEx/5.0.0/5.0.0)