### PR TITLE
azureml-automl-core	1.10.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.85:
     licensed:
       declared: OTHER
+  1.10.0.post1:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core	1.10.0.post1

**Details:**
PyPi site indicates license is Other

**Resolution:**
License file in package also indicates license is Other

**Affected definitions**:
- [azureml-automl-core 1.10.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.10.0.post1/1.10.0.post1)