### PR TITLE
BuildWebCompiler/1.11.328

### DIFF
--- a/curations/nuget/nuget/-/BuildWebCompiler.yaml
+++ b/curations/nuget/nuget/-/BuildWebCompiler.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: BuildWebCompiler
+  provider: nuget
+  type: nuget
+revisions:
+  1.11.328:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BuildWebCompiler/1.11.328

**Details:**
No info in package files. Meta data points to Apache 2.0.

**Resolution:**
https://github.com/madskristensen/WebCompiler/blob/master/LICENSE

**Affected definitions**:
- [BuildWebCompiler 1.11.328](https://clearlydefined.io/definitions/nuget/nuget/-/BuildWebCompiler/1.11.328/1.11.328)