### PR TITLE
org.bouncycastle:bcprov-jdk15on	1.52

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.52':
+    licensed:
+      declared: MIT
   '1.60':
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle:bcprov-jdk15on	1.52

**Details:**
License link in .pom file indicates license is MIT

**Resolution:**
License file on project repository also indicates license is MIT

**Affected definitions**:
- [bcprov-jdk15on 1.52](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.52/1.52)