### PR TITLE
guardsquare/proguard ebe9000c9ba

### DIFF
--- a/curations/git/github/guardsquare/proguard.yaml
+++ b/curations/git/github/guardsquare/proguard.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: proguard
+  namespace: guardsquare
+  provider: github
+  type: git
+revisions:
+  ebe9000c9baa36a53dc63902b96956c9525ab052:
+    licensed:
+      declared: GPL-2.0-or-later AND OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
guardsquare/proguard ebe9000c9ba

**Details:**
Updating to "GPL-2.0-or-later" based on some code file headers (e.g. https://github.com/Guardsquare/proguard/blob/ebe9000c9baa36a53dc63902b96956c9525ab052/core/src/proguard/AssumeNoSideEffectsChecker.java).  Also, adding "OTHER" for the LICENSE_exceptions file.

**Resolution:**
GPL-2.0-or-later AND OTHER

**Affected definitions**:
- [proguard ebe9000c9baa36a53dc63902b96956c9525ab052](https://clearlydefined.io/definitions/git/github/guardsquare/proguard/ebe9000c9baa36a53dc63902b96956c9525ab052/ebe9000c9baa36a53dc63902b96956c9525ab052)