### PR TITLE
graphql-playground-html	1.6.12

### DIFF
--- a/curations/npm/npmjs/-/graphql-playground-html.yaml
+++ b/curations/npm/npmjs/-/graphql-playground-html.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: graphql-playground-html
+  provider: npmjs
+  type: npm
+revisions:
+  1.6.12:
+    licensed:
+      declared: NOASSERTION

--- a/curations/npm/npmjs/-/graphql-playground-html.yaml
+++ b/curations/npm/npmjs/-/graphql-playground-html.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.6.12:
     licensed:
-      declared: NOASSERTION
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
graphql-playground-html	1.6.12

**Details:**
License file in repository indicates license is MIT

**Resolution:**
NPM site also indicates license is MIT

**Affected definitions**:
- [graphql-playground-html 1.6.12](https://clearlydefined.io/definitions/npm/npmjs/-/graphql-playground-html/1.6.12/1.6.12)