### PR TITLE
Microsoft.Extensions.Configuration.AzureAppConfiguration/2.0.0-preview-010050001-38

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0-preview-010050001-38:
+    licensed:
+      declared: OTHER
   3.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Extensions.Configuration.AzureAppConfiguration/2.0.0-preview-010050001-38

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Extensions.Configuration.AzureAppConfiguration/2.0.0-preview-010050001-38

**Affected definitions**:
- [Microsoft.Extensions.Configuration.AzureAppConfiguration 2.0.0-preview-010050001-38](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.Configuration.AzureAppConfiguration/2.0.0-preview-010050001-38/2.0.0-preview-010050001-38)