### PR TITLE
Rx-PlatformServices	2.2.5

### DIFF
--- a/curations/nuget/nuget/-/Rx-PlatformServices.yaml
+++ b/curations/nuget/nuget/-/Rx-PlatformServices.yaml
@@ -9,3 +9,6 @@ revisions:
   2.2.4:
     licensed:
       declared: Apache-2.0
+  2.2.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-PlatformServices	2.2.5

**Details:**
No license information for this version, but the next version is licensed under Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [Rx-PlatformServices 2.2.5](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-PlatformServices/2.2.5/2.2.5)