### PR TITLE
com.sun.jersey:jersey-servlet	1.19

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-servlet.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-servlet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-servlet
+  namespace: com.sun.jersey
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.19':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception

--- a/curations/maven/mavencentral/com.sun.jersey/jersey-servlet.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-servlet.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.19':
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.sun.jersey:jersey-servlet	1.19

**Details:**
.pom file indicates license is CDDL OR GPL-2.0-only WITH Classpath-exception-2.0. License link in file indicates CDDL version is 1.1

**Resolution:**
Please update the curation to the proper SPDX format of “CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0.”

**Affected definitions**:
- [jersey-servlet 1.19](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-servlet/1.19/1.19)