### PR TITLE
axe-core 4.01

### DIFF
--- a/curations/npm/npmjs/-/axe-core.yaml
+++ b/curations/npm/npmjs/-/axe-core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: axe-core
+  provider: npmjs
+  type: npm
+revisions:
+  4.0.1:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
axe-core 4.01

**Details:**
Harvested license file indicates license is MPL 2.0

**Resolution:**
License file in repository also indicates license is MPL 2.0

**Affected definitions**:
- [axe-core 4.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/axe-core/4.0.1/4.0.1)