### PR TITLE
libevent/libevent e3e7bb212e

### DIFF
--- a/curations/git/github/libevent/libevent.yaml
+++ b/curations/git/github/libevent/libevent.yaml
@@ -7,3 +7,6 @@ revisions:
   948ad3043590a36db6c8299bf0fb00ac3e1235ef:
     licensed:
       declared: BSD-3-Clause
+  e3e7bb212ea17aa8a9d5a30163487342e6ebb350:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
libevent/libevente 3e7bb212e

**Details:**
"Declared" is BSD-3-Cluase based on source repo LICENSE

**Resolution:**
https://github.com/libevent/libevent/blob/e3e7bb212ea17aa8a9d5a30163487342e6ebb350/LICENSE

**Affected definitions**:
- [libevent e3e7bb212ea17aa8a9d5a30163487342e6ebb350](https://clearlydefined.io/definitions/git/github/libevent/libevent/e3e7bb212ea17aa8a9d5a30163487342e6ebb350/e3e7bb212ea17aa8a9d5a30163487342e6ebb350)