### PR TITLE
Microsoft.Bot.Schema/4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: MIT
   4.6.3:
     licensed:
-      declared: MIT      
+      declared: MIT
   4.7.0:
     licensed:
       declared: MIT
@@ -19,5 +19,8 @@ revisions:
     licensed:
       declared: MIT
   4.8.0:
+    licensed:
+      declared: MIT
+  4.9.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Schema/4.9.3

**Details:**
Package files indicate MIT and confirm by meta data. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Schema 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.9.3/4.9.3)