### PR TITLE
Microsoft.Azure.AppConfiguration.AspNetCore	4.0.0-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore.yaml
@@ -12,3 +12,6 @@ revisions:
   3.0.2:
     licensed:
       declared: OTHER
+  4.0.0-preview:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.AppConfiguration.AspNetCore	4.0.0-preview

**Details:**
License link on Nuget site indicates license is MICROSOFT PRE-RELEASE SOFTWARE LICENSE TERMS
MICROSOFT AZURE APP CONFIGURATION SOFTWARE

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Azure.AppConfiguration.AspNetCore 4.0.0-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.AppConfiguration.AspNetCore/4.0.0-preview/4.0.0-preview)