### PR TITLE
Microsoft.Bot.Connector.DirectLine	3.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.DirectLine.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.DirectLine.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Connector.DirectLine
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector.DirectLine	3.0.2

**Details:**
No license or repository information available

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Bot.Connector.DirectLine 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector.DirectLine/3.0.2/3.0.2)