### PR TITLE
JetBrains.ReSharper.CommandLineTools/2020.2.0

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -18,3 +18,6 @@ revisions:
   2020.1.4:
     licensed:
       declared: OTHER
+  2020.2.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools/2020.2.0

**Details:**
Package files point to proprietary license. Meta data confirms proprietary Jetbrains license. Curated as OTHER. 

**Resolution:**
https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2020.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2020.2.0/2020.2.0)