### PR TITLE
Microsoft.ApplicationInsights/2.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.yaml
@@ -24,6 +24,9 @@ revisions:
   2.0.0:
     licensed:
       declared: MIT
+  2.0.1:
+    licensed:
+      declared: MIT
   2.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights/2.0.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights/2.0.1/2.0.1)