### PR TITLE
librdkafka.redist/1.1.0

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.0:
     licensed:
       declared: BSD-2-Clause
+  1.1.0:
+    licensed:
+      declared: BSD-2-Clause
   1.3.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkafka.redist/1.1.0

**Details:**
Package file info shows multiple licenses, but meta data confirms BSD 2 Clause. 

**Resolution:**
https://github.com/edenhill/librdkafka/blob/v1.1.0/LICENSE

**Affected definitions**:
- [librdkafka.redist 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.1.0/1.1.0)