### PR TITLE
NLog.Extensions.Logging	1.6.4

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -21,3 +21,6 @@ revisions:
   1.6.2:
     licensed:
       declared: BSD-2-Clause
+  1.6.4:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Extensions.Logging	1.6.4

**Details:**
Harvested license file indicates license is BSD-2

**Resolution:**
License link on Nuget site also indicates license is BSD-2

**Affected definitions**:
- [NLog.Extensions.Logging 1.6.4](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.6.4/1.6.4)