### PR TITLE
is-regex	1.1.1

### DIFF
--- a/curations/npm/npmjs/-/is-regex.yaml
+++ b/curations/npm/npmjs/-/is-regex.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: is-regex
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
is-regex	1.1.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Package.json also indicates license is MIT

**Affected definitions**:
- [is-regex 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/is-regex/1.1.1/1.1.1)