### PR TITLE
Cauldron.Interception.Fody	3.2.2

### DIFF
--- a/curations/nuget/nuget/-/Cauldron.Interception.Fody.yaml
+++ b/curations/nuget/nuget/-/Cauldron.Interception.Fody.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Cauldron.Interception.Fody
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Cauldron.Interception.Fody	3.2.2

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file on project site also indicates license is MIT

**Affected definitions**:
- [Cauldron.Interception.Fody 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Cauldron.Interception.Fody/3.2.2/3.2.2)