### PR TITLE
SonarAnalyzer.CSharp 7.7.0.7192

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  7.7.0.7192:
+    licensed:
+      declared: LGPL-3.0-or-later
   8.4.0.15306:
     licensed:
       declared: LGPL-3.0-only

--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: LGPL-3.0-or-later
   8.4.0.15306:
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SonarAnalyzer.CSharp 7.7.0.7192

**Details:**
Declaring LGPLv3.0 or later

**Resolution:**
NuGet license link is broken

http://vs.sonarlint.org/
Source location, no tagged version. Commit date near release date:
https://github.com/SonarSource/sonarlint-visualstudio/blob/e292812009a129dc3aa264acdba8914e8904adba/LICENSE

**Affected definitions**:
- [SonarAnalyzer.CSharp 7.7.0.7192](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/7.7.0.7192/7.7.0.7192)