### PR TITLE
Microsoft.Bot.Builder.Dialogs	4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
@@ -9,3 +9,6 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.Dialogs	4.9.3

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Builder.Dialogs 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs/4.9.3/4.9.3)