### PR TITLE
Microsoft.ApplicationInsights.AspNetCore/2.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.AspNetCore.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: MIT
   2.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.AspNetCore/2.0.0

**Details:**
No info in package files. Meta data confirms MIT.

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Home/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.ApplicationInsights.AspNetCore 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.AspNetCore/2.0.0/2.0.0)