### PR TITLE
YamlDotNet.Signed/5.2.1

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.Signed.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.Signed.yaml
@@ -9,3 +9,6 @@ revisions:
   4.2.2:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet.Signed/5.2.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/aaubry/YamlDotNet/blob/master/LICENSE.txt

**Affected definitions**:
- [YamlDotNet.Signed 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet.Signed/5.2.1/5.2.1)