### PR TITLE
osenv	0.0.3

### DIFF
--- a/curations/npm/npmjs/-/osenv.yaml
+++ b/curations/npm/npmjs/-/osenv.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.3:
+    licensed:
+      declared: BSD-2-Clause
   0.1.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
osenv	0.0.3

**Details:**
Harvested license file indicates license is BSD-2

**Resolution:**
License file in repository also indicates license is BSD-2

**Affected definitions**:
- [osenv 0.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/osenv/0.0.3/0.0.3)