### PR TITLE
Selenium.WebDriver.IEDriver/3.150.1

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Selenium.WebDriver.IEDriver
+  provider: nuget
+  type: nuget
+revisions:
+  3.150.1:
+    licensed:
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.IEDriver/3.150.1

**Details:**
No info in package files. Meta data confirms Unlicense. 

**Resolution:**
https://unlicense.org/

**Affected definitions**:
- [Selenium.WebDriver.IEDriver 3.150.1](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.IEDriver/3.150.1/3.150.1)