### PR TITLE
OpenXmlPowerTools/4.5.3.2

### DIFF
--- a/curations/nuget/nuget/-/OpenXmlPowerTools.yaml
+++ b/curations/nuget/nuget/-/OpenXmlPowerTools.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.5.3.2:
     licensed:
-      declared: MIT
+      declared: MS-PL

--- a/curations/nuget/nuget/-/OpenXmlPowerTools.yaml
+++ b/curations/nuget/nuget/-/OpenXmlPowerTools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OpenXmlPowerTools
+  provider: nuget
+  type: nuget
+revisions:
+  4.5.3.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
OpenXmlPowerTools/4.5.3.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/OfficeDev/Open-Xml-PowerTools/blob/vNext/LICENSE

**Affected definitions**:
- [OpenXmlPowerTools 4.5.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/OpenXmlPowerTools/4.5.3.2/4.5.3.2)