### PR TITLE
Microsoft.Bot.Connector/3.12.2.4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.12.2.4:
+    licensed:
+      declared: MIT
   3.15.2.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector/3.12.2.4

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/botbuilder%403.12.2/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 3.12.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/3.12.2.4/3.12.2.4)