### PR TITLE
Swashbuckle.AspNetCore 5.5.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -51,6 +51,9 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.0:
+    licensed:
+      declared: MIT
   5.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Swashbuckle.AspNetCore 5.5.0

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined License File is MIT

NuGet metadata: https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.5.0/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.5.0/5.5.0)