### PR TITLE
curator-client/2.4.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.curator/curator-client.yaml
+++ b/curations/maven/mavencentral/org.apache.curator/curator-client.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.4.0:
+    licensed:
+      declared: Apache-2.0
   2.6.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
curator-client/2.4.0

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://repo1.maven.org/maven2/org/apache/curator/curator-client/2.4.0/curator-client-2.4.0.pom

**Affected definitions**:
- [curator-client 2.4.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.curator/curator-client/2.4.0/2.4.0)