### PR TITLE
Microsoft.Bot.Connector/4.9.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -30,3 +30,6 @@ revisions:
   4.9.3:
     licensed:
       declared: MIT
+  4.9.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector/4.9.4

**Details:**
Package files point to MIT and meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botbuilder-dotnet/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.9.4/4.9.4)