### PR TITLE
azureml-train-automl-client/1.11.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -15,6 +15,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.12.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client/1.11.0

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.11.0


**Affected definitions**:
- [azureml-train-automl-client 1.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.11.0/1.11.0)