### PR TITLE
Microsoft.Azure.DocumentDB	2.11.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -9,6 +9,9 @@ revisions:
   2.11.0:
     licensed:
       declared: MIT
+  2.11.3:
+    licensed:
+      declared: MIT
   2.11.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.DocumentDB	2.11.3

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site also indicates license is MIT

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.11.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.11.3/2.11.3)