### PR TITLE
ServerAppFabric.Client	1.1.2106.32

### DIFF
--- a/curations/nuget/nuget/-/ServerAppFabric.Client.yaml
+++ b/curations/nuget/nuget/-/ServerAppFabric.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ServerAppFabric.Client
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2106.32:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ServerAppFabric.Client	1.1.2106.32

**Details:**
License link on Nuget site indicates license is Microsoft Developer Agreement

**Resolution:**
License URL in Nuspec file also indicates license is Microsoft Developer Agreement

**Affected definitions**:
- [ServerAppFabric.Client 1.1.2106.32](https://clearlydefined.io/definitions/nuget/nuget/-/ServerAppFabric.Client/1.1.2106.32/1.1.2106.32)