### PR TITLE
client-app	0.0.0

### DIFF
--- a/curations/npm/npmjs/-/client-app.yaml
+++ b/curations/npm/npmjs/-/client-app.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: client-app
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
client-app	0.0.0

**Details:**
Package.json indicates license is "BSD" per  curation guidelines as no additional information is available this is curated as BSD-3

**Resolution:**
NPM site also indicates license is BSD

**Affected definitions**:
- [client-app 0.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/client-app/0.0.0/0.0.0)