### PR TITLE
morelinq3.3.2

### DIFF
--- a/curations/nuget/nuget/-/morelinq.yaml
+++ b/curations/nuget/nuget/-/morelinq.yaml
@@ -6,3 +6,6 @@ revisions:
   3.2.0:
     licensed:
       declared: Apache-2.0 AND MIT
+  3.3.2:
+    licensed:
+      declared: Apache-2.0 AND MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
morelinq3.3.2

**Details:**
Declare Apache-2.0 and MIT found here (https://github.com/morelinq/MoreLINQ/blob/v3.3.2/COPYING.txt)

**Resolution:**
Matches master, main under Apache-2.0 with a small portion under MIT

**Affected definitions**:
- [morelinq 3.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/morelinq/3.3.2/3.3.2)