### PR TITLE
@microsoft/sp-office-ui-fabric-core/1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-office-ui-fabric-core.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-office-ui-fabric-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sp-office-ui-fabric-core
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/sp-office-ui-fabric-core/1.9.1

**Details:**
No info in package files. Meta data points to Sharepoint EULA, so curated as Other. 

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [sp-office-ui-fabric-core 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-office-ui-fabric-core/1.9.1/1.9.1)