### PR TITLE
org.junit.jupiter/junit-jupiter-engine/5.4.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.4.2:
+    licensed:
+      declared: EPL-2.0
   5.5.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter-engine/5.4.2

**Details:**
No info in package files. Meta data POM file confirms Eclipse Public License 2.0. 

**Resolution:**
https://www.eclipse.org/legal/epl-v20.html

**Affected definitions**:
- [junit-jupiter-engine 5.4.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.4.2/5.4.2)