### PR TITLE
lz4net/1.0.5.93

### DIFF
--- a/curations/nuget/nuget/-/lz4net.yaml
+++ b/curations/nuget/nuget/-/lz4net.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.15.93:
     licensed:
       declared: BSD-2-Clause
+  1.0.5.93:
+    licensed:
+      declared: BSD-2-Clause
   1.0.9.93:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
lz4net/1.0.5.93

**Details:**
No info in package files. Meta data confirms BSD 2 Clause.

**Resolution:**
https://github.com/MiloszKrajewski/lz4net/blob/master/LICENSE.md

**Affected definitions**:
- [lz4net 1.0.5.93](https://clearlydefined.io/definitions/nuget/nuget/-/lz4net/1.0.5.93/1.0.5.93)