### PR TITLE
org.apache.pig:pig	0.12.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.pig/pig.yaml
+++ b/curations/maven/mavencentral/org.apache.pig/pig.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.12.0:
+    licensed:
+      declared: Apache-2.0
   0.12.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.pig:pig	0.12.0

**Details:**
Properties file in sources.jar file indicates license is Apache 2.0

**Resolution:**
.pom file also indicates license is Apache 2.0

**Affected definitions**:
- [pig 0.12.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.pig/pig/0.12.0/0.12.0)