### PR TITLE
commons-math3 3.2

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.commons/commons-math3.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.commons/commons-math3.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: commons-math3
+  namespace: org.apache.commons
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '3.2':
+    described:
+      sourceLocation:
+        name: commons-math
+        namespace: apache
+        provider: github
+        revision: 7ec508828f62c2a3df31cde2a2f3aa32c5135fdb
+        type: git
+        url: 'https://github.com/apache/commons-math/commit/7ec508828f62c2a3df31cde2a2f3aa32c5135fdb'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-math3 3.2

**Details:**
Missing source URL and declared license

**Resolution:**
Add missing source URL and declared license

**Affected definitions**:
- [commons-math3 3.2](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.commons/commons-math3/3.2/3.2)