### PR TITLE
xunit.runner.visualstudio/2.0.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: Apache-2.0
   2.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.runner.visualstudio/2.0.0

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://raw.githubusercontent.com/xunit/xunit/master/license.txt

**Affected definitions**:
- [xunit.runner.visualstudio 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.visualstudio/2.0.0/2.0.0)