### PR TITLE
Microsoft.Bot.Builder.Integration.AspNet.Core	4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -18,3 +18,6 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.Integration.AspNet.Core	4.9.3

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.3/4.9.3)