### PR TITLE
Microsoft.Data.SqlClient.SNI.runtime/2.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Data.SqlClient.SNI.runtime
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Data.SqlClient.SNI.runtime/2.0.0

**Details:**
No info in package files. Meta data confirms a proprietary license. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Data.SqlClient.SNI.runtime/2.0.0/License

**Affected definitions**:
- [Microsoft.Data.SqlClient.SNI.runtime 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime/2.0.0/2.0.0)