### PR TITLE
jaxb-api/2.3.0

### DIFF
--- a/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
@@ -10,6 +10,9 @@ revisions:
   2.2.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath exception 2.0
+  2.3.0:
+    licensed:
+      declared: OTHER
   2.3.1:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath exception 2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxb-api/2.3.0

**Details:**
No info in package files. Meta data indicated MIT in POM file. However, when reviewing the URL to source repo, the author took liberties with the MIT license language. So, curated as OTHER.

**Resolution:**
https://repo1.maven.org/maven2/org/dspace/orcid-jaxb-api/3.0.0/orcid-jaxb-api-3.0.0.pom

https://repo1.maven.org/maven2/org/dspace/orcid-jaxb-api/3.0.0/orcid-jaxb-api-3.0.0.pom

**Affected definitions**:
- [jaxb-api 2.3.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.xml.bind/jaxb-api/2.3.0/2.3.0)