### PR TITLE
MahApps.Metro 1.6.0

### DIFF
--- a/curations/nuget/nuget/-/MahApps.Metro.yaml
+++ b/curations/nuget/nuget/-/MahApps.Metro.yaml
@@ -9,6 +9,9 @@ revisions:
   1.5.0:
     licensed:
       declared: MIT
+  1.6.0:
+    licensed:
+      declared: MIT
   1.6.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MahApps.Metro 1.6.0

**Details:**
Repo license and NuGet license = MIT
(MS-PL is "discovered")

**Resolution:**
MIT

**Affected definitions**:
- [MahApps.Metro 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/MahApps.Metro/1.6.0/1.6.0)