### PR TITLE
@babel/parser	7.11.2

### DIFF
--- a/curations/npm/npmjs/@babel/parser.yaml
+++ b/curations/npm/npmjs/@babel/parser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: parser
+  namespace: '@babel'
+  provider: npmjs
+  type: npm
+revisions:
+  7.11.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@babel/parser	7.11.2

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Package.json also indicates license is MIT

**Affected definitions**:
- [parser 7.11.2](https://clearlydefined.io/definitions/npm/npmjs/@babel/parser/7.11.2/7.11.2)