### PR TITLE
highcharts-react-official 2.0.0

### DIFF
--- a/curations/npm/npmjs/-/highcharts-react-official.yaml
+++ b/curations/npm/npmjs/-/highcharts-react-official.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  2.0.0:
+    licensed:
+      declared: MIT AND OTHER
   2.1.3:
     licensed:
       declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
highcharts-react-official 2.0.0

**Details:**
I think we've been doing MIT AND OTHER for these, where OTHER is for this "The software in Highcharts React repository is free and open source, 
but as highcharts-react relies on Highcharts.js, it requires a valid 
Highcharts license for commercial use."

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [highcharts-react-official 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-react-official/2.0.0/2.0.0)