### PR TITLE
K4os.Compression.LZ4.Streams/1.1.11

### DIFF
--- a/curations/nuget/nuget/-/K4os.Compression.LZ4.Streams.yaml
+++ b/curations/nuget/nuget/-/K4os.Compression.LZ4.Streams.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: K4os.Compression.LZ4.Streams
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.11:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
K4os.Compression.LZ4.Streams/1.1.11

**Details:**
No info in package files. Meta data confirms MIT.

**Resolution:**
https://raw.githubusercontent.com/MiloszKrajewski/K4os.Compression.LZ4/master/LICENSE

**Affected definitions**:
- [K4os.Compression.LZ4.Streams 1.1.11](https://clearlydefined.io/definitions/nuget/nuget/-/K4os.Compression.LZ4.Streams/1.1.11/1.1.11)