### PR TITLE
org.jacoco.agent/0.8.4

### DIFF
--- a/curations/maven/mavencentral/org.jacoco/org.jacoco.agent.yaml
+++ b/curations/maven/mavencentral/org.jacoco/org.jacoco.agent.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: org.jacoco.agent
+  namespace: org.jacoco
+  provider: mavencentral
+  type: maven
+revisions:
+  0.8.4:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jacoco.agent/0.8.4

**Details:**
No info in package files. Meta data confirms Eclipse Public License 1.0. 

**Resolution:**
https://repo1.maven.org/maven2/org/jacoco/org.jacoco.agent/0.8.4/org.jacoco.agent-0.8.4.pom

**Affected definitions**:
- [org.jacoco.agent 0.8.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.4/0.8.4)