### PR TITLE
Microsoft.Diagnostics.Tracing.TraceEvent/2.0.48

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -45,6 +45,9 @@ revisions:
   2.0.45:
     licensed:
       declared: MIT
+  2.0.48:
+    licensed:
+      declared: MIT
   2.0.49:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Diagnostics.Tracing.TraceEvent/2.0.48

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/perfview/blob/T2.0.48/LICENSE.TXT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.48](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.48/2.0.48)