### PR TITLE
XunitXml.TestLogger/2.1.26

### DIFF
--- a/curations/nuget/nuget/-/XunitXml.TestLogger.yaml
+++ b/curations/nuget/nuget/-/XunitXml.TestLogger.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: XunitXml.TestLogger
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.26:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
XunitXml.TestLogger/2.1.26

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/spekt/xunit.testlogger/blob/master/LICENSE

**Affected definitions**:
- [XunitXml.TestLogger 2.1.26](https://clearlydefined.io/definitions/nuget/nuget/-/XunitXml.TestLogger/2.1.26/2.1.26)