### PR TITLE
System.Reflection.TypeExtensions	4.6.0

### DIFF
--- a/curations/nuget/nuget/-/System.Reflection.TypeExtensions.yaml
+++ b/curations/nuget/nuget/-/System.Reflection.TypeExtensions.yaml
@@ -14,4 +14,4 @@ revisions:
       declared: MIT
   4.6.0:
     licensed:
-      declared: NOASSERTION
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Reflection.TypeExtensions.yaml
+++ b/curations/nuget/nuget/-/System.Reflection.TypeExtensions.yaml
@@ -12,3 +12,6 @@ revisions:
   4.5.1:
     licensed:
       declared: MIT
+  4.6.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Reflection.TypeExtensions	4.6.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [System.Reflection.TypeExtensions 4.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reflection.TypeExtensions/4.6.0/4.6.0)