### PR TITLE
ILMerge	3.0.29

### DIFF
--- a/curations/nuget/nuget/-/ILMerge.yaml
+++ b/curations/nuget/nuget/-/ILMerge.yaml
@@ -12,3 +12,6 @@ revisions:
   3.0.21:
     licensed:
       declared: MIT
+  3.0.29:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/ILMerge.yaml
+++ b/curations/nuget/nuget/-/ILMerge.yaml
@@ -14,4 +14,4 @@ revisions:
       declared: MIT
   3.0.29:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ILMerge	3.0.29

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [ILMerge 3.0.29](https://clearlydefined.io/definitions/nuget/nuget/-/ILMerge/3.0.29/3.0.29)