### PR TITLE
Updating Declared gensim3.8.1

### DIFF
--- a/curations/pypi/pypi/-/gensim.yaml
+++ b/curations/pypi/pypi/-/gensim.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  3.8.1:
+    licensed:
+      declared: LGPL-2.1-only
   3.8.3:
     licensed:
       declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updating Declared gensim3.8.1

**Details:**
Removing GPL-3.0 from Declared field.  Looks like LGPL-2.1-only, per COPYING file in package and metadata and source headers.

**Resolution:**
LGPL-2.1-only

**Affected definitions**:
- [gensim 3.8.1](https://clearlydefined.io/definitions/pypi/pypi/-/gensim/3.8.1/3.8.1)