### PR TITLE
MediatR.Extensions.Microsoft.DependencyInjection8.0.0

### DIFF
--- a/curations/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: MIT
   8.0.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection.yaml
@@ -6,3 +6,6 @@ revisions:
   7.0.0:
     licensed:
       declared: MIT
+  8.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MediatR.Extensions.Microsoft.DependencyInjection8.0.0

**Details:**
Declare MIT found here at specific version (https://github.com/jbogard/MediatR.Extensions.Microsoft.DependencyInjection/blob/v8.0.0/LICENSE)

**Resolution:**
Matches master branch but not license on the Nuget page

**Affected definitions**:
- [MediatR.Extensions.Microsoft.DependencyInjection 8.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MediatR.Extensions.Microsoft.DependencyInjection/8.0.0/8.0.0)