### PR TITLE
paramiko2.7.2

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: LGPL-2.1-or-later
   2.7.2:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-or-later

--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -9,3 +9,6 @@ revisions:
   2.7.1:
     licensed:
       declared: LGPL-2.1-or-later
+  2.7.2:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko2.7.2

**Details:**
Fixing Declared License

**Resolution:**
Declared License is LGPL 2.1 only

PyPI meta: LGPL

https://github.com/paramiko/paramiko/blob/2.7.2/LICENSE

**Affected definitions**:
- [paramiko 2.7.2](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.7.2/2.7.2)