### PR TITLE
Xamarin.Essentials/1.3.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Essentials.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Essentials.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.3.1:
+    licensed:
+      declared: MIT
   1.5.2:
     licensed:
-      declared: MIT  
+      declared: MIT
   1.5.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Essentials/1.3.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/xamarin/Essentials/blob/1.3.1/LICENSE

**Affected definitions**:
- [Xamarin.Essentials 1.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Essentials/1.3.1/1.3.1)