### PR TITLE
kendo-schematics/1.1.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-schematics.yaml
+++ b/curations/npm/npmjs/@progress/kendo-schematics.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-schematics
+  namespace: '@progress'
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-schematics/1.1.0

**Details:**
No info in package files. Meta data confirms proprietary license, curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-schematics/v/1.1.0

**Affected definitions**:
- [kendo-schematics 1.1.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-schematics/1.1.0/1.1.0)