### PR TITLE
Elasticsearch.Net	6.6.0

### DIFF
--- a/curations/nuget/nuget/-/Elasticsearch.Net.yaml
+++ b/curations/nuget/nuget/-/Elasticsearch.Net.yaml
@@ -156,6 +156,9 @@ revisions:
   6.5.1:
     licensed:
       declared: Apache-2.0
+  6.6.0:
+    licensed:
+      declared: Apache-2.0
   6.8.6:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Elasticsearch.Net	6.6.0

**Details:**
Harvested license file indicates license is Apache 2.0

**Resolution:**
License file in repository also indicates license is Apache 2.0

**Affected definitions**:
- [Elasticsearch.Net 6.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Elasticsearch.Net/6.6.0/6.6.0)