### PR TITLE
Microsoft.DotNet.PlatformAbstractions/3.1.6

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -39,3 +39,6 @@ revisions:
   3.1.5:
     licensed:
       declared: MIT
+  3.1.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.DotNet.PlatformAbstractions/3.1.6

**Details:**
No info in package files. Meta data confirmed MIT. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.DotNet.PlatformAbstractions/3.1.6/License

**Affected definitions**:
- [Microsoft.DotNet.PlatformAbstractions 3.1.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions/3.1.6/3.1.6)