### PR TITLE
org.ow2.asm:asm	6

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -15,6 +15,9 @@ revisions:
   5.0.4:
     licensed:
       declared: BSD-3-Clause
+  '6.0':
+    licensed:
+      declared: BSD-2-Clause
   '7.0':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.ow2.asm:asm	6

**Details:**
License in .pom file is BSD-2

**Resolution:**
 

**Affected definitions**:
- [asm 6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm/6.0/6.0)