### PR TITLE
jopt-simple 4.6

### DIFF
--- a/curations/sourcearchive/mavencentral/net.sf.jopt-simple/jopt-simple.yaml
+++ b/curations/sourcearchive/mavencentral/net.sf.jopt-simple/jopt-simple.yaml
@@ -4,6 +4,17 @@ coordinates:
   provider: mavencentral
   type: sourcearchive
 revisions:
+  '4.6':
+    described:
+      sourceLocation:
+        name: jopt-simple
+        namespace: jopt-simple
+        provider: github
+        revision: 60979e99102ad93a0e42d9f3a03ad29e1ec0f55c
+        type: git
+        url: 'https://github.com/jopt-simple/jopt-simple/commit/60979e99102ad93a0e42d9f3a03ad29e1ec0f55c'
+    licensed:
+      declared: MIT
   5.0.3:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jopt-simple 4.6

**Details:**
Missing source URL and declare license

**Resolution:**
Add source URL and declared license

**Affected definitions**:
- [jopt-simple 4.6](https://clearlydefined.io/definitions/sourcearchive/mavencentral/net.sf.jopt-simple/jopt-simple/4.6/4.6)