### PR TITLE
active-x-obfuscator/0.0.1

### DIFF
--- a/curations/npm/npmjs/-/active-x-obfuscator.yaml
+++ b/curations/npm/npmjs/-/active-x-obfuscator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: active-x-obfuscator
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
active-x-obfuscator/0.0.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/felixge/node-active-x-obfuscator/blob/master/LICENSE

**Affected definitions**:
- [active-x-obfuscator 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/active-x-obfuscator/0.0.1/0.0.1)