### PR TITLE
Microsoft.Bot.Builder/4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -18,3 +18,6 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder/4.9.3

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/4.9.3/4.9.3)