### PR TITLE
sp-webpart-workbench/1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-webpart-workbench.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-webpart-workbench.yaml
@@ -7,3 +7,6 @@ revisions:
   1.8.2:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-webpart-workbench/1.9.1

**Details:**
No info in package files. Meta data had link to Sharepoint EULA for license. Curated as OTHER.

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [sp-webpart-workbench 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-webpart-workbench/1.9.1/1.9.1)