### PR TITLE
nuget	Google.Protobuf

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -21,6 +21,9 @@ revisions:
   3.11.4:
     licensed:
       declared: BSD-3-Clause
+  3.12.2:
+    licensed:
+      declared: BSD-3-Clause
   3.12.3:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nuget	Google.Protobuf

**Details:**
License link from Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Google.Protobuf 3.12.2](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.12.2/3.12.2)