### PR TITLE
WindowsAzure.Storage	2.0.6

### DIFF
--- a/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.6:
+    licensed:
+      declared: OTHER
   2.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WindowsAzure.Storage	2.0.6

**Details:**
License link on Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT WINDOWS AZURE SOFTWARE DEVELOPMENT KIT, AND FOR
MICROSOFT WINDOWS AZURE LIBRARIES FOR .NET


**Resolution:**
 

**Affected definitions**:
- [WindowsAzure.Storage 2.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/WindowsAzure.Storage/2.0.6/2.0.6)