### PR TITLE
update-notifier/0.2.2

### DIFF
--- a/curations/npm/npmjs/-/update-notifier.yaml
+++ b/curations/npm/npmjs/-/update-notifier.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: update-notifier
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
update-notifier/0.2.2

**Details:**
No info in package files. Meta data confirms BSD 2 Clause. 

**Resolution:**
https://github.com/yeoman/update-notifier/blob/master/license

**Affected definitions**:
- [update-notifier 0.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/update-notifier/0.2.2/0.2.2)