### PR TITLE
ELD: fast-components-msft

### DIFF
--- a/curations/git/github/microsoft/fast.yaml
+++ b/curations/git/github/microsoft/fast.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: fast
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  cb339f92824034d048f5e840633ed3d7ded6b009:
+    files:
+      - attributions:
+          - 'Copyright (c) 2016-2020 The Inter Project Authors https://github.com/rsms/inter'
+        license: OFL-1.1
+        path: packages/tooling/fast-figma-plugin-msft/src/global.css


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: fast-components-msft

**Details:**
File: /fast-dna-microsoft-fast-components-1.1.0/packages/tooling/fast-figma-plugin-msft/src/global.css
Lines - 1 - 6 - Imports material from interfont

**Resolution:**
This material is licensed under the SIL Open Font License 1.1 (see https://github.com/rsms/inter/blob/master/LICENSE.txt). 


**Affected definitions**:
- [fast cb339f92824034d048f5e840633ed3d7ded6b009](https://clearlydefined.io/definitions/git/github/microsoft/fast/cb339f92824034d048f5e840633ed3d7ded6b009/cb339f92824034d048f5e840633ed3d7ded6b009)