### PR TITLE
org.javassist:javassist 3.26.0-GA

### DIFF
--- a/curations/maven/mavencentral/org.javassist/javassist.yaml
+++ b/curations/maven/mavencentral/org.javassist/javassist.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.26.0-GA:
+    licensed:
+      declared: (LGPL-2.1+ OR MPL-1.1) OR Apache-2.0
   3.27.0-GA:
     licensed:
       declared: MPL-1.1 OR LGPL-2.1-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.javassist:javassist 3.26.0-GA

**Details:**
License file in repository indicates license is Apache 2.0 or MPL 1.1 or LGPL 2.1 or later

**Resolution:**
 

**Affected definitions**:
- [javassist 3.26.0-GA](https://clearlydefined.io/definitions/maven/mavencentral/org.javassist/javassist/3.26.0-GA/3.26.0-GA)