### PR TITLE
CHANGELOG.md has no indication of license

### DIFF
--- a/curations/npm/npmjs/-/doctrine.yaml
+++ b/curations/npm/npmjs/-/doctrine.yaml
@@ -9,3 +9,7 @@ revisions:
   1.5.0:
     licensed:
       declared: BSD-2-Clause
+  2.1.0:
+    files:
+      - license: NONE
+        path: package/CHANGELOG.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
CHANGELOG.md has no indication of license

**Details:**
The file does not have any indication of the license of the file itself.

**Resolution:**
Change the discovered license from NOASSERTION to NONE.

**Affected definitions**:
- [doctrine 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/doctrine/2.1.0/2.1.0)