### PR TITLE
jakarta.annotation/jakarta.annotation-api 1.3.5

### DIFF
--- a/curations/maven/mavencentral/jakarta.annotation/jakarta.annotation-api.yaml
+++ b/curations/maven/mavencentral/jakarta.annotation/jakarta.annotation-api.yaml
@@ -5,5 +5,5 @@ coordinates:
   type: maven
 revisions:
   1.3.5:
-    licensed:
-      declared: EPL-2.0 OR GPL-2.0-with Classpath exception 2.0
+    licensed: 
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/jakarta.annotation/jakarta.annotation-api.yaml
+++ b/curations/maven/mavencentral/jakarta.annotation/jakarta.annotation-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jakarta.annotation-api
+  namespace: jakarta.annotation
+  provider: mavencentral
+  type: maven
+revisions:
+  1.3.5:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-with Classpath exception 2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jakarta.annotation/jakarta.annotation-api 1.3.5

**Details:**
Declaring EPL 2.0 or GPLv2.0 with Classpath exception 2.0

**Resolution:**
ClearlyDefined License File: https://clearlydefined.io/file/3852834ebb4c2e04ecc18c9d099a05eab72cbd6edf35fb191390be6306019b4c

Maven POM file: https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/1.3.5/jakarta.annotation-api-1.3.5.pom

**Affected definitions**:
- [jakarta.annotation-api 1.3.5](https://clearlydefined.io/definitions/maven/mavencentral/jakarta.annotation/jakarta.annotation-api/1.3.5/1.3.5)