### PR TITLE
shadow-maint/shadow 607f1dd549c

### DIFF
--- a/curations/git/github/shadow-maint/shadow.yaml
+++ b/curations/git/github/shadow-maint/shadow.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   607f1dd549cf9abc87af1cf29275f0d2d11eea29:
     licensed:
-      declared: OTHER
+      declared: OTHER OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
shadow-maint/shadow 607f1dd549c

**Details:**
Adding "OR BSD-3-Clause" due to license added to code headers

**Resolution:**
Example - https://github.com/shadow-maint/shadow/blob/607f1dd549cf9abc87af1cf29275f0d2d11eea29/src/groupadd.c

**Affected definitions**:
- [shadow 607f1dd549cf9abc87af1cf29275f0d2d11eea29](https://clearlydefined.io/definitions/git/github/shadow-maint/shadow/607f1dd549cf9abc87af1cf29275f0d2d11eea29/607f1dd549cf9abc87af1cf29275f0d2d11eea29)