### PR TITLE
jQuery.Validation	1.15.0

### DIFF
--- a/curations/nuget/nuget/-/jQuery.Validation.yaml
+++ b/curations/nuget/nuget/-/jQuery.Validation.yaml
@@ -21,6 +21,9 @@ revisions:
   1.14.0:
     licensed:
       declared: MIT
+  1.15.0:
+    licensed:
+      declared: MIT
   1.15.1:
     files:
       - license: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery.Validation	1.15.0

**Details:**
License file in repository indicates license is MIT

**Resolution:**
Project site also indicates license is MIT

**Affected definitions**:
- [jQuery.Validation 1.15.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.Validation/1.15.0/1.15.0)