### PR TITLE
Microsoft.VisualStudio.Threading 15.3.23

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
@@ -9,6 +9,9 @@ revisions:
   15.3.20:
     licensed:
       declared: MIT
+  15.3.23:
+    licensed:
+      declared: MIT
   15.4.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.VisualStudio.Threading 15.3.23

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/Microsoft/vs-threading/0ac6955199/LICENSE

Close tagged version:
https://github.com/microsoft/vs-threading/blob/v15.3.83/LICENSE



**Affected definitions**:
- [Microsoft.VisualStudio.Threading 15.3.23](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Threading/15.3.23/15.3.23)