### PR TITLE
Microsoft.AspNetCore.OData	7.2.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.OData.yaml
@@ -6,6 +6,9 @@ revisions:
   7.1.0:
     licensed:
       declared: MIT
+  7.2.1:
+    licensed:
+      declared: MIT
   7.2.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNetCore.OData	7.2.1

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
License URL in Nuspec file also indicates license is MIT

**Affected definitions**:
- [Microsoft.AspNetCore.OData 7.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.OData/7.2.1/7.2.1)