### PR TITLE
Swashbuckle.AspNetCore/2.5.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -12,6 +12,9 @@ revisions:
   2.4.0:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: MIT
   3.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore/2.5.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/2.5.0/2.5.0)