### PR TITLE
PreMailer.Net/1.5.5

### DIFF
--- a/curations/nuget/nuget/-/PreMailer.Net.yaml
+++ b/curations/nuget/nuget/-/PreMailer.Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PreMailer.Net
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PreMailer.Net/1.5.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/milkshakesoftware/PreMailer.Net/blob/master/LICENSE

**Affected definitions**:
- [PreMailer.Net 1.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/PreMailer.Net/1.5.5/1.5.5)