### PR TITLE
PeterKottas.DotNetCore.CmdArgParser 1.0.5

### DIFF
--- a/curations/nuget/nuget/-/PeterKottas.DotNetCore.CmdArgParser.yaml
+++ b/curations/nuget/nuget/-/PeterKottas.DotNetCore.CmdArgParser.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PeterKottas.DotNetCore.CmdArgParser
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PeterKottas.DotNetCore.CmdArgParser 1.0.5

**Details:**
NuGet license link points to MIT.  Source LICENSE has always been MIT.

**Resolution:**
MIT

**Affected definitions**:
- [PeterKottas.DotNetCore.CmdArgParser 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/PeterKottas.DotNetCore.CmdArgParser/1.0.5/1.0.5)