### PR TITLE
Microsoft.ApplicationInsights.TraceListener	2.5.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
@@ -42,6 +42,9 @@ revisions:
   2.4.1:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: MIT
   2.6.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.TraceListener	2.5.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.ApplicationInsights.TraceListener 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener/2.5.0/2.5.0)