### PR TITLE
StackExchange.Redis/1.0.414

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.414:
+    licensed:
+      declared: MIT
   1.0.481:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis/1.0.414

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/StackExchange/StackExchange.Redis/blob/v2.1.39/LICENSE

**Affected definitions**:
- [StackExchange.Redis 1.0.414](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/1.0.414/1.0.414)