### PR TITLE
Microsoft.NETCore.App/2.1.22

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.App.yaml
@@ -24,6 +24,9 @@ revisions:
   2.1.2:
     licensed:
       declared: MIT
+  2.1.22:
+    licensed:
+      declared: MIT
   2.1.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETCore.App/2.1.22

**Details:**
Package files indicates MIT and meta data confirms. 

**Resolution:**
https://clearlydefined.io/file/ff26c8fb716d2381357faa7584901159f70cab3fce65fdc642794cafff3a554b

**Affected definitions**:
- [Microsoft.NETCore.App 2.1.22](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.App/2.1.22/2.1.22)