### PR TITLE
regex	2020.7.14

### DIFF
--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -24,3 +24,6 @@ revisions:
   2020.6.8:
     licensed:
       declared: Python-2.0
+  2020.7.14:
+    licensed:
+      declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
regex	2020.7.14

**Details:**
Pypi site indicates license is Python 2.0

**Resolution:**
Metadata file in package also indicates license is Python 2.0

**Affected definitions**:
- [regex 2020.7.14](https://clearlydefined.io/definitions/pypi/pypi/-/regex/2020.7.14/2020.7.14)