### PR TITLE
Microsoft.CrmSdk.XrmTooling.CoreAssembly	8.2.0.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.CoreAssembly.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.CoreAssembly.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CrmSdk.XrmTooling.CoreAssembly
+  provider: nuget
+  type: nuget
+revisions:
+  8.2.0.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.XrmTooling.CoreAssembly	8.2.0.5

**Details:**
License link on Nuget site indicate license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Resolution:**
License URL in Nuspec file also indicatese license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Affected definitions**:
- [Microsoft.CrmSdk.XrmTooling.CoreAssembly 8.2.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.CoreAssembly/8.2.0.5/8.2.0.5)