### PR TITLE
Microsoft.ServiceHub.Framework	2.4.227

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ServiceHub.Framework.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ServiceHub.Framework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ServiceHub.Framework
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.227:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ServiceHub.Framework	2.4.227

**Details:**
License file in package indicates license is MICROSOFT SOFTWARE LICENSE TERMS
MICROSOFT VISUAL STUDIO ADD-ONs and EXTENSIONS

**Resolution:**
 

**Affected definitions**:
- [Microsoft.ServiceHub.Framework 2.4.227](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ServiceHub.Framework/2.4.227/2.4.227)