### PR TITLE
Microsoft.CodeAnalysis.Workspaces.Common/3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CodeAnalysis.Workspaces.Common.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeAnalysis.Workspaces.Common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CodeAnalysis.Workspaces.Common
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.CodeAnalysis.Workspaces.Common.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeAnalysis.Workspaces.Common.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.0.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CodeAnalysis.Workspaces.Common/3.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/dotnet/roslyn/blob/version-3.0.0/License.txt

**Affected definitions**:
- [Microsoft.CodeAnalysis.Workspaces.Common 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CodeAnalysis.Workspaces.Common/3.0.0/3.0.0)