### PR TITLE
Missing license declaration

### DIFF
--- a/curations/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec.yaml
+++ b/curations/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jboss-transaction-api_1.2_spec
+  namespace: org.jboss.spec.javax.transaction
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.1.Final:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.0

--- a/curations/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec.yaml
+++ b/curations/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.1.1.Final:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.0
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Missing license declaration

**Details:**
The component provides users with a choice of EITHERGPL2.0 OR CDDL-1.0 as documented at https://github.com/jboss/jboss-transaction-api_spec/tree/jboss-transaction-api_1.2_spec-1.1.1.Final

**Resolution:**
Set declared license to GPL-2.0-only OR CDDL-1.0

**Affected definitions**:
- [jboss-transaction-api_1.2_spec 1.1.1.Final](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec/1.1.1.Final/1.1.1.Final)