### PR TITLE
nuget	Microsoft.CrmSdk.UII.CommonAssemblies

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.UII.CommonAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.UII.CommonAssemblies.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CrmSdk.UII.CommonAssemblies
+  provider: nuget
+  type: nuget
+revisions:
+  8.1.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nuget	Microsoft.CrmSdk.UII.CommonAssemblies

**Details:**
License link on Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Resolution:**
License URL in Nuspec file also indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Affected definitions**:
- [Microsoft.CrmSdk.UII.CommonAssemblies 8.1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.UII.CommonAssemblies/8.1.0.2/8.1.0.2)