### PR TITLE
Microsoft.CrmSdk.CoreAssemblies	8.0.2.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  8.0.2.1:
+    licensed:
+      declared: OTHER
   8.2.0.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.CoreAssemblies	8.0.2.1

**Details:**
License link from Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Resolution:**
License URL in Nuget file also indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Affected definitions**:
- [Microsoft.CrmSdk.CoreAssemblies 8.0.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies/8.0.2.1/8.0.2.1)