### PR TITLE
org.scala-lang/scalap/2.11.11

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scalap.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scalap.yaml
@@ -7,3 +7,6 @@ revisions:
   2.11.0:
     licensed:
       declared: BSD-3-Clause
+  2.11.11:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scalap/2.11.11

**Details:**
No info in package files. Meta data points to BSD 3 Clause, however, the link provided in the Pom file states that pacakges licensed after 2018 are under Apache 2.0. This package release date is in 2019. Curated as Apache 2.0. 

**Resolution:**
https://www.scala-lang.org/license/
https://repo1.maven.org/maven2/org/scala-lang/scalap/2.11.11/scalap-2.11.11.pom

**Affected definitions**:
- [scalap 2.11.11](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scalap/2.11.11/2.11.11)