### PR TITLE
azureml-train-automl-client 1.4.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -18,6 +18,9 @@ revisions:
   1.3.0:
     licensed:
       declared: OTHER
+  1.4.0:
+    licensed:
+      declared: OTHER
   1.6.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client 1.4.0

**Details:**
Metadata and LICENSE.txt in package points to proprietary license (https://aka.ms/azureml-sdk-license)

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-train-automl-client 1.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.4.0/1.4.0)