### PR TITLE
License is MIT

### DIFF
--- a/curations/npm/npmjs/-/async-validator.yaml
+++ b/curations/npm/npmjs/-/async-validator.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: async-validator
+  provider: npmjs
+  type: npm
+revisions:
+  1.8.5:
+    files:
+      - license: MIT
+        path: package/package.json


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is MIT

**Details:**
The file expresses MIT licensing

**Resolution:**
Change discovered license from NOASSERTION to MIT.

**Affected definitions**:
- [async-validator 1.8.5](https://clearlydefined.io/definitions/npm/npmjs/-/async-validator/1.8.5/1.8.5)