### PR TITLE
Microsoft.Bot.Connector/4.10.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -9,6 +9,9 @@ revisions:
   4.10.2:
     licensed:
       declared: MIT
+  4.10.3:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector/4.10.3

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/4.10/LICENSE

**Affected definitions**:
- [Microsoft.Bot.Connector 4.10.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.10.3/4.10.3)