### PR TITLE
Nito.Disposables	1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Nito.Disposables.yaml
+++ b/curations/nuget/nuget/-/Nito.Disposables.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: NOASSERTION
   2.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nito.Disposables	1.0.0

**Details:**
License file in repository indicates license is MIT

**Resolution:**
License link from Nuget site also indicates license is MIT

**Affected definitions**:
- [Nito.Disposables 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.Disposables/1.0.0/1.0.0)