### PR TITLE
@progress/kendo-ooxml/1.2.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-ooxml.yaml
+++ b/curations/npm/npmjs/@progress/kendo-ooxml.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.2.0:
+    licensed:
+      declared: OTHER
   1.4.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@progress/kendo-ooxml/1.2.0

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-ooxml/v/1.2.0

**Affected definitions**:
- [kendo-ooxml 1.2.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-ooxml/1.2.0/1.2.0)