### PR TITLE
Microsoft.Azure.Cosmos.Direct/3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.Direct.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.Direct.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.Cosmos.Direct
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Cosmos.Direct/3.0.0

**Details:**
No info in package files. Meta data confirms   MIT. 

**Resolution:**
https://licenses.nuget.org/MIT

**Affected definitions**:
- [Microsoft.Azure.Cosmos.Direct 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos.Direct/3.0.0/3.0.0)