### PR TITLE
pylint2.4.4

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -28,3 +28,6 @@ revisions:
         path: pylint-2.3.0/setup.py
     licensed:
       declared: GPL-2.0-only
+  2.4.4:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint2.4.4

**Details:**
Correcting "declared" license to just be "GPL-2.0-only."

**Resolution:**
Uncertain where the tooling was pulling GPL-3.0

**Affected definitions**:
- [pylint 2.4.4](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.4.4/2.4.4)