### PR TITLE
Missing information for Missing information for Microsoft.Azure.DocumentDB.Core 2.11.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
@@ -6,6 +6,17 @@ revisions:
   2.1.3:
     licensed:
       declared: NOASSERTION
+  2.11.3:
+    described:
+      sourceLocation:
+        name: azure-cosmos-dotnet-v2
+        namespace: azure
+        provider: github
+        revision: 24bd6fb603d8f13c7fcc7dcd53734a91b52c43b3
+        type: git
+        url: 'https://github.com/azure/azure-cosmos-dotnet-v2/commit/24bd6fb603d8f13c7fcc7dcd53734a91b52c43b3'
+    licensed:
+      declared: MIT
   2.4.0:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Missing information for Microsoft.Azure.DocumentDB.Core 2.11.3

**Details:**
Adding source, license

**Resolution:**
Source:
		https://github.com/Azure/azure-cosmos-dotnet-v2/tree/24bd6fb603d8f13c7fcc7dcd53734a91b52c43b3
		MIT License:
		Copyright (c) 2014 Microsoft Corporation
		https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DocumentDB.Core 2.11.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core/2.11.3/2.11.3)