### PR TITLE
uiacomwrapper 1.1.0.14

### DIFF
--- a/curations/nuget/nuget/-/UIAComWrapper.yaml
+++ b/curations/nuget/nuget/-/UIAComWrapper.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: UIAComWrapper
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0.14:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
uiacomwrapper 1.1.0.14

**Details:**
License link on Nuget site indicates license is MS-PL

**Resolution:**
License file in repository also indicates license is MS-PL

**Affected definitions**:
- [UIAComWrapper 1.1.0.14](https://clearlydefined.io/definitions/nuget/nuget/-/UIAComWrapper/1.1.0.14/1.1.0.14)