### PR TITLE
Microsoft.Bot.Builder.LanguageGeneration/4.9.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.LanguageGeneration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.LanguageGeneration.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Bot.Builder.LanguageGeneration
+  provider: nuget
+  type: nuget
+revisions:
+  4.9.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.LanguageGeneration/4.9.3

**Details:**
Package files point to MIT and meta data confirms. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.9/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Builder.LanguageGeneration 4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.LanguageGeneration/4.9.3/4.9.3)