### PR TITLE
Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -18,6 +18,9 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.2:
+    licensed:
+      declared: MIT
   4.9.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.2

**Details:**
Package files points to MIT, meta data confirms. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.2/4.9.2)