### PR TITLE
PeterKottas.DotNetCore.WindowsService 2.0.11

### DIFF
--- a/curations/nuget/nuget/-/PeterKottas.DotNetCore.WindowsService.yaml
+++ b/curations/nuget/nuget/-/PeterKottas.DotNetCore.WindowsService.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PeterKottas.DotNetCore.WindowsService
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.11:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PeterKottas.DotNetCore.WindowsService 2.0.11

**Details:**
NuGet license link points to MIT.  Source LICENSE has always been MIT.

**Resolution:**
MIT

**Affected definitions**:
- [PeterKottas.DotNetCore.WindowsService 2.0.11](https://clearlydefined.io/definitions/nuget/nuget/-/PeterKottas.DotNetCore.WindowsService/2.0.11/2.0.11)