### PR TITLE
Microsoft.Diagnostics.Tracing.EventSource.Redist/2.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.EventSource.Redist.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.EventSource.Redist.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Diagnostics.Tracing.EventSource.Redist
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Diagnostics.Tracing.EventSource.Redist/2.0.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/dotnet/corefx/blob/v2.0.1/LICENSE.TXT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.EventSource.Redist 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.EventSource.Redist/2.0.1/2.0.1)