### PR TITLE
ELD: talknow-oss

### DIFF
--- a/curations/git/github/moozzyk/signalr-client-swift.yaml
+++ b/curations/git/github/moozzyk/signalr-client-swift.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: signalr-client-swift
+  namespace: moozzyk
+  provider: github
+  type: git
+revisions:
+  15e489979ee13b33c3f903a9e499544a94cc3125:
+    files:
+      - attributions:
+          - Copyright (c) 2017 Pawel Kadluczka
+        license: MIT
+        path: LICENSE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ELD: talknow-oss

**Details:**
Add copyright text to license

**Resolution:**
Adds correct copyright for notices generation.

**Affected definitions**:
- [signalr-client-swift 15e489979ee13b33c3f903a9e499544a94cc3125](https://clearlydefined.io/definitions/git/github/moozzyk/signalr-client-swift/15e489979ee13b33c3f903a9e499544a94cc3125/15e489979ee13b33c3f903a9e499544a94cc3125)