### PR TITLE
org.codehaus.janino:commons-compiler	3.0.0

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.janino/commons-compiler.yaml
+++ b/curations/maven/mavencentral/org.codehaus.janino/commons-compiler.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.0.0:
+    licensed:
+      declared: BSD-3-Clause
   3.0.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.codehaus.janino:commons-compiler	3.0.0

**Details:**
License link in .pom file indicates license is BSD-3

**Resolution:**
License file in repository also indicates license is BSD-3

**Affected definitions**:
- [commons-compiler 3.0.0](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.janino/commons-compiler/3.0.0/3.0.0)