### PR TITLE
Microsoft.ApplicationInsights.TraceListener/2.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener.yaml
@@ -39,6 +39,9 @@ revisions:
   2.2.0:
     licensed:
       declared: MIT
+  2.4.0:
+    licensed:
+      declared: MIT
   2.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.TraceListener/2.4.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.TraceListener 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.TraceListener/2.4.0/2.4.0)