### PR TITLE
Grpc.Core	1.18.0

### DIFF
--- a/curations/nuget/nuget/-/Grpc.Core.yaml
+++ b/curations/nuget/nuget/-/Grpc.Core.yaml
@@ -6,3 +6,6 @@ revisions:
   1.12.0:
     licensed:
       declared: Apache-2.0
+  1.18.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Grpc.Core	1.18.0

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apache 2.0

**Affected definitions**:
- [Grpc.Core 1.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/Grpc.Core/1.18.0/1.18.0)