### PR TITLE
matplotlib 3.2.2

### DIFF
--- a/curations/pypi/pypi/-/matplotlib.yaml
+++ b/curations/pypi/pypi/-/matplotlib.yaml
@@ -9,6 +9,9 @@ revisions:
   3.0.2:
     licensed:
       declared: OTHER
+  3.2.2:
+    licensed:
+      declared: OTHER
   3.3.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
matplotlib 3.2.2

**Details:**
I will file an issue for why MIT was declared.  Please see LICENSE agreement.  Overall LICENSE is not an OSS license, so curating OTHER.

**Resolution:**
OTHER

**Affected definitions**:
- [matplotlib 3.2.2](https://clearlydefined.io/definitions/pypi/pypi/-/matplotlib/3.2.2/3.2.2)