### PR TITLE
Microsoft.Bot.Schema	4.9.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Schema.yaml
@@ -24,6 +24,9 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.1:
+    licensed:
+      declared: MIT
   4.9.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Schema	4.9.1

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Schema 4.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Schema/4.9.1/4.9.1)