### PR TITLE
org.scala-lang/scala-reflect/2.11.11

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -7,6 +7,9 @@ revisions:
   2.10.4:
     licensed:
       declared: BSD-3-Clause
+  2.11.11:
+    licensed:
+      declared: BSD-3-Clause
   2.11.12:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scala-reflect/2.11.11

**Details:**
No info in package files. Meta data POM file points to BSD 3 Clause. The scala does say Apache 2.0, but packages before Dec. 2018 was licened under BSD 3 Clause. 

**Resolution:**
https://www.scala-lang.org/license/

**Affected definitions**:
- [scala-reflect 2.11.11](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.11.11/2.11.11)