### PR TITLE
debug/1.0.4

### DIFF
--- a/curations/npm/npmjs/-/debug.yaml
+++ b/curations/npm/npmjs/-/debug.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.3:
     licensed:
       declared: MIT
+  1.0.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
debug/1.0.4

**Details:**
No info in package files. Meta dat confirms MIT. 

**Resolution:**
https://github.com/visionmedia/debug/blob/master/LICENSE

**Affected definitions**:
- [debug 1.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/debug/1.0.4/1.0.4)