### PR TITLE
Microsoft.Azure.Cosmos	3.12.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.12.0:
+    licensed:
+      declared: MIT
   3.3.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Cosmos	3.12.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.Cosmos 3.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos/3.12.0/3.12.0)