### PR TITLE
pypi	grpcio

### DIFF
--- a/curations/pypi/pypi/-/grpcio.yaml
+++ b/curations/pypi/pypi/-/grpcio.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: grpcio
+  provider: pypi
+  type: pypi
+revisions:
+  1.31.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pypi	grpcio

**Details:**
PyPi site indicates license is Apache 2.0

**Resolution:**
Metadata file in package indicates license is Apache 2.0

**Affected definitions**:
- [grpcio 1.31.0](https://clearlydefined.io/definitions/pypi/pypi/-/grpcio/1.31.0/1.31.0)