### PR TITLE
LibGit2Sharp.NativeBinaries/2.0.306

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -15,3 +15,6 @@ revisions:
   2.0.289:
     licensed:
       declared: GPL-2.0-only WITH OTHER
+  2.0.306:
+    licensed:
+      declared: GPL-2.0-only AND OTHER

--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -17,4 +17,4 @@ revisions:
       declared: GPL-2.0-only WITH OTHER
   2.0.306:
     licensed:
-      declared: GPL-2.0-only AND OTHER
+      declared: GPL-2.0-only WITH OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LibGit2Sharp.NativeBinaries/2.0.306

**Details:**
Package files and meta data confirm GPL 2.0 with linking exception. Curated as GPL 2.0 and OTHER, because "WITH" OTHER is not functional. 

**Resolution:**
https://raw.githubusercontent.com/libgit2/libgit2/master/COPYING

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 2.0.306](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/2.0.306/2.0.306)