### PR TITLE
ZooKeeper.Net/3.4.6.2

### DIFF
--- a/curations/nuget/nuget/-/ZooKeeper.Net.yaml
+++ b/curations/nuget/nuget/-/ZooKeeper.Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ZooKeeper.Net
+  provider: nuget
+  type: nuget
+revisions:
+  3.4.6.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ZooKeeper.Net/3.4.6.2

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/ewhauser/zookeeper/blob/trunk/LICENSE.txt

**Affected definitions**:
- [ZooKeeper.Net 3.4.6.2](https://clearlydefined.io/definitions/nuget/nuget/-/ZooKeeper.Net/3.4.6.2/3.4.6.2)