### PR TITLE
Microsoft.VisualStudio.Threading	15.0.240

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.yaml
@@ -6,6 +6,9 @@ revisions:
   14.1.131:
     licensed:
       declared: OTHER
+  15.0.240:
+    licensed:
+      declared: MIT
   15.3.20:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Threading	15.0.240

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.VisualStudio.Threading 15.0.240](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Threading/15.0.240/15.0.240)