### PR TITLE
Missing alternative license

### DIFF
--- a/curations/maven/mavencentral/com.mchange/mchange-commons-java.yaml
+++ b/curations/maven/mavencentral/com.mchange/mchange-commons-java.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   0.2.15:
     licensed:
-      declared: LGPL-2.1 OR EPL-1.0
+      declared: LGPL-2.1-only OR EPL-1.0

--- a/curations/maven/mavencentral/com.mchange/mchange-commons-java.yaml
+++ b/curations/maven/mavencentral/com.mchange/mchange-commons-java.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mchange-commons-java
+  namespace: com.mchange
+  provider: mavencentral
+  type: maven
+revisions:
+  0.2.15:
+    licensed:
+      declared: LGPL-2.1 OR EPL-1.0


### PR DESCRIPTION
**Type:** Incomplete

**Summary:**
Missing alternative license

**Details:**
The component provides users with a choice of EITHER LGPL2.1 OR EPL-1.0 as described here: https://github.com/swaldman/mchange-commons-java/blob/mchange-commons-java-0.2.15/LICENSE

**Resolution:**
Change declared license to an OR expression containing both licenses

**Affected definitions**:
- [mchange-commons-java 0.2.15](https://clearlydefined.io/definitions/maven/mavencentral/com.mchange/mchange-commons-java/0.2.15/0.2.15)