### PR TITLE
DiffPlex/1.2.1

### DIFF
--- a/curations/nuget/nuget/-/DiffPlex.yaml
+++ b/curations/nuget/nuget/-/DiffPlex.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.2.1:
+    licensed:
+      declared: Apache-2.0
   1.4.4:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/DiffPlex.yaml
+++ b/curations/nuget/nuget/-/DiffPlex.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.2.1:
     licensed:
-      declared: Apache-2.0
+      declared: MS-PL
   1.4.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DiffPlex/1.2.1

**Details:**
No info in package files. Meta data shows package moved, but does confirm Apache 2.0 in new location. 

**Resolution:**
https://github.com/mmanela/diffplex/blob/master/License.txt

**Affected definitions**:
- [DiffPlex 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/DiffPlex/1.2.1/1.2.1)