### PR TITLE
Swashbuckle.AspNetCore.SwaggerGen	5.4.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -45,6 +45,9 @@ revisions:
   5.3.3:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT
   5.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.SwaggerGen	5.4.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 5.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/5.4.0/5.4.0)