### PR TITLE
Microsoft.Azure.DocumentDB/2.11.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -9,6 +9,9 @@ revisions:
   2.11.0:
     licensed:
       declared: MIT
+  2.11.4:
+    licensed:
+      declared: MIT
   2.11.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.DocumentDB/2.11.4

**Details:**
Package files point to MIT and meta data confirms. 

**Resolution:**
https://licenses.nuget.org/MIT

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.11.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.11.4/2.11.4)