### PR TITLE
Microsoft.WindowsAzure.ActiveDirectory.Authentication 0.7.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WindowsAzure.ActiveDirectory.Authentication.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WindowsAzure.ActiveDirectory.Authentication.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WindowsAzure.ActiveDirectory.Authentication
+  provider: nuget
+  type: nuget
+revisions:
+  0.7.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.WindowsAzure.ActiveDirectory.Authentication 0.7.0

**Details:**
Curating as OTHER for a MS EULA, even though the fwlink on the NuGet page is broken.  I dont see a link to a source repo.

**Resolution:**
OTHER

**Affected definitions**:
- [Microsoft.WindowsAzure.ActiveDirectory.Authentication 0.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WindowsAzure.ActiveDirectory.Authentication/0.7.0/0.7.0)