### PR TITLE
loadimpact/k64ee1ca9624bdd9fa68a0d534be11ac22328f1821

### DIFF
--- a/curations/git/github/loadimpact/k6.yaml
+++ b/curations/git/github/loadimpact/k6.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: AGPL-3.0-or-later
   4ee1ca9624bdd9fa68a0d534be11ac22328f1821:
     licensed:
-      declared: AGPL-3.0-only
+      declared: AGPL-3.0-or-later

--- a/curations/git/github/loadimpact/k6.yaml
+++ b/curations/git/github/loadimpact/k6.yaml
@@ -7,3 +7,6 @@ revisions:
   479707f90eae51ee385b3424e6a1259702608e8a:
     licensed:
       declared: AGPL-3.0-or-later
+  4ee1ca9624bdd9fa68a0d534be11ac22328f1821:
+    licensed:
+      declared: AGPL-3.0-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
loadimpact/k64ee1ca9624bdd9fa68a0d534be11ac22328f1821

**Details:**
Declaring AGPL 3.0 only

**Resolution:**
ClearlyDefined License file: AGPL 3.0

https://github.com/loadimpact/k6/blob/4ee1ca9624bdd9fa68a0d534be11ac22328f1821/LICENSE.md

**Affected definitions**:
- [k6 4ee1ca9624bdd9fa68a0d534be11ac22328f1821](https://clearlydefined.io/definitions/git/github/loadimpact/k6/4ee1ca9624bdd9fa68a0d534be11ac22328f1821/4ee1ca9624bdd9fa68a0d534be11ac22328f1821)