### PR TITLE
Polly-Signed	5.5.0

### DIFF
--- a/curations/nuget/nuget/-/Polly-Signed.yaml
+++ b/curations/nuget/nuget/-/Polly-Signed.yaml
@@ -9,6 +9,9 @@ revisions:
   5.3.1:
     licensed:
       declared: BSD-3-Clause
+  5.5.0:
+    licensed:
+      declared: BSD-3-Clause
   5.8.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Polly-Signed	5.5.0

**Details:**
License link on Nuget site indicates license is BSD-3

**Resolution:**
License file in repository also indicates license is BSD-3

**Affected definitions**:
- [Polly-Signed 5.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Polly-Signed/5.5.0/5.5.0)