### PR TITLE
Bond.Core.CSharp9.0.1

### DIFF
--- a/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
@@ -49,3 +49,6 @@ revisions:
   9.0.0:
     licensed:
       declared: MIT
+  9.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Core.CSharp9.0.1

**Details:**
Declare MIT found here (https://github.com/microsoft/bond/blob/9.0.1/LICENSE)

**Resolution:**
Matches Master

**Affected definitions**:
- [Bond.Core.CSharp 9.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Core.CSharp/9.0.1/9.0.1)