### PR TITLE
Microsoft.FeatureManagement/1.0.0-preview-009000001-1251

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.FeatureManagement.yaml
+++ b/curations/nuget/nuget/-/Microsoft.FeatureManagement.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0-preview-009000001-1251:
+    licensed:
+      declared: MIT
   2.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.FeatureManagement/1.0.0-preview-009000001-1251

**Details:**
No info in package files. Meta data appears to link to wrong package. Found in github and confirmed MIT. 

**Resolution:**
https://github.com/microsoft/FeatureManagement-Dotnet/blob/1.0.0-preview-009000001-1251/LICENSE

**Affected definitions**:
- [Microsoft.FeatureManagement 1.0.0-preview-009000001-1251](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.FeatureManagement/1.0.0-preview-009000001-1251/1.0.0-preview-009000001-1251)