### PR TITLE
Add declared license for graal-sdk

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: graal-sdk
+  namespace: org.graalvm.sdk
+  provider: mavencentral
+  type: maven
+revisions:
+  20.1.0:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add declared license for graal-sdk

**Details:**
The declared license information for Graal SDK is missing

**Resolution:**
Based on this link
https://github.com/oracle/graal/blob/vm-20.1.0/sdk/LICENSE.md
the declared license is UPL 1.0

**Affected definitions**:
- [graal-sdk 20.1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/20.1.0/20.1.0)