### PR TITLE
System.Spatial/5.8.0

### DIFF
--- a/curations/nuget/nuget/-/System.Spatial.yaml
+++ b/curations/nuget/nuget/-/System.Spatial.yaml
@@ -6,6 +6,9 @@ revisions:
   5.6.4:
     licensed:
       declared: MIT
+  5.8.0:
+    licensed:
+      declared: MIT
   5.8.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Spatial/5.8.0

**Details:**
No info in package files. Meta data confirms MIT.  

**Resolution:**
https://raw.githubusercontent.com/OData/odata.net/master/LICENSE.txt

**Affected definitions**:
- [System.Spatial 5.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Spatial/5.8.0/5.8.0)