### PR TITLE
Unity.AspNet.WebApi/5.0.13

### DIFF
--- a/curations/nuget/nuget/-/Unity.AspNet.WebApi.yaml
+++ b/curations/nuget/nuget/-/Unity.AspNet.WebApi.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  5.0.13:
+    licensed:
+      declared: Apache-2.0
   5.0.15:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.AspNet.WebApi/5.0.13

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/unitycontainer/aspnet-webapi/blob/5.0.13.49/LICENSE

**Affected definitions**:
- [Unity.AspNet.WebApi 5.0.13](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.AspNet.WebApi/5.0.13/5.0.13)