### PR TITLE
MongoDB.Bson/2.11.0

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Bson.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Bson.yaml
@@ -6,6 +6,9 @@ revisions:
   2.10.4:
     licensed:
       declared: Apache-2.0
+  2.11.0:
+    licensed:
+      declared: Apache-2.0
   2.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MongoDB.Bson/2.11.0

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://www.nuget.org/packages/MongoDB.Bson/2.11.0/License

**Affected definitions**:
- [MongoDB.Bson 2.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Bson/2.11.0/2.11.0)