### PR TITLE
StyleCop/4.7.49

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.yaml
+++ b/curations/nuget/nuget/-/StyleCop.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   4.7.49:
     licensed:
-      declared: OTHER
+      declared: MS-PL
   5.0.0:
     licensed:
       declared: MS-PL

--- a/curations/nuget/nuget/-/StyleCop.yaml
+++ b/curations/nuget/nuget/-/StyleCop.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.7.49:
+    licensed:
+      declared: OTHER
   5.0.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StyleCop/4.7.49

**Details:**
No info in package files. Meta data points to proprietary license, but link doesn't work. Looks like source repo confirms. Curated as Other. 

**Resolution:**
https://github.com/StyleCop/StyleCop/blob/master/License.html

**Affected definitions**:
- [StyleCop 4.7.49](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop/4.7.49/4.7.49)