### PR TITLE
Microsoft.Toolkit.Uwp/6.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Toolkit.Uwp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Toolkit.Uwp.yaml
@@ -15,3 +15,6 @@ revisions:
   5.1.1:
     licensed:
       declared: MIT
+  6.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Toolkit.Uwp/6.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/windows-toolkit/WindowsCommunityToolkit/blob/v6.0.0/license.md

**Affected definitions**:
- [Microsoft.Toolkit.Uwp 6.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Toolkit.Uwp/6.0.0/6.0.0)