### PR TITLE
Moment.js 2.13.0

### DIFF
--- a/curations/nuget/nuget/-/Moment.js.yaml
+++ b/curations/nuget/nuget/-/Moment.js.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.13.0:
+    licensed:
+      declared: MIT
   2.18.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Moment.js 2.13.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/timrwood/moment/master/LICENSE

MIT noted on this page: https://momentjs.com/

GitHub license, tagged version:

https://github.com/moment/moment/blob/2.13.0/LICENSE

**Affected definitions**:
- [Moment.js 2.13.0](https://clearlydefined.io/definitions/nuget/nuget/-/Moment.js/2.13.0/2.13.0)