### PR TITLE
MediatR	8.0.0

### DIFF
--- a/curations/nuget/nuget/-/MediatR.yaml
+++ b/curations/nuget/nuget/-/MediatR.yaml
@@ -6,3 +6,6 @@ revisions:
   7.0.0:
     licensed:
       declared: Apache-2.0
+  8.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MediatR	8.0.0

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [MediatR 8.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MediatR/8.0.0/8.0.0)