### PR TITLE
xunit.runner.msbuild	2.3.1

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.msbuild.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.msbuild.yaml
@@ -1,6 +1,5 @@
 coordinates:
   name: xunit.runner.msbuild
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
@@ -8,11 +7,14 @@ revisions:
     described:
       releaseDate: '2015-09-27'
       sourceLocation:
+        name: xunit
+        namespace: xunit
         provider: github
         revision: 47fdc2669ae6aa28f6d642e202840193dfc7dbd7
         type: git
         url: 'https://github.com/xunit/xunit'
-        name: xunit
-        namespace: xunit
+    licensed:
+      declared: Apache-2.0
+  2.3.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.runner.msbuild	2.3.1

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apache 2.0

**Affected definitions**:
- [xunit.runner.msbuild 2.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.msbuild/2.3.1/2.3.1)