### PR TITLE
Microsoft.CrmSdk.CoreAssemblies/9.0.2.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CrmSdk.CoreAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  9.0.2.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.CoreAssemblies/9.0.2.4

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.CrmSdk.CoreAssemblies/9.0.2.4

**Affected definitions**:
- [Microsoft.CrmSdk.CoreAssemblies 9.0.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies/9.0.2.4/9.0.2.4)