### PR TITLE
jQuery/2.1.0

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -62,6 +62,9 @@ revisions:
   2.0.3:
     licensed:
       declared: MIT
+  2.1.0:
+    licensed:
+      declared: MIT
   2.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery/2.1.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://jquery.org/license/

**Affected definitions**:
- [jQuery 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/2.1.0/2.1.0)