### PR TITLE
sphinx-boost	0.0.3

### DIFF
--- a/curations/pypi/pypi/-/sphinx-boost.yaml
+++ b/curations/pypi/pypi/-/sphinx-boost.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sphinx-boost
+  provider: pypi
+  type: pypi
+revisions:
+  0.0.3:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sphinx-boost	0.0.3

**Details:**
Pypi site indicates license is BSL 1.0

**Resolution:**
Setup.py file in package also indicates license is BSL 1.0

**Affected definitions**:
- [sphinx-boost 0.0.3](https://clearlydefined.io/definitions/pypi/pypi/-/sphinx-boost/0.0.3/0.0.3)