### PR TITLE
xlsx2csv 0.7.7

### DIFF
--- a/curations/pypi/pypi/-/xlsx2csv.yaml
+++ b/curations/pypi/pypi/-/xlsx2csv.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xlsx2csv
+  provider: pypi
+  type: pypi
+revisions:
+  0.7.7:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xlsx2csv 0.7.7

**Details:**
Inconsistent license info - LICENSE.txt is GPL-3.0, file header is GPL-2.0-or-later, and COPYING file is LGPL-2.0.  

**Resolution:**
Curating as GPL-2.0-or-later.

**Affected definitions**:
- [xlsx2csv 0.7.7](https://clearlydefined.io/definitions/pypi/pypi/-/xlsx2csv/0.7.7/0.7.7)