### PR TITLE
ClosedXML/0.76.0

### DIFF
--- a/curations/nuget/nuget/-/ClosedXML.yaml
+++ b/curations/nuget/nuget/-/ClosedXML.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.76.0:
+    licensed:
+      declared: MIT
   0.94.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ClosedXML/0.76.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/ClosedXML/ClosedXML/blob/develop/LICENSE

**Affected definitions**:
- [ClosedXML 0.76.0](https://clearlydefined.io/definitions/nuget/nuget/-/ClosedXML/0.76.0/0.76.0)