### PR TITLE
IdentityModel.AspNetCore.OAuth2Introspection	3.3.0

### DIFF
--- a/curations/nuget/nuget/-/IdentityModel.AspNetCore.OAuth2Introspection.yaml
+++ b/curations/nuget/nuget/-/IdentityModel.AspNetCore.OAuth2Introspection.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: IdentityModel.AspNetCore.OAuth2Introspection
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
IdentityModel.AspNetCore.OAuth2Introspection	3.3.0

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License file in repository indicates license is Apache 2.0

**Affected definitions**:
- [IdentityModel.AspNetCore.OAuth2Introspection 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/IdentityModel.AspNetCore.OAuth2Introspection/3.3.0/3.3.0)