### PR TITLE
Microsoft.VisualStudio.Threading	15.8.132

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
@@ -24,6 +24,9 @@ revisions:
   15.8.122:
     licensed:
       declared: MIT
+  15.8.132:
+    licensed:
+      declared: NOASSERTION
   15.8.209:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
@@ -26,7 +26,7 @@ revisions:
       declared: MIT
   15.8.132:
     licensed:
-      declared: NOASSERTION
+      declared: MIT
   15.8.209:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Threading	15.8.132

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.VisualStudio.Threading 15.8.132](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Threading/15.8.132/15.8.132)