### PR TITLE
paranamer 2.7

### DIFF
--- a/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
+++ b/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
@@ -7,3 +7,6 @@ revisions:
   '2.3':
     licensed:
       declared: BSD-3-Clause
+  '2.7':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
paranamer 2.7

**Details:**
BSD-3-Clause on .java source file headers

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [paranamer 2.7](https://clearlydefined.io/definitions/maven/mavencentral/com.thoughtworks.paranamer/paranamer/2.7/2.7)