### PR TITLE
facebook/folly f893bb0a491eed

### DIFF
--- a/curations/git/github/facebook/folly.yaml
+++ b/curations/git/github/facebook/folly.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: folly
+  namespace: facebook
+  provider: github
+  type: git
+revisions:
+  f893bb0a491eedfb080ec520ff111c614ba0aaea:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
facebook/folly f893bb0a491eed

**Details:**
Declared field included "MIT," which only applies to a subset of the code and should be a "discovered" license - https://github.com/facebook/folly/blob/f893bb0a491eedfb080ec520ff111c614ba0aaea/LICENSE

**Resolution:**
Updating declared to "Apache-2.0"

**Affected definitions**:
- [folly f893bb0a491eedfb080ec520ff111c614ba0aaea](https://clearlydefined.io/definitions/git/github/facebook/folly/f893bb0a491eedfb080ec520ff111c614ba0aaea/f893bb0a491eedfb080ec520ff111c614ba0aaea)