### PR TITLE
org.jetbrains.intellij.deps/trove4j/1.0.20181211

### DIFF
--- a/curations/maven/mavencentral/org.jetbrains.intellij.deps/trove4j.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.intellij.deps/trove4j.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.0.20181211:
     licensed:
-      declared: LGPL-2.1
+      declared: LGPL-2.1-or-later

--- a/curations/maven/mavencentral/org.jetbrains.intellij.deps/trove4j.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.intellij.deps/trove4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: trove4j
+  namespace: org.jetbrains.intellij.deps
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.20181211:
+    licensed:
+      declared: LGPL-2.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html

**Details:**
License link in .pom file indicates license is LGPL 2.1

**Resolution:**
  

**Affected definitions**:
- [trove4j 1.0.20181211](https://clearlydefined.io/definitions/maven/mavencentral/org.jetbrains.intellij.deps/trove4j/1.0.20181211/1.0.20181211)