### PR TITLE
javax.annotation/jsr250-api/1.0

### DIFF
--- a/curations/maven/mavencentral/javax.annotation/jsr250-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/jsr250-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsr250-api
+  namespace: javax.annotation
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.annotation/jsr250-api/1.0

**Details:**
No info in package files. Meta data points to CDDL 1.0, but url isn't functional.

**Resolution:**
https://repo1.maven.org/maven2/javax/annotation/jsr250-api/1.0/jsr250-api-1.0.pom

**Affected definitions**:
- [jsr250-api 1.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.annotation/jsr250-api/1.0/1.0)