### PR TITLE
com.sun.jersey/jersey-server1.19 

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-server.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-server.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.19':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
   '1.9':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/com.sun.jersey/jersey-server.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-server.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   '1.19':
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.9':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.sun.jersey/jersey-server1.19 

**Details:**
Declare CDDL 1.1 or GPL 2.0 with classpath exception found here (https://repo1.maven.org/maven2/com/sun/jersey/jersey-server/1.19/jersey-server-1.19.pom)

**Resolution:**
matches source jar

**Affected definitions**:
- [jersey-server 1.19](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-server/1.19/1.19)