### PR TITLE
Microsoft.Azure.DocumentDB/2.11.6

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -9,6 +9,9 @@ revisions:
   2.11.0:
     licensed:
       declared: MIT
+  2.11.6:
+    licensed:
+      declared: MIT
   2.9.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.DocumentDB/2.11.6

**Details:**
Package files indicate MIT, meta data confirms. 

**Resolution:**
https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/LICENSE

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.11.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.11.6/2.11.6)