### PR TITLE
AspNet.ScriptManager.jQuery	3.3.1

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
@@ -6,3 +6,6 @@ revisions:
   1.10.2:
     licensed:
       declared: NONE
+  3.3.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AspNet.ScriptManager.jQuery	3.3.1

**Details:**
No license link on Nuget site

**Resolution:**
No license file in package and no license URL in Nuspec file

**Affected definitions**:
- [AspNet.ScriptManager.jQuery 3.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.jQuery/3.3.1/3.3.1)