### PR TITLE
Microsoft.CrmSdk.CoreTools/9.0.0.7

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreTools.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreTools.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  9.0.0.7:
+    licensed:
+      declared: OTHER
   9.1.0.44:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.CoreTools/9.0.0.7

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools/9.0.0.7

**Affected definitions**:
- [Microsoft.CrmSdk.CoreTools 9.0.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.CoreTools/9.0.0.7/9.0.0.7)