### PR TITLE
Microsoft.ApplicationInsights.JavaScript	0.22.19-build00125

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
@@ -14,7 +14,7 @@ revisions:
       declared: MIT
   0.22.19-build00125:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   0.22.9-build00167:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript.yaml
@@ -12,6 +12,9 @@ revisions:
   0.21.5-build00175:
     licensed:
       declared: MIT
+  0.22.19-build00125:
+    licensed:
+      declared: NOASSERTION
   0.22.9-build00167:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.JavaScript	0.22.19-build00125

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [Microsoft.ApplicationInsights.JavaScript 0.22.19-build00125](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.JavaScript/0.22.19-build00125/0.22.19-build00125)