### PR TITLE
Microsoft.Bot.Connector/4.10.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -6,6 +6,9 @@ revisions:
   3.15.2.2:
     licensed:
       declared: MIT
+  4.10.2:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector/4.10.2

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.10/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 4.10.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.10.2/4.10.2)