### PR TITLE
Microsoft.Azure.Devices/1.18.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
@@ -6,6 +6,9 @@ revisions:
   1.17.1:
     licensed:
       declared: MIT
+  1.18.2:
+    licensed:
+      declared: MIT
   1.19.0:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Devices/1.18.2

**Details:**
Package files are unclear. Meta data appears to point to MIT, but the author seems to have taken some liberties with the heading. 

**Resolution:**
https://github.com/Azure/azure-iot-sdk-csharp/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices 1.18.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices/1.18.2/1.18.2)