### PR TITLE
Microsoft.Bot.Connector/4.9.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -24,6 +24,9 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.1:
+    licensed:
+      declared: MIT
   4.9.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector/4.9.1

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 4.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.9.1/4.9.1)