### PR TITLE
Microsoft.Bot.Builder.Azure 4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Azure.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Azure.yaml
@@ -48,3 +48,6 @@ revisions:
   4.3.2:
     licensed:
       declared: MIT
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Builder.Azure 4.9.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Project license, tagged version:
https://github.com/microsoft/botbuilder-dotnet/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Azure 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Azure/4.9.3/4.9.3)