### PR TITLE
NAudio/1.8.4

### DIFF
--- a/curations/nuget/nuget/-/NAudio.yaml
+++ b/curations/nuget/nuget/-/NAudio.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.0:
     licensed:
       declared: MS-PL
+  1.8.4:
+    licensed:
+      declared: MS-PL
   1.8.5:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NAudio/1.8.4

**Details:**
Package files points to MS-PL License and meta data confirms. 

**Resolution:**
https://github.com/naudio/NAudio/blob/v1.8.4/license.txt

**Affected definitions**:
- [NAudio 1.8.4](https://clearlydefined.io/definitions/nuget/nuget/-/NAudio/1.8.4/1.8.4)