### PR TITLE
azureml-train-automl-client/1.13.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -18,6 +18,9 @@ revisions:
   1.12.0.post1:
     licensed:
       declared: OTHER
+  1.13.0:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client/1.13.0

**Details:**
No info in package files. Meta data point to proprietary license. Curated as OTHER. 

**Resolution:**
https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-train-automl-client 1.13.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.13.0/1.13.0)