### PR TITLE
org.bouncycastle:bcprov-jdk15on	1.51

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.51':
+    licensed:
+      declared: MIT
   '1.52':
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle:bcprov-jdk15on	1.51

**Details:**
License URL in .pom file indicates license is MIT

**Resolution:**
Project homepage also indicates license is MIT

**Affected definitions**:
- [bcprov-jdk15on 1.51](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.51/1.51)