### PR TITLE
regex 2020.5.7

### DIFF
--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -18,6 +18,9 @@ revisions:
   2020.5.14:
     licensed:
       declared: Python-2.0
+  2020.5.7:
+    licensed:
+      declared: CNRI-Python
   2020.6.8:
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
regex 2020.5.7

**Details:**
The metadata says Python Software Foundation License, but the py file headers say: # This version of the SRE library can be redistributed under CNRI's
# Python 1.6 license.  For any other use, please contact Secret Labs
# AB (info@pythonware.com).

**Resolution:**
Based on the above, selecting CNRI-Python

**Affected definitions**:
- [regex 2020.5.7](https://clearlydefined.io/definitions/pypi/pypi/-/regex/2020.5.7/2020.5.7)