### PR TITLE
JasmineTest/2.2.0

### DIFF
--- a/curations/nuget/nuget/-/JasmineTest.yaml
+++ b/curations/nuget/nuget/-/JasmineTest.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: JasmineTest
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JasmineTest/2.2.0

**Details:**
No info for package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/jasmine/jasmine/blob/v2.2.0/MIT.LICENSE

**Affected definitions**:
- [JasmineTest 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/JasmineTest/2.2.0/2.2.0)