### PR TITLE
kendo-angular-intl/1.7.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-intl.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-intl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-angular-intl
+  namespace: '@progress'
+  provider: npmjs
+  type: npm
+revisions:
+  1.7.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-intl/1.7.1

**Details:**
No info in package files. Meta data appears to require user to register for use under EULA. Curated as Other. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-angular-intl/v/1.7.1

**Affected definitions**:
- [kendo-angular-intl 1.7.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-intl/1.7.1/1.7.1)