### PR TITLE
Microsoft.IdentityModel.Protocol.Extensions/1.0.4.402070948

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocol.Extensions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocol.Extensions.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.2.206221351:
     licensed:
       declared: Apache-2.0
+  1.0.4.402070948:
+    licensed:
+      declared: MIT
   1.0.4.403061554:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Protocol.Extensions/1.0.4.402070948

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.Protocol.Extensions 1.0.4.402070948](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocol.Extensions/1.0.4.402070948/1.0.4.402070948)