### PR TITLE
azureml-train-automl-client	1.1.5

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.85:
     licensed:
       declared: OTHER
+  1.1.5:
+    licensed:
+      declared: OTHER
   1.10.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.1.5

**Details:**
License file in package indicates license is [1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the [Microsoft Online Subscription Agreement][2]
(which incorporates the [Online Services Terms

**Resolution:**
 

**Affected definitions**:
- [azureml-train-automl-client 1.1.5](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.1.5/1.1.5)