### PR TITLE
Microsoft.ApplicationInsights.DependencyCollector	2.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector.yaml
@@ -45,6 +45,9 @@ revisions:
   2.7.2:
     licensed:
       declared: MIT
+  2.8.0:
+    licensed:
+      declared: NOASSERTION
   2.8.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.DependencyCollector	2.8.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.ApplicationInsights.DependencyCollector 2.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector/2.8.0/2.8.0)