### PR TITLE
SlnGen/2.1.5

### DIFF
--- a/curations/nuget/nuget/-/SlnGen.yaml
+++ b/curations/nuget/nuget/-/SlnGen.yaml
@@ -9,3 +9,6 @@ revisions:
   2.0.34-beta:
     licensed:
       declared: MIT
+  2.1.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SlnGen/2.1.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/jeffkl/SlnGen/blob/master/LICENSE.txt

**Affected definitions**:
- [SlnGen 2.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/SlnGen/2.1.5/2.1.5)