### PR TITLE
MSBuildTasks/1.4.0.78

### DIFF
--- a/curations/nuget/nuget/-/MSBuildTasks.yaml
+++ b/curations/nuget/nuget/-/MSBuildTasks.yaml
@@ -6,6 +6,9 @@ revisions:
   1.4.0.128:
     licensed:
       declared: BSD-2-Clause
+  1.4.0.78:
+    licensed:
+      declared: BSD-2-Clause
   1.4.0.88:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSBuildTasks/1.4.0.78

**Details:**
No info in package files. Meta data confirms BSD 2 Clause. 

**Resolution:**
https://opensource.org/licenses/bsd-license.php

**Affected definitions**:
- [MSBuildTasks 1.4.0.78](https://clearlydefined.io/definitions/nuget/nuget/-/MSBuildTasks/1.4.0.78/1.4.0.78)