### PR TITLE
Swashbuckle.AspNetCore.Swagger/5.4.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger.yaml
@@ -45,6 +45,9 @@ revisions:
   5.3.3:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT
   5.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.Swagger/5.4.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.Swagger 5.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Swagger/5.4.0/5.4.0)