### PR TITLE
Microsoft.PowerShell.CoreCLR.Eventing/6.2.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing.yaml
@@ -6,3 +6,6 @@ revisions:
   6.2.3:
     licensed:
       declared: MIT
+  6.2.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.CoreCLR.Eventing/6.2.4

**Details:**
No info in package files. Meta data confirm MIT. 

**Resolution:**
https://github.com/PowerShell/PowerShell/blob/v6.2.4/LICENSE.txt

**Affected definitions**:
- [Microsoft.PowerShell.CoreCLR.Eventing 6.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing/6.2.4/6.2.4)