### PR TITLE
Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.8

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -218,3 +218,6 @@ revisions:
         url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/af10dd15cdb082bc3dbe14b0c2c6d81f6ca5b541'
     licensed:
       declared: MIT
+  5.2.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.8

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license, no tagged version for 5.2.8

License for commit close to release date:
https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/bc9b6cc15ad271c1f4f9f1ccdbad6360b826080f/LICENSE


**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.2.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.2.8/5.2.8)