### PR TITLE
Tynamix.ObjectFiller/1.5.5

### DIFF
--- a/curations/nuget/nuget/-/Tynamix.ObjectFiller.yaml
+++ b/curations/nuget/nuget/-/Tynamix.ObjectFiller.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Tynamix.ObjectFiller
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tynamix.ObjectFiller/1.5.5

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/Tynamix/ObjectFiller.NET/blob/1.5.5/LICENSE.txt

**Affected definitions**:
- [Tynamix.ObjectFiller 1.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/Tynamix.ObjectFiller/1.5.5/1.5.5)