### PR TITLE
NETCore.MailKit 2.0.2

### DIFF
--- a/curations/nuget/nuget/-/NETCore.MailKit.yaml
+++ b/curations/nuget/nuget/-/NETCore.MailKit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NETCore.MailKit
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NETCore.MailKit 2.0.2

**Details:**
Declaring MIT

**Resolution:**
NuGet directs to source repo, tagged version:
https://github.com/myloveCc/NETCore.MailKit/blob/2.0.2/lICENSE



**Affected definitions**:
- [NETCore.MailKit 2.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/NETCore.MailKit/2.0.2/2.0.2)