### PR TITLE
MongoDB.Driver/2.11.0

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Driver.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Driver.yaml
@@ -6,6 +6,9 @@ revisions:
   2.10.4:
     licensed:
       declared: Apache-2.0
+  2.11.0:
+    licensed:
+      declared: Apache-2.0
   2.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MongoDB.Driver/2.11.0

**Details:**
No info in package files. meta data confirm Apache 2.0. 

**Resolution:**
https://www.nuget.org/packages/MongoDB.Driver/2.11.0/License

**Affected definitions**:
- [MongoDB.Driver 2.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Driver/2.11.0/2.11.0)