### PR TITLE
org.mariadb.jdbc/mariadb-java-client 2.2.5

### DIFF
--- a/curations/maven/mavencentral/org.mariadb.jdbc/mariadb-java-client.yaml
+++ b/curations/maven/mavencentral/org.mariadb.jdbc/mariadb-java-client.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mariadb-java-client
+  namespace: org.mariadb.jdbc
+  provider: mavencentral
+  type: maven
+revisions:
+  2.2.5:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.mariadb.jdbc/mariadb-java-client 2.2.5

**Details:**
Fixing Declared License to LGPL 2.1 or later

**Resolution:**
https://repo1.maven.org/maven2/org/mariadb/jdbc/mariadb-java-client/2.2.5/mariadb-java-client-2.2.5.pom

**Affected definitions**:
- [mariadb-java-client 2.2.5](https://clearlydefined.io/definitions/maven/mavencentral/org.mariadb.jdbc/mariadb-java-client/2.2.5/2.2.5)