### PR TITLE
astroid2.3.3

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -6,3 +6,6 @@ revisions:
   2.3.1:
     licensed:
       declared: LGPL-2.1-only
+  2.3.3:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid2.3.3

**Details:**
From what I can tell, this package is LGPL-2.1-only from the COPYING.LESSER file and source headers.

**Resolution:**
I do see a COPYING (GPL-2.0) file, but it does not seem it is a "declared" license for the package.

**Affected definitions**:
- [astroid 2.3.3](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.3.3/2.3.3)