### PR TITLE
org.junit.platform/junit-platform-commons/1.4.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-platform-commons
+  namespace: org.junit.platform
+  provider: mavencentral
+  type: maven
+revisions:
+  1.4.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-commons/1.4.2

**Details:**
No info in package files. Meta data POM file confirms EPL 2.0. 

**Resolution:**
http://www.eclipse.org/legal/epl-v20.html

**Affected definitions**:
- [junit-platform-commons 1.4.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.4.2/1.4.2)