### PR TITLE
snakeyaml/1.15

### DIFF
--- a/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
+++ b/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: snakeyaml
+  namespace: org.yaml
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.15':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
snakeyaml/1.15

**Details:**
Pom file points to Apache 2.0. 

**Resolution:**
https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.15/snakeyaml-1.15.pom

**Affected definitions**:
- [snakeyaml 1.15](https://clearlydefined.io/definitions/maven/mavencentral/org.yaml/snakeyaml/1.15/1.15)