### PR TITLE
Rx-Main/1.0.11226

### DIFF
--- a/curations/nuget/nuget/-/Rx-Main.yaml
+++ b/curations/nuget/nuget/-/Rx-Main.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.11226:
+    licensed:
+      declared: OTHER
   2.1.30214:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Main/1.0.11226

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://docs.microsoft.com/en-us/previous-versions/hh295787(v=msdn.10)?redirectedfrom=MSDN

**Affected definitions**:
- [Rx-Main 1.0.11226](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Main/1.0.11226/1.0.11226)