### PR TITLE
@microsoft/sp-application-base 1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-application-base.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-application-base.yaml
@@ -7,3 +7,6 @@ revisions:
   1.8.2:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/sp-application-base 1.9.1

**Details:**
No info in package files. Meta data was sparse. Followed the link to MSFT Sharepoint terms that pointed to license under MSFT EULA. No license mentioned that falls under the SPDX list, so I curated as Other. 

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [sp-application-base 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-application-base/1.9.1/1.9.1)