### PR TITLE
StyleCop.MSBuild	6.0.0-beta04

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.MSBuild.yaml
+++ b/curations/nuget/nuget/-/StyleCop.MSBuild.yaml
@@ -36,6 +36,9 @@ revisions:
   6.0.0:
     licensed:
       declared: MS-PL
+  6.0.0-beta04:
+    licensed:
+      declared: MS-PL
   6.1.0:
     files:
       - license: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StyleCop.MSBuild	6.0.0-beta04

**Details:**
License file in package indicates license is MS-PL

**Resolution:**
 

**Affected definitions**:
- [StyleCop.MSBuild 6.0.0-beta04](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.MSBuild/6.0.0-beta04/6.0.0-beta04)