### PR TITLE
junit-jupiter-api/5.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-jupiter-api
+  namespace: org.junit.jupiter
+  provider: mavencentral
+  type: maven
+revisions:
+  5.5.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter-api/5.5.2

**Details:**
Package files indicate Eclipse Public License 2.0. Meta data confirms. 

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.5.2/junit-jupiter-api-5.5.2.pom

**Affected definitions**:
- [junit-jupiter-api 5.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.5.2/5.5.2)