### PR TITLE
TunnelVisionLabs.Net.UriTemplate/1.0.0-beta004

### DIFF
--- a/curations/nuget/nuget/-/TunnelVisionLabs.Net.UriTemplate.yaml
+++ b/curations/nuget/nuget/-/TunnelVisionLabs.Net.UriTemplate.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TunnelVisionLabs.Net.UriTemplate
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-beta004:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TunnelVisionLabs.Net.UriTemplate/1.0.0-beta004

**Details:**
Package files indicate Apache 2.0 and confirmed by meta data. 

**Resolution:**
https://raw.githubusercontent.com/tunnelvisionlabs/dotnet-uritemplate/v1.0.0-beta004/LICENSE

**Affected definitions**:
- [TunnelVisionLabs.Net.UriTemplate 1.0.0-beta004](https://clearlydefined.io/definitions/nuget/nuget/-/TunnelVisionLabs.Net.UriTemplate/1.0.0-beta004/1.0.0-beta004)