### PR TITLE
Xamarin.Android.Support.Core.Utils	28.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
@@ -14,6 +14,9 @@ revisions:
         path: Xamarin.Android.Support.Core.Utils.nuspec
     licensed:
       declared: MIT
+  28.0.0.1:
+    licensed:
+      declared: NOASSERTION
   28.0.0.3:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
@@ -16,7 +16,7 @@ revisions:
       declared: MIT
   28.0.0.1:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   28.0.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.Core.Utils	28.0.0.1

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [Xamarin.Android.Support.Core.Utils 28.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Core.Utils/28.0.0.1/28.0.0.1)