### PR TITLE
kendo-date-math/1.5.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-date-math.yaml
+++ b/curations/npm/npmjs/@progress/kendo-date-math.yaml
@@ -10,3 +10,6 @@ revisions:
   1.4.0:
     licensed:
       declared: OTHER
+  1.5.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-date-math/1.5.1

**Details:**
No info in package files. Meta data points to EULA, so curated as OTHER.

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-common/v/0.1.1

**Affected definitions**:
- [kendo-date-math 1.5.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-date-math/1.5.1/1.5.1)