### PR TITLE
bcpg-jdk15on 1.66

### DIFF
--- a/curations/sourcearchive/mavencentral/org.bouncycastle/bcpg-jdk15on.yaml
+++ b/curations/sourcearchive/mavencentral/org.bouncycastle/bcpg-jdk15on.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: bcpg-jdk15on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '1.66':
+    described:
+      facets:
+        dev:
+          - pg/src/main/**
+        doc:
+          - docs/**
+        tests:
+          - pg/src/test/**
+      sourceLocation:
+        name: bc-java
+        namespace: bcgit
+        provider: github
+        revision: ed1c8899b1b5ce0ff26feda81708c21b011f9750
+        type: git
+        url: 'https://github.com/bcgit/bc-java/commit/ed1c8899b1b5ce0ff26feda81708c21b011f9750'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bcpg-jdk15on 1.66

**Details:**
missing source url and declared license

**Resolution:**
add missing source url and declared license

**Affected definitions**:
- [bcpg-jdk15on 1.66](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.bouncycastle/bcpg-jdk15on/1.66/1.66)