### PR TITLE
MaxMind.GeoIP2 2.8.0

### DIFF
--- a/curations/nuget/nuget/-/MaxMind.GeoIP2.yaml
+++ b/curations/nuget/nuget/-/MaxMind.GeoIP2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MaxMind.GeoIP2
+  provider: nuget
+  type: nuget
+revisions:
+  2.8.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
MaxMind.GeoIP2 2.8.0

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata goes to GitHub master repo

Tagged version: https://github.com/maxmind/GeoIP2-dotnet/blob/v2.8.0/LICENSE

**Affected definitions**:
- [MaxMind.GeoIP2 2.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/MaxMind.GeoIP2/2.8.0/2.8.0)