### PR TITLE
zlib.redist	1.2.8.7

### DIFF
--- a/curations/nuget/nuget/-/zlib.redist.yaml
+++ b/curations/nuget/nuget/-/zlib.redist.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: zlib.redist
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.8.7:
+    licensed:
+      declared: Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
zlib.redist	1.2.8.7

**Details:**
Readme file in repository indicates license is Zlib

**Resolution:**
 

**Affected definitions**:
- [zlib.redist 1.2.8.7](https://clearlydefined.io/definitions/nuget/nuget/-/zlib.redist/1.2.8.7/1.2.8.7)