### PR TITLE
Microsoft.DotNet.PlatformAbstractions	1.1.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.3:
     licensed:
       declared: MIT
+  1.1.1:
+    licensed:
+      declared: NONE
   1.1.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: MIT
   1.1.1:
     licensed:
-      declared: NONE
+      declared: MIT
   1.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.DotNet.PlatformAbstractions	1.1.1

**Details:**
No license or repository information is available

**Resolution:**
 

**Affected definitions**:
- [Microsoft.DotNet.PlatformAbstractions 1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.DotNet.PlatformAbstractions/1.1.1/1.1.1)