### PR TITLE
Missing information for Missing information for Microsoft.Azure.Devices 1.22.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
@@ -31,6 +31,17 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/a50dbdd017153c05c1492135a51ea064169e61ee'
     licensed:
       declared: MIT
+  1.22.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: 88a5330e462f042f5784fc8e6734bdf4bda0dd53
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/88a5330e462f042f5784fc8e6734bdf4bda0dd53'
+    licensed:
+      declared: MIT
   1.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Missing information for Missing information for Microsoft.Azure.Devices 1.22.0

**Details:**
Adding source, license, and attributions

**Resolution:**
Source:
		https://github.com/Azure/azure-iot-sdk-csharp/tree/88a5330e462f042f5784fc8e6734bdf4bda0dd53
		MIT License:
		Microsoft Azure IoT SDKs Copyright (c) Microsoft Corporation All rights reserved. MIT License
		https://github.com/Azure/azure-iot-sdk-csharp/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.Devices 1.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices/1.22.0/1.22.0)