### PR TITLE
Microsoft.AspNetCore.Authentication.JwtBearer	1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.JwtBearer.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNetCore.Authentication.JwtBearer.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.0:
+    licensed:
+      declared: OTHER
   2.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.AspNetCore.Authentication.JwtBearer	1.1.0

**Details:**
No license information available for this version, but license for next version is an EULA

**Resolution:**
 

**Affected definitions**:
- [Microsoft.AspNetCore.Authentication.JwtBearer 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNetCore.Authentication.JwtBearer/1.1.0/1.1.0)