### PR TITLE
distlib/0.3.1

### DIFF
--- a/curations/pypi/pypi/-/distlib.yaml
+++ b/curations/pypi/pypi/-/distlib.yaml
@@ -6,3 +6,6 @@ revisions:
   0.3.0:
     licensed:
       declared: Python-2.0
+  0.3.1:
+    licensed:
+      declared: '[object Object]'

--- a/curations/pypi/pypi/-/distlib.yaml
+++ b/curations/pypi/pypi/-/distlib.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: Python-2.0
   0.3.1:
     licensed:
-      declared: '[object Object]'
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
distlib/0.3.1

**Details:**
No info in package files. Meta data points to Python Software Foundation License 2.0, but found source repo confirms. The "Declared" field would not accept the SPDX abbreviation "PSF-2.0"

**Resolution:**
https://github.com/vsajip/distlib/blob/0.3.1/LICENSE.txt

**Affected definitions**:
- [distlib 0.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/distlib/0.3.1/0.3.1)