### PR TITLE
@microsoft/sp-loader 1.10.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-loader.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-loader.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.10.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@microsoft/sp-loader 1.10.0

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
NPM: Homepage aka.ms/spfx

The SharePoint Framework components are licensed under this Microsoft EULA.

**Affected definitions**:
- [sp-loader 1.10.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-loader/1.10.0/1.10.0)