### PR TITLE
JmesPath.Net/1.0.125

### DIFF
--- a/curations/nuget/nuget/-/JmesPath.Net.yaml
+++ b/curations/nuget/nuget/-/JmesPath.Net.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.101:
     licensed:
       declared: Apache-2.0
+  1.0.125:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JmesPath.Net/1.0.125

**Details:**
No info on package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/jdevillard/JmesPath.Net/blob/master/LICENSE

**Affected definitions**:
- [JmesPath.Net 1.0.125](https://clearlydefined.io/definitions/nuget/nuget/-/JmesPath.Net/1.0.125/1.0.125)