### PR TITLE
rgbcolor	1.0.1

### DIFF
--- a/curations/npm/npmjs/-/rgbcolor.yaml
+++ b/curations/npm/npmjs/-/rgbcolor.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rgbcolor
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rgbcolor	1.0.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Harvested .json file also indicates license is MIT

**Affected definitions**:
- [rgbcolor 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/rgbcolor/1.0.1/1.0.1)