### PR TITLE
ply 3.11

### DIFF
--- a/curations/pypi/pypi/-/ply.yaml
+++ b/curations/pypi/pypi/-/ply.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ply
+  provider: pypi
+  type: pypi
+revisions:
+  '3.11':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ply 3.11

**Details:**
Declaring BSD-3-Clause

**Resolution:**
PyPi metadata: "BSD"

ClearlyDefined Files ReadMe has BSD-3-Clause

Package ReadMe has BSD-3-Clause

**Affected definitions**:
- [ply 3.11](https://clearlydefined.io/definitions/pypi/pypi/-/ply/3.11/3.11)