### PR TITLE
Microsoft.DotNet.PlatformAbstractions/3.1.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -33,3 +33,6 @@ revisions:
   3.1.3:
     licensed:
       declared: MIT
+  3.1.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.DotNet.PlatformAbstractions/3.1.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.DotNet.PlatformAbstractions/3.1.4/License

**Affected definitions**:
- [Microsoft.DotNet.PlatformAbstractions 3.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions/3.1.4/3.1.4)