### PR TITLE
Microsoft.ApplicationInsights.Kubernetes/1.1.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Kubernetes.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Kubernetes.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ApplicationInsights.Kubernetes
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.Kubernetes/1.1.2

**Details:**
Package files point to MIT and meta data confirms. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.ApplicationInsights.Kubernetes/1.1.2/License

**Affected definitions**:
- [Microsoft.ApplicationInsights.Kubernetes 1.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.Kubernetes/1.1.2/1.1.2)