### PR TITLE
torchvision	0.6.1

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -18,3 +18,6 @@ revisions:
   0.6.0:
     licensed:
       declared: BSD-3-Clause
+  0.6.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision	0.6.1

**Details:**
PyPi site indicates license is BSD-3

**Resolution:**
License file in repository also indicates license is BSD-3

**Affected definitions**:
- [torchvision 0.6.1](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.6.1/0.6.1)