### PR TITLE
commander/1.0.4

### DIFF
--- a/curations/npm/npmjs/-/commander.yaml
+++ b/curations/npm/npmjs/-/commander.yaml
@@ -6,6 +6,9 @@ revisions:
   0.6.1:
     licensed:
       declared: MIT
+  1.0.4:
+    licensed:
+      declared: MIT
   1.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commander/1.0.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/tj/commander.js/blob/master/LICENSE

**Affected definitions**:
- [commander 1.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/commander/1.0.4/1.0.4)