### PR TITLE
Microsoft.VisualStudio.CommandBars	8.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.CommandBars.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.CommandBars.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.CommandBars
+  provider: nuget
+  type: nuget
+revisions:
+  8.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.CommandBars	8.0.0

**Details:**
There is no license link on the Nuget site

**Resolution:**
There is no license file in the package and there is no license URL in the Nuspec file

**Affected definitions**:
- [Microsoft.VisualStudio.CommandBars 8.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.CommandBars/8.0.0/8.0.0)