### PR TITLE
jdom2/2.0.6

### DIFF
--- a/curations/maven/mavencentral/org.jdom/jdom2.yaml
+++ b/curations/maven/mavencentral/org.jdom/jdom2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jdom2
+  namespace: org.jdom
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.6:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jdom2/2.0.6

**Details:**
No info in package files. Meta data is odd. Points to apache, but acknowledges amendments. The URL provided looks like a BSD, but with revisions. Curated as Other. 

**Resolution:**
https://repo1.maven.org/maven2/org/jdom/jdom2/2.0.6/jdom2-2.0.6.pom

https://raw.githubusercontent.com/hunterhacker/jdom/master/LICENSE.txt

**Affected definitions**:
- [jdom2 2.0.6](https://clearlydefined.io/definitions/maven/mavencentral/org.jdom/jdom2/2.0.6/2.0.6)