### PR TITLE
Microsoft.VisualStudio.Utilities.Internal	14.0.79-master7f49a4e3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Utilities.Internal
+  provider: nuget
+  type: nuget
+revisions:
+  14.0.79-master7f49a4e3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Utilities.Internal	14.0.79-master7f49a4e3

**Details:**
License link on Nuget site indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT VISUAL STUDIO INTERNAL UTILITIES

**Resolution:**
License URL in Nuspec file also indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT VISUAL STUDIO INTERNAL UTILITIES

**Affected definitions**:
- [Microsoft.VisualStudio.Utilities.Internal 14.0.79-master7f49a4e3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal/14.0.79-master7f49a4e3/14.0.79-master7f49a4e3)