### PR TITLE
Microsoft.PowerShell.3.ReferenceAssemblies/1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.3.ReferenceAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.3.ReferenceAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.3.ReferenceAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.PowerShell.3.ReferenceAssemblies/1.0.0

**Details:**
Closest commit to published date has MIT license.

**Resolution:**
https://github.com/PowerShell/PowerShell-Tests/blob/8f400987081f22c38d644282376927cdb6fdd3ab/LICENSE

**Affected definitions**:
- [Microsoft.PowerShell.3.ReferenceAssemblies 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.3.ReferenceAssemblies/1.0.0/1.0.0)