### PR TITLE
debug/2.0.0

### DIFF
--- a/curations/npm/npmjs/-/debug.yaml
+++ b/curations/npm/npmjs/-/debug.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.3:
     licensed:
       declared: MIT
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
debug/2.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/visionmedia/debug/blob/master/LICENSE

**Affected definitions**:
- [debug 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/debug/2.0.0/2.0.0)