### PR TITLE
Microsoft.CrmSdk.XrmTooling.CoreAssembly/9.1.0.49

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.CoreAssembly.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.CoreAssembly.yaml
@@ -6,3 +6,6 @@ revisions:
   8.2.0.5:
     licensed:
       declared: OTHER
+  9.1.0.49:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.XrmTooling.CoreAssembly/9.1.0.49

**Details:**
No info in package files. Meta data confirm proprietary license and curated as OTHER.  

**Resolution:**
https://docs.microsoft.com/en-us/dynamics365/legal/license-terms

**Affected definitions**:
- [Microsoft.CrmSdk.XrmTooling.CoreAssembly 9.1.0.49](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.XrmTooling.CoreAssembly/9.1.0.49/9.1.0.49)