### PR TITLE
Microsoft.Bot.Streaming/4.9.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -21,3 +21,6 @@ revisions:
   4.9.3:
     licensed:
       declared: MIT
+  4.9.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Streaming/4.9.4

**Details:**
Package files point to MIT. Meta data confirms. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.9.4/4.9.4)