### PR TITLE
CacheManager.Core/1.1.2

### DIFF
--- a/curations/nuget/nuget/-/CacheManager.Core.yaml
+++ b/curations/nuget/nuget/-/CacheManager.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CacheManager.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CacheManager.Core/1.1.2

**Details:**
No info in package files. Meta data confirms Apache 2.0.

**Resolution:**
https://github.com/MichaCo/CacheManager/blob/1.1.2/LICENSE

**Affected definitions**:
- [CacheManager.Core 1.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/CacheManager.Core/1.1.2/1.1.2)