### PR TITLE
ansible 2.9.10

### DIFF
--- a/curations/pypi/pypi/-/ansible.yaml
+++ b/curations/pypi/pypi/-/ansible.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ansible
+  provider: pypi
+  type: pypi
+revisions:
+  2.9.10:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ansible 2.9.10

**Details:**
Correcting "Declared" license to just be "GPL-3.0-or later," per the setup.py that says   license='GPLv3+'

**Resolution:**
GPL-3.0-or later

**Affected definitions**:
- [ansible 2.9.10](https://clearlydefined.io/definitions/pypi/pypi/-/ansible/2.9.10/2.9.10)