### PR TITLE
CsvHelper.Excel	1.0.5

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.Excel.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.Excel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CsvHelper.Excel
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CsvHelper.Excel	1.0.5

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [CsvHelper.Excel 1.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper.Excel/1.0.5/1.0.5)