### PR TITLE
Curate five licenses

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.Client.yaml
@@ -42,6 +42,17 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/a50dbdd017153c05c1492135a51ea064169e61ee'
     licensed:
       declared: MIT
+  1.27.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: 88a5330e462f042f5784fc8e6734bdf4bda0dd53
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/88a5330e462f042f5784fc8e6734bdf4bda0dd53'
+    licensed:
+      declared: MIT
   1.5.1:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Devices.yaml
@@ -31,6 +31,17 @@ revisions:
         url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/a50dbdd017153c05c1492135a51ea064169e61ee'
     licensed:
       declared: MIT
+  1.22.0:
+    described:
+      sourceLocation:
+        name: azure-iot-sdk-csharp
+        namespace: azure
+        provider: github
+        revision: 88a5330e462f042f5784fc8e6734bdf4bda0dd53
+        type: git
+        url: 'https://github.com/azure/azure-iot-sdk-csharp/commit/88a5330e462f042f5784fc8e6734bdf4bda0dd53'
+    licensed:
+      declared: MIT
   1.4.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
@@ -6,6 +6,17 @@ revisions:
   2.1.3:
     licensed:
       declared: NOASSERTION
+  2.11.3:
+    described:
+      sourceLocation:
+        name: azure-cosmos-dotnet-v2
+        namespace: azure
+        provider: github
+        revision: 3d36bbc8ef96f51102892f5377ff42cc025f86ee
+        type: git
+        url: 'https://github.com/azure/azure-cosmos-dotnet-v2/commit/3d36bbc8ef96f51102892f5377ff42cc025f86ee'
+    licensed:
+      declared: MIT
   2.4.0:
     described:
       sourceLocation:

--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
@@ -7,7 +7,6 @@ revisions:
     licensed:
       declared: NOASSERTION
   2.11.3:
-    described:
     licensed:
       declared: MIT
   2.4.0:

--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core.yaml
@@ -8,13 +8,6 @@ revisions:
       declared: NOASSERTION
   2.11.3:
     described:
-      sourceLocation:
-        name: azure-cosmos-dotnet-v2
-        namespace: azure
-        provider: github
-        revision: 3d36bbc8ef96f51102892f5377ff42cc025f86ee
-        type: git
-        url: 'https://github.com/azure/azure-cosmos-dotnet-v2/commit/3d36bbc8ef96f51102892f5377ff42cc025f86ee'
     licensed:
       declared: MIT
   2.4.0:

--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage.yaml
@@ -13,4 +13,4 @@ revisions:
         type: git
         url: 'https://github.com/azure/azure-webjobs-sdk/commit/2593d4f12c14c3ca609faaf90805eaa2a808c29f'
     licensed:
-      declared: MIT
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: Microsoft.Azure.WebJobs.Extensions.Storage
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.2:
+    described:
+      sourceLocation:
+        name: azure-webjobs-sdk
+        namespace: azure
+        provider: github
+        revision: 2593d4f12c14c3ca609faaf90805eaa2a808c29f
+        type: git
+        url: 'https://github.com/azure/azure-webjobs-sdk/commit/2593d4f12c14c3ca609faaf90805eaa2a808c29f'
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
@@ -33,7 +33,7 @@ revisions:
         type: git
         url: 'https://github.com/bcgit/bc-csharp/commit/2f8db0669637e2217fd749ed987377f6ae71e192'
     licensed:
-      declared: MIT        
+      declared: MIT
   1.8.6.7:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Curate five licenses

**Details:**
Filled out licenses accordingly

**Resolution:**
Filled out licenses accordingly

**Affected definitions**:
- [Microsoft.Azure.Devices 1.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices/1.22.0),- [Microsoft.Azure.Devices.Client 1.27.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Devices.Client/1.27.0),- [Microsoft.Azure.DocumentDB.Core 2.11.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB.Core/2.11.3),- [Microsoft.Azure.WebJobs.Extensions.Storage 4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.WebJobs.Extensions.Storage/4.0.2),- [Portable.BouncyCastle 1.8.6.7](https://clearlydefined.io/definitions/nuget/nuget/-/Portable.BouncyCastle/1.8.6.7)