### PR TITLE
ag-grid-enterprise 21.2.2

### DIFF
--- a/curations/npm/npmjs/-/ag-grid-enterprise.yaml
+++ b/curations/npm/npmjs/-/ag-grid-enterprise.yaml
@@ -12,6 +12,9 @@ revisions:
   20.2.0:
     licensed:
       declared: OTHER
+  21.2.2:
+    licensed:
+      declared: OTHER
   22.1.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ag-grid-enterprise 21.2.2

**Details:**
License file states this "enterprise" NPM is under commercial license terms.

**Resolution:**
OTHER for Commercial

**Affected definitions**:
- [ag-grid-enterprise 21.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/ag-grid-enterprise/21.2.2/21.2.2)