### PR TITLE
NUnitTestAdapter/1.2.0

### DIFF
--- a/curations/nuget/nuget/-/NUnitTestAdapter.yaml
+++ b/curations/nuget/nuget/-/NUnitTestAdapter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NUnitTestAdapter
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NUnitTestAdapter/1.2.0

**Details:**
No info in package files. Meta data has a subsequent version with an MIT license, so curated as MIT. 

**Resolution:**
https://github.com/nunit/nunit-vs-adapter/blob/V2.1/LICENSE.txt

**Affected definitions**:
- [NUnitTestAdapter 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NUnitTestAdapter/1.2.0/1.2.0)