### PR TITLE
README states MIT

### DIFF
--- a/curations/npm/npmjs/-/url-parse.yaml
+++ b/curations/npm/npmjs/-/url-parse.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: url-parse
+  provider: npmjs
+  type: npm
+revisions:
+  1.4.6:
+    files:
+      - license: MIT
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
README states MIT

**Details:**
The license is incorrectly shown as NOASSERTION.

**Resolution:**
Change the license from NOASSERTION to MIT.

**Affected definitions**:
- [url-parse 1.4.6](https://clearlydefined.io/definitions/npm/npmjs/-/url-parse/1.4.6/1.4.6)