### PR TITLE
highcharts	8.1.2

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -30,3 +30,6 @@ revisions:
   8.1.1:
     licensed:
       declared: OTHER
+  8.1.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
highcharts	8.1.2

**Details:**
License URL in package.json file indicates license is Highsoft Standard License

**Resolution:**
Licensing link on project homepage also indicates license is Highsoft Standard License

**Affected definitions**:
- [highcharts 8.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/8.1.2/8.1.2)