### PR TITLE
Microsoft.AspNetCore.OData	7.4.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -15,3 +15,6 @@ revisions:
   7.4.0:
     licensed:
       declared: MIT
+  7.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNetCore.OData	7.4.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.AspNetCore.OData 7.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.OData/7.4.1/7.4.1)