### PR TITLE
@progress/kendo-drawing/1.7.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-drawing.yaml
+++ b/curations/npm/npmjs/@progress/kendo-drawing.yaml
@@ -7,3 +7,6 @@ revisions:
   1.6.0:
     licensed:
       declared: OTHER
+  1.7.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@progress/kendo-drawing/1.7.0

**Details:**
No info in package files. Meta data points to proprietary license. Curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-drawing/v/1.7.0

**Affected definitions**:
- [kendo-drawing 1.7.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-drawing/1.7.0/1.7.0)