### PR TITLE
Zlib.Portable.Signed/1.11.0

### DIFF
--- a/curations/nuget/nuget/-/Zlib.Portable.Signed.yaml
+++ b/curations/nuget/nuget/-/Zlib.Portable.Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Zlib.Portable.Signed
+  provider: nuget
+  type: nuget
+revisions:
+  1.11.0:
+    licensed:
+      declared: Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Zlib.Portable.Signed/1.11.0

**Details:**
No info in package files. Meta data literally cites Wikipedia. Curated as Zlib. 

**Resolution:**
https://en.wikipedia.org/wiki/Zlib_License

**Affected definitions**:
- [Zlib.Portable.Signed 1.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/Zlib.Portable.Signed/1.11.0/1.11.0)