### PR TITLE
xmlpull/xmlpull/1.1.3.1

### DIFF
--- a/curations/maven/mavencentral/xmlpull/xmlpull.yaml
+++ b/curations/maven/mavencentral/xmlpull/xmlpull.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xmlpull
+  namespace: xmlpull
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.3.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xmlpull/xmlpull/1.1.3.1

**Details:**
No info in package files. Meta data in POM file confirms OTHER. 

**Resolution:**
http://www.xmlpull.org/v1/download/unpacked/LICENSE.txt

**Affected definitions**:
- [xmlpull 1.1.3.1](https://clearlydefined.io/definitions/maven/mavencentral/xmlpull/xmlpull/1.1.3.1/1.1.3.1)