### PR TITLE
VSSDK.IDE.12 12.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.IDE.12.yaml
+++ b/curations/nuget/nuget/-/VSSDK.IDE.12.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   12.0.4:
     licensed:
-      declared: OTHER
+      declared: NONE

--- a/curations/nuget/nuget/-/VSSDK.IDE.12.yaml
+++ b/curations/nuget/nuget/-/VSSDK.IDE.12.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.IDE.12
+  provider: nuget
+  type: nuget
+revisions:
+  12.0.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
VSSDK.IDE.12 12.0.4

**Details:**
Declaring None

**Resolution:**
Nuspec file in package:

This is a metadata-only package used as a dependency for reference packages and extensions that target Visual Studio 2013 and newer. 

**Affected definitions**:
- [VSSDK.IDE.12 12.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.IDE.12/12.0.4/12.0.4)