### PR TITLE
EntityFramework.MappingAPI/6.1.0.9

### DIFF
--- a/curations/nuget/nuget/-/EntityFramework.MappingAPI.yaml
+++ b/curations/nuget/nuget/-/EntityFramework.MappingAPI.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: EntityFramework.MappingAPI
+  provider: nuget
+  type: nuget
+revisions:
+  6.1.0.9:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EntityFramework.MappingAPI/6.1.0.9

**Details:**
No info in package files. Meta data contained broken links. Found on github and confirmed BSD 2 Clause. 

**Resolution:**
https://github.com/kjbartel/efmappingapi/blob/master/License.md

**Affected definitions**:
- [EntityFramework.MappingAPI 6.1.0.9](https://clearlydefined.io/definitions/nuget/nuget/-/EntityFramework.MappingAPI/6.1.0.9/6.1.0.9)