### PR TITLE
openssh/openssh-portable ed6bef77f5b

### DIFF
--- a/curations/git/github/openssh/openssh-portable.yaml
+++ b/curations/git/github/openssh/openssh-portable.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   ed6bef77f5bb5b8f9ca2914478949e29f2f0a780:
     licensed:
-      declared: OTHER
+      declared: SSH-OpenSSH

--- a/curations/git/github/openssh/openssh-portable.yaml
+++ b/curations/git/github/openssh/openssh-portable.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: openssh-portable
+  namespace: openssh
+  provider: github
+  type: git
+revisions:
+  ed6bef77f5bb5b8f9ca2914478949e29f2f0a780:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
openssh/openssh-portable ed6bef77f5b

**Details:**
I think the top part of the LICENSE file would be considered the 'declared' license and it does not have a SPDX match.  Curating as OTHER.

**Resolution:**
https://github.com/openssh/openssh-portable/blob/ed6bef77f5bb5b8f9ca2914478949e29f2f0a780/LICENCE

**Affected definitions**:
- [openssh-portable ed6bef77f5bb5b8f9ca2914478949e29f2f0a780](https://clearlydefined.io/definitions/git/github/openssh/openssh-portable/ed6bef77f5bb5b8f9ca2914478949e29f2f0a780/ed6bef77f5bb5b8f9ca2914478949e29f2f0a780)