### PR TITLE
ControlzEx 3.0.1.66

### DIFF
--- a/curations/nuget/nuget/-/ControlzEx.yaml
+++ b/curations/nuget/nuget/-/ControlzEx.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.1-dev0028:
     licensed:
       declared: MIT
+  3.0.1.66:
+    licensed:
+      declared: MIT
   3.0.2.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ControlzEx 3.0.1.66

**Details:**
License file in repository indicates license is MIT

**Resolution:**
  

**Affected definitions**:
- [ControlzEx 3.0.1.66](https://clearlydefined.io/definitions/nuget/nuget/-/ControlzEx/3.0.1.66/3.0.1.66)