### PR TITLE
FluentCommandLineParser	1.4.3

### DIFF
--- a/curations/nuget/nuget/-/FluentCommandLineParser.yaml
+++ b/curations/nuget/nuget/-/FluentCommandLineParser.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FluentCommandLineParser
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.3:
+    licensed:
+      declared: BSD-2-Clause-FreeBSD


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentCommandLineParser	1.4.3

**Details:**
License file in repository indicates license is BSD 2- Clause Free BSD

**Resolution:**
License file in package also indicates license is BSD 2- Clause Free BSD

**Affected definitions**:
- [FluentCommandLineParser 1.4.3](https://clearlydefined.io/definitions/nuget/nuget/-/FluentCommandLineParser/1.4.3/1.4.3)