### PR TITLE
numpy1.19.0

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -53,7 +53,10 @@ revisions:
       declared: BSD-3-Clause
   1.18.4:
     licensed:
-      declared: BSD-3-Clause  
+      declared: BSD-3-Clause
   1.18.5:
+    licensed:
+      declared: BSD-3-Clause
+  1.19.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
numpy1.19.0

**Details:**
LICENSE.txt in package is BSD-3-Clause; metadata is "BSD"

**Resolution:**
 BSD-3-Clause

**Affected definitions**:
- [numpy 1.19.0](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.19.0/1.19.0)