### PR TITLE
add source code references

### DIFF
--- a/curations/pypi/pypi/-/scons.yaml
+++ b/curations/pypi/pypi/-/scons.yaml
@@ -1,0 +1,27 @@
+coordinates:
+  name: scons
+  provider: pypi
+  type: pypi
+revisions:
+  3.1.1:
+    described:
+      sourceLocation:
+        name: scons
+        namespace: scons
+        provider: github
+        revision: 72ae09dc35ac2626f8ff711d8c4b30b6138e08e3
+        type: git
+        url: 'https://github.com/scons/scons/commit/72ae09dc35ac2626f8ff711d8c4b30b6138e08e3'
+    licensed:
+      declared: MIT
+  3.1.2:
+    described:
+      sourceLocation:
+        name: scons
+        namespace: scons
+        provider: github
+        revision: 5828924c3dd46532c2dd85f4b6da22802c9e453e
+        type: git
+        url: 'https://github.com/scons/scons/commit/5828924c3dd46532c2dd85f4b6da22802c9e453e'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
add source code references

**Details:**
source code references for 3.1.1 and 3.1.2 releases

**Resolution:**
adds github links and version tags for 3.1.1 and 3.1.2 releases

**Affected definitions**:
- [scons 3.1.2](https://clearlydefined.io/definitions/pypi/pypi/-/scons/3.1.2)