### PR TITLE
Extended.Wpf.Toolkit 2.4.0

### DIFF
--- a/curations/nuget/nuget/-/Extended.Wpf.Toolkit.yaml
+++ b/curations/nuget/nuget/-/Extended.Wpf.Toolkit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.4.0:
+    licensed:
+      declared: MS-PL
   3.7.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Extended.Wpf.Toolkit 2.4.0

**Details:**
The description of the NuGet says "...all offered under the Microsoft Public License for maximum freedom."  And the link says "MS-PL License."

**Resolution:**
MS-PL

**Affected definitions**:
- [Extended.Wpf.Toolkit 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Extended.Wpf.Toolkit/2.4.0/2.4.0)