### PR TITLE
Google.Protobuf.Tools	3.4.0

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
@@ -6,6 +6,9 @@ revisions:
   3.11.4:
     licensed:
       declared: BSD-3-Clause
+  3.4.0:
+    licensed:
+      declared: BSD-3-Clause
   3.6.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf.Tools	3.4.0

**Details:**
License link on Nuget site indicates license is BSD-3

**Resolution:**
License file in repository also indicates license is BSD-3

**Affected definitions**:
- [Google.Protobuf.Tools 3.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf.Tools/3.4.0/3.4.0)