### PR TITLE
httpcomponents-core 4.4.13

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents/httpcore.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents/httpcore.yaml
@@ -7,3 +7,6 @@ revisions:
   4.3.2:
     licensed:
       declared: Apache-2.0
+  4.4.13:
+    described:
+      releaseDate: '2020-01-13'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
httpcomponents-core 4.4.13

**Details:**
Wrong release date.

**Resolution:**
Fix it to the date given in https://github.com/apache/httpcomponents-core/releases/tag/rel%2Fv4.4.13

**Affected definitions**:
- [httpcore 4.4.13](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.httpcomponents/httpcore/4.4.13/4.4.13)