### PR TITLE
Bond.Compiler.CSharp/8.1.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Compiler.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Compiler.CSharp.yaml
@@ -6,3 +6,6 @@ revisions:
   8.0.0:
     licensed:
       declared: MIT
+  8.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Compiler.CSharp/8.1.0

**Details:**
No info in package files. Meta data confirm MIT. 

**Resolution:**
https://github.com/microsoft/bond/blob/8.1.0/LICENSE

**Affected definitions**:
- [Bond.Compiler.CSharp 8.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Compiler.CSharp/8.1.0/8.1.0)