### PR TITLE
YamlDotNet	4.1.0

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.1.0:
+    licensed:
+      declared: MIT
   4.3.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet	4.1.0

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [YamlDotNet 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet/4.1.0/4.1.0)