### PR TITLE
Microsoft.Bot.Schema	4.9.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -30,3 +30,6 @@ revisions:
   4.9.3:
     licensed:
       declared: MIT
+  4.9.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Schema	4.9.4

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Schema 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.9.4/4.9.4)