### PR TITLE
org.antlr:antlr	3.4

### DIFF
--- a/curations/maven/mavencentral/org.antlr/antlr.yaml
+++ b/curations/maven/mavencentral/org.antlr/antlr.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: antlr
+  namespace: org.antlr
+  provider: mavencentral
+  type: maven
+revisions:
+  '3.4':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.antlr:antlr	3.4

**Details:**
Project site indicates license is BSD-3

**Resolution:**
License file in repository also indicates license is BSD-3

**Affected definitions**:
- [antlr 3.4](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/antlr/3.4/3.4)