### PR TITLE
Unity.Abstractions	5.11.6

### DIFF
--- a/curations/nuget/nuget/-/Unity.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Unity.Abstractions.yaml
@@ -18,3 +18,6 @@ revisions:
   5.11.2:
     licensed:
       declared: Apache-2.0
+  5.11.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Abstractions	5.11.6

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [Unity.Abstractions 5.11.6](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Abstractions/5.11.6/5.11.6)