### PR TITLE
NUnitTestAdapter.WithFramework 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
+++ b/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NUnitTestAdapter.WithFramework
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NUnitTestAdapter.WithFramework 2.0.0

**Details:**
Declaring NONE

**Resolution:**
NuGet metadata and project links are broken. 
ClearlyDefined nuspec: license "none"

**Affected definitions**:
- [NUnitTestAdapter.WithFramework 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/NUnitTestAdapter.WithFramework/2.0.0/2.0.0)