### PR TITLE
Microsoft.VisualStudio.Telemetry/15.8.956

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Telemetry
+  provider: nuget
+  type: nuget
+revisions:
+  15.8.956:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Telemetry/15.8.956

**Details:**
No info in package files. Subsequent version confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://visualstudio.microsoft.com/license-terms/mt736442/

**Affected definitions**:
- [Microsoft.VisualStudio.Telemetry 15.8.956](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Telemetry/15.8.956/15.8.956)