### PR TITLE
Microsoft.NETCore.DotNetHostPolicy/2.1.22

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.22:
+    licensed:
+      declared: MIT
   2.1.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETCore.DotNetHostPolicy/2.1.22

**Details:**
Package files point to MIT and meta data confirms. Curated as MIT. 

**Resolution:**
https://clearlydefined.io/file/ff26c8fb716d2381357faa7584901159f70cab3fce65fdc642794cafff3a554b

**Affected definitions**:
- [Microsoft.NETCore.DotNetHostPolicy 2.1.22](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.DotNetHostPolicy/2.1.22/2.1.22)