### PR TITLE
The README file does not indicate any license

### DIFF
--- a/curations/npm/npmjs/-/postcss-discard-overridden.yaml
+++ b/curations/npm/npmjs/-/postcss-discard-overridden.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: postcss-discard-overridden
+  provider: npmjs
+  type: npm
+revisions:
+  4.0.1:
+    files:
+      - license: NONE
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
The README file does not indicate any license

**Details:**
The harvesting process has incorrectly identified the license as NOASSERTION.

**Resolution:**
Change the license from NOASSERTION to NONE.

**Affected definitions**:
- [postcss-discard-overridden 4.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/postcss-discard-overridden/4.0.1/4.0.1)