### PR TITLE
tensorboard-plugin-wit	1.7.0

### DIFF
--- a/curations/pypi/pypi/-/tensorboard-plugin-wit.yaml
+++ b/curations/pypi/pypi/-/tensorboard-plugin-wit.yaml
@@ -6,3 +6,6 @@ revisions:
   1.6.0.post3:
     licensed:
       declared: Apache-2.0
+  1.7.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tensorboard-plugin-wit	1.7.0

**Details:**
PyPi site indicates license is Apache 2.0

**Resolution:**
Metadata file in package also indicates license is Apache 2.0

**Affected definitions**:
- [tensorboard-plugin-wit 1.7.0](https://clearlydefined.io/definitions/pypi/pypi/-/tensorboard-plugin-wit/1.7.0/1.7.0)