### PR TITLE
Knockout.Validation/1.0.1

### DIFF
--- a/curations/nuget/nuget/-/Knockout.Validation.yaml
+++ b/curations/nuget/nuget/-/Knockout.Validation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Knockout.Validation
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Knockout.Validation/1.0.1

**Details:**
No info in package files. Meta data is unclear, but looks like MIT in Readme. 

**Resolution:**
https://github.com/ericmbarnard/Knockout-Validation/blob/master/ReadMe.md

**Affected definitions**:
- [Knockout.Validation 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Knockout.Validation/1.0.1/1.0.1)