### PR TITLE
InputSimulator 1.0.4

### DIFF
--- a/curations/nuget/nuget/-/InputSimulator.yaml
+++ b/curations/nuget/nuget/-/InputSimulator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: InputSimulator
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.4:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
InputSimulator 1.0.4

**Details:**
Declaring MS-PL

**Resolution:**
Nuget metadata goes to Codeplex - InputSimulator1.0.4.

MS-PL license is in the package zip file (download archive).

**Affected definitions**:
- [InputSimulator 1.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/InputSimulator/1.0.4/1.0.4)