### PR TITLE
Unity.Container	5.8.6

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -24,3 +24,6 @@ revisions:
   5.8.11:
     licensed:
       declared: Apache-2.0
+  5.8.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Container	5.8.6

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apache 2.0

**Affected definitions**:
- [Unity.Container 5.8.6](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.8.6/5.8.6)