### PR TITLE
RabbitMQ.Client	5.1.1

### DIFF
--- a/curations/nuget/nuget/-/RabbitMQ.Client.yaml
+++ b/curations/nuget/nuget/-/RabbitMQ.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RabbitMQ.Client
+  provider: nuget
+  type: nuget
+revisions:
+  5.1.1:
+    licensed:
+      declared: Apache-2.0 OR MPL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RabbitMQ.Client	5.1.1

**Details:**
Project home page indicates license is Apache 2.0 or MPL 1.1

**Resolution:**
Project repository also indicates license is Apache 2.0 or MPL 1.1

**Affected definitions**:
- [RabbitMQ.Client 5.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/RabbitMQ.Client/5.1.1/5.1.1)