### PR TITLE
SimMetrics.Net/1.0.5

### DIFF
--- a/curations/nuget/nuget/-/SimMetrics.Net.yaml
+++ b/curations/nuget/nuget/-/SimMetrics.Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SimMetrics.Net
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SimMetrics.Net/1.0.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/StefH/SimMetrics.Net/master/LICENSE

**Affected definitions**:
- [SimMetrics.Net 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/SimMetrics.Net/1.0.5/1.0.5)