### PR TITLE
Google.Protobuf/3.4.1

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -30,6 +30,9 @@ revisions:
   3.4.0:
     licensed:
       declared: BSD-3-Clause
+  3.4.1:
+    licensed:
+      declared: BSD-3-Clause
   3.5.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf/3.4.1

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/protocolbuffers/protobuf/blob/v3.4.1/LICENSE

**Affected definitions**:
- [Google.Protobuf 3.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.4.1/3.4.1)