### PR TITLE
Akka.Cluster	1.3.15

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Cluster
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.15:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster	1.3.15

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [Akka.Cluster 1.3.15](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster/1.3.15/1.3.15)