### PR TITLE
Unofficial.Microsoft.WindowsAzure.ServiceRuntime 2.7.0

### DIFF
--- a/curations/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.ServiceRuntime.yaml
+++ b/curations/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.ServiceRuntime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Unofficial.Microsoft.WindowsAzure.ServiceRuntime
+  provider: nuget
+  type: nuget
+revisions:
+  2.7.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Unofficial.Microsoft.WindowsAzure.ServiceRuntime 2.7.0

**Details:**
Declaring NONE

**Resolution:**
No NuGet license metadata
No license or license link found in package download
No license found for other versions on NuGet

**Affected definitions**:
- [Unofficial.Microsoft.WindowsAzure.ServiceRuntime 2.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.ServiceRuntime/2.7.0/2.7.0)