### PR TITLE
http-browserify/1.3.2

### DIFF
--- a/curations/npm/npmjs/-/http-browserify.yaml
+++ b/curations/npm/npmjs/-/http-browserify.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.3.2:
+    licensed:
+      declared: MIT
   1.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
http-browserify/1.3.2

**Details:**
Package files mention MIT. Meta data and source repo point to MIT. 

**Resolution:**
https://github.com/browserify/http-browserify/blob/1.3.2/LICENSE

**Affected definitions**:
- [http-browserify 1.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/http-browserify/1.3.2/1.3.2)