### PR TITLE
pylint 2.5.3

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -31,3 +31,6 @@ revisions:
   2.4.4:
     licensed:
       declared: GPL-2.0-only
+  2.5.3:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint 2.5.3

**Details:**
Looks like just GPL 2.0 
# Licensed under the GPL: https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
# For details: https://github.com/PyCQA/pylint/blob/master/COPYING

**Resolution:**
Removing GPL-3.0 from "Declared" field

**Affected definitions**:
- [pylint 2.5.3](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.5.3/2.5.3)