### PR TITLE
GitInfo/2.0.11

### DIFF
--- a/curations/nuget/nuget/-/GitInfo.yaml
+++ b/curations/nuget/nuget/-/GitInfo.yaml
@@ -15,9 +15,12 @@ revisions:
   2.0.10:
     licensed:
       declared: MIT
+  2.0.11:
+    licensed:
+      declared: MIT
   2.0.17:
     licensed:
-      declared: MIT 
+      declared: MIT
   2.0.20:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GitInfo/2.0.11

**Details:**
No info in package files. Meta data confirms  MIT. 

**Resolution:**
https://github.com/kzu/GitInfo/blob/master/LICENSE

**Affected definitions**:
- [GitInfo 2.0.11](https://clearlydefined.io/definitions/nuget/nuget/-/GitInfo/2.0.11/2.0.11)