### PR TITLE
DotNet.Contracts/1.10.10126.4

### DIFF
--- a/curations/nuget/nuget/-/DotNet.Contracts.yaml
+++ b/curations/nuget/nuget/-/DotNet.Contracts.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNet.Contracts
+  provider: nuget
+  type: nuget
+revisions:
+  1.10.10126.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNet.Contracts/1.10.10126.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/CodeContracts/blob/v1.10.10126.2/LICENSE.txt

**Affected definitions**:
- [DotNet.Contracts 1.10.10126.4](https://clearlydefined.io/definitions/nuget/nuget/-/DotNet.Contracts/1.10.10126.4/1.10.10126.4)