### PR TITLE
add declared license MIT

### DIFF
--- a/curations/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12.yaml
+++ b/curations/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12.yaml
@@ -20,3 +20,5 @@ revisions:
         revision: 0b97c416e42a184ff9728877b461c616187c58f7
         type: git
         url: 'https://github.com/qos-ch/slf4j/commit/0b97c416e42a184ff9728877b461c616187c58f7'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
add declared license MIT

**Details:**
declare license was missing

**Resolution:**
add the declare license of the component

**Affected definitions**:
- [slf4j-log4j12 1.7.30](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.slf4j/slf4j-log4j12/1.7.30)