### PR TITLE
Microsoft.Data.SqlClient.SNI	1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Data.SqlClient.SNI
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Data.SqlClient.SNI	1.1.0

**Details:**
License link on Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS

**Resolution:**
License file in package indicates license is MICROSOFT SOFTWARE LICENSE TERMS

**Affected definitions**:
- [Microsoft.Data.SqlClient.SNI 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.SqlClient.SNI/1.1.0/1.1.0)