### PR TITLE
@apollographql/graphql-language-service-utils 2.0.2

### DIFF
--- a/curations/npm/npmjs/@apollographql/graphql-language-service-utils.yaml
+++ b/curations/npm/npmjs/@apollographql/graphql-language-service-utils.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: graphql-language-service-utils
+  namespace: '@apollographql'
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@apollographql/graphql-language-service-utils 2.0.2

**Details:**
Declaring NONE

**Resolution:**
NPM page notes none for license
Links are broken on NPM page

**Affected definitions**:
- [graphql-language-service-utils 2.0.2](https://clearlydefined.io/definitions/npm/npmjs/@apollographql/graphql-language-service-utils/2.0.2/2.0.2)