### PR TITLE
SonarAnalyzer.CSharp	6.6.0.3969

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  6.6.0.3969:
+    licensed:
+      declared: LGPL-3.0-or-later
   8.4.0.15306:
     licensed:
       declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SonarAnalyzer.CSharp	6.6.0.3969

**Details:**
License file in repository indicates license is LGPL 3.0 or later

**Resolution:**
   

**Affected definitions**:
- [SonarAnalyzer.CSharp 6.6.0.3969](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/6.6.0.3969/6.6.0.3969)