### PR TITLE
ServiceFabric.Mocks/4.1.4

### DIFF
--- a/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
+++ b/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
@@ -6,3 +6,6 @@ revisions:
   3.4.17:
     licensed:
       declared: MIT
+  4.1.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ServiceFabric.Mocks/4.1.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/loekd/ServiceFabric.Mocks/blob/master/LICENSE.md

**Affected definitions**:
- [ServiceFabric.Mocks 4.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/ServiceFabric.Mocks/4.1.4/4.1.4)