### PR TITLE
Microsoft.Build.CentralPackageVersions/2.0.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Build.CentralPackageVersions.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Build.CentralPackageVersions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Build.CentralPackageVersions
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Build.CentralPackageVersions/2.0.1

**Details:**
No info in package files. Meta data's subsequent version has MIT, Curated as MIT. 

**Resolution:**
https://github.com/microsoft/MSBuildSdks/blob/Microsoft.Build.CentralPackageVersions.2.0.26/LICENSE.txt

**Affected definitions**:
- [Microsoft.Build.CentralPackageVersions 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Build.CentralPackageVersions/2.0.1/2.0.1)