### PR TITLE
EPPlus	4.5.2.1

### DIFF
--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -6,6 +6,9 @@ revisions:
   4.1.0:
     licensed:
       declared: LGPL-2.1-or-later
+  4.5.2.1:
+    licensed:
+      declared: LGPL-3.0-only
   5.1.0:
     licensed:
       declared: PolyForm-Noncommercial-1.0.0 OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EPPlus	4.5.2.1

**Details:**
License link on Nuget site indicates license is LGPL 3.0

**Resolution:**
License URL in Nuspec file also indicates license is LGPL 3.0

**Affected definitions**:
- [EPPlus 4.5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/EPPlus/4.5.2.1/4.5.2.1)