### PR TITLE
Swashbuckle.AspNetCore.Annotations 5.4.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Annotations.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Annotations.yaml
@@ -12,3 +12,6 @@ revisions:
   5.0.0:
     licensed:
       declared: MIT
+  5.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.Annotations 5.4.1

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Files: License is MIT

NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.4.1/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Annotations 5.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Annotations/5.4.1/5.4.1)