### PR TITLE
Microsoft.Bot.Configuration/4.10.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Configuration.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.10.3:
+    licensed:
+      declared: MIT
   4.5.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Configuration/4.10.3

**Details:**
No info in package files. Meta data confirm MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.10/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Configuration 4.10.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Configuration/4.10.3/4.10.3)