### PR TITLE
dom5/1.1.0

### DIFF
--- a/curations/npm/npmjs/-/dom5.yaml
+++ b/curations/npm/npmjs/-/dom5.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dom5
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dom5/1.1.0

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/Polymer/tools/blob/wct-mocha%401.1.0/LICENSE

**Affected definitions**:
- [dom5 1.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/dom5/1.1.0/1.1.0)