### PR TITLE
debug 1.0.2

### DIFF
--- a/curations/npm/npmjs/-/debug.yaml
+++ b/curations/npm/npmjs/-/debug.yaml
@@ -9,6 +9,9 @@ revisions:
   0.8.1:
     licensed:
       declared: MIT
+  1.0.2:
+    licensed:
+      declared: MIT
   1.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
debug 1.0.2

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Files: MIT license text

License text on this page, under tagged version

https://github.com/visionmedia/debug/tree/1.0.2

**Affected definitions**:
- [debug 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/debug/1.0.2/1.0.2)