### PR TITLE
Microsoft.Bot.Builder.Integration.AspNet.Core 4.7.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -9,6 +9,9 @@ revisions:
   4.6.3:
     licensed:
       declared: MIT
+  4.7.0:
+    licensed:
+      declared: MIT
   4.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Bot.Builder.Integration.AspNet.Core 4.7.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license

Project license, tagged version: https://github.com/microsoft/botbuilder-dotnet/blob/4.7/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.7.0/4.7.0)