### PR TITLE
Microsoft.Bot.Builder/3.15.2.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.15.2.2:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder/3.15.2.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/botbuilder%403.15.2.2/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder 3.15.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/3.15.2.2/3.15.2.2)