### PR TITLE
Microsoft.CrmSdk.XrmTooling.PackageDeployment/9.0.0.4-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.PackageDeployment.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.PackageDeployment.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.CrmSdk.XrmTooling.PackageDeployment
+  provider: nuget
+  type: nuget
+revisions:
+  9.0.0.4-preview:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.XrmTooling.PackageDeployment/9.0.0.4-preview

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.CrmSdk.XrmTooling.PackageDeployment/9.0.0.4-preview

**Affected definitions**:
- [Microsoft.CrmSdk.XrmTooling.PackageDeployment 9.0.0.4-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.PackageDeployment/9.0.0.4-preview/9.0.0.4-preview)