### PR TITLE
Microsoft.SqlServer.Types	11.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.SqlServer.Types.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.Types.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.SqlServer.Types
+  provider: nuget
+  type: nuget
+revisions:
+  11.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.SqlServer.Types	11.0.2

**Details:**
No license or repository information available for this version. License for next version is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT SYSTEM CLR TYPES FOR MICROSOFT SQL SERVER 2014


**Resolution:**
 

**Affected definitions**:
- [Microsoft.SqlServer.Types 11.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.SqlServer.Types/11.0.2/11.0.2)