### PR TITLE
FluentFTP 32.3.3

### DIFF
--- a/curations/nuget/nuget/-/FluentFTP.yaml
+++ b/curations/nuget/nuget/-/FluentFTP.yaml
@@ -15,3 +15,6 @@ revisions:
   23.1.0:
     licensed:
       declared: MIT
+  32.3.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
FluentFTP 32.3.3

**Details:**
Declaring MIT

**Resolution:**
NuGet  metadata goes to GitHub master license, MIT,

License (commit to release date): https://github.com/robinrodricks/FluentFTP/blob/73c1343a103cf4324924f940fa0d5c5db2061c36/LICENSE.TXT

**Affected definitions**:
- [FluentFTP 32.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/FluentFTP/32.3.3/32.3.3)