### PR TITLE
Microsoft.Azure.CosmosDB.BulkExecutor/1.8.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.CosmosDB.BulkExecutor.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.CosmosDB.BulkExecutor.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.CosmosDB.BulkExecutor
+  provider: nuget
+  type: nuget
+revisions:
+  1.8.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.CosmosDB.BulkExecutor/1.8.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://licenses.nuget.org/MIT

**Affected definitions**:
- [Microsoft.Azure.CosmosDB.BulkExecutor 1.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.CosmosDB.BulkExecutor/1.8.5/1.8.5)