### PR TITLE
omggif/1.0.9

### DIFF
--- a/curations/npm/npmjs/-/omggif.yaml
+++ b/curations/npm/npmjs/-/omggif.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: omggif
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
omggif/1.0.9

**Details:**
Package files point to MIT, Meta data confirms, but it was in the README file. 

**Resolution:**
https://github.com/deanm/omggif

**Affected definitions**:
- [omggif 1.0.9](https://clearlydefined.io/definitions/npm/npmjs/-/omggif/1.0.9/1.0.9)