### PR TITLE
Microsoft.OData.Edm	7.7.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
@@ -57,3 +57,6 @@ revisions:
   7.6.4:
     licensed:
       declared: MIT
+  7.7.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.OData.Edm	7.7.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.OData.Edm 7.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Edm/7.7.0/7.7.0)