### PR TITLE
WebP.Touch/1.0.8

### DIFF
--- a/curations/nuget/nuget/-/WebP.Touch.yaml
+++ b/curations/nuget/nuget/-/WebP.Touch.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WebP.Touch
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WebP.Touch/1.0.8

**Details:**
No info in package files. meta data confirms MIT. 

**Resolution:**
https://github.com/luberda-molinet/WebP.Touch/blob/master/LICENSE

**Affected definitions**:
- [WebP.Touch 1.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/WebP.Touch/1.0.8/1.0.8)