### PR TITLE
VaultSharp 0.11.0

### DIFF
--- a/curations/nuget/nuget/-/VaultSharp.yaml
+++ b/curations/nuget/nuget/-/VaultSharp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VaultSharp
+  provider: nuget
+  type: nuget
+revisions:
+  0.11.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
VaultSharp 0.11.0

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/rajanadar/VaultSharp/master/LICENSE

Source repo, tagged version:
https://github.com/rajanadar/VaultSharp/blob/0.11.0/LICENSE

**Affected definitions**:
- [VaultSharp 0.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/VaultSharp/0.11.0/0.11.0)