### PR TITLE
LiveCharts/0.9.7

### DIFF
--- a/curations/nuget/nuget/-/LiveCharts.yaml
+++ b/curations/nuget/nuget/-/LiveCharts.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: LiveCharts
+  provider: nuget
+  type: nuget
+revisions:
+  0.9.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LiveCharts/0.9.7

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Live-Charts/Live-Charts/blob/master/LICENSE.TXT

**Affected definitions**:
- [LiveCharts 0.9.7](https://clearlydefined.io/definitions/nuget/nuget/-/LiveCharts/0.9.7/0.9.7)