### PR TITLE
matplotlib/2.2.2

### DIFF
--- a/curations/pypi/pypi/-/matplotlib.yaml
+++ b/curations/pypi/pypi/-/matplotlib.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  2.2.2:
+    licensed:
+      declared: OTHER
   3.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
matplotlib/2.2.2

**Details:**
No info in package files. Meta data was unclear. Found source repo to confirm proprietary license, which was curated as OTHER. 

**Resolution:**
https://github.com/matplotlib/matplotlib/blob/v2.2.0/LICENSE/LICENSE

**Affected definitions**:
- [matplotlib 2.2.2](https://clearlydefined.io/definitions/pypi/pypi/-/matplotlib/2.2.2/2.2.2)