### PR TITLE
Declare MIT Swashbuckle.AspNetCore.SwaggerUI 5.5.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI.yaml
@@ -51,3 +51,6 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/domaindrivendev/Swashbuckle.AspNetCore/tree/v5.5.1)

**Resolution:**
Matches license info

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerUI 5.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerUI/5.5.1/5.5.1)