### PR TITLE
CsvHelper/2.13.2/2.13.2

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -9,6 +9,9 @@ revisions:
   12.2.1:
     licensed:
       declared: MS-PL
+  2.13.2:
+    licensed:
+      declared: MS-PL AND Apache-2.0
   2.16.3:
     licensed:
       declared: MS-PL OR Apache-2.0

--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -5,13 +5,13 @@ coordinates:
 revisions:
   12.1.2:
     licensed:
-      declared: Apache-2.0 AND MS-PL
+      declared: MS-PL OR Apache-2.0
   12.2.1:
     licensed:
-      declared: MS-PL
+      declared: MS-PL OR Apache-2.0
   2.13.2:
     licensed:
-      declared: MS-PL AND Apache-2.0
+      declared: MS-PL OR Apache-2.0
   2.16.3:
     licensed:
       declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CsvHelper/2.13.2/2.13.2

**Details:**
Corrected declared license. 

**Resolution:**
https://github.com/JoshClose/CsvHelper/blob/2.13.2/LICENSE.txt

**Affected definitions**:
- [CsvHelper 2.13.2](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/2.13.2/2.13.2)