### PR TITLE
CommandLineArgumentsParser/3.0.7

### DIFF
--- a/curations/nuget/nuget/-/CommandLineArgumentsParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineArgumentsParser.yaml
@@ -9,3 +9,6 @@ revisions:
   3.0.20:
     licensed:
       declared: MIT
+  3.0.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommandLineArgumentsParser/3.0.7

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/j-maly/CommandLineParser/master/LICENCE.md

**Affected definitions**:
- [CommandLineArgumentsParser 3.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineArgumentsParser/3.0.7/3.0.7)