### PR TITLE
kendo-angular-pdf-export/1.3.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-pdf-export.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-pdf-export.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-angular-pdf-export
+  namespace: '@progress'
+  provider: npmjs
+  type: npm
+revisions:
+  1.3.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-pdf-export/1.3.1

**Details:**
No info in package files. Meta data confirms a proprietary license. Curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-angular-pdf-export/v/1.3.1

**Affected definitions**:
- [kendo-angular-pdf-export 1.3.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-pdf-export/1.3.1/1.3.1)