### PR TITLE
Microsoft.Azure.DataLake.Store	1.2.3-alpha

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
@@ -45,3 +45,6 @@ revisions:
   1.1.9:
     licensed:
       declared: MIT
+  1.2.3-alpha:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.DataLake.Store	1.2.3-alpha

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.DataLake.Store 1.2.3-alpha](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DataLake.Store/1.2.3-alpha/1.2.3-alpha)