### PR TITLE
Newtonsoft.Json.Schema/3.0.4

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -29,7 +29,7 @@ revisions:
       declared: AGPL-3.0-only OR OTHER
   3.0.4:
     licensed:
-      declared: AGPL-3.0-only AND OTHER
+      declared: AGPL-3.0-only OR OTHER
   3.0.5:
     licensed:
       declared: AGPL-3.0-only OR OTHER

--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -27,6 +27,9 @@ revisions:
   3.0.13:
     licensed:
       declared: AGPL-3.0-only OR OTHER
+  3.0.4:
+    licensed:
+      declared: AGPL-3.0-only AND OTHER
   3.0.5:
     licensed:
       declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json.Schema/3.0.4

**Details:**
Package files have two licenses - AGPL 3.0 and "commercial license." We have seen this before. I previously curated as AGPL 3.0 and that only, because "commercial license" is broad and unclear. It seemed inapplicable. But, since, we questioned whether it should be curated as "OTHER." 

**Resolution:**
https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json.Schema/master/LICENSE.md

**Affected definitions**:
- [Newtonsoft.Json.Schema 3.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json.Schema/3.0.4/3.0.4)