### PR TITLE
Missing information for Microsoft.Azure.WebJobs.Extensions.Storage/4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Microsoft.Azure.WebJobs.Extensions.Storage
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.2:
+    described:
+      sourceLocation:
+        name: azure-webjobs-sdk
+        namespace: azure
+        provider: github
+        revision: 2593d4f12c14c3ca609faaf90805eaa2a808c29f
+        type: git
+        url: 'https://github.com/azure/azure-webjobs-sdk/commit/2593d4f12c14c3ca609faaf90805eaa2a808c29f'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing information for Microsoft.Azure.WebJobs.Extensions.Storage/4.0.2

**Details:**
Adding source, license, and attributions

**Resolution:**
Source:
https://github.com/Azure/azure-webjobs-sdk/tree/2593d4f12c14c3ca609faaf90805eaa2a808c29f

License:
﻿The MIT License (MIT)

Copyright (c) .NET Foundation.  All rights reserved.  
https://github.com/Azure/azure-webjobs-sdk/blob/2593d4f12c14c3ca609faaf90805eaa2a808c29f/LICENSE.txt

**Affected definitions**:
- [Microsoft.Azure.WebJobs.Extensions.Storage 4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage/4.0.2/4.0.2)