### PR TITLE
kendo-common/0.1.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-common.yaml
+++ b/curations/npm/npmjs/@progress/kendo-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-common
+  namespace: '@progress'
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-common/0.1.1

**Details:**
No info in package files. Meta data seems to request user to register to use under a EULA. Curated as Other. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-common/v/0.1.1

**Affected definitions**:
- [kendo-common 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-common/0.1.1/0.1.1)