### PR TITLE
System.IO.Abstractions.TestingHelpers/2.1.0.178

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.0.176:
     licensed:
       declared: MS-PL
+  2.1.0.178:
+    licensed:
+      declared: MIT
   7.0.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions.TestingHelpers/2.1.0.178

**Details:**
No info in package files. Meta data confirms MIT on subsequent version. 

**Resolution:**
https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v2.2.10-beta/LICENSE

**Affected definitions**:
- [System.IO.Abstractions.TestingHelpers 2.1.0.178](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions.TestingHelpers/2.1.0.178/2.1.0.178)