### PR TITLE
azureml-automl-core/1.9.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -24,3 +24,6 @@ revisions:
   1.7.0.post1:
     licensed:
       declared: OTHER
+  1.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core/1.9.0

**Details:**
No info in package files. Meta data confirms proprietary license, which is curated as OTHER. 

**Resolution:**
https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Affected definitions**:
- [azureml-automl-core 1.9.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.9.0/1.9.0)