### PR TITLE
azureml-train-automl-client	1.10.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.85:
     licensed:
       declared: OTHER
+  1.10.0:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.10.0

**Details:**
PyPi site indicates license is Other

**Resolution:**
License file in package also indicates license is other

**Affected definitions**:
- [azureml-train-automl-client 1.10.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.10.0/1.10.0)