### PR TITLE
Akka 1.3.10

### DIFF
--- a/curations/nuget/nuget/-/Akka.yaml
+++ b/curations/nuget/nuget/-/Akka.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Akka 1.3.10

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master license.

License for tagged version: https://github.com/akkadotnet/akka.net/blob/v1.3.10/LICENSE

**Affected definitions**:
- [Akka 1.3.10](https://clearlydefined.io/definitions/nuget/nuget/-/Akka/1.3.10/1.3.10)