### PR TITLE
NuGetPowerTools/0.29.0

### DIFF
--- a/curations/nuget/nuget/-/NuGetPowerTools.yaml
+++ b/curations/nuget/nuget/-/NuGetPowerTools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGetPowerTools
+  provider: nuget
+  type: nuget
+revisions:
+  0.29.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGetPowerTools/0.29.0

**Details:**
No info in package files. Meta data points to a redirection page where Nuget is apparently licensed under Apache 2.0. Found Nuget Power Tools source repo, which also points to that redirection page and ultimately Apache 2.0. 

**Resolution:**
https://clearlydefined.io/definitions/nuget/nuget/-/NuGetPowerTools/0.29.0

https://github.com/davidfowl/NuGetPowerTools/blob/master/README.md

**Affected definitions**:
- [NuGetPowerTools 0.29.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGetPowerTools/0.29.0/0.29.0)