### PR TITLE
SimpleInjector.Integration.WebApi/4.3.0

### DIFF
--- a/curations/nuget/nuget/-/SimpleInjector.Integration.WebApi.yaml
+++ b/curations/nuget/nuget/-/SimpleInjector.Integration.WebApi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SimpleInjector.Integration.WebApi
+  provider: nuget
+  type: nuget
+revisions:
+  4.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SimpleInjector.Integration.WebApi/4.3.0

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/simpleinjector/SimpleInjector/blob/master/LICENSE

**Affected definitions**:
- [SimpleInjector.Integration.WebApi 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/SimpleInjector.Integration.WebApi/4.3.0/4.3.0)