### PR TITLE
NUnitTestAdapter.WithFramework	1.1.0

### DIFF
--- a/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
+++ b/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.1.0:
     licensed:
-      declared: zlib-acknowledgement
+      declared: MIT AND zlib-acknowledgement
   2.0.0:
     licensed:
       declared: MIT AND zlib-acknowledgement

--- a/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
+++ b/curations/nuget/nuget/-/NUnitTestAdapter.WithFramework.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.0:
+    licensed:
+      declared: zlib-acknowledgement
   2.0.0:
     licensed:
       declared: MIT AND zlib-acknowledgement


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NUnitTestAdapter.WithFramework	1.1.0

**Details:**
Per this discussion, zlib-acknowledgement is the correct expression to use for NUnit.
spdx/license-list-XML#405
https://spdx.org/licenses/zlib-acknowledgement.html


**Resolution:**
 

**Affected definitions**:
- [NUnitTestAdapter.WithFramework 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/NUnitTestAdapter.WithFramework/1.1.0/1.1.0)