### PR TITLE
kendo-angular-common/1.2.2

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-common.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-angular-common
+  namespace: '@progress'
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-common/1.2.2

**Details:**
No info in package files. Meta data confirms proprietary license, so curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-angular-common/v/1.2.2

**Affected definitions**:
- [kendo-angular-common 1.2.2](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-common/1.2.2/1.2.2)