### PR TITLE
json-stringify-safe/5.0.0

### DIFF
--- a/curations/npm/npmjs/-/json-stringify-safe.yaml
+++ b/curations/npm/npmjs/-/json-stringify-safe.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.0:
     licensed:
       declared: BSD-2-Clause
+  5.0.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
json-stringify-safe/5.0.0

**Details:**
No info in package files. Meta data confirms BSD 2 Clause. 

**Resolution:**
https://github.com/moll/json-stringify-safe/blob/v5.0.0/LICENSE

**Affected definitions**:
- [json-stringify-safe 5.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/json-stringify-safe/5.0.0/5.0.0)