### PR TITLE
Unity5.11.7

### DIFF
--- a/curations/nuget/nuget/-/Unity.yaml
+++ b/curations/nuget/nuget/-/Unity.yaml
@@ -48,6 +48,9 @@ revisions:
   5.11.6:
     licensed:
       declared: Apache-2.0
+  5.11.7:
+    licensed:
+      declared: Apache-2.0
   5.2.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity5.11.7

**Details:**
Declare Apache-2.0 found in the master here (https://github.com/unitycontainer/unity/blob/master/LICENSE) no specific tag for 5.11.7

**Resolution:**
Checked history and appears to always have been under Apache-2.0

**Affected definitions**:
- [Unity 5.11.7](https://clearlydefined.io/definitions/nuget/nuget/-/Unity/5.11.7/5.11.7)