### PR TITLE
WebSocketSharp-netstandard/1.0.1

### DIFF
--- a/curations/nuget/nuget/-/WebSocketSharp-netstandard.yaml
+++ b/curations/nuget/nuget/-/WebSocketSharp-netstandard.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WebSocketSharp-netstandard
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
WebSocketSharp-netstandard/1.0.1

**Details:**
MIT

**Resolution:**
https://github.com/PingmanTools/websocket-sharp/blob/7f526f72ba855bb85128430414d88feb53bbf8d6/LICENSE.txt

**Affected definitions**:
- [WebSocketSharp-netstandard 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/WebSocketSharp-netstandard/1.0.1/1.0.1)