### PR TITLE
security-framework0.4.4

### DIFF
--- a/curations/crate/cratesio/-/security-framework.yaml
+++ b/curations/crate/cratesio/-/security-framework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: security-framework
+  provider: cratesio
+  type: crate
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
security-framework0.4.4

**Details:**
Declared would just be MIT OR Apache

**Resolution:**
APSL is mentioned on the THIRD_PARTY file

**Affected definitions**:
- [security-framework 0.4.4](https://clearlydefined.io/definitions/crate/cratesio/-/security-framework/0.4.4/0.4.4)