### PR TITLE
Pipelines.Sockets.Unofficial 2.0.7

### DIFF
--- a/curations/nuget/nuget/-/Pipelines.Sockets.Unofficial.yaml
+++ b/curations/nuget/nuget/-/Pipelines.Sockets.Unofficial.yaml
@@ -15,3 +15,6 @@ revisions:
   2.0.22:
     licensed:
       declared: MIT
+  2.0.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Pipelines.Sockets.Unofficial 2.0.7

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/mgravell/Pipelines.Sockets.Unofficial/master/LICENSE

Project license, no tagged version match. Commit to release date:
https://github.com/mgravell/Pipelines.Sockets.Unofficial/blob/aca87a109398e838cf2cd17b754a2c7dd3268219/LICENSE

**Affected definitions**:
- [Pipelines.Sockets.Unofficial 2.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Pipelines.Sockets.Unofficial/2.0.7/2.0.7)