### PR TITLE
Swashbuckle.AspNetCore/5.3.2

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -45,6 +45,9 @@ revisions:
   5.3.1:
     licensed:
       declared: MIT
+  5.3.2:
+    licensed:
+      declared: MIT
   5.3.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore/5.3.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.3.2/5.3.2)