### PR TITLE
Microsoft.WindowsAzure.Caching/2.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WindowsAzure.Caching.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WindowsAzure.Caching.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WindowsAzure.Caching
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.WindowsAzure.Caching/2.4.0

**Details:**
No info in package files. Meta data points to MS EULA. Curated as OTHER.

**Resolution:**
https://www.nuget.org/packages/Microsoft.WindowsAzure.Caching/2.4.0

**Affected definitions**:
- [Microsoft.WindowsAzure.Caching 2.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WindowsAzure.Caching/2.4.0/2.4.0)