### PR TITLE
RandomForest 0.2.3

### DIFF
--- a/curations/nuget/nuget/-/RandomForest.yaml
+++ b/curations/nuget/nuget/-/RandomForest.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RandomForest
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RandomForest 0.2.3

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master repo license, no tagged version

Commit to release date:
https://github.com/g3rv4/RandomForest/blob/bce8f1192ddc70a86827472b196af427d3ae6c06/LICENSE.md

**Affected definitions**:
- [RandomForest 0.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/RandomForest/0.2.3/0.2.3)