### PR TITLE
sp-build-core-tasks/1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-build-core-tasks.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-build-core-tasks.yaml
@@ -10,3 +10,6 @@ revisions:
   1.8.2:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-build-core-tasks/1.9.1

**Details:**
No info in package files. Meta data points to MSFT EULA. Curated as OTHER. 

**Resolution:**
https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview

**Affected definitions**:
- [sp-build-core-tasks 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-build-core-tasks/1.9.1/1.9.1)