### PR TITLE
runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy 2.1.19

### DIFF
--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -6,6 +6,9 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.19:
+    licensed:
+      declared: MIT
   2.1.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy 2.1.19

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license

Tagged version:
https://github.com/dotnet/core-setup/blob/v2.1.19/LICENSE.TXT

**Affected definitions**:
- [runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy 2.1.19](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy/2.1.19/2.1.19)