### PR TITLE
Ionic.Zip	1.9.1.8

### DIFF
--- a/curations/nuget/nuget/-/Ionic.Zip.yaml
+++ b/curations/nuget/nuget/-/Ionic.Zip.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ionic.Zip
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.1.8:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ionic.Zip	1.9.1.8

**Details:**
No license link on Nuget site

**Resolution:**
No license URL in Nuspec file

**Affected definitions**:
- [Ionic.Zip 1.9.1.8](https://clearlydefined.io/definitions/nuget/nuget/-/Ionic.Zip/1.9.1.8/1.9.1.8)