### PR TITLE
StyleCop/6.1.0

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.yaml
+++ b/curations/nuget/nuget/-/StyleCop.yaml
@@ -6,3 +6,6 @@ revisions:
   5.0.0:
     licensed:
       declared: MS-PL
+  6.1.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StyleCop/6.1.0

**Details:**
No info in package files. Meta data confirms MS-PL license. 

**Resolution:**
https://github.com/StyleCop/StyleCop/blob/master/License.html

**Affected definitions**:
- [StyleCop 6.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop/6.1.0/6.1.0)