### PR TITLE
FFmpeg.AutoGen 4.2.0

### DIFF
--- a/curations/nuget/nuget/-/FFmpeg.AutoGen.yaml
+++ b/curations/nuget/nuget/-/FFmpeg.AutoGen.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FFmpeg.AutoGen
+  provider: nuget
+  type: nuget
+revisions:
+  4.2.0:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FFmpeg.AutoGen 4.2.0

**Details:**
NuGet license link and LICENSE.txt are LGPL-3.0

**Resolution:**
LGPL-3.0-only

**Affected definitions**:
- [FFmpeg.AutoGen 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/FFmpeg.AutoGen/4.2.0/4.2.0)