### PR TITLE
chmodr/0.1.0

### DIFF
--- a/curations/npm/npmjs/-/chmodr.yaml
+++ b/curations/npm/npmjs/-/chmodr.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: chmodr
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
chmodr/0.1.0

**Details:**
No info in package files. Meta data confirms ISC. 

**Resolution:**
https://github.com/isaacs/chmodr/blob/v0.1.0/LICENSE

**Affected definitions**:
- [chmodr 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/chmodr/0.1.0/0.1.0)