### PR TITLE
Microsoft.Azure.AppConfiguration.AspNetCore	3.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.AppConfiguration.AspNetCore
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.AppConfiguration.AspNetCore	3.0.1

**Details:**
License link on Nuget site indicates license is Microsoft Pre-Release Software License Terms

**Resolution:**
License link in Nuspec file also indicates license is Microsoft Pre-Release Software License Terms

**Affected definitions**:
- [Microsoft.Azure.AppConfiguration.AspNetCore 3.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore/3.0.1/3.0.1)