### PR TITLE
Microsoft.Azure.Amqp/2.4.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
@@ -33,6 +33,9 @@ revisions:
   2.3.7:
     licensed:
       declared: MIT
+  2.4.1:
+    licensed:
+      declared: MIT
   2.4.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Amqp/2.4.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Azure/azure-amqp/blob/v2.4.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.Amqp 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Amqp/2.4.1/2.4.1)