### PR TITLE
xunit.core	2.0.0

### DIFF
--- a/curations/nuget/nuget/-/xunit.core.yaml
+++ b/curations/nuget/nuget/-/xunit.core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: Apache-2.0
   2.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.core	2.0.0

**Details:**
License link on Nuget site indicates license is Apache 2.0

**Resolution:**
License URL in Nuspec file also indicates license is Apache 2.0

**Affected definitions**:
- [xunit.core 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.core/2.0.0/2.0.0)