### PR TITLE
org.apache.pig/pig 0.11.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.pig/pig.yaml
+++ b/curations/maven/mavencentral/org.apache.pig/pig.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.11.1:
+    licensed:
+      declared: Apache-2.0
   0.12.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.apache.pig/pig 0.11.1

**Details:**
Declaring Apache 2.0

**Resolution:**
Maven POM file:

https://repo1.maven.org/maven2/org/apache/pig/pig/0.11.1/pig-0.11.1.pom

**Affected definitions**:
- [pig 0.11.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.pig/pig/0.11.1/0.11.1)