### PR TITLE
javax.servlet-api/4.0.1

### DIFF
--- a/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
@@ -46,4 +46,4 @@ revisions:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   4.0.1:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.1
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
@@ -44,3 +44,6 @@ revisions:
         path: javax/servlet/annotation/package.html
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+  4.0.1:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.servlet-api/4.0.1

**Details:**
No info in package files. Meta data confirms CDDL 1.1 or GPL 2.0 only.

**Resolution:**
https://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/4.0.1/javax.servlet-api-4.0.1.pom

**Affected definitions**:
- [javax.servlet-api 4.0.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.servlet/javax.servlet-api/4.0.1/4.0.1)