### PR TITLE
popper.js/1.16.1

### DIFF
--- a/curations/nuget/nuget/-/popper.js.yaml
+++ b/curations/nuget/nuget/-/popper.js.yaml
@@ -12,3 +12,6 @@ revisions:
   1.16.0:
     licensed:
       declared: MIT
+  1.16.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
popper.js/1.16.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/popperjs/popper-core/blob/v1.16.1/LICENSE.md

**Affected definitions**:
- [popper.js 1.16.1](https://clearlydefined.io/definitions/nuget/nuget/-/popper.js/1.16.1/1.16.1)