### PR TITLE
prometheus-net/3.1.4

### DIFF
--- a/curations/nuget/nuget/-/prometheus-net.yaml
+++ b/curations/nuget/nuget/-/prometheus-net.yaml
@@ -18,3 +18,6 @@ revisions:
   3.1.2:
     licensed:
       declared: MIT
+  3.1.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
prometheus-net/3.1.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/prometheus-net/prometheus-net/master/LICENSE

**Affected definitions**:
- [prometheus-net 3.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/prometheus-net/3.1.4/3.1.4)