### PR TITLE
Akka.Cluster/1.3.10

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Cluster
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster/1.3.10

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/akkadotnet/akka.net/blob/v1.3.10/LICENSE

**Affected definitions**:
- [Akka.Cluster 1.3.10](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster/1.3.10/1.3.10)