### PR TITLE
io.netty/netty-common

### DIFF
--- a/curations/sourcearchive/mavencentral/io.netty/netty-common.yaml
+++ b/curations/sourcearchive/mavencentral/io.netty/netty-common.yaml
@@ -1,0 +1,21 @@
+coordinates:
+  name: netty-common
+  namespace: io.netty
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  4.1.52.Final:
+    described:
+      facets:
+        dev:
+          - common/**
+      releaseDate: '2020-09-08'
+      sourceLocation:
+        name: netty
+        namespace: netty
+        provider: github
+        revision: ada9c38c0a96e593b895b93dd4600d5299e77cef
+        type: git
+        url: 'https://github.com/netty/netty/commit/ada9c38c0a96e593b895b93dd4600d5299e77cef'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
io.netty/netty-common

**Details:**
Missing source URL and declared license

**Resolution:**
Add missing source URL and declared license

**Affected definitions**:
- [netty-common 4.1.52.Final](https://clearlydefined.io/definitions/sourcearchive/mavencentral/io.netty/netty-common/4.1.52.Final/4.1.52.Final)