### PR TITLE
org.datanucleus/datanucleus-accessplatform-jdo-rdbms 3.2.1

### DIFF
--- a/curations/maven/mavencentral/org.datanucleus/datanucleus-accessplatform-jdo-rdbms.yaml
+++ b/curations/maven/mavencentral/org.datanucleus/datanucleus-accessplatform-jdo-rdbms.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: datanucleus-accessplatform-jdo-rdbms
+  namespace: org.datanucleus
+  provider: mavencentral
+  type: maven
+revisions:
+  3.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.datanucleus/datanucleus-accessplatform-jdo-rdbms 3.2.1

**Details:**
Declaring Apache 2.0

**Resolution:**
org.datanucleus/datanucleus-accessplatform-jdo-rdbms3.2.1

https://github.com/datanucleus/datanucleus-rdbms/blob/2804c35e80b1761f9997bea4d70bd386ee017135/META-INF/LICENSE.txt


**Affected definitions**:
- [datanucleus-accessplatform-jdo-rdbms 3.2.1](https://clearlydefined.io/definitions/maven/mavencentral/org.datanucleus/datanucleus-accessplatform-jdo-rdbms/3.2.1/3.2.1)