### PR TITLE
Bond.Compiler	8.2.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Compiler.yaml
+++ b/curations/nuget/nuget/-/Bond.Compiler.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Bond.Compiler
+  provider: nuget
+  type: nuget
+revisions:
+  8.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Compiler	8.2.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Bond.Compiler 8.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Compiler/8.2.0/8.2.0)