### PR TITLE
@babel/runtime	7.11.1

### DIFF
--- a/curations/npm/npmjs/@babel/runtime.yaml
+++ b/curations/npm/npmjs/@babel/runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: runtime
+  namespace: '@babel'
+  provider: npmjs
+  type: npm
+revisions:
+  7.11.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@babel/runtime	7.11.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
Harvested package.json file also indicates license is MIT

**Affected definitions**:
- [runtime 7.11.1](https://clearlydefined.io/definitions/npm/npmjs/@babel/runtime/7.11.1/7.11.1)