### PR TITLE
pcf-scripts	1.1.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pcf-scripts
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.6:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts	1.1.6

**Details:**
Harvested license file indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT POWERAPPS DEVELOPER CLI
MICROSOFT POWERAPPS CLI
MICROSOFT POWERAPPS EXTENSION FOR VISUAL STUDIO

**Resolution:**
Package.json indicates license is in the license file

**Affected definitions**:
- [pcf-scripts 1.1.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.1.6/1.1.6)