### PR TITLE
ELD: Platformmobileclient apps

### DIFF
--- a/curations/git/github/nodeca/pako.yaml
+++ b/curations/git/github/nodeca/pako.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pako
+  namespace: nodeca
+  provider: github
+  type: git
+revisions:
+  a718e4f6e5ce87b0964d8f84541d92a23263365b:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ELD: Platformmobileclient apps

**Details:**
Comp: pako v1.0.11

Update declared license to be just MIT

**Resolution:**
This material is licensed under the MIT License (see https://github.com/nodeca/pako/blob/1.0.11/LICENSE and file /pako-1.0.11/LICENSE in the materials)

**Affected definitions**:
- [pako a718e4f6e5ce87b0964d8f84541d92a23263365b](https://clearlydefined.io/definitions/git/github/nodeca/pako/a718e4f6e5ce87b0964d8f84541d92a23263365b/a718e4f6e5ce87b0964d8f84541d92a23263365b)