### PR TITLE
org.bouncycastle/bcprov-jdk16/1.46

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk16.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk16.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: bcprov-jdk16
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.46':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle/bcprov-jdk16/1.46

**Details:**
No info in package files. Pom file points to  Bouncy Castle, which curates as MIT. 

**Resolution:**
http://www.bouncycastle.org/license.html

**Affected definitions**:
- [bcprov-jdk16 1.46](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk16/1.46/1.46)