### PR TITLE
typing-extensions/3.7.4.3

### DIFF
--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -15,3 +15,6 @@ revisions:
   3.7.4.2:
     licensed:
       declared: Python-2.0
+  3.7.4.3:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
typing-extensions/3.7.4.3

**Details:**
No info in package files. Meta data confirms Python Software Foundation License Version 2. 

**Resolution:**
https://github.com/python/typing/blob/3.7.4.3/LICENSE

**Affected definitions**:
- [typing-extensions 3.7.4.3](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/3.7.4.3/3.7.4.3)