### PR TITLE
StringTemplate4 4.0.8

### DIFF
--- a/curations/nuget/nuget/-/StringTemplate4.yaml
+++ b/curations/nuget/nuget/-/StringTemplate4.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StringTemplate4
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.8:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
StringTemplate4 4.0.8

**Details:**
Declaring BSD-3-Clause

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/antlr/antlrcs/master/LICENSE.txt

Project license, commit to release date: https://github.com/antlr/antlrcs/blob/4b3b39a820feea1d4a4575d6bc4bfc36b9db5b41/LICENSE.txt

**Affected definitions**:
- [StringTemplate4 4.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/StringTemplate4/4.0.8/4.0.8)