### PR TITLE
Jil.StrongName/2.14.5

### DIFF
--- a/curations/nuget/nuget/-/Jil.StrongName.yaml
+++ b/curations/nuget/nuget/-/Jil.StrongName.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Jil.StrongName
+  provider: nuget
+  type: nuget
+revisions:
+  2.14.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Jil.StrongName/2.14.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/kevin-montrose/Jil/blob/2.14.5/LICENSE

**Affected definitions**:
- [Jil.StrongName 2.14.5](https://clearlydefined.io/definitions/nuget/nuget/-/Jil.StrongName/2.14.5/2.14.5)