### PR TITLE
Microsoft.Azure.WebJobs.Logging.ApplicationInsights	3.0.18

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.0.18:
     licensed:
-      declared: MIT
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Logging.ApplicationInsights.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.WebJobs.Logging.ApplicationInsights
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.18:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.WebJobs.Logging.ApplicationInsights	3.0.18

**Details:**
License file in repository indicates license is MIT

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Azure.WebJobs.Logging.ApplicationInsights 3.0.18](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.WebJobs.Logging.ApplicationInsights/3.0.18/3.0.18)