### PR TITLE
CsvHelper	2.11.0

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -9,6 +9,9 @@ revisions:
   12.2.1:
     licensed:
       declared: MS-PL OR Apache-2.0
+  2.11.0:
+    licensed:
+      declared: MS-PL OR Apache-2.0
   2.13.0:
     licensed:
       declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CsvHelper	2.11.0

**Details:**
License link on Nuget site indicates dual license under MS-PL and Apache 2.0

**Resolution:**
License file in repository also indicates dual license under MS-PL and Apache 2.0

**Affected definitions**:
- [CsvHelper 2.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/2.11.0/2.11.0)