### PR TITLE
azureml-train-automl-client/1.9.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -21,6 +21,9 @@ revisions:
   1.7.0.post1:
     licensed:
       declared: OTHER
+  1.9.0:
+    licensed:
+      declared: OTHER
   1.9.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client/1.9.0

**Details:**
No info in package files. Meta data shows proprietary license. Curated as OTHER. 

**Resolution:**
https://pypi.org/project/azureml-train-automl-client/1.9.0/

**Affected definitions**:
- [azureml-train-automl-client 1.9.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.9.0/1.9.0)