### PR TITLE
Prism.Core/7.2.0.1367

### DIFF
--- a/curations/nuget/nuget/-/Prism.Core.yaml
+++ b/curations/nuget/nuget/-/Prism.Core.yaml
@@ -6,3 +6,6 @@ revisions:
   6.3.0:
     licensed:
       declared: Apache-2.0
+  7.2.0.1367:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Core/7.2.0.1367

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/PrismLibrary/Prism/blob/v7.2.0.1367/LICENSE

**Affected definitions**:
- [Prism.Core 7.2.0.1367](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Core/7.2.0.1367/7.2.0.1367)