### PR TITLE
Microsoft.AspNet.WebApi.Extensions.Compression.Server	2.0.6

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.WebApi.Extensions.Compression.Server.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.WebApi.Extensions.Compression.Server.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.WebApi.Extensions.Compression.Server
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNet.WebApi.Extensions.Compression.Server	2.0.6

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [Microsoft.AspNet.WebApi.Extensions.Compression.Server 2.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.WebApi.Extensions.Compression.Server/2.0.6/2.0.6)