### PR TITLE
Microsoft.AdaptiveCards/0.5.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AdaptiveCards.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AdaptiveCards.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AdaptiveCards
+  provider: nuget
+  type: nuget
+revisions:
+  0.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AdaptiveCards/0.5.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/AdaptiveCards/blob/typed-schema%400.5.1/LICENSE

**Affected definitions**:
- [Microsoft.AdaptiveCards 0.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AdaptiveCards/0.5.1/0.5.1)