### PR TITLE
osenv/0.1.0

### DIFF
--- a/curations/npm/npmjs/-/osenv.yaml
+++ b/curations/npm/npmjs/-/osenv.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: osenv
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
osenv/0.1.0

**Details:**
Package files point to BSD license, meta data and source repo confirm BSD 2 Clause. 

**Resolution:**
https://github.com/npm/osenv/blob/v0.1.0/LICENSE

**Affected definitions**:
- [osenv 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/osenv/0.1.0/0.1.0)