### PR TITLE
JetBrains.ReSharper.CommandLineTools/2019.3.4

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2019.3.4:
+    licensed:
+      declared: OTHER
   2020.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools/2019.3.4

**Details:**
Package files points to Jetbrains proprietary license and meta data confirms. Curated as OTHER. 

**Resolution:**
https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2019.3.4](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2019.3.4/2019.3.4)