### PR TITLE
JetBrains.ReSharper.CommandLineTools/2020.2.1

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -24,3 +24,6 @@ revisions:
   2020.2.0:
     licensed:
       declared: OTHER
+  2020.2.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools/2020.2.1

**Details:**
License info was unclear in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2020.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2020.2.1/2020.2.1)