### PR TITLE
pause-stream/0.0.11

### DIFF
--- a/curations/npm/npmjs/-/pause-stream.yaml
+++ b/curations/npm/npmjs/-/pause-stream.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.0.11:
     licensed:
-      declared: MIT AND Apache-2.0
+      declared: MIT OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pause-stream/0.0.11

**Details:**
Correcting dual license designation to "OR"

**Resolution:**
https://github.com/dominictarr/pause-stream/blob/master/LICENSE

**Affected definitions**:
- [pause-stream 0.0.11](https://clearlydefined.io/definitions/npm/npmjs/-/pause-stream/0.0.11/0.0.11)