### PR TITLE
NLog.Config/4.7.2

### DIFF
--- a/curations/nuget/nuget/-/NLog.Config.yaml
+++ b/curations/nuget/nuget/-/NLog.Config.yaml
@@ -117,3 +117,6 @@ revisions:
   4.6.2:
     licensed:
       declared: BSD-3-Clause
+  4.7.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Config/4.7.2

**Details:**
Package files is unclear. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/NLog/NLog/blob/v4.7.2/LICENSE.txt

**Affected definitions**:
- [NLog.Config 4.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Config/4.7.2/4.7.2)