### PR TITLE
Microsoft.VisualStudio.Services.Client/16.153.0-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Services.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Services.Client.yaml
@@ -6,3 +6,6 @@ revisions:
   16.153.0:
     licensed:
       declared: OTHER
+  16.153.0-preview:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Services.Client/16.153.0-preview

**Details:**
No info in package files. Meta data confirms proprietary license, so curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.VisualStudio.Services.Client/16.153.0-preview/License

**Affected definitions**:
- [Microsoft.VisualStudio.Services.Client 16.153.0-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Services.Client/16.153.0-preview/16.153.0-preview)