### PR TITLE
CacheManager.SystemRuntimeCaching/1.1.0

### DIFF
--- a/curations/nuget/nuget/-/CacheManager.SystemRuntimeCaching.yaml
+++ b/curations/nuget/nuget/-/CacheManager.SystemRuntimeCaching.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CacheManager.SystemRuntimeCaching
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CacheManager.SystemRuntimeCaching/1.1.0

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/MichaCo/CacheManager/blob/1.1.0/LICENSE

**Affected definitions**:
- [CacheManager.SystemRuntimeCaching 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/CacheManager.SystemRuntimeCaching/1.1.0/1.1.0)