### PR TITLE
net.sf.py4j:py4j	0.10.4

### DIFF
--- a/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
+++ b/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   0.10.4:
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause
   0.10.6:
     licensed:
       declared: BSD-3-Clause

--- a/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
+++ b/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.10.4:
+    licensed:
+      declared: BSD-2-Clause
   0.10.6:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
net.sf.py4j:py4j	0.10.4

**Details:**
.pom file indicates license is BSD-2

**Resolution:**
 

**Affected definitions**:
- [py4j 0.10.4](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.py4j/py4j/0.10.4/0.10.4)