### PR TITLE
uglify-js/1.2.5

### DIFF
--- a/curations/npm/npmjs/-/uglify-js.yaml
+++ b/curations/npm/npmjs/-/uglify-js.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.2.5:
+    licensed:
+      declared: BSD-2-Clause
   1.3.5:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
uglify-js/1.2.5

**Details:**
No info in package files. Meta data confirms BSD 2 Clause. 

**Resolution:**
https://github.com/mishoo/UglifyJS/blob/master/LICENSE

**Affected definitions**:
- [uglify-js 1.2.5](https://clearlydefined.io/definitions/npm/npmjs/-/uglify-js/1.2.5/1.2.5)