### PR TITLE
Declare MIT

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -12,6 +12,9 @@ revisions:
   1.0.19:
     licensed:
       declared: MIT
+  1.0.2:
+    licensed:
+      declared: MIT
   1.0.22:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/Azure/azure-functions-vs-build-sdk/blob/main/LICENSE)

**Resolution:**
Specific tag not identified but no change to the license since the beginning of the project 

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.2/1.0.2)