### PR TITLE
dnspython/1.16.0

### DIFF
--- a/curations/pypi/pypi/-/dnspython.yaml
+++ b/curations/pypi/pypi/-/dnspython.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dnspython
+  provider: pypi
+  type: pypi
+revisions:
+  1.16.0:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dnspython/1.16.0

**Details:**
No package files. Meta data and source repo confirm ISC license. 

**Resolution:**
https://github.com/rthalley/dnspython/blob/v1.16.0/LICENSE

**Affected definitions**:
- [dnspython 1.16.0](https://clearlydefined.io/definitions/pypi/pypi/-/dnspython/1.16.0/1.16.0)