### PR TITLE
Missing alternative license

### DIFF
--- a/curations/maven/mavencentral/com.mchange/c3p0.yaml
+++ b/curations/maven/mavencentral/com.mchange/c3p0.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: c3p0
+  namespace: com.mchange
+  provider: mavencentral
+  type: maven
+revisions:
+  0.9.5.4:
+    licensed:
+      declared: LGPL-2.1 OR EPL-1.0

--- a/curations/maven/mavencentral/com.mchange/c3p0.yaml
+++ b/curations/maven/mavencentral/com.mchange/c3p0.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   0.9.5.4:
     licensed:
-      declared: LGPL-2.1 OR EPL-1.0
+      declared: LGPL-2.1-only OR EPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing alternative license

**Details:**
The component provides users with a choice of EITHER LGPL2.1 OR EPL-1.0 as described here: https://github.com/swaldman/c3p0/tree/c3p0-0.9.5.4

**Resolution:**
Change declared license to an OR expression containing both licenses

**Affected definitions**:
- [c3p0 0.9.5.4](https://clearlydefined.io/definitions/maven/mavencentral/com.mchange/c3p0/0.9.5.4/0.9.5.4)