### PR TITLE
Rx-Linq	2.2.2

### DIFF
--- a/curations/nuget/nuget/-/Rx-Linq.yaml
+++ b/curations/nuget/nuget/-/Rx-Linq.yaml
@@ -6,6 +6,9 @@ revisions:
   2.1.30214:
     licensed:
       declared: Apache-2.0
+  2.2.2:
+    licensed:
+      declared: MIT
   2.2.4:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Rx-Linq.yaml
+++ b/curations/nuget/nuget/-/Rx-Linq.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: Apache-2.0
   2.2.2:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.2.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Linq	2.2.2

**Details:**
License link now points to MIT

**Resolution:**
License file on repository also indicates license is MIT

**Affected definitions**:
- [Rx-Linq 2.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Linq/2.2.2/2.2.2)