### PR TITLE
sp-search-extensibility/1.10.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-search-extensibility.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-search-extensibility.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sp-search-extensibility
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.10.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-search-extensibility/1.10.0

**Details:**
No info in package files. Meta data had link to Sharepoint EULA for license. Curated as OTHER.

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [sp-search-extensibility 1.10.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-search-extensibility/1.10.0/1.10.0)