### PR TITLE
Microsoft.WindowsAzure.Caching	2.5.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WindowsAzure.Caching.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WindowsAzure.Caching.yaml
@@ -6,3 +6,6 @@ revisions:
   2.4.0:
     licensed:
       declared: OTHER
+  2.5.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.WindowsAzure.Caching	2.5.0

**Details:**
No license information is available for this package, but the license for the package immediately before and after the package is MS EULA

**Resolution:**
 

**Affected definitions**:
- [Microsoft.WindowsAzure.Caching 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WindowsAzure.Caching/2.5.0/2.5.0)