### PR TITLE
Microsoft.CodeAnalysis.CSharp.Workspaces/3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CodeAnalysis.CSharp.Workspaces.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeAnalysis.CSharp.Workspaces.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CodeAnalysis.CSharp.Workspaces
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CodeAnalysis.CSharp.Workspaces/3.0.0

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/dotnet/roslyn/blob/version-3.0.0/License.txt

**Affected definitions**:
- [Microsoft.CodeAnalysis.CSharp.Workspaces 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CodeAnalysis.CSharp.Workspaces/3.0.0/3.0.0)