### PR TITLE
Mousekeyhook 5.6

### DIFF
--- a/curations/nuget/nuget/-/MouseKeyHook.yaml
+++ b/curations/nuget/nuget/-/MouseKeyHook.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MouseKeyHook
+  provider: nuget
+  type: nuget
+revisions:
+  5.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Mousekeyhook 5.6

**Details:**
License file in repository was updated to MIT when package was released

**Resolution:**
  

**Affected definitions**:
- [MouseKeyHook 5.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/MouseKeyHook/5.6.0/5.6.0)