### PR TITLE
Microsoft.ML/1.5.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ML.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ML.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ML
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ML/1.5.1

**Details:**
Package files point to MIT and meta data confirms. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.ML/1.5.1/License

**Affected definitions**:
- [Microsoft.ML 1.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ML/1.5.1/1.5.1)