### PR TITLE
org.junit.platform/junit-platform-engine/1.4.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.4.2:
+    licensed:
+      declared: EPL-2.0
   1.5.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-engine/1.4.2

**Details:**
No info in package files. Meta data confirms Eclipse Public License 2.0. 

**Resolution:**
http://www.eclipse.org/legal/epl-v20.html

https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.4.2/junit-platform-engine-1.4.2.pom

**Affected definitions**:
- [junit-platform-engine 1.4.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-engine/1.4.2/1.4.2)