### PR TITLE
oslo.config8.2.0

### DIFF
--- a/curations/pypi/pypi/-/oslo.config.yaml
+++ b/curations/pypi/pypi/-/oslo.config.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: oslo.config
+  provider: pypi
+  type: pypi
+revisions:
+  8.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
oslo.config8.2.0

**Details:**
Updating "Declared" field to just Apache-2.0

**Resolution:**
LICENSE file is Apache with a reference to earlier versions of "python-keystoneclient" being under BSD-2-Clause.  I dont see anything called that in this package.

**Affected definitions**:
- [oslo.config 8.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/oslo.config/8.2.0/8.2.0)