### PR TITLE
org.bouncycastle/bcprov-jdk15on/1.64

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
@@ -18,3 +18,6 @@ revisions:
         path: META-INF/MANIFEST.MF
     licensed:
       declared: MIT
+  '1.64':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle/bcprov-jdk15on/1.64

**Details:**
No info in package files. Meta data POM file confirms Bouncy Castle License, which we decided to curate as MIT, given its language. 

**Resolution:**
https://repo1.maven.org/maven2/org/bouncycastle/bcprov-jdk15on/1.64/bcprov-jdk15on-1.64.pom

**Affected definitions**:
- [bcprov-jdk15on 1.64](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.64/1.64)