### PR TITLE
StyleCop.MSBuild	6.2.0

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.MSBuild.yaml
+++ b/curations/nuget/nuget/-/StyleCop.MSBuild.yaml
@@ -45,3 +45,6 @@ revisions:
         path: license.txt
     licensed:
       declared: MS-PL
+  6.2.0:
+    licensed:
+      declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StyleCop.MSBuild	6.2.0

**Details:**
Harvested license file indicates license is MS-PL

**Resolution:**
License link on Nuget page also indicates licenses is MS-PL

**Affected definitions**:
- [StyleCop.MSBuild 6.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.MSBuild/6.2.0/6.2.0)