### PR TITLE
System.CommandLine.Rendering/0.2.0-alpha.19174.3

### DIFF
--- a/curations/nuget/nuget/-/System.CommandLine.Rendering.yaml
+++ b/curations/nuget/nuget/-/System.CommandLine.Rendering.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.CommandLine.Rendering
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.0-alpha.19174.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.CommandLine.Rendering/0.2.0-alpha.19174.3

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/dotnet/command-line-api/master/LICENSE.md

**Affected definitions**:
- [System.CommandLine.Rendering 0.2.0-alpha.19174.3](https://clearlydefined.io/definitions/nuget/nuget/-/System.CommandLine.Rendering/0.2.0-alpha.19174.3/0.2.0-alpha.19174.3)