### PR TITLE
DeepCloner/0.10.2

### DIFF
--- a/curations/nuget/nuget/-/DeepCloner.yaml
+++ b/curations/nuget/nuget/-/DeepCloner.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DeepCloner
+  provider: nuget
+  type: nuget
+revisions:
+  0.10.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DeepCloner/0.10.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/force-net/DeepCloner/blob/v0.10.2/LICENSE

**Affected definitions**:
- [DeepCloner 0.10.2](https://clearlydefined.io/definitions/nuget/nuget/-/DeepCloner/0.10.2/0.10.2)