### PR TITLE
ini/1.0.0

### DIFF
--- a/curations/npm/npmjs/-/ini.yaml
+++ b/curations/npm/npmjs/-/ini.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ini
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ini/1.0.0

**Details:**
No info in package files. Meta data and source repo confirm ISC License. 

**Resolution:**
https://github.com/npm/ini/blob/master/LICENSE

**Affected definitions**:
- [ini 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/ini/1.0.0/1.0.0)