### PR TITLE
org.codehaus.janino:commons-compiler	3.0.16

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.janino/commons-compiler.yaml
+++ b/curations/maven/mavencentral/org.codehaus.janino/commons-compiler.yaml
@@ -7,6 +7,9 @@ revisions:
   3.0.0:
     licensed:
       declared: BSD-3-Clause
+  3.0.16:
+    licensed:
+      declared: BSD-3-Clause
   3.0.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.codehaus.janino:commons-compiler	3.0.16

**Details:**
License link in manifest file indicates license is BSD-3

**Resolution:**
 

**Affected definitions**:
- [commons-compiler 3.0.16](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.janino/commons-compiler/3.0.16/3.0.16)