### PR TITLE
Irony/0.9.1

### DIFF
--- a/curations/nuget/nuget/-/Irony.yaml
+++ b/curations/nuget/nuget/-/Irony.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Irony
+  provider: nuget
+  type: nuget
+revisions:
+  0.9.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Irony/0.9.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/IronyProject/Irony/blob/master/LICENSE

**Affected definitions**:
- [Irony 0.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Irony/0.9.1/0.9.1)