### PR TITLE
Microsoft.Bot.Schema/4.10.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.10.2:
+    licensed:
+      declared: MIT
   4.4.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Schema/4.10.2

**Details:**
Package files point to MIT and meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.10/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Schema 4.10.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.10.2/4.10.2)