### PR TITLE
Ninject	3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.yaml
+++ b/curations/nuget/nuget/-/Ninject.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL
   3.2.2:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject	3.2.0

**Details:**
Nuget site indicates license is Apache 2.0 or MS-PL

**Resolution:**
License file in repository also indicates license is Apache 2.0 or MS-PL

**Affected definitions**:
- [Ninject 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject/3.2.0/3.2.0)