### PR TITLE
Microsoft.VisualStudio.Shell.Embeddable/16.6.30107.105

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Shell.Embeddable.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Shell.Embeddable.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Shell.Embeddable
+  provider: nuget
+  type: nuget
+revisions:
+  16.6.30107.105:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Shell.Embeddable/16.6.30107.105

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.VisualStudio.Shell.Embeddable/16.6.30107.105/License

**Affected definitions**:
- [Microsoft.VisualStudio.Shell.Embeddable 16.6.30107.105](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Shell.Embeddable/16.6.30107.105/16.6.30107.105)