### PR TITLE
regex	2020.5.14

### DIFF
--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -15,6 +15,9 @@ revisions:
   2020.4.4:
     licensed:
       declared: Python-2.0
+  2020.5.14:
+    licensed:
+      declared: PSF-2.0
   2020.6.8:
     licensed:
       declared: Python-2.0

--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -17,7 +17,7 @@ revisions:
       declared: Python-2.0
   2020.5.14:
     licensed:
-      declared: PSF-2.0
+      declared: Python-2.0
   2020.6.8:
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
regex	2020.5.14

**Details:**
PyPi site indicates license is Python Software Foundation License

**Resolution:**
Setup.py file also indicates license is Python Software Foundation License

**Affected definitions**:
- [regex 2020.5.14](https://clearlydefined.io/definitions/pypi/pypi/-/regex/2020.5.14/2020.5.14)