### PR TITLE
escape	0.0.4

### DIFF
--- a/curations/gem/rubygems/-/escape.yaml
+++ b/curations/gem/rubygems/-/escape.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: escape
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
escape	0.0.4

**Details:**
Readme file in repository indicates license is BSD-3

**Resolution:**
Project homepage also indicates license is BSD-3

**Affected definitions**:
- [escape 0.0.4](https://clearlydefined.io/definitions/gem/rubygems/-/escape/0.0.4/0.0.4)