### PR TITLE
FluentValidation/7.1.1

### DIFF
--- a/curations/nuget/nuget/-/FluentValidation.yaml
+++ b/curations/nuget/nuget/-/FluentValidation.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  7.1.1:
+    licensed:
+      declared: Apache-2.0
   7.6.104:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentValidation/7.1.1

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/FluentValidation/FluentValidation/blob/7.1.1/License.txt

**Affected definitions**:
- [FluentValidation 7.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentValidation/7.1.1/7.1.1)