### PR TITLE
google/boringssl 83b74c6a7a1

### DIFF
--- a/curations/git/github/google/boringssl.yaml
+++ b/curations/git/github/google/boringssl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: boringssl
+  namespace: google
+  provider: github
+  type: git
+revisions:
+  83b74c6a7a1ad33792be3adf10820ae287de8c40:
+    licensed:
+      declared: OpenSSL AND ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
google/boringssl 83b74c6a7a1

**Details:**
Top of license file says most of the code is OpenSSL and new code is ISC.  It refers to some MIT code, but I think that would be "discovered" licenses.

**Resolution:**
For "declared" - OpenSSL and ISC

**Affected definitions**:
- [boringssl 83b74c6a7a1ad33792be3adf10820ae287de8c40](https://clearlydefined.io/definitions/git/github/google/boringssl/83b74c6a7a1ad33792be3adf10820ae287de8c40/83b74c6a7a1ad33792be3adf10820ae287de8c40)