### PR TITLE
opendp-whitenoise 0.1.2

### DIFF
--- a/curations/pypi/pypi/-/opendp-whitenoise.yaml
+++ b/curations/pypi/pypi/-/opendp-whitenoise.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: opendp-whitenoise
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
opendp-whitenoise 0.1.2

**Details:**
Declaring NONE

**Resolution:**
No PyPi metadata

Package meta file: license none

**Affected definitions**:
- [opendp-whitenoise 0.1.2](https://clearlydefined.io/definitions/pypi/pypi/-/opendp-whitenoise/0.1.2/0.1.2)