### PR TITLE
azureml-automl-core	1.11.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -12,6 +12,9 @@ revisions:
   1.10.0.post1:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core	1.11.0

**Details:**
PyPi site indicates license is (https://aka.ms/azureml-sdk-license)

**Resolution:**
License file in package indicates "This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure...."

**Affected definitions**:
- [azureml-automl-core 1.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.11.0/1.11.0)