### PR TITLE
Swashbuckle.AspNetCore.SwaggerGen/2.3.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.yaml
@@ -9,6 +9,9 @@ revisions:
   1.1.0:
     licensed:
       declared: MIT
+  2.3.0:
+    licensed:
+      declared: MIT
   2.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.AspNetCore.SwaggerGen/2.3.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/domaindrivendev/Swashbuckle.AspNetCore/master/LICENSE

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen/2.3.0/2.3.0)