### PR TITLE
org.apache.pig:pigunit	0.11.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.pig/pigunit.yaml
+++ b/curations/maven/mavencentral/org.apache.pig/pigunit.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pigunit
+  namespace: org.apache.pig
+  provider: mavencentral
+  type: maven
+revisions:
+  0.11.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.pig:pigunit	0.11.1

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
.pom file also indicates license is Apache 2.0

**Affected definitions**:
- [pigunit 0.11.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.pig/pigunit/0.11.1/0.11.1)