### PR TITLE
@progress/kendo-drawing/1.8.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-drawing.yaml
+++ b/curations/npm/npmjs/@progress/kendo-drawing.yaml
@@ -10,3 +10,6 @@ revisions:
   1.7.0:
     licensed:
       declared: OTHER
+  1.8.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@progress/kendo-drawing/1.8.1

**Details:**
No info in package files. Meta data confirms proprietary EULA, so curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-drawing/v/1.8.1

**Affected definitions**:
- [kendo-drawing 1.8.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-drawing/1.8.1/1.8.1)