### PR TITLE
NEST	6.6.0

### DIFF
--- a/curations/nuget/nuget/-/NEST.yaml
+++ b/curations/nuget/nuget/-/NEST.yaml
@@ -150,3 +150,6 @@ revisions:
   6.5.1:
     licensed:
       declared: Apache-2.0
+  6.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NEST	6.6.0

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [NEST 6.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/NEST/6.6.0/6.6.0)