### PR TITLE
threadpoolctl 2.1.0

### DIFF
--- a/curations/pypi/pypi/-/threadpoolctl.yaml
+++ b/curations/pypi/pypi/-/threadpoolctl.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: threadpoolctl
+  provider: pypi
+  type: pypi
+revisions:
+  2.1.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
threadpoolctl 2.1.0

**Details:**
Declaring BSD-3-Clause

**Resolution:**
I  only see one license - BSD-3-Clause

https://github.com/joblib/threadpoolctl/blob/2.1.0/LICENSE


**Affected definitions**:
- [threadpoolctl 2.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/threadpoolctl/2.1.0/2.1.0)