### PR TITLE
paranamer/2.6

### DIFF
--- a/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
+++ b/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
@@ -7,6 +7,9 @@ revisions:
   '2.3':
     licensed:
       declared: BSD-3-Clause
+  '2.6':
+    licensed:
+      declared: BSD-3-Clause
   '2.7':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
paranamer/2.6

**Details:**
No info in package files. Meta data was unclear in Maven repo POM file. Found source repo and it points to BSD 3 Clause. 

**Resolution:**
https://github.com/paul-hammant/paranamer/blob/paranamer-parent-2.6/LICENSE.txt

**Affected definitions**:
- [paranamer 2.6](https://clearlydefined.io/definitions/maven/mavencentral/com.thoughtworks.paranamer/paranamer/2.6/2.6)