### PR TITLE
nuget	Microsoft.NETCore.DotNetAppHost

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetAppHost.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetAppHost.yaml
@@ -20,6 +20,9 @@ revisions:
   2.1.2:
     licensed:
       declared: MIT
+  2.1.21:
+    licensed:
+      declared: MIT
   2.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nuget	Microsoft.NETCore.DotNetAppHost

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link from Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.NETCore.DotNetAppHost 2.1.21](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.DotNetAppHost/2.1.21/2.1.21)