### PR TITLE
Microsoft.Net.Compilers/2.3.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Net.Compilers.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Net.Compilers.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.3.0:
     licensed:
-      declared: Other
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.Net.Compilers.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Net.Compilers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Net.Compilers
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.0:
+    licensed:
+      declared: Other


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Net.Compilers/2.3.0

**Details:**
No info in package files. Meta data confirm proprietary license. Curated as Other. 

**Resolution:**
https://www.microsoft.com/web/webpi/eula/dotnet_library_license_non_redistributable.htm

**Affected definitions**:
- [Microsoft.Net.Compilers 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Net.Compilers/2.3.0/2.3.0)