### PR TITLE
Shouldly	3.0.0

### DIFF
--- a/curations/nuget/nuget/-/Shouldly.yaml
+++ b/curations/nuget/nuget/-/Shouldly.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.0.0:
+    licensed:
+      declared: BSD-3-Clause
   3.0.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Shouldly	3.0.0

**Details:**
License file in repository indicates license is BSD 3

**Resolution:**
License link on Nuget site also indicates license is BSD 3

**Affected definitions**:
- [Shouldly 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Shouldly/3.0.0/3.0.0)