### PR TITLE
httpcomponents-client 5.0.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: httpclient5
+  namespace: org.apache.httpcomponents.client5
+  provider: mavencentral
+  type: maven
+revisions:
+  5.0.1:
+    described:
+      releaseDate: '2020-06-12'
+      sourceLocation:
+        name: httpcomponents-client
+        namespace: apache
+        provider: github
+        revision: 44e464ac200a15da3b6a73ddc39e48d12cdaf865
+        type: git
+        url: 'https://github.com/apache/httpcomponents-client/commit/44e464ac200a15da3b6a73ddc39e48d12cdaf865'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
httpcomponents-client 5.0.1

**Details:**
wrong source url and release date

**Resolution:**
Provide source url and release date given in https://github.com/apache/httpcomponents-client/releases/tag/rel%2Fv5.0.1

**Affected definitions**:
- [httpclient5 5.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.0.1/5.0.1)