### PR TITLE
FluentAssertions/2.0.1

### DIFF
--- a/curations/nuget/nuget/-/FluentAssertions.yaml
+++ b/curations/nuget/nuget/-/FluentAssertions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.1:
+    licensed:
+      declared: Apache-2.0
   2.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentAssertions/2.0.1

**Details:**
No info in package files. Meta data has broken links. Found on Github and appears to be Apache 2.0. 

**Resolution:**
https://github.com/fluentassertions/fluentassertions/blob/develop/LICENSE

**Affected definitions**:
- [FluentAssertions 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentAssertions/2.0.1/2.0.1)