### PR TITLE
cmd-shim/2.0.1

### DIFF
--- a/curations/npm/npmjs/-/cmd-shim.yaml
+++ b/curations/npm/npmjs/-/cmd-shim.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cmd-shim
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cmd-shim/2.0.1

**Details:**
No info in package files. Meta data confirms BSD 2 Clause. 

**Resolution:**
https://github.com/npm/cmd-shim/blob/2.0.1/LICENSE

**Affected definitions**:
- [cmd-shim 2.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/cmd-shim/2.0.1/2.0.1)