### PR TITLE
emscripten-core/emscripten/3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8

### DIFF
--- a/curations/git/github/emscripten-core/emscripten.yaml
+++ b/curations/git/github/emscripten-core/emscripten.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: emscripten
+  namespace: emscripten-core
+  provider: github
+  type: git
+revisions:
+  3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8:
+    licensed:
+      declared: MIT OR NCSA


### PR DESCRIPTION

**Type:** Missing

**Summary:**
emscripten-core/emscripten/3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8

**Details:**
MIT OR NCSA

**Resolution:**
https://github.com/emscripten-core/emscripten/blob/3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8/LICENSE

I wasn't sure if it should be AND or OR. Picked OR since the license states they offer both. Update if it should be AND.

**Affected definitions**:
- [emscripten 3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8](https://clearlydefined.io/definitions/git/github/emscripten-core/emscripten/3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8/3903f7babd29a5aa2f7fd60df0f8f2f2a950cab8)