### PR TITLE
Microsoft.PowerShell.4.ReferenceAssemblies/1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.4.ReferenceAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.4.ReferenceAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.4.ReferenceAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.4.ReferenceAssemblies/1.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/PowerShell/PowerShell-Tests/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.PowerShell.4.ReferenceAssemblies 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.4.ReferenceAssemblies/1.0.0/1.0.0)