### PR TITLE
Chutzpah/4.4.8

### DIFF
--- a/curations/nuget/nuget/-/Chutzpah.yaml
+++ b/curations/nuget/nuget/-/Chutzpah.yaml
@@ -6,3 +6,6 @@ revisions:
   4.2.3:
     licensed:
       declared: Apache-2.0
+  4.4.8:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Chutzpah/4.4.8

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/mmanela/chutzpah/blob/v4.4.8/License.txt

**Affected definitions**:
- [Chutzpah 4.4.8](https://clearlydefined.io/definitions/nuget/nuget/-/Chutzpah/4.4.8/4.4.8)