### PR TITLE
MSBuild.Extension.Pack	1.9.0

### DIFF
--- a/curations/nuget/nuget/-/MSBuild.Extension.Pack.yaml
+++ b/curations/nuget/nuget/-/MSBuild.Extension.Pack.yaml
@@ -5,7 +5,10 @@ coordinates:
 revisions:
   1.2.0:
     licensed:
-      declared: MS-PL  
+      declared: MS-PL
   1.6.0:
+    licensed:
+      declared: MS-PL
+  1.9.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSBuild.Extension.Pack	1.9.0

**Details:**
License.json file in package indicates license is MS-PL

**Resolution:**
Nuget site also indicates license is MS-PL

**Affected definitions**:
- [MSBuild.Extension.Pack 1.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuild.Extension.Pack/1.9.0/1.9.0)