### PR TITLE
libpng1.5.10.9

### DIFF
--- a/curations/nuget/nuget/-/libpng.yaml
+++ b/curations/nuget/nuget/-/libpng.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: libpng
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.10.9:
+    licensed:
+      declared: Libpng


### PR DESCRIPTION

**Type:** Missing

**Summary:**
libpng1.5.10.9

**Details:**
License on png.h file - Libpng

**Resolution:**
Match to SPDX "Libpng"

**Affected definitions**:
- [libpng 1.5.10.9](https://clearlydefined.io/definitions/nuget/nuget/-/libpng/1.5.10.9)