### PR TITLE
Flurl 2.8.0

### DIFF
--- a/curations/nuget/nuget/-/Flurl.yaml
+++ b/curations/nuget/nuget/-/Flurl.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Flurl
+  provider: nuget
+  type: nuget
+revisions:
+  2.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Flurl 2.8.0

**Details:**
Adding MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/tmenier/Flurl/master/LICENSE

Source repo, tagged version:
https://github.com/tmenier/Flurl/blob/Flurl.2.8.0/LICENSE

**Affected definitions**:
- [Flurl 2.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Flurl/2.8.0/2.8.0)