### PR TITLE
Sandboxable.Microsoft.WindowsAzure.Storage/1.1.9

### DIFF
--- a/curations/nuget/nuget/-/Sandboxable.Microsoft.WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/Sandboxable.Microsoft.WindowsAzure.Storage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Sandboxable.Microsoft.WindowsAzure.Storage
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.9:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Sandboxable.Microsoft.WindowsAzure.Storage/1.1.9

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/Winvision/Sandboxable/blob/master/LICENSE

**Affected definitions**:
- [Sandboxable.Microsoft.WindowsAzure.Storage 1.1.9](https://clearlydefined.io/definitions/nuget/nuget/-/Sandboxable.Microsoft.WindowsAzure.Storage/1.1.9/1.1.9)