### PR TITLE
Microsoft.Azure.AppConfiguration.AspNetCore	3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.0.0:
+    licensed:
+      declared: OTHER
   3.0.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.AppConfiguration.AspNetCore	3.0.0

**Details:**
License link on Nuget site indicates license is MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
MICROSOFT AZURE APP CONFIGURATION SOFTWARE


**Resolution:**
License URL in Nuspec file also indicates license is MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
MICROSOFT AZURE APP CONFIGURATION SOFTWARE


**Affected definitions**:
- [Microsoft.Azure.AppConfiguration.AspNetCore 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore/3.0.0/3.0.0)