### PR TITLE
azureml-train-automl-client/1.12.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -12,6 +12,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.12.0.post1:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client/1.12.0.post1

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://github.com/Azure/MachineLearningNotebooks/blob/azureml-sdk-1.12.0/Licenses/sdk-license/LICENSE

**Affected definitions**:
- [azureml-train-automl-client 1.12.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.12.0.post1/1.12.0.post1)