### PR TITLE
Microsoft.Toolkit.Parsers	6.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Toolkit.Parsers.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Toolkit.Parsers.yaml
@@ -12,3 +12,6 @@ revisions:
   5.1.1:
     licensed:
       declared: MIT
+  6.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Toolkit.Parsers	6.0.0

**Details:**
The harvested license file indicates the license is MIT

**Resolution:**
The license file in the repository also indicates the license is MIT

**Affected definitions**:
- [Microsoft.Toolkit.Parsers 6.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Toolkit.Parsers/6.0.0/6.0.0)