### PR TITLE
Microsoft.AspNetCore.OData/7.4.0-beta

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -15,6 +15,9 @@ revisions:
   7.4.0:
     licensed:
       declared: MIT
+  7.4.0-beta:
+    licensed:
+      declared: MIT
   7.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNetCore.OData/7.4.0-beta

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/OData/WebApi/master/License.txt

**Affected definitions**:
- [Microsoft.AspNetCore.OData 7.4.0-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.OData/7.4.0-beta/7.4.0-beta)