### PR TITLE
Microsoft.Bot.Schema/4.5.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -6,12 +6,15 @@ revisions:
   4.4.5:
     licensed:
       declared: MIT
+  4.5.1:
+    licensed:
+      declared: MIT
   4.5.3:
     licensed:
       declared: MIT
   4.6.3:
     licensed:
-      declared: MIT      
+      declared: MIT
   4.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Schema/4.5.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Schema 4.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.5.1/4.5.1)