### PR TITLE
azureml-core	1.11.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -15,6 +15,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.6.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-core	1.11.0

**Details:**
PyPi site indicates license is https://aka.ms/azureml-sdk-license

**Resolution:**
License file in package indicates license is "This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure..."

**Affected definitions**:
- [azureml-core 1.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.11.0/1.11.0)