### PR TITLE
JetBrains.ReSharper.CommandLineTools	2020.2.2

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -27,3 +27,6 @@ revisions:
   2020.2.1:
     licensed:
       declared: OTHER
+  2020.2.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools	2020.2.2

**Details:**
License link on Nuget site indicates license is JETBRAINS USER AGREEMENT

**Resolution:**
License URL in Nuspec file also indicates license is JETBRAINS USER AGREEMENT

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2020.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2020.2.2/2020.2.2)