### PR TITLE
Newtonsoft.Json/6.0.2

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -46,6 +46,9 @@ revisions:
   6.0.1:
     licensed:
       declared: MIT
+  6.0.2:
+    licensed:
+      declared: MIT
   6.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json/6.0.2

**Details:**
No info in package files. Meta data confirms MIT.

**Resolution:**
https://raw.githubusercontent.com/JamesNK/Newtonsoft.Json/master/LICENSE.md

**Affected definitions**:
- [Newtonsoft.Json 6.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/6.0.2/6.0.2)