### PR TITLE
System.Interactive/3.2.0

### DIFF
--- a/curations/nuget/nuget/-/System.Interactive.yaml
+++ b/curations/nuget/nuget/-/System.Interactive.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: Apache-2.0
   3.2.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/System.Interactive.yaml
+++ b/curations/nuget/nuget/-/System.Interactive.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.0:
     licensed:
       declared: Apache-2.0
+  3.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Interactive/3.2.0

**Details:**
No info in package files. Meta data points to MIT. 

**Resolution:**
https://github.com/dotnet/reactive/blob/master/LICENSE

**Affected definitions**:
- [System.Interactive 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Interactive/3.2.0/3.2.0)