### PR TITLE
Consul/0.7.2.3

### DIFF
--- a/curations/nuget/nuget/-/Consul.yaml
+++ b/curations/nuget/nuget/-/Consul.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Consul
+  provider: nuget
+  type: nuget
+revisions:
+  0.7.2.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Consul/0.7.2.3

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/PlayFab/consuldotnet/blob/master/LICENSE

**Affected definitions**:
- [Consul 0.7.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Consul/0.7.2.3/0.7.2.3)