### PR TITLE
Microsoft.Toolkit	6.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Toolkit.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Toolkit.yaml
@@ -15,3 +15,6 @@ revisions:
   5.1.1:
     licensed:
       declared: MIT
+  6.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Toolkit	6.0.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Toolkit 6.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Toolkit/6.0.0/6.0.0)