### PR TITLE
Ninject.Web.WebApi/3.2.4

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Web.WebApi.yaml
+++ b/curations/nuget/nuget/-/Ninject.Web.WebApi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Web.WebApi
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.4:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Web.WebApi/3.2.4

**Details:**
No info in package files. Meta data confirms Apache 2.0 or MS-PL. 

**Resolution:**
https://raw.githubusercontent.com/ninject/ninject.web.webapi/master/LICENSE.txt

**Affected definitions**:
- [Ninject.Web.WebApi 3.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Web.WebApi/3.2.4/3.2.4)