### PR TITLE
databricks-cli/0.9.1

### DIFF
--- a/curations/pypi/pypi/-/databricks-cli.yaml
+++ b/curations/pypi/pypi/-/databricks-cli.yaml
@@ -9,3 +9,6 @@ revisions:
   0.11.0:
     licensed:
       declared: Apache-2.0 AND OTHER
+  0.9.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
databricks-cli/0.9.1

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/databricks/databricks-cli/blob/0.9.1/LICENSE.txt

**Affected definitions**:
- [databricks-cli 0.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/databricks-cli/0.9.1/0.9.1)