### PR TITLE
NuGet.Versioning/4.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -18,6 +18,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.5.0:
+    licensed:
+      declared: Apache-2.0
   4.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Versioning/4.5.0

**Details:**
No info in package files. Meta data confirm Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Versioning 4.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/4.5.0/4.5.0)