### PR TITLE
org.hsqldb/hsqldb/2.3.4

### DIFF
--- a/curations/maven/mavencentral/org.hsqldb/hsqldb.yaml
+++ b/curations/maven/mavencentral/org.hsqldb/hsqldb.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.3.4:
     licensed:
-      declared: OTHER
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/org.hsqldb/hsqldb.yaml
+++ b/curations/maven/mavencentral/org.hsqldb/hsqldb.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hsqldb
+  namespace: org.hsqldb
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.hsqldb/hsqldb/2.3.4

**Details:**
No info in package files. Pom file points to HyperSQL license, which it says is based on BSD License. However, curated at OTHER. 

**Resolution:**
http://hsqldb.org/web/hsqlLicense.html

**Affected definitions**:
- [hsqldb 2.3.4](https://clearlydefined.io/definitions/maven/mavencentral/org.hsqldb/hsqldb/2.3.4/2.3.4)