### PR TITLE
Microsoft.Azure.Amqp	2.4.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Amqp.yaml
@@ -45,3 +45,6 @@ revisions:
   2.4.4:
     licensed:
       declared: MIT
+  2.4.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.Amqp	2.4.5

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.Amqp 2.4.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Amqp/2.4.5/2.4.5)