### PR TITLE
Microsoft.Management.Infrastructure.CimCmdlets/7.0.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Management.Infrastructure.CimCmdlets.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Management.Infrastructure.CimCmdlets.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Management.Infrastructure.CimCmdlets
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Management.Infrastructure.CimCmdlets/7.0.3

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/PowerShell/PowerShell/blob/v7.0.3/LICENSE.txt

**Affected definitions**:
- [Microsoft.Management.Infrastructure.CimCmdlets 7.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Management.Infrastructure.CimCmdlets/7.0.3/7.0.3)