### PR TITLE
HtmlAgilityPack	1.11.24

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -27,6 +27,9 @@ revisions:
   1.11.23:
     licensed:
       declared: MIT
+  1.11.24:
+    licensed:
+      declared: MIT
   1.11.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack	1.11.24

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [HtmlAgilityPack 1.11.24](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.24/1.11.24)