### PR TITLE
azureml-dataset-runtime	1.12.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -6,3 +6,6 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.12.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime	1.12.0

**Details:**
License file in package indicates license is [your agreement][1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the [Microsoft Online Subscription Agreement][2]
(which incorporates the [Onlin

**Resolution:**
 

**Affected definitions**:
- [azureml-dataset-runtime 1.12.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.12.0/1.12.0)