### PR TITLE
Add missing source location of slf4j-log4j12 1.7.30

### DIFF
--- a/curations/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12.yaml
+++ b/curations/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12.yaml
@@ -1,0 +1,22 @@
+coordinates:
+  name: slf4j-log4j12
+  namespace: org.slf4j
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.7.30:
+    described:
+      facets:
+        data: []
+        dev:
+          - slf4j-log4j12/src/main/**
+        tests:
+          - slf4j-log4j12/src/test/**
+      releaseDate: '2019-12-16'
+      sourceLocation:
+        name: slf4j
+        namespace: qos-ch
+        provider: github
+        revision: 0b97c416e42a184ff9728877b461c616187c58f7
+        type: git
+        url: 'https://github.com/qos-ch/slf4j/commit/0b97c416e42a184ff9728877b461c616187c58f7'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing source location

**Details:**
Source location was missing

**Resolution:**
Add source location and dev and tests facets to specify which folders contain source code of the log4j12 slf4j binding and its tests

**Affected definitions**:
- [slf4j-log4j12 1.7.30](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12/1.7.30/1.7.30)