### PR TITLE
NJsonSchema	10.1.18

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -12,6 +12,9 @@ revisions:
   10.0.27:
     licensed:
       declared: MIT
+  10.1.18:
+    licensed:
+      declared: MIT
   10.1.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NJsonSchema	10.1.18

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [NJsonSchema 10.1.18](https://clearlydefined.io/definitions/nuget/nuget/-/NJsonSchema/10.1.18/10.1.18)