### PR TITLE
Microsoft.WindowsAPICodePack-Shell/1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WindowsAPICodePack-Shell.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WindowsAPICodePack-Shell.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WindowsAPICodePack-Shell
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.WindowsAPICodePack-Shell/1.1.0

**Details:**
No info in package files. Meta data confirms proprietary license - MS EULA. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.WindowsAPICodePack-Shell/1.1.0

**Affected definitions**:
- [Microsoft.WindowsAPICodePack-Shell 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WindowsAPICodePack-Shell/1.1.0/1.1.0)