### PR TITLE
Microsoft.SqlServer.SqlManagementObjects/160.2004021.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.SqlServer.SqlManagementObjects.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.SqlManagementObjects.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.SqlServer.SqlManagementObjects
+  provider: nuget
+  type: nuget
+revisions:
+  160.2004021.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.SqlServer.SqlManagementObjects/160.2004021.0

**Details:**
No info in package files. Meta data confirms proprietary license, so curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.SqlServer.SqlManagementObjects/160.2004021.0/License

**Affected definitions**:
- [Microsoft.SqlServer.SqlManagementObjects 160.2004021.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.SqlServer.SqlManagementObjects/160.2004021.0/160.2004021.0)