### PR TITLE
MathNet.Numerics.Signed/4.9.0

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.Signed.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MathNet.Numerics.Signed
+  provider: nuget
+  type: nuget
+revisions:
+  4.9.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MathNet.Numerics.Signed/4.9.0

**Details:**
No info in package files. Meta data confirms MIT, despite mention of X11.

**Resolution:**
https://numerics.mathdotnet.com/License.html

**Affected definitions**:
- [MathNet.Numerics.Signed 4.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics.Signed/4.9.0/4.9.0)