### PR TITLE
TSLint.MSBuild/1.2.1

### DIFF
--- a/curations/nuget/nuget/-/TSLint.MSBuild.yaml
+++ b/curations/nuget/nuget/-/TSLint.MSBuild.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TSLint.MSBuild
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TSLint.MSBuild/1.2.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/JoshuaKGoldberg/TSLint.MSBuild/blob/master/LICENSE.md

**Affected definitions**:
- [TSLint.MSBuild 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/TSLint.MSBuild/1.2.1/1.2.1)