### PR TITLE
ELD: Client Rushmore Tools Aug3

### DIFF
--- a/curations/git/github/ericf/css-mediaquery.yaml
+++ b/curations/git/github/ericf/css-mediaquery.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: css-mediaquery
+  namespace: ericf
+  provider: github
+  type: git
+revisions:
+  315b8f2324f29b517a1a9dbb5dd2d2ba6c921f11:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ELD: Client Rushmore Tools Aug3

**Details:**
Set declared license for css-mediaquery v0.1.2.

**Resolution:**
This material is licensed under the BSD License (see https://github.com/ericf/css-mediaquery/blob/v0.1.2/LICENSE and file /css-mediaquery-0.1.2/LICENSE

**Affected definitions**:
- [css-mediaquery 315b8f2324f29b517a1a9dbb5dd2d2ba6c921f11](https://clearlydefined.io/definitions/git/github/ericf/css-mediaquery/315b8f2324f29b517a1a9dbb5dd2d2ba6c921f11/315b8f2324f29b517a1a9dbb5dd2d2ba6c921f11)