### PR TITLE
engine.io-pure/1.5.9

### DIFF
--- a/curations/npm/npmjs/-/engine.io-pure.yaml
+++ b/curations/npm/npmjs/-/engine.io-pure.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: engine.io-pure
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
engine.io-pure/1.5.9

**Details:**
No info in package files. Subsequent version has MIT license, curated as MIT. 

**Resolution:**
https://github.com/socketio/engine.io/blob/1.6.0/LICENSE

**Affected definitions**:
- [engine.io-pure 1.5.9](https://clearlydefined.io/definitions/npm/npmjs/-/engine.io-pure/1.5.9/1.5.9)