### PR TITLE
Microsoft.Data.Tools.Msbuild	10.0.61804.210

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.Tools.Msbuild.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.Tools.Msbuild.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Data.Tools.Msbuild
+  provider: nuget
+  type: nuget
+revisions:
+  10.0.61804.210:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Data.Tools.Msbuild	10.0.61804.210

**Details:**
License link on Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS

**Resolution:**
License link in Nuspec file also indicates license is MICROSOFT SOFTWARE LICENSE TERMS

**Affected definitions**:
- [Microsoft.Data.Tools.Msbuild 10.0.61804.210](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.Tools.Msbuild/10.0.61804.210/10.0.61804.210)