### PR TITLE
nss-altfiles

### DIFF
--- a/curations/git/github/aperezdc/nss-altfiles.yaml
+++ b/curations/git/github/aperezdc/nss-altfiles.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: nss-altfiles
+  namespace: aperezdc
+  provider: github
+  type: git
+revisions:
+  20fb62c61aad40c311c2c43ea2f7bd051015ca52:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nss-altfiles

**Details:**
Copying file in repository indicates license is LGPL 2.1 only

**Resolution:**
 

**Affected definitions**:
- [nss-altfiles 20fb62c61aad40c311c2c43ea2f7bd051015ca52](https://clearlydefined.io/definitions/git/github/aperezdc/nss-altfiles/20fb62c61aad40c311c2c43ea2f7bd051015ca52/20fb62c61aad40c311c2c43ea2f7bd051015ca52)