### PR TITLE
azureml-automl-core/1.13.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -21,6 +21,9 @@ revisions:
   1.12.0:
     licensed:
       declared: OTHER
+  1.13.0:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core/1.13.0

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://github.com/Azure/MachineLearningNotebooks/blob/azureml-sdk-1.13.0/Licenses/sdk-license/LICENSE

**Affected definitions**:
- [azureml-automl-core 1.13.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.13.0/1.13.0)