### PR TITLE
Microsoft.NETCore.Targets	3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.Targets.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.Targets.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETCore.Targets	3.0.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
 

**Affected definitions**:
- [Microsoft.NETCore.Targets 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.Targets/3.0.0/3.0.0)