### PR TITLE
org.ow2.asm/asm-analysis/6.0

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm-analysis.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm-analysis.yaml
@@ -12,6 +12,9 @@ revisions:
         path: META-INF/MANIFEST.MF
     licensed:
       declared: BSD-3-Clause
+  '6.0':
+    licensed:
+      declared: BSD-3-Clause
   '7.0':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.ow2.asm/asm-analysis/6.0

**Details:**
No info in package files. Pom file confirms BSD 3 Clause. 

**Resolution:**
https://repo1.maven.org/maven2/org/ow2/asm/asm-analysis/6.0/asm-analysis-6.0.pom

**Affected definitions**:
- [asm-analysis 6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm-analysis/6.0/6.0)