### PR TITLE
gym/0.17.2

### DIFF
--- a/curations/pypi/pypi/-/gym.yaml
+++ b/curations/pypi/pypi/-/gym.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: gym
+  provider: pypi
+  type: pypi
+revisions:
+  0.17.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gym/0.17.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/openai/gym/blob/0.17.2/LICENSE.md

**Affected definitions**:
- [gym 0.17.2](https://clearlydefined.io/definitions/pypi/pypi/-/gym/0.17.2/0.17.2)