### PR TITLE
Microsoft.VisualStudio.Services.ServiceHooks.WebApi 16.153.0-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Services.ServiceHooks.WebApi.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Services.ServiceHooks.WebApi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Services.ServiceHooks.WebApi
+  provider: nuget
+  type: nuget
+revisions:
+  16.153.0-preview:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.VisualStudio.Services.ServiceHooks.WebApi 16.153.0-preview

**Details:**
Microsoft EULA

**Resolution:**
Nuget License info: https://www.nuget.org/packages/Microsoft.VisualStudio.Services.ServiceHooks.WebApi/16.153.0-preview/License

**Affected definitions**:
- [Microsoft.VisualStudio.Services.ServiceHooks.WebApi 16.153.0-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Services.ServiceHooks.WebApi/16.153.0-preview/16.153.0-preview)