### PR TITLE
Cauldron.Interception.Fody 3.2.2

### DIFF
--- a/curations/nuget/nuget/-/Cauldron.Interception.Fody.yaml
+++ b/curations/nuget/nuget/-/Cauldron.Interception.Fody.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Cauldron.Interception.Fody
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Cauldron.Interception.Fody 3.2.2

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/Capgemini/Cauldron/master/LICENSE

Project license, tagged version:
https://github.com/Capgemini/Cauldron/blob/v3.2.2/LICENSE

**Affected definitions**:
- [Cauldron.Interception.Fody 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Cauldron.Interception.Fody/3.2.2/3.2.2)