### PR TITLE
prometheus-net.DotNetRuntime3.3.1

### DIFF
--- a/curations/nuget/nuget/-/prometheus-net.DotNetRuntime.yaml
+++ b/curations/nuget/nuget/-/prometheus-net.DotNetRuntime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: prometheus-net.DotNetRuntime
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
prometheus-net.DotNetRuntime3.3.1

**Details:**
Declare MIT found here (https://github.com/djluck/prometheus-net.DotNetRuntime/blob/3.3.1/LICENSE.txt)

**Resolution:**
Matches Master

**Affected definitions**:
- [prometheus-net.DotNetRuntime 3.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/prometheus-net.DotNetRuntime/3.3.1/3.3.1)