### PR TITLE
AdaptiveExpressions	4.9.3

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveExpressions.yaml
+++ b/curations/nuget/nuget/-/AdaptiveExpressions.yaml
@@ -9,3 +9,6 @@ revisions:
   4.9.0:
     licensed:
       declared: MIT
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AdaptiveExpressions	4.9.3

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [AdaptiveExpressions 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveExpressions/4.9.3/4.9.3)