### PR TITLE
is-running	2.1.0

### DIFF
--- a/curations/npm/npmjs/-/is-running.yaml
+++ b/curations/npm/npmjs/-/is-running.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: is-running
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
is-running	2.1.0

**Details:**
Package.json indicates license is BSD. No other license information is available so this is curated as BSD-3

**Resolution:**
NPM site also indicates license is BSD

**Affected definitions**:
- [is-running 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/is-running/2.1.0/2.1.0)