### PR TITLE
Hl7.Fhir.Support.Poco1.7.0

### DIFF
--- a/curations/nuget/nuget/-/Hl7.Fhir.Support.Poco.yaml
+++ b/curations/nuget/nuget/-/Hl7.Fhir.Support.Poco.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Hl7.Fhir.Support.Poco
+  provider: nuget
+  type: nuget
+revisions:
+  1.7.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Hl7.Fhir.Support.Poco1.7.0

**Details:**
Declare BSD-3-Clause found here https://github.com/FirelyTeam/fhir-net-common/blob/v1.7.0/LICENSE)

**Resolution:**
Matches the license and main branch

**Affected definitions**:
- [Hl7.Fhir.Support.Poco 1.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Hl7.Fhir.Support.Poco/1.7.0/1.7.0)