### PR TITLE
HtmlAgilityPack/1.11.21

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -24,6 +24,9 @@ revisions:
   1.11.2:
     licensed:
       declared: MIT
+  1.11.21:
+    licensed:
+      declared: MIT
   1.11.23:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack/1.11.21

**Details:**
Package files point to MIT. Meta data confirms. 

**Resolution:**
https://github.com/zzzprojects/html-agility-pack/blob/v1.11.21/LICENSE

**Affected definitions**:
- [HtmlAgilityPack 1.11.21](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.21/1.11.21)