### PR TITLE
pandas1.0.5

### DIFF
--- a/curations/pypi/pypi/-/pandas.yaml
+++ b/curations/pypi/pypi/-/pandas.yaml
@@ -15,3 +15,6 @@ revisions:
   1.0.4:
     licensed:
       declared: BSD-3-Clause
+  1.0.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pandas1.0.5

**Details:**
LICENSE in package is BSD-3-Clause; metadata is BSD

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [pandas 1.0.5](https://clearlydefined.io/definitions/pypi/pypi/-/pandas/1.0.5/1.0.5)