### PR TITLE
Confluent.Kafka/1.2.1

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -47,7 +47,7 @@ revisions:
       declared: Apache-2.0 AND BSD-2-Clause
   1.2.1:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 AND BSD-2-Clause
   1.2.2:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause

--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -45,6 +45,9 @@ revisions:
   1.1.0:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause
+  1.2.1:
+    licensed:
+      declared: Apache-2.0
   1.2.2:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Confluent.Kafka/1.2.1

**Details:**
No info in package files. Meta data confirms Apache 2.0. 

**Resolution:**
https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.2.1/LICENSE

**Affected definitions**:
- [Confluent.Kafka 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.2.1/1.2.1)