### PR TITLE
dom4j/2.1.1

### DIFF
--- a/curations/maven/mavencentral/org.dom4j/dom4j.yaml
+++ b/curations/maven/mavencentral/org.dom4j/dom4j.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.1.1:
     licensed:
-      declared: OTHER
+      declared: Plexus

--- a/curations/maven/mavencentral/org.dom4j/dom4j.yaml
+++ b/curations/maven/mavencentral/org.dom4j/dom4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dom4j
+  namespace: org.dom4j
+  provider: mavencentral
+  type: maven
+revisions:
+  2.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dom4j/2.1.1

**Details:**
No info in package files. Meta data points to BSD 3 Clause, how ever it looks like the author took liberties with the license language that deviated enough to curate as OTHER. 

**Resolution:**
https://github.com/dom4j/dom4j/blob/version-2.1.1/LICENSE

https://repo1.maven.org/maven2/org/dom4j/dom4j/2.1.1/dom4j-2.1.1.pom

**Affected definitions**:
- [dom4j 2.1.1](https://clearlydefined.io/definitions/maven/mavencentral/org.dom4j/dom4j/2.1.1/2.1.1)