### PR TITLE
debug 1.0.2

### DIFF
--- a/curations/npm/npmjs/-/debug.yaml
+++ b/curations/npm/npmjs/-/debug.yaml
@@ -9,6 +9,9 @@ revisions:
   0.8.1:
     licensed:
       declared: MIT
+  1.0.2:
+    licensed:
+      declared: MIT
   1.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
debug 1.0.2

**Details:**
Declaring MIT

**Resolution:**
ClearlyDefined Readme has MIT license text

NPM page has MIT license text:
https://www.npmjs.com/package/debug/v/1.0.2

Repo license, tagged version:
https://github.com/visionmedia/debug/blob/1.0.2/Readme.md

**Affected definitions**:
- [debug 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/debug/1.0.2/1.0.2)