### PR TITLE
ELD: git v2.26.0.windows.1

### DIFF
--- a/curations/git/github/git-for-windows/git.yaml
+++ b/curations/git/github/git-for-windows/git.yaml
@@ -12,3 +12,6 @@ revisions:
   907ab1011dce9112700498e034b974ba60f8b407:
     licensed:
       declared: GPL-2.0-only
+  9c98e1ccdfd839e4eaae1c2747d0088ef89d446b:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ELD: git v2.26.0.windows.1

**Details:**
Fix the overall declared licensed to GPL v2 ONLY.

**Resolution:**
This material is licensed under the GPL v2 (see https://github.com/git-for-windows/git/blob/v2.26.0.windows.1/COPYING and file /git-2.26.0.windows.1/COPYING

**Affected definitions**:
- [git 9c98e1ccdfd839e4eaae1c2747d0088ef89d446b](https://clearlydefined.io/definitions/git/github/git-for-windows/git/9c98e1ccdfd839e4eaae1c2747d0088ef89d446b/9c98e1ccdfd839e4eaae1c2747d0088ef89d446b)