### PR TITLE
Microsoft.Windows.CppWinRT/2.0.190730.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Windows.CppWinRT.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Windows.CppWinRT.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Windows.CppWinRT
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.190730.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Windows.CppWinRT/2.0.190730.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Windows.CppWinRT/2.0.190730.2/License

**Affected definitions**:
- [Microsoft.Windows.CppWinRT 2.0.190730.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Windows.CppWinRT/2.0.190730.2/2.0.190730.2)