### PR TITLE
Microsoft.NETFramework.ReferenceAssemblies.net462/1.0.0-preview.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net462.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net462.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0:
     licensed:
       declared: MIT
+  1.0.0-preview.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETFramework.ReferenceAssemblies.net462/1.0.0-preview.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Microsoft/dotnet/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.NETFramework.ReferenceAssemblies.net462 1.0.0-preview.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETFramework.ReferenceAssemblies.net462/1.0.0-preview.2/1.0.0-preview.2)