### PR TITLE
onecolor/2.4.2

### DIFF
--- a/curations/npm/npmjs/-/onecolor.yaml
+++ b/curations/npm/npmjs/-/onecolor.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  2.4.2:
+    licensed:
+      declared: BSD-2-Clause
   2.5.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
onecolor/2.4.2

**Details:**
No info in package files. Meta data confirms BSD 2 Clause. 

**Resolution:**
https://github.com/One-com/one-color/blob/v2.4.2/LICENSE

**Affected definitions**:
- [onecolor 2.4.2](https://clearlydefined.io/definitions/npm/npmjs/-/onecolor/2.4.2/2.4.2)