### PR TITLE
Microsoft.VisualStudio.Threading/15.8.209

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
@@ -18,3 +18,6 @@ revisions:
   15.8.122:
     licensed:
       declared: MIT
+  15.8.209:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Threading/15.8.209

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/Microsoft/vs-threading/ac8db33256/LICENSE

**Affected definitions**:
- [Microsoft.VisualStudio.Threading 15.8.209](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Threading/15.8.209/15.8.209)