### PR TITLE
ncrontab.signed	3.3.2

### DIFF
--- a/curations/nuget/nuget/-/NCrontab.Signed.yaml
+++ b/curations/nuget/nuget/-/NCrontab.Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NCrontab.Signed
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ncrontab.signed	3.3.2

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
Harvested copying.txt file also indicates license is Apache 2.0

**Affected definitions**:
- [NCrontab.Signed 3.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/NCrontab.Signed/3.3.2/3.3.2)