### PR TITLE
electron-to-chromium	1.3.520

### DIFF
--- a/curations/npm/npmjs/-/electron-to-chromium.yaml
+++ b/curations/npm/npmjs/-/electron-to-chromium.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: electron-to-chromium
+  provider: npmjs
+  type: npm
+revisions:
+  1.3.520:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
electron-to-chromium	1.3.520

**Details:**
Harvested license file indicates license is ISC

**Resolution:**
Package.json also indicates license is ISC

**Affected definitions**:
- [electron-to-chromium 1.3.520](https://clearlydefined.io/definitions/npm/npmjs/-/electron-to-chromium/1.3.520/1.3.520)