### PR TITLE
org.junit.platform:junit-platform-commons	1.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -7,3 +7,6 @@ revisions:
   1.4.2:
     licensed:
       declared: EPL-2.0
+  1.5.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform:junit-platform-commons	1.5.2

**Details:**
Harvested license file indicates license is EPL 2.0

**Resolution:**
License file in sources.jar also indicates license is EPL 2.0 

**Affected definitions**:
- [junit-platform-commons 1.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.5.2/1.5.2)