### PR TITLE
pysocks/1.7.1

### DIFF
--- a/curations/pypi/pypi/-/PySocks.yaml
+++ b/curations/pypi/pypi/-/PySocks.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PySocks
+  provider: pypi
+  type: pypi
+revisions:
+  1.7.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pysocks/1.7.1

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://github.com/Anorov/PySocks/blob/master/LICENSE

**Affected definitions**:
- [PySocks 1.7.1](https://clearlydefined.io/definitions/pypi/pypi/-/PySocks/1.7.1/1.7.1)