### PR TITLE
Parquet.Net/3.3.9

### DIFF
--- a/curations/nuget/nuget/-/Parquet.Net.yaml
+++ b/curations/nuget/nuget/-/Parquet.Net.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.4:
     licensed:
       declared: MIT
+  3.3.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Parquet.Net/3.3.9

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/elastacloud/parquet-dotnet/blob/3.3.9/LICENSE

**Affected definitions**:
- [Parquet.Net 3.3.9](https://clearlydefined.io/definitions/nuget/nuget/-/Parquet.Net/3.3.9/3.3.9)