### PR TITLE
javax.xml.bind/jaxb-api/2.3.1

### DIFF
--- a/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
@@ -6,10 +6,10 @@ coordinates:
 revisions:
   2.2.11:
     licensed:
-      declared: CDDL-1.1 OR GPL 2.0 only WITH Classpath exception 2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath exception 2.0
   2.2.2:
     licensed:
-      declared: CDDL-1.1 OR GPL 2.0 only WITH Classpath exception 2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath exception 2.0
   2.3.1:
     licensed:
-      declared: CDDL-1.1 AND GPL-2.0-only
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath exception 2.0

--- a/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
@@ -10,3 +10,6 @@ revisions:
   2.2.2:
     licensed:
       declared: CDDL-1.1 OR GPL 2.0 only WITH Classpath exception 2.0
+  2.3.1:
+    licensed:
+      declared: CDDL-1.1 AND GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.xml.bind/jaxb-api/2.3.1

**Details:**
No info in package files. Meta data confirms CDDL and GPL licenses. 

**Resolution:**
https://oss.oracle.com/licenses/CDDL+GPL-1.1

**Affected definitions**:
- [jaxb-api 2.3.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1/2.3.1)