### PR TITLE
tweetnacl 0.14.3

### DIFF
--- a/curations/npm/npmjs/-/tweetnacl.yaml
+++ b/curations/npm/npmjs/-/tweetnacl.yaml
@@ -6,6 +6,9 @@ revisions:
   0.14.1:
     licensed:
       declared: OTHER
+  0.14.3:
+    licensed:
+      declared: OTHER
   0.14.4:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tweetnacl 0.14.3

**Details:**
This project switches to the Unlicense at a later version, however this version only has a public domain declaration. 

**Resolution:**
OTHER for public domain

**Affected definitions**:
- [tweetnacl 0.14.3](https://clearlydefined.io/definitions/npm/npmjs/-/tweetnacl/0.14.3/0.14.3)