### PR TITLE
org.bouncycastle/bcprov-jdk15on/1.56

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk15on.yaml
@@ -10,6 +10,9 @@ revisions:
   '1.52':
     licensed:
       declared: MIT
+  '1.56':
+    licensed:
+      declared: MIT
   '1.60':
     licensed:
       declared: MIT
@@ -24,13 +27,13 @@ revisions:
   '1.64':
     licensed:
       declared: MIT
-  '1.65.01':
+  1.65.01:
     described:
       sourceLocation:
         name: bcprov-jdk15on
         namespace: org.bouncycastle
         provider: mavencentral
-        revision: '1.65.01'
+        revision: 1.65.01
         type: sourcearchive
         url: 'https://search.maven.org/remotecontent?filepath=org/bouncycastle/bcprov-jdk15on/1.65.01/bcprov-jdk15on-1.65.01-sources.jar'
     licensed:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle/bcprov-jdk15on/1.56

**Details:**
No info in package files. Pom file confirms MIT license via Bouncy Castle. 

**Resolution:**
http://www.bouncycastle.org/license.html

**Affected definitions**:
- [bcprov-jdk15on 1.56](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk15on/1.56/1.56)