### PR TITLE
javax.el/3.0.0

### DIFF
--- a/curations/maven/mavencentral/org.glassfish/javax.el.yaml
+++ b/curations/maven/mavencentral/org.glassfish/javax.el.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.0.0:
+    licensed:
+      declared: GPL-2.0-only OR CDDL-1.1
   3.0.1-b08:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception

--- a/curations/maven/mavencentral/org.glassfish/javax.el.yaml
+++ b/curations/maven/mavencentral/org.glassfish/javax.el.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: GPL-2.0-only OR CDDL-1.1
   3.0.1-b08:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.el/3.0.0

**Details:**
No info in package files. Pom file confirms GPL 2.0 or CDDL 1.1. 

**Resolution:**
https://repo1.maven.org/maven2/javax/el/javax.el-api/3.0.0/javax.el-api-3.0.0.pom

**Affected definitions**:
- [javax.el 3.0.0](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish/javax.el/3.0.0/3.0.0)