### PR TITLE
Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus/6.0.1304

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.1304:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus/6.0.1304

**Details:**
No info in package files. Meta data files show no license. Curated as None. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus/6.0.1304

**Affected definitions**:
- [Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus 6.0.1304](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Practices.EnterpriseLibrary.TransientFaultHandling.ServiceBus/6.0.1304/6.0.1304)