### PR TITLE
Curate license for Microsoft.Diagnostics.Tracing.TraceEvent 2.0.57

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -51,3 +51,14 @@ revisions:
   2.0.56:
     licensed:
       declared: MIT
+  2.0.57:
+    described:
+      sourceLocation:
+        name: perfview
+        namespace: microsoft
+        provider: github
+        revision: 3c80832b1d71cae317ea1de45b043bd826eb99a5
+        type: git
+        url: 'https://github.com/microsoft/perfview/commit/3c80832b1d71cae317ea1de45b043bd826eb99a5'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Curate license for Microsoft.Diagnostics.Tracing.TraceEvent 2.0.57

**Details:**
https://github.com/Microsoft/perfview/blob/master/LICENSE.TXT
MIT license

**Resolution:**
https://github.com/Microsoft/perfview/blob/master/LICENSE.TXT
MIT license

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.57](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.57/2.0.57)