### PR TITLE
Microsoft.ApplicationInsights.Web/0.17.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Web.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Web.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.17.0:
+    licensed:
+      declared: MIT
   1.2.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.Web/0.17.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.Web 0.17.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.Web/0.17.0/0.17.0)