### PR TITLE
LiveCharts.Wpf/0.9.7

### DIFF
--- a/curations/nuget/nuget/-/LiveCharts.Wpf.yaml
+++ b/curations/nuget/nuget/-/LiveCharts.Wpf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: LiveCharts.Wpf
+  provider: nuget
+  type: nuget
+revisions:
+  0.9.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LiveCharts.Wpf/0.9.7

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Live-Charts/Live-Charts/blob/master/LICENSE.TXT

**Affected definitions**:
- [LiveCharts.Wpf 0.9.7](https://clearlydefined.io/definitions/nuget/nuget/-/LiveCharts.Wpf/0.9.7/0.9.7)