### PR TITLE
System.IO.Abstractions/6.0.14

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.0.178:
     licensed:
       declared: MS-PL
+  6.0.14:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions/6.0.14

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v6.0.14/LICENSE

**Affected definitions**:
- [System.IO.Abstractions 6.0.14](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/6.0.14/6.0.14)