### PR TITLE
ELD: Platformmobileclient apps

### DIFF
--- a/curations/git/github/ionic-team/cordova-plugin-ionic-keyboard.yaml
+++ b/curations/git/github/ionic-team/cordova-plugin-ionic-keyboard.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cordova-plugin-ionic-keyboard
+  namespace: ionic-team
+  provider: github
+  type: git
+revisions:
+  147409df732a8e49eaf359e8f3039dc86ebcf8c7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: Platformmobileclient apps

**Details:**
Component: cordova-plugin-ionic-keyboard v2.2.0

Set overall declared license to MIT

**Resolution:**
This material is licensed under the MIT License (see https://github.com/ionic-team/cordova-plugin-ionic-keyboard/blob/v2.2.0/LICENSE and file /cordova-plugin-ionic-keyboard-2.2.0/LICENSE in the materials)

**Affected definitions**:
- [cordova-plugin-ionic-keyboard 147409df732a8e49eaf359e8f3039dc86ebcf8c7](https://clearlydefined.io/definitions/git/github/ionic-team/cordova-plugin-ionic-keyboard/147409df732a8e49eaf359e8f3039dc86ebcf8c7/147409df732a8e49eaf359e8f3039dc86ebcf8c7)