### PR TITLE
copyright from notice file

### DIFF
--- a/curations/maven/mavencentral/org.springframework/spring-beans.yaml
+++ b/curations/maven/mavencentral/org.springframework/spring-beans.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: spring-beans
+  namespace: org.springframework
+  provider: mavencentral
+  type: maven
+revisions:
+  5.2.6.RELEASE:
+    files:
+      - attributions:
+          - 'Copyright (c) 2002-2020 Pivotal, Inc.'
+        license: ''
+        path: META-INF/notice.txt


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
copyright from notice file

**Details:**
The notice.txt contains the copyright of the component itself, apart from the copyrights of the license file.

**Resolution:**
Extract the copyright from the notice file.

Not sure, where to ask this: It would be interesting to know, why this copyright was not discovered automatically by scancode or clearlydefined?

**Affected definitions**:
- [spring-beans 5.2.6.RELEASE](https://clearlydefined.io/definitions/maven/mavencentral/org.springframework/spring-beans/5.2.6.RELEASE/5.2.6.RELEASE)