### PR TITLE
Microsoft.FeatureManagement 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.FeatureManagement.yaml
+++ b/curations/nuget/nuget/-/Microsoft.FeatureManagement.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.FeatureManagement
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.FeatureManagement.yaml
+++ b/curations/nuget/nuget/-/Microsoft.FeatureManagement.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.0.0:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.FeatureManagement 2.0.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license: MIT. No tagged version

License from commit date matching to release date:
https://github.com/Azure/AppConfiguration/blob/06be4d8a3ad9497cda6490b3943a50fa40110455/LICENSE

**Affected definitions**:
- [Microsoft.FeatureManagement 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.FeatureManagement/2.0.0/2.0.0)