### PR TITLE
Unity/5.11.5

### DIFF
--- a/curations/nuget/nuget/-/Unity.yaml
+++ b/curations/nuget/nuget/-/Unity.yaml
@@ -42,6 +42,9 @@ revisions:
   5.11.4:
     licensed:
       declared: Apache-2.0
+  5.11.5:
+    licensed:
+      declared: Apache-2.0
   5.11.6:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity/5.11.5

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/unitycontainer/unity/blob/5.11.5.959/LICENSE

**Affected definitions**:
- [Unity 5.11.5](https://clearlydefined.io/definitions/nuget/nuget/-/Unity/5.11.5/5.11.5)