### PR TITLE
redis/0.7.3

### DIFF
--- a/curations/npm/npmjs/-/redis.yaml
+++ b/curations/npm/npmjs/-/redis.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: redis
+  provider: npmjs
+  type: npm
+revisions:
+  0.7.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
redis/0.7.3

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/NodeRedis/node-redis/blob/master/LICENSE

**Affected definitions**:
- [redis 0.7.3](https://clearlydefined.io/definitions/npm/npmjs/-/redis/0.7.3/0.7.3)