### PR TITLE
jquery-globalize 0.1.1

### DIFF
--- a/curations/nuget/nuget/-/jquery-globalize.yaml
+++ b/curations/nuget/nuget/-/jquery-globalize.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.1.1:
+    licensed:
+      declared: MIT
   0.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jquery-globalize 0.1.1

**Details:**
Declaring MIT

**Resolution:**
NuGet license link:
https://jquery.org/license/

Source: https://github.com/globalizejs/globalize/blob/d5f71da492d2be97c6224bd7671d6a02f3c65980/LICENSE


**Affected definitions**:
- [jquery-globalize 0.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/jquery-globalize/0.1.1/0.1.1)