### PR TITLE
Microsoft.Bot.Streaming/4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -15,3 +15,6 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Streaming/4.9.3

**Details:**
Package files indicate MIT and meta data confirms. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.9.3/4.9.3)