### PR TITLE
Microsoft.Bot.Builder	4.7.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -12,6 +12,9 @@ revisions:
   4.7.0:
     licensed:
       declared: MIT
-  4.8.0:      
+  4.7.2:
+    licensed:
+      declared: NOASSERTION
+  4.8.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -14,7 +14,7 @@ revisions:
       declared: MIT
   4.7.2:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   4.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder	4.7.2

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link from Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Builder 4.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/4.7.2/4.7.2)