### PR TITLE
Microsoft.AspNet.Razor/3.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.Razor.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.Razor.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.Razor
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNet.Razor/3.1.0

**Details:**
No info in package files. Meta data appears to point to Apache 2.0. 

**Resolution:**
https://github.com/OData/WebApi/blob/v3.1/License.txt

**Affected definitions**:
- [Microsoft.AspNet.Razor 3.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.Razor/3.1.0/3.1.0)