### PR TITLE
flatbuffers/1.11.0

### DIFF
--- a/curations/npm/npmjs/-/flatbuffers.yaml
+++ b/curations/npm/npmjs/-/flatbuffers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: flatbuffers
+  provider: npmjs
+  type: npm
+revisions:
+  1.11.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
flatbuffers/1.11.0

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/google/flatbuffers/blob/v1.11.0/LICENSE.txt

**Affected definitions**:
- [flatbuffers 1.11.0](https://clearlydefined.io/definitions/npm/npmjs/-/flatbuffers/1.11.0/1.11.0)