### PR TITLE
Microsoft.ML.DataView1.5.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ML.DataView.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ML.DataView.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ML.DataView
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ML.DataView1.5.1

**Details:**
Declare MIT found here (https://www.nuget.org/packages/Microsoft.ML.DataView/1.5.1/License)

**Resolution:**
Found MIT tagged at 1.5.1 in License Info, project file didn't have 1.5.1, last was 1.5.0 no history on license tab and appears MIT declared all along

**Affected definitions**:
- [Microsoft.ML.DataView 1.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ML.DataView/1.5.1/1.5.1)