### PR TITLE
reactive-streams/1.0.3

### DIFF
--- a/curations/maven/mavencentral/org.reactivestreams/reactive-streams.yaml
+++ b/curations/maven/mavencentral/org.reactivestreams/reactive-streams.yaml
@@ -7,3 +7,6 @@ revisions:
   1.0.2:
     licensed:
       declared: CC0-1.0
+  1.0.3:
+    licensed:
+      declared: '[object Object]'

--- a/curations/maven/mavencentral/org.reactivestreams/reactive-streams.yaml
+++ b/curations/maven/mavencentral/org.reactivestreams/reactive-streams.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: CC0-1.0
   1.0.3:
     licensed:
-      declared: '[object Object]'
+      declared: CC0-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
reactive-streams/1.0.3

**Details:**
No info in package files. Meta data confirms Creative Commons Zero v1.0 Universal, which SPDX indicates is curated as CCO-1.0, but I am unsure whether that actually took in the curation. 

**Resolution:**
https://repo1.maven.org/maven2/org/reactivestreams/reactive-streams/1.0.3/reactive-streams-1.0.3.pom

**Affected definitions**:
- [reactive-streams 1.0.3](https://clearlydefined.io/definitions/maven/mavencentral/org.reactivestreams/reactive-streams/1.0.3/1.0.3)