### PR TITLE
Microsoft.CrmSdk.CoreAssemblies/9.0.2.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies.yaml
@@ -9,6 +9,9 @@ revisions:
   8.2.0.2:
     licensed:
       declared: OTHER
+  9.0.2.3:
+    licensed:
+      declared: OTHER
   9.0.2.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.CoreAssemblies/9.0.2.3

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.CrmSdk.CoreAssemblies/9.0.2.3

**Affected definitions**:
- [Microsoft.CrmSdk.CoreAssemblies 9.0.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.CoreAssemblies/9.0.2.3/9.0.2.3)