### PR TITLE
Microsoft.Azure.Cosmos	3.3.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.3.3:
+    licensed:
+      declared: NOASSERTION
   3.8.0:
     licensed:
       declared: MIT
   3.9.1:
     licensed:
-      declared: MIT  
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.3.3:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   3.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Cosmos	3.3.3

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.Cosmos 3.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos/3.3.3/3.3.3)