### PR TITLE
Microsoft.ApplicationServer.Caching.Client

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationServer.Caching.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationServer.Caching.Client.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.4657.2:
     licensed:
-      declared: NOASSERTION
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.ApplicationServer.Caching.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationServer.Caching.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ApplicationServer.Caching.Client
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.4657.2:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationServer.Caching.Client

**Details:**
License link on Nuget site indicates license is Microsoft Developer Agreement

**Resolution:**
License URL in Nuspec file also indicates license is Microsoft Developer Agreement

**Affected definitions**:
- [Microsoft.ApplicationServer.Caching.Client 1.0.4657.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationServer.Caching.Client/1.0.4657.2/1.0.4657.2)