### PR TITLE
GreenPipes	2.1.4

### DIFF
--- a/curations/nuget/nuget/-/GreenPipes.yaml
+++ b/curations/nuget/nuget/-/GreenPipes.yaml
@@ -18,3 +18,6 @@ revisions:
   2.1.3:
     licensed:
       declared: Apache-2.0
+  2.1.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GreenPipes	2.1.4

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
License link on Nuget page also indicates license is Apache 2.0

**Affected definitions**:
- [GreenPipes 2.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/GreenPipes/2.1.4/2.1.4)