### PR TITLE
Microsoft.PowerShell.4.ReferenceAssemblies	1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.4.ReferenceAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.4.ReferenceAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.4.ReferenceAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.4.ReferenceAssemblies	1.0.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [Microsoft.PowerShell.4.ReferenceAssemblies 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.4.ReferenceAssemblies/1.0.0/1.0.0)