### PR TITLE
azureml-train-automl-client/1.6.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -15,6 +15,9 @@ revisions:
   1.3.0:
     licensed:
       declared: OTHER
+  1.6.0.post1:
+    licensed:
+      declared: OTHER
   1.7.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client/1.6.0.post1

**Details:**
No info in package files. Meta data points to proprietary license, curated as OTHER. 

**Resolution:**
https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Affected definitions**:
- [azureml-train-automl-client 1.6.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.6.0.post1/1.6.0.post1)