### PR TITLE
System.IO.Abstractions/3.0.10

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -15,6 +15,9 @@ revisions:
   2.1.0.178:
     licensed:
       declared: MS-PL
+  3.0.10:
+    licensed:
+      declared: MIT
   6.0.14:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions/3.0.10

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v3.0.10/LICENSE

**Affected definitions**:
- [System.IO.Abstractions 3.0.10](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/3.0.10/3.0.10)