### PR TITLE
Set microsoft.net.sdk.functions 3.0.8 license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -63,3 +63,14 @@ revisions:
   3.0.7:
     licensed:
       declared: MIT
+  3.0.8:
+    described:
+      sourceLocation:
+        name: azure-functions-vs-build-sdk
+        namespace: azure
+        provider: github
+        revision: 480bea4cb41547597eeb0fe874fc4a5a5c83c7e1
+        type: git
+        url: 'https://github.com/azure/azure-functions-vs-build-sdk/commit/480bea4cb41547597eeb0fe874fc4a5a5c83c7e1'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Set microsoft.net.sdk.functions 3.0.8 license

**Details:**
https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/LICENSE

**Resolution:**
https://github.com/Azure/azure-functions-vs-build-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 3.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/3.0.8/3.0.8)