### PR TITLE
LibGit2Sharp	0.26.1

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.yaml
@@ -66,6 +66,9 @@ revisions:
   0.26.0-preview-0080:
     licensed:
       declared: MIT
+  0.26.1:
+    licensed:
+      declared: NOASSERTION
   0.26.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LibGit2Sharp	0.26.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [LibGit2Sharp 0.26.1](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp/0.26.1/0.26.1)