### PR TITLE
Sarif.Sdk/1.5.40

### DIFF
--- a/curations/nuget/nuget/-/Sarif.Sdk.yaml
+++ b/curations/nuget/nuget/-/Sarif.Sdk.yaml
@@ -6,6 +6,9 @@ revisions:
   1.4.34-beta:
     licensed:
       declared: MIT
+  1.5.40:
+    licensed:
+      declared: MIT
   2.0.0-csd.1.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Sarif.Sdk/1.5.40

**Details:**
No info in package files. Meta data confirms  MIT. 

**Resolution:**
https://github.com/Microsoft/sarif-sdk/blob/master/LICENSE

**Affected definitions**:
- [Sarif.Sdk 1.5.40](https://clearlydefined.io/definitions/nuget/nuget/-/Sarif.Sdk/1.5.40/1.5.40)