### PR TITLE
Microsoft.PowerApps.MSBuild.Pcf	1.3.6

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerApps.MSBuild.Pcf.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerApps.MSBuild.Pcf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerApps.MSBuild.Pcf
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.6:
+    licensed:
+      declared: NOASSERTION

--- a/curations/nuget/nuget/-/Microsoft.PowerApps.MSBuild.Pcf.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerApps.MSBuild.Pcf.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.3.6:
     licensed:
-      declared: NOASSERTION
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerApps.MSBuild.Pcf	1.3.6

**Details:**
License file in package indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT POWERAPPS CLI

**Resolution:**
 

**Affected definitions**:
- [Microsoft.PowerApps.MSBuild.Pcf 1.3.6](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerApps.MSBuild.Pcf/1.3.6/1.3.6)