### PR TITLE
YamlDotNet/5.3.0

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.yaml
@@ -9,6 +9,9 @@ revisions:
   5.0.1:
     licensed:
       declared: MIT
+  5.3.0:
+    licensed:
+      declared: MIT
   6.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet/5.3.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/aaubry/YamlDotNet/blob/master/LICENSE.txt

**Affected definitions**:
- [YamlDotNet 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet/5.3.0/5.3.0)