### PR TITLE
Microsoft.Extensions.DependencyModel	1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Extensions.DependencyModel.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Extensions.DependencyModel.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.3:
     licensed:
       declared: MIT
+  1.1.0:
+    licensed:
+      declared: MIT
   1.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Extensions.DependencyModel	1.1.0

**Details:**
No license information is available for this version, but later version is licensed under MIT

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Extensions.DependencyModel 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Extensions.DependencyModel/1.1.0/1.1.0)