### PR TITLE
azureml-automl-core	1.4.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -18,6 +18,9 @@ revisions:
   1.4.0:
     licensed:
       declared: OTHER
+  1.4.0.post1:
+    licensed:
+      declared: OTHER
   1.6.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core	1.4.0.post1

**Details:**
PyPi site indicates license is Other/Proprietary License (https://aka.ms/azureml-sdk-license)

**Resolution:**
License file in package states This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the [Microsoft Onli

**Affected definitions**:
- [azureml-automl-core 1.4.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.4.0.post1/1.4.0.post1)