### PR TITLE
azureml-train-automl-client	1.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
@@ -42,6 +42,9 @@ revisions:
   2.4.1:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: NOASSERTION
   2.6.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.4.0

**Details:**
PyPi site indicates license is Other/Proprietary License (https://aka.ms/azureml-sdk-license)

**Resolution:**
License file in package also indicates license is Other

**Affected definitions**:
- [Microsoft.ApplicationInsights.TraceListener 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener/2.5.0/2.5.0)