### PR TITLE
AngleSharp	0.13.0

### DIFF
--- a/curations/nuget/nuget/-/AngleSharp.yaml
+++ b/curations/nuget/nuget/-/AngleSharp.yaml
@@ -6,6 +6,9 @@ revisions:
   0.11.0:
     licensed:
       declared: MIT
+  0.13.0:
+    licensed:
+      declared: MIT
   0.14.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngleSharp	0.13.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [AngleSharp 0.13.0](https://clearlydefined.io/definitions/nuget/nuget/-/AngleSharp/0.13.0/0.13.0)