### PR TITLE
TimeZoneConverter 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/TimeZoneConverter.yaml
+++ b/curations/nuget/nuget/-/TimeZoneConverter.yaml
@@ -6,3 +6,6 @@ revisions:
   2.4.1:
     licensed:
       declared: MIT
+  3.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
TimeZoneConverter 3.2.0

**Details:**
Declaring MIT

**Resolution:**
Project license, tagged version:
https://github.com/mj1856/TimeZoneConverter/blob/3.2.0/LICENSE.txt

**Affected definitions**:
- [TimeZoneConverter 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/TimeZoneConverter/3.2.0/3.2.0)