### PR TITLE
largeaddressaware 1.0.5

### DIFF
--- a/curations/nuget/nuget/-/LargeAddressAware.yaml
+++ b/curations/nuget/nuget/-/LargeAddressAware.yaml
@@ -1,9 +1,11 @@
 coordinates:
   name: LargeAddressAware
-  namespace: null
   provider: nuget
   type: nuget
 revisions:
   1.0.1:
+    licensed:
+      declared: MIT
+  1.0.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
largeaddressaware 1.0.5

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [LargeAddressAware 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/LargeAddressAware/1.0.5/1.0.5)