### PR TITLE
databricks-cli/0.11.0

### DIFF
--- a/curations/pypi/pypi/-/databricks-cli.yaml
+++ b/curations/pypi/pypi/-/databricks-cli.yaml
@@ -6,3 +6,6 @@ revisions:
   0.10.0:
     licensed:
       declared: Apache-2.0
+  0.11.0:
+    licensed:
+      declared: Apache-2.0 AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
databricks-cli/0.11.0

**Details:**
No info in package files. Meta data points to Apache 2.0 and some additional license for API functions. Curated as Apache 2.0 and OTHER. 

**Resolution:**
https://protect-us.mimecast.com/s/NRRyCQWOgYi70wV3sPIzDF?domain=github.com

**Affected definitions**:
- [databricks-cli 0.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/databricks-cli/0.11.0/0.11.0)