### PR TITLE
Microsoft.Extensions.Configuration.AzureAppConfiguration3.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
@@ -12,3 +12,6 @@ revisions:
   3.0.1:
     licensed:
       declared: OTHER
+  3.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Extensions.Configuration.AzureAppConfiguration3.0.2

**Details:**
NuGet license link downloads a MSFT EULA - Downloads/Microsoft.Azure.App.Configuration.Pre-Release.Software.License.Terms.pdf

**Resolution:**
OTHER for EULA

**Affected definitions**:
- [Microsoft.Extensions.Configuration.AzureAppConfiguration 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration/3.0.2/3.0.2)