### PR TITLE
astroid 2.3.1

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: astroid
+  provider: pypi
+  type: pypi
+revisions:
+  2.3.1:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid 2.3.1

**Details:**
According to the setup.py, it looks like the 'declared license is LGPL-2.1-only.

**Resolution:**
LGPL-2.1-only.

**Affected definitions**:
- [astroid 2.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.3.1/2.3.1)