### PR TITLE
System.Data.SQLite.Core/1.0.102

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Data.SQLite.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.102:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.Core/1.0.102

**Details:**
No info in package files. No license aligning with SPDX list. Curated as Other. 

**Resolution:**
https://www.sqlite.org/copyright.html

**Affected definitions**:
- [System.Data.SQLite.Core 1.0.102](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Core/1.0.102/1.0.102)