### PR TITLE
azureml-train-automl-client	1.8.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -30,6 +30,9 @@ revisions:
   1.7.0.post1:
     licensed:
       declared: OTHER
+  1.8.0:
+    licensed:
+      declared: OTHER
   1.9.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.8.0

**Details:**
Pypi site indicates license is Other/Proprietary License (https://aka.ms/azureml-sdk-license)

**Resolution:**
License file in package indicates license is This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the 


**Affected definitions**:
- [azureml-train-automl-client 1.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.8.0/1.8.0)