### PR TITLE
omggif	1.0.7

### DIFF
--- a/curations/npm/npmjs/-/omggif.yaml
+++ b/curations/npm/npmjs/-/omggif.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.7:
+    licensed:
+      declared: MIT
   1.0.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
omggif	1.0.7

**Details:**
Harvested Readme file indicates license is MIT

**Resolution:**
Repository also indicates license is MIT

**Affected definitions**:
- [omggif 1.0.7](https://clearlydefined.io/definitions/npm/npmjs/-/omggif/1.0.7/1.0.7)