### PR TITLE
System.Data.HashFunction.Interfaces	2.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.Data.HashFunction.Interfaces.yaml
+++ b/curations/nuget/nuget/-/System.Data.HashFunction.Interfaces.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0.2:
     licensed:
       declared: MIT
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.HashFunction.Interfaces	2.0.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [System.Data.HashFunction.Interfaces 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.HashFunction.Interfaces/2.0.0/2.0.0)