### PR TITLE
Declare MIT Microsoft.IdentityModel.Clients.ActiveDirectory 4.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -121,6 +121,9 @@ revisions:
   4.3.0:
     licensed:
       declared: MIT
+  4.4.0:
+    licensed:
+      declared: MIT
   4.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declare MIT

**Details:**
Declare MIT found here (https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/v4.0.0/LICENSE)

**Resolution:**
Declare MIT found here (https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/v4.0.0/LICENSE)

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/4.4.0/4.4.0)