### PR TITLE
org.kohsuke:graphviz-api

### DIFF
--- a/curations/maven/mavencentral/org.kohsuke/graphviz-api.yaml
+++ b/curations/maven/mavencentral/org.kohsuke/graphviz-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: graphviz-api
+  namespace: org.kohsuke
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.kohsuke:graphviz-api

**Details:**
No license or repository information is available

**Resolution:**
 

**Affected definitions**:
- [graphviz-api 1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.kohsuke/graphviz-api/1.0/1.0)