### PR TITLE
wildfly-openssl/1.0.7.final

### DIFF
--- a/curations/maven/mavencentral/org.wildfly.openssl/wildfly-openssl.yaml
+++ b/curations/maven/mavencentral/org.wildfly.openssl/wildfly-openssl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: wildfly-openssl
+  namespace: org.wildfly.openssl
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.7.Final:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
wildfly-openssl/1.0.7.final

**Details:**
No info in package files. Meta data POM file did not contain license. Found source repo, which points to Apache 2.0. 

**Resolution:**
https://github.com/wildfly-security/wildfly-openssl/blob/1.0.7.Final/LICENSE.txt

**Affected definitions**:
- [wildfly-openssl 1.0.7.Final](https://clearlydefined.io/definitions/maven/mavencentral/org.wildfly.openssl/wildfly-openssl/1.0.7.Final/1.0.7.Final)