### PR TITLE
Nito.Disposables/1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Nito.Disposables.yaml
+++ b/curations/nuget/nuget/-/Nito.Disposables.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: MIT
   2.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nito.Disposables/1.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/StephenCleary/Disposables/master/LICENSE

**Affected definitions**:
- [Nito.Disposables 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.Disposables/1.0.0/1.0.0)