### PR TITLE
Microsoft.BuildTracker.Client	6.0.30808.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.BuildTracker.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.BuildTracker.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.BuildTracker.Client
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.30808.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.BuildTracker.Client	6.0.30808.2

**Details:**
No license link on Nuget site

**Resolution:**
No license file in package and no license URL in Nuspec file

**Affected definitions**:
- [Microsoft.BuildTracker.Client 6.0.30808.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.BuildTracker.Client/6.0.30808.2/6.0.30808.2)