### PR TITLE
Add source and declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/com.hierynomus/sshj.yaml
+++ b/curations/sourcearchive/mavencentral/com.hierynomus/sshj.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: sshj
+  namespace: com.hierynomus
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  0.27.0:
+    described:
+      sourceLocation:
+        name: sshj
+        namespace: hierynomus
+        provider: github
+        revision: 2f7b181306b076e262d566438ef6c145ade158e6
+        type: git
+        url: 'https://github.com/hierynomus/sshj/commit/2f7b181306b076e262d566438ef6c145ade158e6'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add source and declared license

**Details:**
The Source and declared license are missing. I'm hopeful that this change will kick the harvester to have another look.

**Resolution:**
Set the source and declared license fields.

**Affected definitions**:
- [sshj 0.27.0](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.hierynomus/sshj/0.27.0/0.27.0)