### PR TITLE
rgbcolor	1.0.1

### DIFF
--- a/curations/npm/npmjs/-/rgbcolor.yaml
+++ b/curations/npm/npmjs/-/rgbcolor.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rgbcolor
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: 'NOASSERTION '

--- a/curations/npm/npmjs/-/rgbcolor.yaml
+++ b/curations/npm/npmjs/-/rgbcolor.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.1:
     licensed:
-      declared: 'NOASSERTION '
+      declared: MIT OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rgbcolor	1.0.1

**Details:**
Harvested license file indicates license is MIT or Other

**Resolution:**
Repository also indicates license is MIT or Other

**Affected definitions**:
- [rgbcolor 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/rgbcolor/1.0.1/1.0.1)