### PR TITLE
azureml-dataset-runtime	1.10.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: azureml-dataset-runtime
+  provider: pypi
+  type: pypi
+revisions:
+  1.10.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime	1.10.0

**Details:**
PyPi site indicates license is OTHER

**Resolution:**
License file in package also indicates license is other

**Affected definitions**:
- [azureml-dataset-runtime 1.10.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.10.0/1.10.0)