### PR TITLE
azureml-train-automl-client	1.9.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -21,3 +21,6 @@ revisions:
   1.7.0.post1:
     licensed:
       declared: OTHER
+  1.9.0.post1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.9.0.post1

**Details:**
PyPi site indicates license is OTHER

**Resolution:**
License file in package indicates license is This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the [

**Affected definitions**:
- [azureml-train-automl-client 1.9.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.9.0.post1/1.9.0.post1)