### PR TITLE
Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -30,6 +30,9 @@ revisions:
   2.26.305102204:
     licensed:
       declared: Apache-2.0
+  2.28.0:
+    licensed:
+      declared: MIT
   2.28.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -32,7 +32,7 @@ revisions:
       declared: Apache-2.0
   2.28.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.28.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 2.28.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/2.28.0/2.28.0)