### PR TITLE
@microsoft/sp-office-ui-fabric-core 1.10.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-office-ui-fabric-core.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-office-ui-fabric-core.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.10.0:
+    licensed:
+      declared: OTHER
   1.9.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@microsoft/sp-office-ui-fabric-core 1.10.0

**Details:**
Declaring Other for Microsoft EULA

**Resolution:**
NPMjs points to aka.ms/spfx, on this page:

The SharePoint Framework components are licensed under this Microsoft EULA.

**Affected definitions**:
- [sp-office-ui-fabric-core 1.10.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-office-ui-fabric-core/1.10.0/1.10.0)