### PR TITLE
Aspose.Slides.NET17.12.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Slides.NET.yaml
+++ b/curations/nuget/nuget/-/Aspose.Slides.NET.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Aspose.Slides.NET
+  provider: nuget
+  type: nuget
+revisions:
+  17.12.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Slides.NET17.12.0

**Details:**
NuGet "License info" link goes to EULA - https://company.aspose.com/legal/eula

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Aspose.Slides.NET 17.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Slides.NET/17.12.0/17.12.0)