### PR TITLE
librdkafka.redist	1.3.0

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.0:
     licensed:
       declared: BSD-2-Clause
+  1.3.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkafka.redist	1.3.0

**Details:**
License link on Nuget site indicates license is BSD-2

**Resolution:**
License file in repository also indicates license is BSD-2

**Affected definitions**:
- [librdkafka.redist 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.3.0/1.3.0)