### PR TITLE
protobuf 3.12.1

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -21,6 +21,9 @@ revisions:
   3.12.0:
     licensed:
       declared: BSD-3-Clause
+  3.12.1:
+    licensed:
+      declared: BSD-3-Clause
   3.12.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
protobuf 3.12.1

**Details:**
Metadata is BSD-3-Clause and .py file header is same

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [protobuf 3.12.1](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/3.12.1/3.12.1)