### PR TITLE
@progress/kendo-ooxml/1.6.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-ooxml.yaml
+++ b/curations/npm/npmjs/@progress/kendo-ooxml.yaml
@@ -10,3 +10,6 @@ revisions:
   1.4.2:
     licensed:
       declared: OTHER
+  1.6.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@progress/kendo-ooxml/1.6.0

**Details:**
No info in package files. Meta data shows proprietary license. Curated as OTHER. 

**Resolution:**
https://www.npmjs.com/package/@progress/kendo-ooxml/v/1.6.0

**Affected definitions**:
- [kendo-ooxml 1.6.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-ooxml/1.6.0/1.6.0)