### PR TITLE
azureml-train-automl-client	1.7.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -15,3 +15,6 @@ revisions:
   1.3.0:
     licensed:
       declared: OTHER
+  1.7.0.post1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.7.0.post1

**Details:**
PyPi site indicates license is Other

**Resolution:**
License file in package indicates license is https://azure.microsoft.com/en-us/support/legal/ or https://azure.microsoft.com/en-us/support/legal/subscription-agreement/

**Affected definitions**:
- [azureml-train-automl-client 1.7.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.7.0.post1/1.7.0.post1)