### PR TITLE
Microsoft.Practices.ObjectBuilder.dll	3.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Practices.ObjectBuilder.dll.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Practices.ObjectBuilder.dll.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Practices.ObjectBuilder.dll
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Practices.ObjectBuilder.dll	3.1.0

**Details:**
No license or repository information available

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Practices.ObjectBuilder.dll 3.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Practices.ObjectBuilder.dll/3.1.0/3.1.0)