### PR TITLE
Xamarin.Nuget.Validator/1.1.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Nuget.Validator.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Nuget.Validator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Nuget.Validator
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Nuget.Validator/1.1.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/xamarin/XamarinComponents/blob/master/Util/NugetAuditor/LICENSE.md

**Affected definitions**:
- [Xamarin.Nuget.Validator 1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Nuget.Validator/1.1.1/1.1.1)