### PR TITLE
org.apache.pig:pigsmoke	0.12.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.pig/pigsmoke.yaml
+++ b/curations/maven/mavencentral/org.apache.pig/pigsmoke.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pigsmoke
+  namespace: org.apache.pig
+  provider: mavencentral
+  type: maven
+revisions:
+  0.12.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.pig:pigsmoke	0.12.1

**Details:**
.pom file indicates license is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [pigsmoke 0.12.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.pig/pigsmoke/0.12.1/0.12.1)