### PR TITLE
supervisor/supervisor 44eefd5846b6

### DIFF
--- a/curations/git/github/supervisor/supervisor.yaml
+++ b/curations/git/github/supervisor/supervisor.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: supervisor
+  namespace: supervisor
+  provider: github
+  type: git
+revisions:
+  44eefd5846b68fab4dc7ce57b9a30629d9aa5c4a:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
supervisor/supervisor 44eefd5846b6

**Details:**
This looks like a modified ZPL license, but it is not an exact match so curating as OTHER. 

**Resolution:**
Note:  The reference to http://www.repoze.org/LICENSE.txt on the Copyright file doesn't resolve to a live page.

**Affected definitions**:
- [supervisor 44eefd5846b68fab4dc7ce57b9a30629d9aa5c4a](https://clearlydefined.io/definitions/git/github/supervisor/supervisor/44eefd5846b68fab4dc7ce57b9a30629d9aa5c4a/44eefd5846b68fab4dc7ce57b9a30629d9aa5c4a)