### PR TITLE
Microsoft.Net.Compilers/2.3.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Net.Compilers.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Net.Compilers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Net.Compilers
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Net.Compilers/2.3.2

**Details:**
No info in package files. Meta data confirms a proprietary license. Curated as OTHER. 

**Resolution:**
https://www.microsoft.com/web/webpi/eula/dotnet_library_license_non_redistributable.htm

**Affected definitions**:
- [Microsoft.Net.Compilers 2.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Net.Compilers/2.3.2/2.3.2)