### PR TITLE
azureml-dataset-runtime/1.11.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.11.0.post1:
+    licensed:
+      declared: OTHER
   1.12.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime/1.11.0.post1

**Details:**
No info in package files. Meta data confirms proprietary license.Curated as Other.

**Resolution:**
https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-dataset-runtime 1.11.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.11.0.post1/1.11.0.post1)