### PR TITLE
DotNetZip.Reduced	1.9.1.8

### DIFF
--- a/curations/nuget/nuget/-/DotNetZip.Reduced.yaml
+++ b/curations/nuget/nuget/-/DotNetZip.Reduced.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetZip.Reduced
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.1.8:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetZip.Reduced	1.9.1.8

**Details:**
License.json file in package indicates license is MS-PL

**Resolution:**
Nuget site also indicates license is MS-PL

**Affected definitions**:
- [DotNetZip.Reduced 1.9.1.8](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetZip.Reduced/1.9.1.8/1.9.1.8)