### PR TITLE
Vse.Web.Serialization.ControlledSerializationJsonConverter/1.0.4

### DIFF
--- a/curations/nuget/nuget/-/Vse.Web.Serialization.ControlledSerializationJsonConverter.yaml
+++ b/curations/nuget/nuget/-/Vse.Web.Serialization.ControlledSerializationJsonConverter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Vse.Web.Serialization.ControlledSerializationJsonConverter
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Vse.Web.Serialization.ControlledSerializationJsonConverter/1.0.4

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://raw.githubusercontent.com/rpokrovskij/ControlledSerializationJsonConverter/master/LICENSE

**Affected definitions**:
- [Vse.Web.Serialization.ControlledSerializationJsonConverter 1.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/Vse.Web.Serialization.ControlledSerializationJsonConverter/1.0.4/1.0.4)