### PR TITLE
NLog/4.6.3

### DIFF
--- a/curations/nuget/nuget/-/NLog.yaml
+++ b/curations/nuget/nuget/-/NLog.yaml
@@ -176,6 +176,9 @@ revisions:
   4.6.2:
     licensed:
       declared: BSD-3-Clause
+  4.6.3:
+    licensed:
+      declared: BSD-3-Clause
   4.6.4:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog/4.6.3

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/NLog/NLog/blob/v4.6.3/LICENSE.txt

**Affected definitions**:
- [NLog 4.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/NLog/4.6.3/4.6.3)