### PR TITLE
Fractions	4.0.1

### DIFF
--- a/curations/nuget/nuget/-/Fractions.yaml
+++ b/curations/nuget/nuget/-/Fractions.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.1:
     licensed:
       declared: BSD-2-Clause
+  4.0.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Fractions	4.0.1

**Details:**
Harvested license file indicates license is BSD-2

**Resolution:**
License file in repository also indicates license is BSD-2

**Affected definitions**:
- [Fractions 4.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Fractions/4.0.1/4.0.1)