### PR TITLE
ansible 2.9.9

### DIFF
--- a/curations/pypi/pypi/-/ansible.yaml
+++ b/curations/pypi/pypi/-/ansible.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ansible
+  provider: pypi
+  type: pypi
+revisions:
+  2.9.9:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ansible 2.9.9

**Details:**
Correcting declared license to just be "GPL-3.0-or later," per setup.py that says:  license='GPLv3+'. 

**Resolution:**
GPL-3.0-or later
(Note: I filed a bug related to this here: https://github.com/clearlydefined/crawler/issues/396)

**Affected definitions**:
- [ansible 2.9.9](https://clearlydefined.io/definitions/pypi/pypi/-/ansible/2.9.9/2.9.9)