### PR TITLE
Akka.Remote	1.3.15

### DIFF
--- a/curations/nuget/nuget/-/Akka.Remote.yaml
+++ b/curations/nuget/nuget/-/Akka.Remote.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Remote
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.15:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Remote	1.3.15

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [Akka.Remote 1.3.15](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Remote/1.3.15/1.3.15)