### PR TITLE
Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn/1.8.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.yaml
+++ b/curations/nuget/nuget/-/Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn
+  provider: nuget
+  type: nuget
+revisions:
+  1.8.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn/1.8.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/Microsoft/TestAdapterForGoogleTest/dev15/GoogleTestNuGet/license%20(MIT).txt

**Affected definitions**:
- [Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn 1.8.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.googletest.v140.windesktop.msvcstl.static.rt-dyn/1.8.1/1.8.1)