### PR TITLE
Google.Protobuf/3.12.3

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -21,6 +21,9 @@ revisions:
   3.11.4:
     licensed:
       declared: BSD-3-Clause
+  3.12.3:
+    licensed:
+      declared: BSD-3-Clause
   3.3.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf/3.12.3

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/protocolbuffers/protobuf/blob/v3.12.3/LICENSE

**Affected definitions**:
- [Google.Protobuf 3.12.3](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.12.3/3.12.3)