### PR TITLE
StatsdClient/3.0.86

### DIFF
--- a/curations/nuget/nuget/-/StatsdClient.yaml
+++ b/curations/nuget/nuget/-/StatsdClient.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StatsdClient
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.86:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StatsdClient/3.0.86

**Details:**
Been deprecated. No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/Pereingo/statsd-csharp-client/blob/v3.0.86/MIT-LICENCE.md

**Affected definitions**:
- [StatsdClient 3.0.86](https://clearlydefined.io/definitions/nuget/nuget/-/StatsdClient/3.0.86/3.0.86)