### PR TITLE
jts/1.13

### DIFF
--- a/curations/maven/mavencentral/com.vividsolutions/jts.yaml
+++ b/curations/maven/mavencentral/com.vividsolutions/jts.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jts
+  namespace: com.vividsolutions
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.13':
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jts/1.13

**Details:**
No info in package files. Pom file confirms LGPL 3.0. 

**Resolution:**
http://www.gnu.org/copyleft/lesser.txt

**Affected definitions**:
- [jts 1.13](https://clearlydefined.io/definitions/maven/mavencentral/com.vividsolutions/jts/1.13/1.13)