### PR TITLE
murmurhash-signed/1.0.1

### DIFF
--- a/curations/nuget/nuget/-/murmurhash-signed.yaml
+++ b/curations/nuget/nuget/-/murmurhash-signed.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0:
     licensed:
       declared: Apache-2.0
+  1.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
murmurhash-signed/1.0.1

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/darrenkopp/murmurhash-net/blob/master/LICENSE.md

**Affected definitions**:
- [murmurhash-signed 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/murmurhash-signed/1.0.1/1.0.1)