### PR TITLE
pywin32	223

### DIFF
--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  '223':
+    licensed:
+      declared: '[object Object]'
   '224':
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pywin32	223

**Details:**
PyPi site indicates license is PSF

**Resolution:**
Metadata file in package also indicates license is PSF

**Affected definitions**:
- [pywin32 223](https://clearlydefined.io/definitions/pypi/pypi/-/pywin32/223/223)