### PR TITLE
BouncyCastle	1.8.6.1

### DIFF
--- a/curations/nuget/nuget/-/BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/BouncyCastle.yaml
@@ -21,3 +21,6 @@ revisions:
   1.8.5:
     licensed:
       declared: MIT
+  1.8.6.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BouncyCastle	1.8.6.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Project site also indicates license is MIT

**Affected definitions**:
- [BouncyCastle 1.8.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/BouncyCastle/1.8.6.1/1.8.6.1)