### PR TITLE
Microsoft.DotNet.PlatformAbstractions/3.1.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -36,3 +36,6 @@ revisions:
   3.1.4:
     licensed:
       declared: MIT
+  3.1.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.DotNet.PlatformAbstractions/3.1.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.DotNet.PlatformAbstractions/3.1.5/License

**Affected definitions**:
- [Microsoft.DotNet.PlatformAbstractions 3.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions/3.1.5/3.1.5)