### PR TITLE
sacremoses/0.0.41

### DIFF
--- a/curations/pypi/pypi/-/sacremoses.yaml
+++ b/curations/pypi/pypi/-/sacremoses.yaml
@@ -17,4 +17,4 @@ revisions:
       declared: LGPL-2.1-or-later
   0.0.41:
     licensed:
-      declared: MIT
+      declared: LGPL-2.1-or-later

--- a/curations/pypi/pypi/-/sacremoses.yaml
+++ b/curations/pypi/pypi/-/sacremoses.yaml
@@ -15,3 +15,6 @@ revisions:
         path: sacremoses-0.0.40/README.md
     licensed:
       declared: LGPL-2.1-or-later
+  0.0.41:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sacremoses/0.0.41

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/alvations/sacremoses/blob/master/LICENSE

**Affected definitions**:
- [sacremoses 0.0.41](https://clearlydefined.io/definitions/pypi/pypi/-/sacremoses/0.0.41/0.0.41)