### PR TITLE
Microsoft.PowerShell.ConsoleHost/7.0.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.ConsoleHost.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.ConsoleHost.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.ConsoleHost
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.ConsoleHost/7.0.3

**Details:**
Package files points to MIT and meta data confirms. 

**Resolution:**
https://github.com/PowerShell/PowerShell/blob/v7.0.3/LICENSE.txt

**Affected definitions**:
- [Microsoft.PowerShell.ConsoleHost 7.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.ConsoleHost/7.0.3/7.0.3)