### PR TITLE
Microsoft.OData.Core	7.3.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Core.yaml
@@ -9,6 +9,9 @@ revisions:
   7.2.0:
     licensed:
       declared: MIT
+  7.3.1:
+    licensed:
+      declared: MIT
   7.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.OData.Core	7.3.1

**Details:**
License link on Nuget site indicates license for code is MIT

**Resolution:**
License URL in Nuspec file also indicates license for code is MIT

**Affected definitions**:
- [Microsoft.OData.Core 7.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Core/7.3.1/7.3.1)