### PR TITLE
DotNetSeleniumExtras.PageObjects	3.11.0

### DIFF
--- a/curations/nuget/nuget/-/DotNetSeleniumExtras.PageObjects.yaml
+++ b/curations/nuget/nuget/-/DotNetSeleniumExtras.PageObjects.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetSeleniumExtras.PageObjects
+  provider: nuget
+  type: nuget
+revisions:
+  3.11.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetSeleniumExtras.PageObjects	3.11.0

**Details:**
No license or repository information available

**Resolution:**
 

**Affected definitions**:
- [DotNetSeleniumExtras.PageObjects 3.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetSeleniumExtras.PageObjects/3.11.0/3.11.0)