### PR TITLE
numpy	1.16.6

### DIFF
--- a/curations/pypi/pypi/-/numpy.yaml
+++ b/curations/pypi/pypi/-/numpy.yaml
@@ -21,6 +21,9 @@ revisions:
   1.16.4:
     licensed:
       declared: BSD-3-Clause
+  1.16.6:
+    licensed:
+      declared: BSD-3-Clause
   1.17.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
numpy	1.16.6

**Details:**
License file in package indicates license is BSD-3

**Resolution:**
PyPi site indicates license is BSD

**Affected definitions**:
- [numpy 1.16.6](https://clearlydefined.io/definitions/pypi/pypi/-/numpy/1.16.6/1.16.6)