### PR TITLE
Microsoft.CodeAnalysis.BinSkim	1.6.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CodeAnalysis.BinSkim.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeAnalysis.BinSkim.yaml
@@ -18,3 +18,6 @@ revisions:
   1.4.5:
     licensed:
       declared: MIT
+  1.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CodeAnalysis.BinSkim	1.6.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.CodeAnalysis.BinSkim 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CodeAnalysis.BinSkim/1.6.0/1.6.0)