### PR TITLE
junit-jupiter-engine 5.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-jupiter-engine
+  namespace: org.junit.jupiter
+  provider: mavencentral
+  type: maven
+revisions:
+  5.5.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter-engine 5.5.2

**Details:**
LICENSE.md in package is EPL-2.0.  POM also says EPL-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.5.2/junit-jupiter-engine-5.5.2.pom

**Affected definitions**:
- [junit-jupiter-engine 5.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.5.2/5.5.2)