### PR TITLE
Tx.Windows.TypeGeneration/1.0.40213

### DIFF
--- a/curations/nuget/nuget/-/Tx.Windows.TypeGeneration.yaml
+++ b/curations/nuget/nuget/-/Tx.Windows.TypeGeneration.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Tx.Windows.TypeGeneration
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.40213:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Tx.Windows.TypeGeneration/1.0.40213

**Details:**
No info in package files. Meta data's subsequent version has Apache 2.0, curated as Apache 2.0. 

**Resolution:**
https://github.com/microsoft/Tx/blob/v2.0.0/license.txt

**Affected definitions**:
- [Tx.Windows.TypeGeneration 1.0.40213](https://clearlydefined.io/definitions/nuget/nuget/-/Tx.Windows.TypeGeneration/1.0.40213/1.0.40213)