### PR TITLE
janino/3.0.0

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.janino/janino.yaml
+++ b/curations/maven/mavencentral/org.codehaus.janino/janino.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.0.0:
+    licensed:
+      declared: BSD-3-Clause
   3.0.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
janino/3.0.0

**Details:**
No info in package files. Maven repo did not contain any license info. Found source repo and it points to BSD 3 Clause. 

**Resolution:**
https://github.com/janino-compiler/janino/blob/master/LICENSE

**Affected definitions**:
- [janino 3.0.0](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.janino/janino/3.0.0/3.0.0)