### PR TITLE
javax.servlet/javax.servlet-api/3.0.1

### DIFF
--- a/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.0.1:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.0
   3.1.0:
     described:
       sourceLocation:

--- a/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/javax.servlet-api.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   3.0.1:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   3.1.0:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.servlet/javax.servlet-api/3.0.1

**Details:**
No info in package files. Maven Pom file confirms GPL 2.0 only or CDDL. 

**Resolution:**
https://repo1.maven.org/maven2/javax/servlet/javax.servlet-api/3.0.1/javax.servlet-api-3.0.1.pom

**Affected definitions**:
- [javax.servlet-api 3.0.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.servlet/javax.servlet-api/3.0.1/3.0.1)