### PR TITLE
@react-native-community/eslint-config	0.0.5

### DIFF
--- a/curations/npm/npmjs/@react-native-community/eslint-config.yaml
+++ b/curations/npm/npmjs/@react-native-community/eslint-config.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: eslint-config
+  namespace: '@react-native-community'
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@react-native-community/eslint-config	0.0.5

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [eslint-config 0.0.5](https://clearlydefined.io/definitions/npm/npmjs/@react-native-community/eslint-config/0.0.5/0.0.5)