### PR TITLE
Microsoft.PowerShell.SDK 6.2.0-preview.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.SDK.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.SDK.yaml
@@ -16,3 +16,6 @@ revisions:
   6.1.0:
     licensed:
       declared: MIT
+  6.2.0-preview.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.PowerShell.SDK 6.2.0-preview.4

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license (MIT)

Tagged version:
https://github.com/PowerShell/PowerShell/blob/v6.2.0-preview.4/LICENSE.txt

**Affected definitions**:
- [Microsoft.PowerShell.SDK 6.2.0-preview.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.SDK/6.2.0-preview.4/6.2.0-preview.4)