### PR TITLE
getenv 0.7.0

### DIFF
--- a/curations/npm/npmjs/-/getenv.yaml
+++ b/curations/npm/npmjs/-/getenv.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: getenv
+  provider: npmjs
+  type: npm
+revisions:
+  0.7.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
getenv 0.7.0

**Details:**
README in package says MIT, NPM page says MIT

**Resolution:**
MIT

**Affected definitions**:
- [getenv 0.7.0](https://clearlydefined.io/definitions/npm/npmjs/-/getenv/0.7.0/0.7.0)