### PR TITLE
mysql-connector-python 8.0.13

### DIFF
--- a/curations/pypi/pypi/-/mysql-connector-python.yaml
+++ b/curations/pypi/pypi/-/mysql-connector-python.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mysql-connector-python
+  provider: pypi
+  type: pypi
+revisions:
+  8.0.13:
+    licensed:
+      declared: GPL-2.0-only AND WITH Universal-FOSS-exception-1.0

--- a/curations/pypi/pypi/-/mysql-connector-python.yaml
+++ b/curations/pypi/pypi/-/mysql-connector-python.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   8.0.13:
     licensed:
-      declared: GPL-2.0-only AND WITH Universal-FOSS-exception-1.0
+      declared: GPL-2.0-only WITH Universal-FOSS-exception-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mysql-connector-python 8.0.13

**Details:**
Metadata is License: GNU GPLv2 (with FOSS License Exception).  Header of py files say# Without limiting anything contained in the foregoing, this file,
# which is part of MySQL Connector/Python, is also subject to the
# Universal FOSS Exception, version 1.0, a copy of which can be found at
# http://

**Resolution:**
GPL-2.0 WITH Universal-FOSS-exception

**Affected definitions**:
- [mysql-connector-python 8.0.13](https://clearlydefined.io/definitions/pypi/pypi/-/mysql-connector-python/8.0.13/8.0.13)