### PR TITLE
Microsoft.ApplicationInsights.DependencyCollector/2.8.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector.yaml
@@ -48,6 +48,9 @@ revisions:
   2.7.2:
     licensed:
       declared: MIT
+  2.8.0:
+    licensed:
+      declared: MIT
   2.8.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.DependencyCollector/2.8.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.DependencyCollector 2.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.DependencyCollector/2.8.0/2.8.0)