### PR TITLE
XPath2.Extensions/1.0.6.1

### DIFF
--- a/curations/nuget/nuget/-/XPath2.Extensions.yaml
+++ b/curations/nuget/nuget/-/XPath2.Extensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: XPath2.Extensions
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.6.1:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
XPath2.Extensions/1.0.6.1

**Details:**
No info in package files. Meta data confirms MS-PL.

**Resolution:**
https://raw.githubusercontent.com/StefH/XPath2.Net/master/license

**Affected definitions**:
- [XPath2.Extensions 1.0.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/XPath2.Extensions/1.0.6.1/1.0.6.1)