### PR TITLE
com.sun.jersey.contribs/jersey-guice 1.19

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey.contribs/jersey-guice.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey.contribs/jersey-guice.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.19':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath exception 2.0
   '1.9':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
com.sun.jersey.contribs/jersey-guice 1.19

**Details:**
Declaring CDDL 1.1 or GPLv2.0 only WITH Classpath exception 2.0

**Resolution:**
POM file: https://repo1.maven.org/maven2/com/sun/jersey/contribs/jersey-guice/1.19/jersey-guice-1.19.pom

**Affected definitions**:
- [jersey-guice 1.19](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey.contribs/jersey-guice/1.19/1.19)