### PR TITLE
google/flogger 0.5.1

### DIFF
--- a/curations/maven/mavencentral/com.google.flogger/flogger.yaml
+++ b/curations/maven/mavencentral/com.google.flogger/flogger.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: flogger
+  namespace: com.google.flogger
+  provider: mavencentral
+  type: maven
+revisions:
+  0.5.1:
+    described:
+      sourceLocation:
+        name: flogger
+        namespace: google
+        provider: github
+        revision: 3b8f8087f1e0dc344e7a236b9a5ffc568021b96c
+        type: git
+        url: 'https://github.com/google/flogger/commit/3b8f8087f1e0dc344e7a236b9a5ffc568021b96c'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
google/flogger 0.5.1

**Details:**
Missing source URL

**Resolution:**
Add missing source URL

**Affected definitions**:
- [flogger 0.5.1](https://clearlydefined.io/definitions/maven/mavencentral/com.google.flogger/flogger/0.5.1/0.5.1)