### PR TITLE
ELD: STL #2849d9c3

### DIFF
--- a/curations/git/github/microsoft/stl.yaml
+++ b/curations/git/github/microsoft/stl.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  2849d9c39f10379c7725b99011d03469dc59a280:
+    licensed:
+      declared: Apache-2.0
   447f879b136950baf3ca35dfb54c359494fa2a77:
     licensed:
       declared: Apache-2.0 WITH LLVM-exception

--- a/curations/git/github/microsoft/stl.yaml
+++ b/curations/git/github/microsoft/stl.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   2849d9c39f10379c7725b99011d03469dc59a280:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 WITH LLVM-exception
   447f879b136950baf3ca35dfb54c359494fa2a77:
     licensed:
       declared: Apache-2.0 WITH LLVM-exception


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ELD: STL #2849d9c3

**Details:**
Declared license should be corrected to be Apache v2 WITH LLVM exception

**Resolution:**
This material is licensed under the Apache Software License v2.0 with an LLVM Exception (see https://github.com/microsoft/STL/blob/2849d9c39f10379c7725b99011d03469dc59a280/LICENSE.txt and file /STL-2849d9c39f10379c7725b99011d03469dc59a280/LICENSE.txt

**Affected definitions**:
- [stl 2849d9c39f10379c7725b99011d03469dc59a280](https://clearlydefined.io/definitions/git/github/microsoft/stl/2849d9c39f10379c7725b99011d03469dc59a280/2849d9c39f10379c7725b99011d03469dc59a280)