### PR TITLE
Xamarin.Android.Support.Fragment 28.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Fragment.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Fragment.yaml
@@ -14,6 +14,9 @@ revisions:
         path: Xamarin.Android.Support.Fragment.nuspec
     licensed:
       declared: MIT
+  28.0.0.1:
+    licensed:
+      declared: MIT
   28.0.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.Android.Support.Fragment 28.0.0.1

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license

Tagged version:
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.1/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Fragment 28.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Fragment/28.0.0.1/28.0.0.1)