### PR TITLE
System.IO.Abstractions.TestingHelpers 7.0.7

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0.176:
     licensed:
       declared: MS-PL
+  7.0.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
System.IO.Abstractions.TestingHelpers 7.0.7

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub master license
Tagged version: https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v7.0.7/LICENSE

**Affected definitions**:
- [System.IO.Abstractions.TestingHelpers 7.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions.TestingHelpers/7.0.7/7.0.7)