### PR TITLE
FluentAssertions.Json	5.5.0

### DIFF
--- a/curations/nuget/nuget/-/FluentAssertions.Json.yaml
+++ b/curations/nuget/nuget/-/FluentAssertions.Json.yaml
@@ -15,3 +15,6 @@ revisions:
   5.3.0:
     licensed:
       declared: Apache-2.0
+  5.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentAssertions.Json	5.5.0

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apache 2.0

**Affected definitions**:
- [FluentAssertions.Json 5.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/FluentAssertions.Json/5.5.0/5.5.0)