### PR TITLE
socket.io-client/0.9.16

### DIFF
--- a/curations/npm/npmjs/-/socket.io-client.yaml
+++ b/curations/npm/npmjs/-/socket.io-client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: socket.io-client
+  provider: npmjs
+  type: npm
+revisions:
+  0.9.16:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
socket.io-client/0.9.16

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/socketio/socket.io-client/blob/master/LICENSE

**Affected definitions**:
- [socket.io-client 0.9.16](https://clearlydefined.io/definitions/npm/npmjs/-/socket.io-client/0.9.16/0.9.16)