### PR TITLE
Declare MIT Swashbuckle.AspNetCore.Swagger 5.5.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -48,3 +48,6 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.5.1/LICENSE)

**Resolution:**
Matches license info

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.5.1/5.5.1)