### PR TITLE
office-ui-fabric-react-bundle/1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/office-ui-fabric-react-bundle.yaml
+++ b/curations/npm/npmjs/@microsoft/office-ui-fabric-react-bundle.yaml
@@ -7,3 +7,6 @@ revisions:
   1.8.2:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
office-ui-fabric-react-bundle/1.9.1

**Details:**
No info in package files. Meta data had link to Sharepoint EULA for license. Curated as OTHER.

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [office-ui-fabric-react-bundle 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/office-ui-fabric-react-bundle/1.9.1/1.9.1)