### PR TITLE
NJsonSchema	10.1.23

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -21,6 +21,9 @@ revisions:
   10.1.18:
     licensed:
       declared: MIT
+  10.1.23:
+    licensed:
+      declared: MIT
   10.1.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NJsonSchema	10.1.23

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Nuget site also indicates license is MIT

**Affected definitions**:
- [NJsonSchema 10.1.23](https://clearlydefined.io/definitions/nuget/nuget/-/NJsonSchema/10.1.23/10.1.23)