### PR TITLE
Microsoft.Data.Tools.UnitTest/10.0.60809

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.Tools.UnitTest.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.Tools.UnitTest.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Data.Tools.UnitTest
+  provider: nuget
+  type: nuget
+revisions:
+  10.0.60809:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Data.Tools.UnitTest/10.0.60809

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as Other. 

**Resolution:**
https://docs.microsoft.com/en-us/Legal/sql/sql-server-data-tools-license-terms?redirectedfrom=MSDN&view=sql-server-ver15

**Affected definitions**:
- [Microsoft.Data.Tools.UnitTest 10.0.60809](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.Tools.UnitTest/10.0.60809/10.0.60809)