### PR TITLE
Serilog.Exceptions/4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Serilog.Exceptions.yaml
+++ b/curations/nuget/nuget/-/Serilog.Exceptions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Serilog.Exceptions
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Serilog.Exceptions/4.1.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://clearlydefined.io/definitions/nuget/nuget/-/Serilog.Exceptions/4.1.0

**Affected definitions**:
- [Serilog.Exceptions 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Serilog.Exceptions/4.1.0/4.1.0)