### PR TITLE
psycopg2-binary 2.8.5

### DIFF
--- a/curations/pypi/pypi/-/psycopg2-binary.yaml
+++ b/curations/pypi/pypi/-/psycopg2-binary.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.8.5:
     licensed:
-      declared: LGPL-3.0-or-later
+      declared: LGPL-3.0-or-later WITH OTHER

--- a/curations/pypi/pypi/-/psycopg2-binary.yaml
+++ b/curations/pypi/pypi/-/psycopg2-binary.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: psycopg2-binary
+  provider: pypi
+  type: pypi
+revisions:
+  2.8.5:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
psycopg2-binary 2.8.5

**Details:**
Metadata and py files say LGPL-3.0-or later

# psycopg2 is free software: you can redistribute it and/or modify it
# under the terms of the GNU Lesser General Public License as published
# by the Free Software Foundation, either version 3 of the License, or
# (at your option) any later version.

**Resolution:**
I dont see a SPDX for the exception so will do "WITH OTHER"

 In addition, as a special exception, the copyright holders give
# permission to link this program with the OpenSSL library (or with
# modified versions of OpenSSL that use the same license as OpenSSL),
# and distribute linked combinations

**Affected definitions**:
- [psycopg2-binary 2.8.5](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2-binary/2.8.5/2.8.5)