### PR TITLE
jszip/2.4.0

### DIFF
--- a/curations/npm/npmjs/-/jszip.yaml
+++ b/curations/npm/npmjs/-/jszip.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  2.4.0:
+    licensed:
+      declared: MIT OR GPL-3.0-only
   2.5.0:
     licensed:
       declared: MIT OR GPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jszip/2.4.0

**Details:**
No info in package files. Meta data confirms MIT or GPL 3.0. 

**Resolution:**
https://github.com/Stuk/jszip/blob/v2.4.0/LICENSE.markdown

**Affected definitions**:
- [jszip 2.4.0](https://clearlydefined.io/definitions/npm/npmjs/-/jszip/2.4.0/2.4.0)