### PR TITLE
SpecFlow/2.4.1

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: BSD-3-Clause
+  2.4.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow/2.4.1

**Details:**
No info in package files. Meta data confirms BSD 3 Clause.

**Resolution:**
https://raw.githubusercontent.com/techtalk/SpecFlow/4bfc919a6f0771066ce002cb2bccd999c94be958/LICENSE.txt

**Affected definitions**:
- [SpecFlow 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow/2.4.1/2.4.1)