### PR TITLE
Microsoft.Spatial/7.4.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Spatial.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Spatial.yaml
@@ -9,6 +9,9 @@ revisions:
   7.2.0:
     licensed:
       declared: MIT
+  7.4.1:
+    licensed:
+      declared: MIT
   7.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Spatial/7.4.1

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as MIT. 

**Resolution:**
https://raw.githubusercontent.com/OData/odata.net/master/LICENSE.txt

**Affected definitions**:
- [Microsoft.Spatial 7.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Spatial/7.4.1/7.4.1)