### PR TITLE
Extended.Wpf.Toolkit 2.1.0

### DIFF
--- a/curations/nuget/nuget/-/Extended.Wpf.Toolkit.yaml
+++ b/curations/nuget/nuget/-/Extended.Wpf.Toolkit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: MS-PL
   2.4.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Extended.Wpf.Toolkit 2.1.0

**Details:**
This NuGet is still under MS-PL, per license link on NuGet page.  Versions prior to the license change are still under MS-PL per  Issue #1557

**Resolution:**
https://github.com/xceedsoftware/wpftoolkit/issues/

**Affected definitions**:
- [Extended.Wpf.Toolkit 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Extended.Wpf.Toolkit/2.1.0/2.1.0)