### PR TITLE
flexbuffer	0.0.6

### DIFF
--- a/curations/npm/npmjs/-/flexbuffer.yaml
+++ b/curations/npm/npmjs/-/flexbuffer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: flexbuffer
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
flexbuffer	0.0.6

**Details:**
License file in repository indicates license is MIT

**Resolution:**
 

**Affected definitions**:
- [flexbuffer 0.0.6](https://clearlydefined.io/definitions/npm/npmjs/-/flexbuffer/0.0.6/0.0.6)