### PR TITLE
Microsoft.NET.Sdk.Functions/1.0.37

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NET.Sdk.Functions.yaml
@@ -42,6 +42,9 @@ revisions:
   1.0.36:
     licensed:
       declared: MIT
+  1.0.37:
+    licensed:
+      declared: MIT
   1.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NET.Sdk.Functions/1.0.37

**Details:**
Package files point to MIT. Meta data confirms. 

**Resolution:**
https://github.com/Azure/azure-functions-vs-build-sdk/blob/1.0.36/LICENSE

**Affected definitions**:
- [Microsoft.NET.Sdk.Functions 1.0.37](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NET.Sdk.Functions/1.0.37/1.0.37)