### PR TITLE
Microsoft.PowerShell.Commands.Management/7.0.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.Commands.Management.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.Commands.Management.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.Commands.Management
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.Commands.Management/7.0.3

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/PowerShell/PowerShell/blob/v7.0.3/LICENSE.txt

**Affected definitions**:
- [Microsoft.PowerShell.Commands.Management 7.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.Commands.Management/7.0.3/7.0.3)