### PR TITLE
precond	0.2.3

### DIFF
--- a/curations/npm/npmjs/-/precond.yaml
+++ b/curations/npm/npmjs/-/precond.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: precond
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
precond	0.2.3

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [precond 0.2.3](https://clearlydefined.io/definitions/npm/npmjs/-/precond/0.2.3/0.2.3)