### PR TITLE
NUnitTestAdapter.WithFramework 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
+++ b/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.0.0:
     licensed:
-      declared: MIT AND Zlib
+      declared: MIT AND zlib-acknowledgement

--- a/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
+++ b/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NUnitTestAdapter.WithFramework
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: MIT AND Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NUnitTestAdapter.WithFramework 2.0.0

**Details:**
Nuget site indicates license is MIT and Zlib

**Resolution:**
License link on Visual Studio Marketplace also indicates license is MIT and Zlib

**Affected definitions**:
- [NUnitTestAdapter.WithFramework 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/NUnitTestAdapter.WithFramework/2.0.0/2.0.0)