### PR TITLE
Xamarin.Android.Support.Animated.Vector.Drawable/28.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Animated.Vector.Drawable.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Animated.Vector.Drawable.yaml
@@ -14,6 +14,9 @@ revisions:
         path: Xamarin.Android.Support.Animated.Vector.Drawable.nuspec
     licensed:
       declared: MIT
+  28.0.0.1:
+    licensed:
+      declared: MIT
   28.0.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.Animated.Vector.Drawable/28.0.0.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/28.0.0.1/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Animated.Vector.Drawable 28.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Animated.Vector.Drawable/28.0.0.1/28.0.0.1)