### PR TITLE
jQuery	1.12.4

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -29,6 +29,9 @@ revisions:
         path: Tools/uninstall.ps1
     licensed:
       declared: MIT
+  1.12.4:
+    licensed:
+      declared: MIT
   1.4.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery	1.12.4

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [jQuery 1.12.4](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/1.12.4/1.12.4)