### PR TITLE
Moq	4.14.4

### DIFF
--- a/curations/nuget/nuget/-/Moq.yaml
+++ b/curations/nuget/nuget/-/Moq.yaml
@@ -30,6 +30,9 @@ revisions:
   4.14.2:
     licensed:
       declared: BSD-3-Clause
+  4.14.4:
+    licensed:
+      declared: BSD-3-Clause
   4.2.1402.2112:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Moq	4.14.4

**Details:**
License link on Nuget site indicates license is BSD-3

**Resolution:**
License file on project site also indicates license is BSD-3

**Affected definitions**:
- [Moq 4.14.4](https://clearlydefined.io/definitions/nuget/nuget/-/Moq/4.14.4/4.14.4)