### PR TITLE
AngularJS.Core/1.7.8

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Core.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Core.yaml
@@ -9,3 +9,6 @@ revisions:
   1.4.7:
     licensed:
       declared: MIT
+  1.7.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngularJS.Core/1.7.8

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/angular/angular.js/blob/v1.7.x/LICENSE

**Affected definitions**:
- [AngularJS.Core 1.7.8](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Core/1.7.8/1.7.8)