### PR TITLE
Google.Protobuf.Tools/3.11.4

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.11.4:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf.Tools/3.11.4

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/protocolbuffers/protobuf/blob/v3.11.4/LICENSE

**Affected definitions**:
- [Google.Protobuf.Tools 3.11.4](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf.Tools/3.11.4/3.11.4)