### PR TITLE
System.Linq.Dynamic.Core	1.0.12

### DIFF
--- a/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
+++ b/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.12:
+    licensed:
+      declared: Apache-2.0
   1.0.19:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Linq.Dynamic.Core	1.0.12

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [System.Linq.Dynamic.Core 1.0.12](https://clearlydefined.io/definitions/nuget/nuget/-/System.Linq.Dynamic.Core/1.0.12/1.0.12)