### PR TITLE
Microsoft.Azure.DocumentDB 2.9.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -5,7 +5,10 @@ coordinates:
 revisions:
   2.10.3:
     licensed:
-      declared: MIT  
+      declared: MIT
   2.11.0:
+    licensed:
+      declared: MIT
+  2.9.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Microsoft.Azure.DocumentDB 2.9.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://licenses.nuget.org/MIT

Project license, no tagged version.

Commit near release date:
https://github.com/Azure/azure-cosmos-dotnet-v2/blob/bf03584b31bab3adeda30629efe7bb366085d29a/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.9.0/2.9.0)