### PR TITLE
Microsoft.Azure.Devices.Shared	1.19.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Shared.yaml
@@ -31,6 +31,9 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/da20ff83c5aeb3ce0a736520b86283a6192cdaec'
     licensed:
       declared: MIT
+  1.19.0:
+    licensed:
+      declared: MIT
   1.20.1:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Devices.Shared	1.19.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.Devices.Shared 1.19.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices.Shared/1.19.0/1.19.0)