### PR TITLE
sp-webpart-base/1.10.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-webpart-base.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-webpart-base.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.10.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-webpart-base/1.10.0

**Details:**
No info in package files. Meta data points to MSFT EULA, so curated as OTHER. 

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [sp-webpart-base 1.10.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-webpart-base/1.10.0/1.10.0)