### PR TITLE
get-document 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/get-document.yaml
+++ b/curations/npm/npmjs/-/get-document.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: get-document
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
get-document 1.0.0

**Details:**
Declaring MIT

**Resolution:**
NuGet directs to GitHub repo

License for v1.0.0 https://github.com/webmodules/get-document/commit/a04ccb499d6e0433a368c3bb150b4899b698461f#diff-b9cfc7f2cdf78a7f4b91a753d10865a2

**Affected definitions**:
- [get-document 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/get-document/1.0.0/1.0.0)