### PR TITLE
Microsoft.CrmSdk.Deployment	8.2.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.Deployment.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.Deployment.yaml
@@ -6,3 +6,6 @@ revisions:
   8.0.0:
     licensed:
       declared: OTHER
+  8.2.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.Deployment	8.2.0.2

**Details:**
License link on Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Resolution:**
License URL in Nuspec file also indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT DYNAMICS CRM 2015 SOFTWARE DEVELOPMENT KIT (SDK)
MICROSOFT DYNAMICS CRM ONLINE SOFTWARE DEVELOPMENT KIT (SDK) 


**Affected definitions**:
- [Microsoft.CrmSdk.Deployment 8.2.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.Deployment/8.2.0.2/8.2.0.2)