### PR TITLE
qs	0.4.2

### DIFF
--- a/curations/npm/npmjs/-/qs.yaml
+++ b/curations/npm/npmjs/-/qs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.4.2:
+    licensed:
+      declared: MIT
   0.5.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
qs	0.4.2

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
Readme file in repository also indicates license is MIT

**Affected definitions**:
- [qs 0.4.2](https://clearlydefined.io/definitions/npm/npmjs/-/qs/0.4.2/0.4.2)