### PR TITLE
vscode-chrome-debug-core	6.8.9

### DIFF
--- a/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
+++ b/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
@@ -21,3 +21,6 @@ revisions:
   6.8.7:
     licensed:
       declared: MIT
+  6.8.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
vscode-chrome-debug-core	6.8.9

**Details:**
License file in repository indicates license is MIT

**Resolution:**
  

**Affected definitions**:
- [vscode-chrome-debug-core 6.8.9](https://clearlydefined.io/definitions/npm/npmjs/-/vscode-chrome-debug-core/6.8.9/6.8.9)