### PR TITLE
jsonlint/1.6.0

### DIFF
--- a/curations/npm/npmjs/-/jsonlint.yaml
+++ b/curations/npm/npmjs/-/jsonlint.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.6.0:
+    licensed:
+      declared: MIT
   1.6.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsonlint/1.6.0

**Details:**
No info in package files. Meta data confirms MIT in ReadMe. 

**Resolution:**
https://github.com/zaach/jsonlint/blob/v1.6.0/README.md

**Affected definitions**:
- [jsonlint 1.6.0](https://clearlydefined.io/definitions/npm/npmjs/-/jsonlint/1.6.0/1.6.0)