### PR TITLE
NEST.JsonNetSerializer 6.6.0

### DIFF
--- a/curations/nuget/nuget/-/NEST.JsonNetSerializer.yaml
+++ b/curations/nuget/nuget/-/NEST.JsonNetSerializer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NEST.JsonNetSerializer
+  provider: nuget
+  type: nuget
+revisions:
+  6.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NEST.JsonNetSerializer 6.6.0

**Details:**
Declaring Apache 2.0

**Resolution:**
ClearlyDefined Files: LIcense.txt is Apache 2.0

NuGet metadata: NEST.JsonNetSerializer6.6.0

Project license, tagged version:
https://github.com/elastic/elasticsearch-net/blob/6.6.0/license.txt

**Affected definitions**:
- [NEST.JsonNetSerializer 6.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/NEST.JsonNetSerializer/6.6.0/6.6.0)