### PR TITLE
Microsoft.CrmSdk.Workflow	9.0.2.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.Workflow.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.Workflow.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CrmSdk.Workflow
+  provider: nuget
+  type: nuget
+revisions:
+  9.0.2.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.Workflow	9.0.2.4

**Details:**
License link on Nuget site indicates license is http://download.microsoft.com/download/E/1/8/E18C0FAD-FEC8-44CD-9A16-98EDC4DAC7A2/LicenseTerms.docx</licenseUrl

**Resolution:**
 

**Affected definitions**:
- [Microsoft.CrmSdk.Workflow 9.0.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.Workflow/9.0.2.4/9.0.2.4)