### PR TITLE
pcf-start	1.1.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pcf-start
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.6:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start	1.1.6

**Details:**
License file indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT POWERAPPS DEVELOPER CLI
MICROSOFT POWERAPPS CLI
MICROSOFT POWERAPPS EXTENSION FOR VISUAL STUDIO

**Resolution:**
  

**Affected definitions**:
- [pcf-start 1.1.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.1.6/1.1.6)