### PR TITLE
LibGit2Sharp.NativeBinaries	1.0.185

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: GPL-2.0-only WITH OTHER
   1.0.185:
     licensed:
-      declared: GPL-2.0-with-GCC-exception
+      declared: GPL-2.0-only WITH OTHER
   1.0.81:
     licensed:
       declared: GPL-2.0-only WITH OTHER

--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.129:
     licensed:
       declared: GPL-2.0-only WITH OTHER
+  1.0.185:
+    licensed:
+      declared: GPL-2.0-with-GCC-exception
   1.0.81:
     licensed:
       declared: GPL-2.0-only WITH OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LibGit2Sharp.NativeBinaries	1.0.185

**Details:**
License link from Nuget site indicates license is GPL-2.0-with-GCC-exception

**Resolution:**
Link to copying file in Nuspec file also indicates license is GPL-2.0-with-GCC-exception

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 1.0.185](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/1.0.185/1.0.185)