### PR TITLE
jquery.datatables	1.10.15

### DIFF
--- a/curations/nuget/nuget/-/jquery.datatables.yaml
+++ b/curations/nuget/nuget/-/jquery.datatables.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jquery.datatables
+  provider: nuget
+  type: nuget
+revisions:
+  1.10.15:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jquery.datatables	1.10.15

**Details:**
License link from Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [jquery.datatables 1.10.15](https://clearlydefined.io/definitions/nuget/nuget/-/jquery.datatables/1.10.15/1.10.15)