### PR TITLE
Microsoft.OData.Client/7.6.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Client.yaml
@@ -27,3 +27,6 @@ revisions:
   7.6.1:
     licensed:
       declared: MIT
+  7.6.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.OData.Client/7.6.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/OData/odata.net/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.OData.Client 7.6.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Client/7.6.4/7.6.4)