### PR TITLE
GreenPipes	2.1.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.HDInsight.Job.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.HDInsight.Job.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.Management.HDInsight.Job
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GreenPipes	2.1.4

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Azure.Management.HDInsight.Job 2.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Management.HDInsight.Job/2.0.5/2.0.5)