### PR TITLE
azure/azure-powershell 5965f33fd527ce538cf7cc724622111b5b69bbe5

### DIFF
--- a/curations/git/github/azure/azure-powershell.yaml
+++ b/curations/git/github/azure/azure-powershell.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  5965f33fd527ce538cf7cc724622111b5b69bbe5:
+    licensed:
+      declared: Apache-2.0
   74034ed985e6efe68b2cfc0158aee1c229c13cf3:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
azure/azure-powershell 5965f33fd527ce538cf7cc724622111b5b69bbe5

**Details:**
Fixing the Declared Field to Apache 2.0 only

**Resolution:**
https://github.com/Azure/azure-powershell/blob/5965f33fd527ce538cf7cc724622111b5b69bbe5/LICENSE.txt

**Affected definitions**:
- [azure-powershell 5965f33fd527ce538cf7cc724622111b5b69bbe5](https://clearlydefined.io/definitions/git/github/azure/azure-powershell/5965f33fd527ce538cf7cc724622111b5b69bbe5/5965f33fd527ce538cf7cc724622111b5b69bbe5)