### PR TITLE
SharpYaml 1.6.1

### DIFF
--- a/curations/nuget/nuget/-/SharpYaml.yaml
+++ b/curations/nuget/nuget/-/SharpYaml.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SharpYaml
+  provider: nuget
+  type: nuget
+revisions:
+  1.6.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SharpYaml 1.6.1

**Details:**
"Source" link goes to MIT and the NuGet package license link is MIT.

**Resolution:**
https://github.com/xoofx/SharpYaml/blob/a83d1836dc5d40ad7a5f53c90a92fd92e6794fd2/LICENSE.txt

**Affected definitions**:
- [SharpYaml 1.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/SharpYaml/1.6.1/1.6.1)