### PR TITLE
Markdig.Signed 0.16.0

### DIFF
--- a/curations/nuget/nuget/-/Markdig.Signed.yaml
+++ b/curations/nuget/nuget/-/Markdig.Signed.yaml
@@ -24,6 +24,6 @@ revisions:
         license: ''
         path: .signature.p7s
       - attributions:
-          - 'Copyright (c) 2018-2019, Alexandre Mutel All rights reserved.'
+          - 'Alexandre Mutel'
         license: ''
         path: Markdig.Signed.nuspec

--- a/curations/nuget/nuget/-/Markdig.Signed.yaml
+++ b/curations/nuget/nuget/-/Markdig.Signed.yaml
@@ -18,3 +18,12 @@ revisions:
   0.15.7:
     licensed:
       declared: BSD-2-Clause
+  0.16.0:
+    files:
+      - attributions: []
+        license: ''
+        path: .signature.p7s
+      - attributions:
+          - 'Copyright (c) 2018-2019, Alexandre Mutel All rights reserved.'
+        license: ''
+        path: Markdig.Signed.nuspec


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Markdig.Signed 0.16.0

**Details:**
Adding copyright info

**Resolution:**
Copyright (c) 2018-2019, Alexandre Mutel
All rights reserved.

**Affected definitions**:
- [Markdig.Signed 0.16.0](https://clearlydefined.io/definitions/nuget/nuget/-/Markdig.Signed/0.16.0/0.16.0)