### PR TITLE
Microsoft.NETCore.DotNetHostResolver/2.1.22

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
+++ b/curations/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver.yaml
@@ -12,6 +12,9 @@ revisions:
   2.1.19:
     licensed:
       declared: MIT
+  2.1.22:
+    licensed:
+      declared: MIT
   2.1.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.NETCore.DotNetHostResolver/2.1.22

**Details:**
Package files points to MIT and meta data confirms MIT. 

**Resolution:**
https://clearlydefined.io/file/ff26c8fb716d2381357faa7584901159f70cab3fce65fdc642794cafff3a554b

https://github.com/dotnet/core-setup/blob/v2.1.22/LICENSE.TXT

**Affected definitions**:
- [Microsoft.NETCore.DotNetHostResolver 2.1.22](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.NETCore.DotNetHostResolver/2.1.22/2.1.22)