### PR TITLE
org.antlr:antlr4-runtime	4.5.3

### DIFF
--- a/curations/maven/mavencentral/org.antlr/antlr4-runtime.yaml
+++ b/curations/maven/mavencentral/org.antlr/antlr4-runtime.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  4.5.3:
+    licensed:
+      declared: BSD-3-Clause
   '4.7':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.antlr:antlr4-runtime	4.5.3

**Details:**
License file in repository indicates license is BSD-3

**Resolution:**
License URL in Manifest file in .jar also indicates license is BSD-3

**Affected definitions**:
- [antlr4-runtime 4.5.3](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/antlr4-runtime/4.5.3/4.5.3)