### PR TITLE
Swashbuckle.AspNetCore.Newtonsoft	5.5.1

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft.yaml
@@ -12,3 +12,6 @@ revisions:
   5.5.0:
     licensed:
       declared: MIT
+  5.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.Newtonsoft	5.5.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.Newtonsoft 5.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.Newtonsoft/5.5.1/5.5.1)