### PR TITLE
@apollographql/graphql-language-service-types 2.0.2

### DIFF
--- a/curations/npm/npmjs/@apollographql/graphql-language-service-types.yaml
+++ b/curations/npm/npmjs/@apollographql/graphql-language-service-types.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: graphql-language-service-types
+  namespace: '@apollographql'
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@apollographql/graphql-language-service-types 2.0.2

**Details:**
Declaring NONE

**Resolution:**
NONE noted on NPM for license and links for package are broken

**Affected definitions**:
- [graphql-language-service-types 2.0.2](https://clearlydefined.io/definitions/npm/npmjs/@apollographql/graphql-language-service-types/2.0.2/2.0.2)