### PR TITLE
Grpc.Tools	1.12.0

### DIFF
--- a/curations/nuget/nuget/-/Grpc.Tools.yaml
+++ b/curations/nuget/nuget/-/Grpc.Tools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Grpc.Tools
+  provider: nuget
+  type: nuget
+revisions:
+  1.12.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Grpc.Tools	1.12.0

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
License link on Nuget site also indicates license is Apache 2.0

**Affected definitions**:
- [Grpc.Tools 1.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Grpc.Tools/1.12.0/1.12.0)