### PR TITLE
com.jcraft:jsch	0.1.55

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.yaml
@@ -10,3 +10,6 @@ revisions:
   0.1.54:
     licensed:
       declared: BSD-3-Clause
+  0.1.55:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.jcraft:jsch	0.1.55

**Details:**
.pom file indicates license is BSD-3

**Resolution:**
License link in .pom file also indicates license is BSD-3

**Affected definitions**:
- [jsch 0.1.55](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch/0.1.55/0.1.55)