### PR TITLE
azureml-train-restclients-hyperdrive	1.11.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.60:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-restclients-hyperdrive	1.11.0

**Details:**
PyPi site indicates license is https://aka.ms/azureml-sdk-license

**Resolution:**
License file in package indicates license is "This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure...."

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.11.0/1.11.0)