### PR TITLE
MongoDB.Bson	2.10.4

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Bson.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Bson.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.10.4:
+    licensed:
+      declared: Apache-2.0
   2.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MongoDB.Bson	2.10.4

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [MongoDB.Bson 2.10.4](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Bson/2.10.4/2.10.4)