### PR TITLE
Declare MIT StackExchange.Redis 2.0.495

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -27,6 +27,9 @@ revisions:
   1.2.6:
     licensed:
       declared: MIT
+  2.0.495:
+    licensed:
+      declared: MIT
   2.0.513:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/StackExchange/StackExchange.Redis/blob/v2.0.495/LICENSE)

**Resolution:**
matches license info

**Affected definitions**:
- [StackExchange.Redis 2.0.495](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/2.0.495/2.0.495)