### PR TITLE
Scrutor/3.0.2

### DIFF
--- a/curations/nuget/nuget/-/Scrutor.yaml
+++ b/curations/nuget/nuget/-/Scrutor.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.1:
     licensed:
       declared: MIT
+  3.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Scrutor/3.0.2

**Details:**
No info in package files. MIT confirmed by meta data. 

**Resolution:**
https://raw.githubusercontent.com/khellang/Scrutor/master/LICENSE

**Affected definitions**:
- [Scrutor 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Scrutor/3.0.2/3.0.2)