### PR TITLE
Microsoft.Bot.Streaming/4.9.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -15,6 +15,9 @@ revisions:
   4.8.0:
     licensed:
       declared: MIT
+  4.9.1:
+    licensed:
+      declared: MIT
   4.9.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Streaming/4.9.1

**Details:**
Package files points to MIT. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.9.1/4.9.1)