### PR TITLE
K4os.Hash.xxHash/1.0.6

### DIFF
--- a/curations/nuget/nuget/-/K4os.Hash.xxHash.yaml
+++ b/curations/nuget/nuget/-/K4os.Hash.xxHash.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: K4os.Hash.xxHash
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
K4os.Hash.xxHash/1.0.6

**Details:**
Package files point to MIT and meta data confirms. 

**Resolution:**
https://raw.githubusercontent.com/MiloszKrajewski/K4os.Hash.xxHash/master/LICENSE

**Affected definitions**:
- [K4os.Hash.xxHash 1.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/K4os.Hash.xxHash/1.0.6/1.0.6)