### PR TITLE
BuildBundlerMinifier 2.8.391

### DIFF
--- a/curations/nuget/nuget/-/BuildBundlerMinifier.yaml
+++ b/curations/nuget/nuget/-/BuildBundlerMinifier.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.8.391:
+    licensed:
+      declared: Apache-2.0
   2.9.406:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
BuildBundlerMinifier 2.8.391

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet license link goes to GitHub master repo license, no tagged version

License for commit close to release date:
https://github.com/madskristensen/BundlerMinifier/blob/637ef4983743599812c6caf938306eb8623a2638/LICENSE

**Affected definitions**:
- [BuildBundlerMinifier 2.8.391](https://clearlydefined.io/definitions/nuget/nuget/-/BuildBundlerMinifier/2.8.391/2.8.391)