### PR TITLE
Microsoft.VisualStudio.Threading/15.4.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
@@ -9,6 +9,9 @@ revisions:
   15.3.20:
     licensed:
       declared: MIT
+  15.4.4:
+    licensed:
+      declared: MIT
   15.5.32:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Threading/15.4.4

**Details:**
No info in package files. Meta data and source repo confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/Microsoft/vs-threading/da0daeef0c/LICENSE

https://github.com/microsoft/vs-threading/blob/v15.4.4/LICENSE

**Affected definitions**:
- [Microsoft.VisualStudio.Threading 15.4.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Threading/15.4.4/15.4.4)