### PR TITLE
Microsoft.Azure.AppConfiguration.AspNetCore/3.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
@@ -9,3 +9,6 @@ revisions:
   3.0.1:
     licensed:
       declared: OTHER
+  3.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.AppConfiguration.AspNetCore/3.0.2

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.Azure.AppConfiguration.AspNetCore/3.0.2

**Affected definitions**:
- [Microsoft.Azure.AppConfiguration.AspNetCore 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore/3.0.2/3.0.2)