### PR TITLE
WindowsAzure.Storage/2.1.0

### DIFF
--- a/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.0:
+    licensed:
+      declared: OTHER
   3.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WindowsAzure.Storage/2.1.0

**Details:**
No info in package files. Meta data confirms MS-EULA, so curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/WindowsAzure.Storage/2.1.0

**Affected definitions**:
- [WindowsAzure.Storage 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/WindowsAzure.Storage/2.1.0/2.1.0)