### PR TITLE
Microsoft.AspNet.Providers.LocalDB	1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.Providers.LocalDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.Providers.LocalDB.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.Providers.LocalDB
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNet.Providers.LocalDB	1.1.0

**Details:**
License links on Nuget site for versions before and after this package indicate license is MS EULA

**Resolution:**
 

**Affected definitions**:
- [Microsoft.AspNet.Providers.LocalDB 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.Providers.LocalDB/1.1.0/1.1.0)