### PR TITLE
replaceall	0.1.6

### DIFF
--- a/curations/npm/npmjs/-/replaceall.yaml
+++ b/curations/npm/npmjs/-/replaceall.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: replaceall
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
replaceall	0.1.6

**Details:**
Harvested readme file indicates license is MIT

**Resolution:**
 

**Affected definitions**:
- [replaceall 0.1.6](https://clearlydefined.io/definitions/npm/npmjs/-/replaceall/0.1.6/0.1.6)