### PR TITLE
Microsoft.Bot.Builder.Integration.AspNet.Core/4.5.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.5.1:
+    licensed:
+      declared: MIT
   4.5.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.Integration.AspNet.Core/4.5.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.5.1/4.5.1)