### PR TITLE
org.junit.jupiter/junit-jupiter-params 5.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-jupiter-params
+  namespace: org.junit.jupiter
+  provider: mavencentral
+  type: maven
+revisions:
+  5.5.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.junit.jupiter/junit-jupiter-params 5.5.2

**Details:**
Declaring EPL 2.0

**Resolution:**
POM file
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/5.5.2/junit-jupiter-params-5.5.2.pom

**Affected definitions**:
- [junit-jupiter-params 5.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.5.2/5.5.2)