### PR TITLE
YamlDotNet.Signed/4.2.1

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.Signed.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.Signed.yaml
@@ -6,6 +6,9 @@ revisions:
   4.0.1-pre291:
     licensed:
       declared: MIT
+  4.2.1:
+    licensed:
+      declared: MIT
   4.2.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet.Signed/4.2.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://aaubry.net/pages/license.html

**Affected definitions**:
- [YamlDotNet.Signed 4.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet.Signed/4.2.1/4.2.1)