### PR TITLE
react-native-camera 3.30.0

### DIFF
--- a/curations/npm/npmjs/-/react-native-camera.yaml
+++ b/curations/npm/npmjs/-/react-native-camera.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: react-native-camera
+  provider: npmjs
+  type: npm
+revisions:
+  3.30.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
react-native-camera 3.30.0

**Details:**
Correcting 'declared' license to just be MIT.  Rest are 'discovered' licenses from ThirdPartyNotices file.

**Resolution:**
MIT

**Affected definitions**:
- [react-native-camera 3.30.0](https://clearlydefined.io/definitions/npm/npmjs/-/react-native-camera/3.30.0/3.30.0)