### PR TITLE
Microsoft.NET.Sdk.Functions	1.0.36

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -36,6 +36,9 @@ revisions:
   1.0.34:
     licensed:
       declared: MIT
+  1.0.36:
+    licensed:
+      declared: MIT
   1.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NET.Sdk.Functions	1.0.36

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.36](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.36/1.0.36)