### PR TITLE
Microsoft.Bot.Builder/4.9.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -30,3 +30,6 @@ revisions:
   4.9.3:
     licensed:
       declared: MIT
+  4.9.4:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.yaml
@@ -32,4 +32,4 @@ revisions:
       declared: MIT
   4.9.4:
     licensed:
-      declared: OTHER
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder/4.9.4

**Details:**
Package files seem to point to MIT. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder/4.9.4/4.9.4)