### PR TITLE
Microsoft.IdentityModel.Clients.ActiveDirectory	5.1.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -184,6 +184,9 @@ revisions:
         url: 'https://github.com/azuread/azure-activedirectory-library-for-dotnet/commit/9f4472ab6dff4fa74bddfa622da4ac3823beb4b8'
     licensed:
       declared: MIT
+  5.1.1:
+    licensed:
+      declared: MIT
   5.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Clients.ActiveDirectory	5.1.1

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Clients.ActiveDirectory 5.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory/5.1.1/5.1.1)