### PR TITLE
resource	0.2.1

### DIFF
--- a/curations/pypi/pypi/-/Resource.yaml
+++ b/curations/pypi/pypi/-/Resource.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Resource
+  provider: pypi
+  type: pypi
+revisions:
+  0.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
resource	0.2.1

**Details:**
PyPi site indicates license is MIT

**Resolution:**
Setup.py also indicates license is MIT

**Affected definitions**:
- [Resource 0.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/Resource/0.2.1/0.2.1)