### PR TITLE
DiffPlex/1.4.1

### DIFF
--- a/curations/nuget/nuget/-/DiffPlex.yaml
+++ b/curations/nuget/nuget/-/DiffPlex.yaml
@@ -6,6 +6,9 @@ revisions:
   1.2.1:
     licensed:
       declared: MS-PL
+  1.4.1:
+    licensed:
+      declared: Apache-2.0
   1.4.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DiffPlex/1.4.1

**Details:**
No info in package files. Meta data confirms Apache 2.0 

**Resolution:**
https://github.com/mmanela/diffplex/blob/master/License.txt

**Affected definitions**:
- [DiffPlex 1.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/DiffPlex/1.4.1/1.4.1)