### PR TITLE
Microsoft.VisualStudio.Azure.Fabric.MSBuild	1.7.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild.yaml
@@ -12,3 +12,6 @@ revisions:
   1.7.0:
     licensed:
       declared: OTHER
+  1.7.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Azure.Fabric.MSBuild	1.7.1

**Details:**
License link on Nuget site indicates license is ## MICROSOFT SOFTWARE LICENSE TERMS
## MICROSOFT VISUAL STUDIO SERVICE FABRIC APPLICATION TOOLS TARGETS

**Resolution:**
 

**Affected definitions**:
- [Microsoft.VisualStudio.Azure.Fabric.MSBuild 1.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Azure.Fabric.MSBuild/1.7.1/1.7.1)