### PR TITLE
The README file indicates ISC

### DIFF
--- a/curations/npm/npmjs/-/request-promise-core.yaml
+++ b/curations/npm/npmjs/-/request-promise-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: request-promise-core
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.2:
+    files:
+      - license: ISC
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
The README file indicates ISC

**Details:**
The README file indicates ISC but the harvester has determined NOASSERTION

**Resolution:**
Change the discovered license from NOASSERTION to ISC.

**Affected definitions**:
- [request-promise-core 1.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/request-promise-core/1.1.2/1.1.2)