### PR TITLE
opendp-whitenoise-core	0.1.3

### DIFF
--- a/curations/pypi/pypi/-/opendp-whitenoise-core.yaml
+++ b/curations/pypi/pypi/-/opendp-whitenoise-core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: opendp-whitenoise-core
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
opendp-whitenoise-core	0.1.3

**Details:**
License file in repository indicates license is MIT

**Resolution:**
 

**Affected definitions**:
- [opendp-whitenoise-core 0.1.3](https://clearlydefined.io/definitions/pypi/pypi/-/opendp-whitenoise-core/0.1.3/0.1.3)