### PR TITLE
MSBuildTasks	1.4.0.128

### DIFF
--- a/curations/nuget/nuget/-/MSBuildTasks.yaml
+++ b/curations/nuget/nuget/-/MSBuildTasks.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.4.0.128:
+    licensed:
+      declared: BSD-2-Clause
   1.4.0.88:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSBuildTasks	1.4.0.128

**Details:**
License link on Nuget site indicates license is BSD-2

**Resolution:**
License file in repository also indicates license is BSD-2

**Affected definitions**:
- [MSBuildTasks 1.4.0.128](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuildTasks/1.4.0.128/1.4.0.128)