### PR TITLE
Unity.Interception/5.11.1

### DIFF
--- a/curations/nuget/nuget/-/Unity.Interception.yaml
+++ b/curations/nuget/nuget/-/Unity.Interception.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Unity.Interception
+  provider: nuget
+  type: nuget
+revisions:
+  5.11.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Interception/5.11.1

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/unitycontainer/unity/blob/5.11.1.847/LICENSE

**Affected definitions**:
- [Unity.Interception 5.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Interception/5.11.1/5.11.1)