### PR TITLE
Roslyn.Compilers.Common/1.2.20906.2

### DIFF
--- a/curations/nuget/nuget/-/Roslyn.Compilers.Common.yaml
+++ b/curations/nuget/nuget/-/Roslyn.Compilers.Common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Roslyn.Compilers.Common
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.20906.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Roslyn.Compilers.Common/1.2.20906.2

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://docs.microsoft.com/en-us/previous-versions/jj150688(v=msdn.10)?redirectedfrom=MSDN

**Affected definitions**:
- [Roslyn.Compilers.Common 1.2.20906.2](https://clearlydefined.io/definitions/nuget/nuget/-/Roslyn.Compilers.Common/1.2.20906.2/1.2.20906.2)