### PR TITLE
org.scala-lang:scala-reflect	2.11.7

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -13,6 +13,9 @@ revisions:
   2.11.12:
     licensed:
       declared: BSD-3-Clause
+  2.11.7:
+    licensed:
+      declared: BSD-3-Clause
   2.11.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang:scala-reflect	2.11.7

**Details:**
.pom file indicates license is BSD-3

**Resolution:**
  

**Affected definitions**:
- [scala-reflect 2.11.7](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.11.7/2.11.7)