### PR TITLE
runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy	2.1.21

### DIFF
--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.19:
     licensed:
       declared: MIT
+  2.1.21:
+    licensed:
+      declared: MIT
   2.1.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy	2.1.21

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy 2.1.21](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetHostPolicy/2.1.21/2.1.21)