### PR TITLE
IdentityModel	3.6.0

### DIFF
--- a/curations/nuget/nuget/-/IdentityModel.yaml
+++ b/curations/nuget/nuget/-/IdentityModel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: IdentityModel
+  provider: nuget
+  type: nuget
+revisions:
+  3.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
IdentityModel	3.6.0

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License file in repository indicates license is Apache 2.0

**Affected definitions**:
- [IdentityModel 3.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/IdentityModel/3.6.0/3.6.0)