### PR TITLE
YamlDotNet.Signed/5.3.0

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.Signed.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.Signed.yaml
@@ -15,3 +15,6 @@ revisions:
   5.2.1:
     licensed:
       declared: MIT
+  5.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet.Signed/5.3.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/aaubry/YamlDotNet/blob/master/LICENSE.txt

**Affected definitions**:
- [YamlDotNet.Signed 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet.Signed/5.3.0/5.3.0)