### PR TITLE
NuGet.Frameworks/4.8.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -24,6 +24,9 @@ revisions:
   4.7.0-rtm.5148:
     licensed:
       declared: Apache-2.0
+  4.8.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Frameworks/4.8.0

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Frameworks 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Frameworks/4.8.0/4.8.0)