### PR TITLE
buffer-crc32/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/buffer-crc32.yaml
+++ b/curations/npm/npmjs/-/buffer-crc32.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: buffer-crc32
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
buffer-crc32/0.2.1

**Details:**
No info in package files. Meta data and source repo confirm MIT. 

**Resolution:**
https://github.com/brianloveswords/buffer-crc32/blob/v0.2.1/LICENSE

**Affected definitions**:
- [buffer-crc32 0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/buffer-crc32/0.2.1/0.2.1)