### PR TITLE
Microsoft.Azure.DataLake.Store	1.1.21

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DataLake.Store.yaml
@@ -33,6 +33,9 @@ revisions:
   1.1.20:
     licensed:
       declared: MIT
+  1.1.21:
+    licensed:
+      declared: MIT
   1.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.DataLake.Store	1.1.21

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.DataLake.Store 1.1.21](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DataLake.Store/1.1.21/1.1.21)