### PR TITLE
javax.mail/mail/1.4.5

### DIFF
--- a/curations/maven/mavencentral/javax.mail/mail.yaml
+++ b/curations/maven/mavencentral/javax.mail/mail.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.4.5:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.0
   1.4.7:
     licensed:
       declared: GPL-2.0-only OR CDDL-1.1

--- a/curations/maven/mavencentral/javax.mail/mail.yaml
+++ b/curations/maven/mavencentral/javax.mail/mail.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.4.7:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.01
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/javax.mail/mail.yaml
+++ b/curations/maven/mavencentral/javax.mail/mail.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1.4.5:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.4.7:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.1
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.01


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.mail/mail/1.4.5

**Details:**
No info in package files. Meta data looks to confirm GPL 2.0 or CDDL. 

**Resolution:**
https://repo1.maven.org/maven2/javax/mail/mail/1.4.5/mail-1.4.5.pom

**Affected definitions**:
- [mail 1.4.5](https://clearlydefined.io/definitions/maven/mavencentral/javax.mail/mail/1.4.5/1.4.5)