### PR TITLE
RabbitMQ.Client	5.1.0

### DIFF
--- a/curations/nuget/nuget/-/RabbitMQ.Client.yaml
+++ b/curations/nuget/nuget/-/RabbitMQ.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RabbitMQ.Client
+  provider: nuget
+  type: nuget
+revisions:
+  5.1.0:
+    licensed:
+      declared: Apache-2.0 OR MPL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RabbitMQ.Client	5.1.0

**Details:**
License link on Nuget site indicates license is Apache 2.0 or MPL 1.1

**Resolution:**
 

**Affected definitions**:
- [RabbitMQ.Client 5.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/RabbitMQ.Client/5.1.0/5.1.0)