### PR TITLE
@microsoft/sp-core-library 1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-core-library.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-core-library.yaml
@@ -10,3 +10,6 @@ revisions:
   1.8.2:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@microsoft/sp-core-library 1.9.1

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
NPM page points to aka.ms/spfx, as note on the page:

The SharePoint Framework components are licensed under this Microsoft EULA.

**Affected definitions**:
- [sp-core-library 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-core-library/1.9.1/1.9.1)