### PR TITLE
xss-filters/1.2.7

### DIFF
--- a/curations/npm/npmjs/-/xss-filters.yaml
+++ b/curations/npm/npmjs/-/xss-filters.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xss-filters
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xss-filters/1.2.7

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/YahooArchive/xss-filters/blob/v1.2.7/LICENSE

**Affected definitions**:
- [xss-filters 1.2.7](https://clearlydefined.io/definitions/npm/npmjs/-/xss-filters/1.2.7/1.2.7)