### PR TITLE
Microsoft.CrmSdk.CoreTools/9.0.0.4-preview

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreTools.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CrmSdk.CoreTools.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  9.0.0.4-preview:
+    licensed:
+      declared: OTHER
   9.0.0.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CrmSdk.CoreTools/9.0.0.4-preview

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.CrmSdk.CoreTools/9.0.0.4-preview

**Affected definitions**:
- [Microsoft.CrmSdk.CoreTools 9.0.0.4-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CrmSdk.CoreTools/9.0.0.4-preview/9.0.0.4-preview)