### PR TITLE
AdaptiveExpressions/4.9.0

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveExpressions.yaml
+++ b/curations/nuget/nuget/-/AdaptiveExpressions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AdaptiveExpressions
+  provider: nuget
+  type: nuget
+revisions:
+  4.9.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AdaptiveExpressions/4.9.0

**Details:**
Package files point to MIT and meta data confirms. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [AdaptiveExpressions 4.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveExpressions/4.9.0/4.9.0)