### PR TITLE
mongodb/mongo 2261279b51ea....

### DIFF
--- a/curations/git/github/mongodb/mongo.yaml
+++ b/curations/git/github/mongodb/mongo.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: mongo
+  namespace: mongodb
+  provider: github
+  type: git
+revisions:
+  2261279b51ea13df08ae708ff278f0679c59dc32:
+    files:
+      - attributions:
+          - 'Copyright (c) 2018 MongoDB, Inc.'
+        license: SSPL-1.0
+        path: LICENSE-Community.txt
+    licensed:
+      declared: SSPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mongodb/mongo 2261279b51ea....

**Details:**
I think the Apache license is included in "declared" erroneously. It looks like the SSPL-1.0 is the overall "declared" license.  Apache would be "discovered."

**Resolution:**
SSPL-1.0https://github.com/mongodb/mongo/blob/2261279b51ea13df08ae708ff278f0679c59dc32/LICENSE-Community.txt

**Affected definitions**:
- [mongo 2261279b51ea13df08ae708ff278f0679c59dc32](https://clearlydefined.io/definitions/git/github/mongodb/mongo/2261279b51ea13df08ae708ff278f0679c59dc32)