### PR TITLE
kendo-angular-popup/2.6.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-angular-popup
+  namespace: '@progress'
+  provider: npmjs
+  type: npm
+revisions:
+  2.6.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-popup/2.6.0

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-angular-popup/v/2.6.0

**Affected definitions**:
- [kendo-angular-popup 2.6.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-popup/2.6.0/2.6.0)