### PR TITLE
azureml-train-automl-client/1.5.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -21,6 +21,9 @@ revisions:
   1.4.0:
     licensed:
       declared: OTHER
+  1.5.0.post1:
+    licensed:
+      declared: OTHER
   1.6.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client/1.5.0.post1

**Details:**
No info in package files. Meta data confirm proprietary license. Curated as OTHER. 

**Resolution:**
https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-train-automl-client 1.5.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.5.0.post1/1.5.0.post1)