### PR TITLE
IdentityServer4.AccessTokenValidation	2.6.0

### DIFF
--- a/curations/nuget/nuget/-/IdentityServer4.AccessTokenValidation.yaml
+++ b/curations/nuget/nuget/-/IdentityServer4.AccessTokenValidation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: IdentityServer4.AccessTokenValidation
+  provider: nuget
+  type: nuget
+revisions:
+  2.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
IdentityServer4.AccessTokenValidation	2.6.0

**Details:**
License file in repository is Apache 2.0

**Resolution:**
   

**Affected definitions**:
- [IdentityServer4.AccessTokenValidation 2.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/IdentityServer4.AccessTokenValidation/2.6.0/2.6.0)