### PR TITLE
gong-wpf-dragdrop 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/gong-wpf-dragdrop.yaml
+++ b/curations/nuget/nuget/-/gong-wpf-dragdrop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: gong-wpf-dragdrop
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
gong-wpf-dragdrop 2.2.0

**Details:**
Declaring BSD-3-Clause

**Resolution:**
Clearly Defined License File: BSD-3-Clause

NuGet metadata: https://www.nuget.org/packages/gong-wpf-dragdrop/2.2.0/License

Source license: https://github.com/punker76/gong-wpf-dragdrop/blob/2.2.0/LICENSE

**Affected definitions**:
- [gong-wpf-dragdrop 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/gong-wpf-dragdrop/2.2.0/2.2.0)