### PR TITLE
Microsoft.FeatureManagement.AspNetCore	2.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.FeatureManagement.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.FeatureManagement.AspNetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.FeatureManagement.AspNetCore
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.FeatureManagement.AspNetCore	2.0.0

**Details:**
License link on Nuget site indicates license is MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
MICROSOFT AZURE APP CONFIGURATION SOFTWARE

**Resolution:**
License link in Nuspec file also indicates license is MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
MICROSOFT AZURE APP CONFIGURATION SOFTWARE

**Affected definitions**:
- [Microsoft.FeatureManagement.AspNetCore 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.FeatureManagement.AspNetCore/2.0.0/2.0.0)