### PR TITLE
Microsoft.OpenApi/1.2.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OpenApi.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OpenApi.yaml
@@ -9,3 +9,6 @@ revisions:
   1.1.4:
     licensed:
       declared: MIT
+  1.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.OpenApi/1.2.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/Microsoft/OpenAPI.NET/master/LICENSE

**Affected definitions**:
- [Microsoft.OpenApi 1.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OpenApi/1.2.2/1.2.2)