### PR TITLE
unorm 1.6.0

### DIFF
--- a/curations/npm/npmjs/-/unorm.yaml
+++ b/curations/npm/npmjs/-/unorm.yaml
@@ -17,3 +17,6 @@ revisions:
         path: package/LICENSE.md
     licensed:
       declared: MIT OR GPL-2.0-only
+  1.6.0:
+    licensed:
+      declared: MIT OR GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
unorm 1.6.0

**Details:**
Declaring MIT or GPLv2.0 or later

**Resolution:**
ClearlyDefined Files: LIcense.md (MIT or GPLv2.o or later)

License text also located on NPM page

Project license, tagged version:
https://github.com/walling/unorm/blob/v1.6.0/LICENSE.md

**Affected definitions**:
- [unorm 1.6.0](https://clearlydefined.io/definitions/npm/npmjs/-/unorm/1.6.0/1.6.0)