### PR TITLE
The CHANGELOG.md file does not include any license information

### DIFF
--- a/curations/npm/npmjs/-/vue-i18n.yaml
+++ b/curations/npm/npmjs/-/vue-i18n.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: vue-i18n
+  provider: npmjs
+  type: npm
+revisions:
+  8.9.0:
+    files:
+      - license: NONE
+        path: package/CHANGELOG.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
The CHANGELOG.md file does not include any license information

**Details:**
The file does not contain any license information about the file itself.

**Resolution:**
Change the discovered license from NOASSERTION to NONE.

**Affected definitions**:
- [vue-i18n 8.9.0](https://clearlydefined.io/definitions/npm/npmjs/-/vue-i18n/8.9.0/8.9.0)