### PR TITLE
paranamer 2.8

### DIFF
--- a/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
+++ b/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
@@ -10,3 +10,6 @@ revisions:
   '2.7':
     licensed:
       declared: BSD-3-Clause
+  '2.8':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
paranamer 2.8

**Details:**
Top of .java files has BSD-3-Clause license

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [paranamer 2.8](https://clearlydefined.io/definitions/maven/mavencentral/com.thoughtworks.paranamer/paranamer/2.8/2.8)