### PR TITLE
npm	@babel/parser

### DIFF
--- a/curations/npm/npmjs/@babel/parser.yaml
+++ b/curations/npm/npmjs/@babel/parser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: parser
+  namespace: '@babel'
+  provider: npmjs
+  type: npm
+revisions:
+  7.11.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm	@babel/parser

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Package.json also indicates license is MIT

**Affected definitions**:
- [parser 7.11.1](https://clearlydefined.io/definitions/npm/npmjs/@babel/parser/7.11.1/7.11.1)