### PR TITLE
torchvision	0.7.0

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -24,3 +24,6 @@ revisions:
   0.6.1:
     licensed:
       declared: BSD-3-Clause
+  0.7.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision	0.7.0

**Details:**
License file in package indicates license is BSD-3

**Resolution:**
Pypi site indicates license is BSD

**Affected definitions**:
- [torchvision 0.7.0](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.7.0/0.7.0)