### PR TITLE
Bond.CSharp9.0.1

### DIFF
--- a/curations/nuget/nuget/-/Bond.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.CSharp.yaml
@@ -81,3 +81,6 @@ revisions:
   9.0.0:
     licensed:
       declared: MIT
+  9.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.CSharp9.0.1

**Details:**
Declare MIT found here (https://github.com/microsoft/bond/blob/9.0.1/LICENSE

**Resolution:**
Matches master.

**Affected definitions**:
- [Bond.CSharp 9.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.CSharp/9.0.1/9.0.1)