### PR TITLE
org.apache.pig/pig/0.12.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.pig/pig.yaml
+++ b/curations/maven/mavencentral/org.apache.pig/pig.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pig
+  namespace: org.apache.pig
+  provider: mavencentral
+  type: maven
+revisions:
+  0.12.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.pig/pig/0.12.1

**Details:**
No info in package files. Meta data POM file confirms Apache 2.0. 

**Resolution:**
https://repo1.maven.org/maven2/org/apache/pig/pig/0.12.1/pig-0.12.1.pom

**Affected definitions**:
- [pig 0.12.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.pig/pig/0.12.1/0.12.1)