### PR TITLE
Flurl.Http 2.4.0

### DIFF
--- a/curations/nuget/nuget/-/Flurl.Http.yaml
+++ b/curations/nuget/nuget/-/Flurl.Http.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Flurl.Http
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Flurl.Http 2.4.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/tmenier/Flurl/master/LICENSE

Project license, tagged version: https://github.com/tmenier/Flurl/blob/Flurl.2.4.0/LICENSE



**Affected definitions**:
- [Flurl.Http 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Flurl.Http/2.4.0/2.4.0)