### PR TITLE
Swashbuckle.AspNetCore.Annotations	5.5.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Annotations.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Annotations.yaml
@@ -15,3 +15,6 @@ revisions:
   5.4.1:
     licensed:
       declared: MIT
+  5.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.Annotations	5.5.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget page also indicates license is MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.Annotations 5.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Annotations/5.5.1/5.5.1)