### PR TITLE
onnx 1.7.0

### DIFF
--- a/curations/pypi/pypi/-/onnx.yaml
+++ b/curations/pypi/pypi/-/onnx.yaml
@@ -6,3 +6,6 @@ revisions:
   1.6.0:
     licensed:
       declared: MIT
+  1.7.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
onnx 1.7.0

**Details:**
Declaring MIT

**Resolution:**
Project homepage: https://github.com/onnx/onnx/blob/v1.7.0/LICENSE

**Affected definitions**:
- [onnx 1.7.0](https://clearlydefined.io/definitions/pypi/pypi/-/onnx/1.7.0/1.7.0)