### PR TITLE
Microsoft.NETFramework.ReferenceAssemblies.net461 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net461.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net461.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: MIT
   1.0.0-preview.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.NETFramework.ReferenceAssemblies.net461 1.0.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license: MIT

Commit to package release date:
https://github.com/microsoft/dotnet/blob/a19239e6e1a3ea87b4d0fa5bcba6d7e34fff6b61/LICENSE

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net461 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net461/1.0.0/1.0.0)