### PR TITLE
Microsoft.IdentityModel.Tokens.Saml	5.2.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Tokens.Saml.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Tokens.Saml.yaml
@@ -6,6 +6,9 @@ revisions:
   5.2.0:
     licensed:
       declared: MIT
+  5.2.1:
+    licensed:
+      declared: MIT
   5.2.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Tokens.Saml	5.2.1

**Details:**
License file in repository indicates license is MIT

**Resolution:**
License link in Nuspec file also indicates license is MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Tokens.Saml 5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Tokens.Saml/5.2.1/5.2.1)