### PR TITLE
SQLitePCLRaw.provider.e_sqlite3.net45/1.1.12

### DIFF
--- a/curations/nuget/nuget/-/SQLitePCLRaw.provider.e_sqlite3.net45.yaml
+++ b/curations/nuget/nuget/-/SQLitePCLRaw.provider.e_sqlite3.net45.yaml
@@ -6,6 +6,9 @@ revisions:
   1.1.11:
     licensed:
       declared: Apache-2.0
+  1.1.12:
+    licensed:
+      declared: Apache-2.0
   1.1.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SQLitePCLRaw.provider.e_sqlite3.net45/1.1.12

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://raw.githubusercontent.com/ericsink/SQLitePCL.raw/master/LICENSE.TXT

**Affected definitions**:
- [SQLitePCLRaw.provider.e_sqlite3.net45 1.1.12](https://clearlydefined.io/definitions/nuget/nuget/-/SQLitePCLRaw.provider.e_sqlite3.net45/1.1.12/1.1.12)