### PR TITLE
angularjs/1.7.8.1

### DIFF
--- a/curations/nuget/nuget/-/angularjs.yaml
+++ b/curations/nuget/nuget/-/angularjs.yaml
@@ -6,3 +6,6 @@ revisions:
   1.5.5:
     licensed:
       declared: MIT
+  1.7.8.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
angularjs/1.7.8.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/angular/angular.js/blob/v1.7.8/LICENSE

**Affected definitions**:
- [angularjs 1.7.8.1](https://clearlydefined.io/definitions/nuget/nuget/-/angularjs/1.7.8.1/1.7.8.1)