### PR TITLE
log4j:log4j	1.2.12

### DIFF
--- a/curations/maven/mavencentral/log4j/log4j.yaml
+++ b/curations/maven/mavencentral/log4j/log4j.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.2.12:
+    licensed:
+      declared: Apache-2.0
   1.2.17:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
log4j:log4j	1.2.12

**Details:**
Project site indicates license is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [log4j 1.2.12](https://clearlydefined.io/definitions/maven/mavencentral/log4j/log4j/1.2.12/1.2.12)