### PR TITLE
@microsoft/sp-module-interfaces 1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-module-interfaces.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-module-interfaces.yaml
@@ -10,3 +10,6 @@ revisions:
   1.8.2:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@microsoft/sp-module-interfaces 1.9.1

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
NPM: Project homepage aka.ms/spfx

The SharePoint Framework components are licensed under this Microsoft EULA.

**Affected definitions**:
- [sp-module-interfaces 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-module-interfaces/1.9.1/1.9.1)