### PR TITLE
ServiceFabric.Mocks/4.0.0

### DIFF
--- a/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
+++ b/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
@@ -6,6 +6,9 @@ revisions:
   3.4.17:
     licensed:
       declared: MIT
+  4.0.0:
+    licensed:
+      declared: MIT
   4.1.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ServiceFabric.Mocks/4.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/loekd/ServiceFabric.Mocks/blob/master/LICENSE.md

**Affected definitions**:
- [ServiceFabric.Mocks 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/ServiceFabric.Mocks/4.0.0/4.0.0)