### PR TITLE
StackExchange.Redis/2.0.600

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -39,6 +39,9 @@ revisions:
   2.0.593:
     licensed:
       declared: MIT
+  2.0.600:
+    licensed:
+      declared: MIT
   2.0.601:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis/2.0.600

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/StackExchange/StackExchange.Redis/master/LICENSE

**Affected definitions**:
- [StackExchange.Redis 2.0.600](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/2.0.600/2.0.600)