### PR TITLE
libexpat/libexpat 39e487da353b20b

### DIFF
--- a/curations/git/github/libexpat/libexpat.yaml
+++ b/curations/git/github/libexpat/libexpat.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: libexpat
+  namespace: libexpat
+  provider: github
+  type: git
+revisions:
+  39e487da353b20bb3a724311d179ba0fddffc65b:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
libexpat/libexpat 39e487da353b20b

**Details:**
COPYING file referenced on README.  Found COPYING file here: https://github.com/libexpat/libexpat/blob/39e487da353b20bb3a724311d179ba0fddffc65b/expat/COPYING

**Resolution:**
MIT

**Affected definitions**:
- [libexpat 39e487da353b20bb3a724311d179ba0fddffc65b](https://clearlydefined.io/definitions/git/github/libexpat/libexpat/39e487da353b20bb3a724311d179ba0fddffc65b/39e487da353b20bb3a724311d179ba0fddffc65b)