### PR TITLE
morelinq 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/morelinq.yaml
+++ b/curations/nuget/nuget/-/morelinq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: morelinq
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 AND MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
morelinq 3.2.0

**Details:**
Declaring Apache 2.0 and MIT

**Resolution:**
ClearlyDefined Files: Copying.txt is Apache 2.0 and a small portion of the code is under MIT

NuGet metadata: https://www.nuget.org/packages/morelinq/3.2.0/License

Project license, tagged version:
https://github.com/morelinq/MoreLINQ/blob/v3.2.0/COPYING.txt

**Affected definitions**:
- [morelinq 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/morelinq/3.2.0/3.2.0)