### PR TITLE
org.jacoco/org.jacoco.report 0.8.5

### DIFF
--- a/curations/maven/mavencentral/org.jacoco/org.jacoco.report.yaml
+++ b/curations/maven/mavencentral/org.jacoco/org.jacoco.report.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: org.jacoco.report
+  namespace: org.jacoco
+  provider: mavencentral
+  type: maven
+revisions:
+  0.8.5:
+    files:
+      - attributions:
+          - Copyright 2011 Mike Samuel
+        license: EPL-2.0
+        path: about.html
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.jacoco/org.jacoco.report 0.8.5

**Details:**
I am not seeing where the tooling got "Apache-2.0"  on the about.html file.  I only see reference to EPL-2.0.  Updating that file and the declared field to EPL.2.0

**Resolution:**
EPL.20

**Affected definitions**:
- [org.jacoco.report 0.8.5](https://clearlydefined.io/definitions/maven/mavencentral/org.jacoco/org.jacoco.report/0.8.5/0.8.5)