### PR TITLE
Strathweb.CacheOutput.WebApi2/0.9.0

### DIFF
--- a/curations/nuget/nuget/-/Strathweb.CacheOutput.WebApi2.yaml
+++ b/curations/nuget/nuget/-/Strathweb.CacheOutput.WebApi2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Strathweb.CacheOutput.WebApi2
+  provider: nuget
+  type: nuget
+revisions:
+  0.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Strathweb.CacheOutput.WebApi2/0.9.0

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/filipw/Strathweb.CacheOutput/blob/master/License.txt

**Affected definitions**:
- [Strathweb.CacheOutput.WebApi2 0.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/Strathweb.CacheOutput.WebApi2/0.9.0/0.9.0)