### PR TITLE
Rx-Interfaces/2.2.2

### DIFF
--- a/curations/nuget/nuget/-/Rx-Interfaces.yaml
+++ b/curations/nuget/nuget/-/Rx-Interfaces.yaml
@@ -6,6 +6,9 @@ revisions:
   2.1.30214:
     licensed:
       declared: Apache-2.0
+  2.2.2:
+    licensed:
+      declared: MIT
   2.2.4:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Rx-Interfaces.yaml
+++ b/curations/nuget/nuget/-/Rx-Interfaces.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: Apache-2.0
   2.2.2:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.2.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Interfaces/2.2.2

**Details:**
No info in package files. Meta data seems to point to MS EULA, but source repo says MIT. 

**Resolution:**
https://github.com/dotnet/reactive/blob/master/LICENSE

**Affected definitions**:
- [Rx-Interfaces 2.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Interfaces/2.2.2/2.2.2)