### PR TITLE
BouncyCastle.NetCore/1.8.3

### DIFF
--- a/curations/nuget/nuget/-/BouncyCastle.NetCore.yaml
+++ b/curations/nuget/nuget/-/BouncyCastle.NetCore.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.8.3:
+    licensed:
+      declared: MIT
   1.8.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BouncyCastle.NetCore/1.8.3

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/chrishaly/bc-csharp/blob/master/README.md

**Affected definitions**:
- [BouncyCastle.NetCore 1.8.3](https://clearlydefined.io/definitions/nuget/nuget/-/BouncyCastle.NetCore/1.8.3/1.8.3)