### PR TITLE
Xamarin.Android.Arch.Lifecycle.ViewModel/1.1.1.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.ViewModel.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.ViewModel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.1.1:
+    licensed:
+      declared: MIT
   1.1.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Arch.Lifecycle.ViewModel/1.1.1.1

**Details:**
No info in package files. Meta data confirms  MIT. 

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/master/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Arch.Lifecycle.ViewModel 1.1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Arch.Lifecycle.ViewModel/1.1.1.1/1.1.1.1)