### PR TITLE
io.netty/netty-buffer

### DIFF
--- a/curations/maven/mavencentral/io.netty/netty-buffer.yaml
+++ b/curations/maven/mavencentral/io.netty/netty-buffer.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: netty-buffer
+  namespace: io.netty
+  provider: mavencentral
+  type: maven
+revisions:
+  4.1.52.Final:
+    described:
+      facets:
+        dev:
+          - buffer/**
+      releaseDate: '2020-09-08'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
io.netty/netty-buffer

**Details:**
Wrong release date

**Resolution:**
Fix release date and add source folder for netty-buffer library

**Affected definitions**:
- [netty-buffer 4.1.52.Final](https://clearlydefined.io/definitions/maven/mavencentral/io.netty/netty-buffer/4.1.52.Final/4.1.52.Final)