### PR TITLE
Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core.yaml
@@ -18,6 +18,9 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.1:
+    licensed:
+      declared: MIT
   4.9.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.1

**Details:**
Package files point to MIT and is confirmed by meta data. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.Integration.AspNet.Core 4.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Integration.AspNet.Core/4.9.1/4.9.1)