### PR TITLE
RazorGenerator.MsBuild 2.5.0

### DIFF
--- a/curations/nuget/nuget/-/RazorGenerator.MsBuild.yaml
+++ b/curations/nuget/nuget/-/RazorGenerator.MsBuild.yaml
@@ -6,3 +6,6 @@ revisions:
   2.4.1:
     licensed:
       declared: Apache-2.0
+  2.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RazorGenerator.MsBuild 2.5.0

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata: License link goes to GitHub master repo license, no matching tagged version

Commit matching to release date:
https://github.com/RazorGenerator/RazorGenerator/blob/032180e4d36638d894f50eabd97bbc68d833d2bc/LICENSE.txt

**Affected definitions**:
- [RazorGenerator.MsBuild 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/RazorGenerator.MsBuild/2.5.0/2.5.0)