### PR TITLE
Microsoft.IdentityModel.Xml	5.2.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Xml.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Xml.yaml
@@ -6,6 +6,9 @@ revisions:
   5.2.0:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.2.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Xml	5.2.1

**Details:**
License file in repository indicates license is MIT

**Resolution:**
License link in Nuspec file also indicates license is MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Xml 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Xml/5.2.1/5.2.1)