### PR TITLE
Swashbuckle.AspNetCore.Swagger 5.5.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -48,6 +48,9 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.0:
+    licensed:
+      declared: MIT
   5.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore.Swagger 5.5.0

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined License File is MIT

NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

Project license, tagged version:
https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.5.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.5.0/5.5.0)