### PR TITLE
Microsoft.Bot.Builder/4.9.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -21,6 +21,9 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.2:
+    licensed:
+      declared: MIT
   4.9.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder/4.9.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder 4.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/4.9.2/4.9.2)