### PR TITLE
Microsoft.Owin.Security.Google	4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Owin.Security.Google.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Owin.Security.Google.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Owin.Security.Google
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Owin.Security.Google	4.1.0

**Details:**
Harvested license file is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apached 2.0

**Affected definitions**:
- [Microsoft.Owin.Security.Google 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Owin.Security.Google/4.1.0/4.1.0)