### PR TITLE
bcprov-jdk15on 1.66

### DIFF
--- a/curations/sourcearchive/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
+++ b/curations/sourcearchive/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: bcprov-jdk15on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '1.66':
+    described:
+      facets:
+        dev:
+          - prov/src/main/**
+        doc:
+          - docs/**
+        tests:
+          - prov/src/test/**
+      sourceLocation:
+        name: bc-java
+        namespace: bcgit
+        provider: github
+        revision: ed1c8899b1b5ce0ff26feda81708c21b011f9750
+        type: git
+        url: 'https://github.com/bcgit/bc-java/commit/ed1c8899b1b5ce0ff26feda81708c21b011f9750'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bcprov-jdk15on 1.66

**Details:**
missing source URL and declared license

**Resolution:**
Add missing source URL and declared license

**Affected definitions**:
- [bcprov-jdk15on 1.66](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.bouncycastle/bcprov-jdk15on/1.66/1.66)