### PR TITLE
azureml-train-automl-client	1.11.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -15,6 +15,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.11.0.post1:
+    licensed:
+      declared: OTHER
   1.12.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client	1.11.0.post1

**Details:**
License file in package indicates license is [your agreement][1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the [Microsoft Online Subscription Agreement]

**Resolution:**
 

**Affected definitions**:
- [azureml-train-automl-client 1.11.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.11.0.post1/1.11.0.post1)