### PR TITLE
Content license is Apache-2.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.maven.doxia/doxia-module-fml.yaml
+++ b/curations/maven/mavencentral/org.apache.maven.doxia/doxia-module-fml.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: doxia-module-fml
+  namespace: org.apache.maven.doxia
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    described:
+      sourceLocation:
+        name: maven-doxia
+        namespace: apache
+        provider: github
+        revision: 730d8516db0d70f47804418155c3ce66bbf3a9be
+        type: git
+        url: 'https://github.com/apache/maven-doxia/commit/730d8516db0d70f47804418155c3ce66bbf3a9be'
+    files:
+      - license: Apache-2.0
+        path: org/apache/maven/doxia/module/fml/FmlParser.class


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Content license is Apache-2.0

**Details:**
One file is incorrectly marked as NOASSERTION

**Resolution:**
Update the license information.

I've updated the source URL to point to the GitHub repository. Is there a means of pointing to a specific directory in the repository?

**Affected definitions**:
- [doxia-module-fml 1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.maven.doxia/doxia-module-fml/1.0/1.0)