### PR TITLE
System.Runtime.CompilerServices.Unsafe/4.6.0-preview6.19303.8

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
@@ -18,6 +18,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview6.19303.8:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Runtime.CompilerServices.Unsafe/4.6.0-preview6.19303.8

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Affected definitions**:
- [System.Runtime.CompilerServices.Unsafe 4.6.0-preview6.19303.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe/4.6.0-preview6.19303.8/4.6.0-preview6.19303.8)