### PR TITLE
Confluent.Kafka	1.3.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -44,7 +44,7 @@ revisions:
       declared: Apache-2.0 AND BSD-2-Clause
   1.3.0:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.4.0:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause

--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -42,6 +42,9 @@ revisions:
   1.1.0:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause
+  1.3.0:
+    licensed:
+      declared: Apache-2.0
   1.4.0:
     licensed:
-      declared: Apache-2.0 AND BSD-2-Clause      
+      declared: Apache-2.0 AND BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Confluent.Kafka	1.3.0

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [Confluent.Kafka 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.3.0/1.3.0)