### PR TITLE
Prism.Wpf/6.3.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.Wpf.yaml
+++ b/curations/nuget/nuget/-/Prism.Wpf.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   6.3.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Prism.Wpf.yaml
+++ b/curations/nuget/nuget/-/Prism.Wpf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Prism.Wpf
+  provider: nuget
+  type: nuget
+revisions:
+  6.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Wpf/6.3.0

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/PrismLibrary/Prism/blob/master/LICENSE

**Affected definitions**:
- [Prism.Wpf 6.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Wpf/6.3.0/6.3.0)