### PR TITLE
jQuery.UI.Combined/1.9.2

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -21,3 +21,6 @@ revisions:
   1.8.24:
     licensed:
       declared: MIT
+  1.9.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery.UI.Combined/1.9.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://jquery.org/license/

**Affected definitions**:
- [jQuery.UI.Combined 1.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.9.2/1.9.2)