### PR TITLE
Microsoft.IdentityModel.Clients.ActiveDirectory 5.0.2-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -156,6 +156,9 @@ revisions:
         path: Microsoft.IdentityModel.Clients.ActiveDirectory.nuspec
     licensed:
       declared: MIT
+  5.0.2-preview:
+    licensed:
+      declared: MIT
   5.0.5:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Clients.ActiveDirectory 5.0.2-preview

**Details:**
"License info" link is fwlink that goes to MIT license here: https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/dev/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.0.2-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.0.2-preview/5.0.2-preview)