### PR TITLE
yamllint1.18.0

### DIFF
--- a/curations/pypi/pypi/-/yamllint.yaml
+++ b/curations/pypi/pypi/-/yamllint.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: yamllint
+  provider: pypi
+  type: pypi
+revisions:
+  1.18.0:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
yamllint1.18.0

**Details:**
Fixing "Declared" license to just be "GPL-3.0-or later," per setup.py

**Resolution:**
https://clearlydefined.io/file/ca83e70c32960f68c38fd9125bc87a9623a21a21565eeb8c33698579a1789bc2

**Affected definitions**:
- [yamllint 1.18.0](https://clearlydefined.io/definitions/pypi/pypi/-/yamllint/1.18.0/1.18.0)