### PR TITLE
browserify-sign	4.2.1

### DIFF
--- a/curations/npm/npmjs/-/browserify-sign.yaml
+++ b/curations/npm/npmjs/-/browserify-sign.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: browserify-sign
+  provider: npmjs
+  type: npm
+revisions:
+  4.2.1:
+    licensed:
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
browserify-sign	4.2.1

**Details:**
Harvested license file indicates license is ISC

**Resolution:**
License file in repository also indicates license is ISC

**Affected definitions**:
- [browserify-sign 4.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/browserify-sign/4.2.1/4.2.1)