### PR TITLE
system.io.abstractions 7.0.7

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -18,3 +18,6 @@ revisions:
   6.0.14:
     licensed:
       declared: MIT
+  7.0.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
system.io.abstractions 7.0.7

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [System.IO.Abstractions 7.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/7.0.7/7.0.7)