### PR TITLE
Microsoft.IdentityModel.KeyVaultExtensions/5.3.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.KeyVaultExtensions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.KeyVaultExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.IdentityModel.KeyVaultExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  5.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.KeyVaultExtensions/5.3.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/5.3.0/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.KeyVaultExtensions 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.KeyVaultExtensions/5.3.0/5.3.0)