### PR TITLE
path-platform/0.0.1

### DIFF
--- a/curations/npm/npmjs/-/path-platform.yaml
+++ b/curations/npm/npmjs/-/path-platform.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: path-platform
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
path-platform/0.0.1

**Details:**
No info in package files. Followed meta data to a source repo that mentioned MIT, but was apparently relocated. Followed link to relocation and confirmed. 

**Resolution:**
https://github.com/tjfontaine/node-path-platform/blob/master/LICENSE

...followed to this next link. 

https://github.com/nodejs/node/blob/master/LICENSE

**Affected definitions**:
- [path-platform 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/path-platform/0.0.1/0.0.1)