### PR TITLE
yargs/1.3.3

### DIFF
--- a/curations/npm/npmjs/-/yargs.yaml
+++ b/curations/npm/npmjs/-/yargs.yaml
@@ -6,6 +6,9 @@ revisions:
   1.2.6:
     licensed:
       declared: MIT
+  1.3.3:
+    licensed:
+      declared: MIT
   3.5.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
yargs/1.3.3

**Details:**
Package files point to MIT and meta data and source repo confirm MIT. 

**Resolution:**
https://github.com/yargs/yargs/blob/master/LICENSE

**Affected definitions**:
- [yargs 1.3.3](https://clearlydefined.io/definitions/npm/npmjs/-/yargs/1.3.3/1.3.3)