### PR TITLE
prometheus-net3.1.2

### DIFF
--- a/curations/nuget/nuget/-/prometheus-net.yaml
+++ b/curations/nuget/nuget/-/prometheus-net.yaml
@@ -15,3 +15,6 @@ revisions:
   2.1.3:
     licensed:
       declared: MIT
+  3.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
prometheus-net3.1.2

**Details:**
Declare MIT found here (https://github.com/prometheus-net/prometheus-net/blob/v3.1.2/LICENSE)

**Resolution:**
Matches license and master.

**Affected definitions**:
- [prometheus-net 3.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/prometheus-net/3.1.2/3.1.2)