### PR TITLE
org.mockito/mockito-all/1.10.8

### DIFF
--- a/curations/maven/mavencentral/org.mockito/mockito-all.yaml
+++ b/curations/maven/mavencentral/org.mockito/mockito-all.yaml
@@ -7,3 +7,6 @@ revisions:
   1.10.19:
     licensed:
       declared: MIT
+  1.10.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.mockito/mockito-all/1.10.8

**Details:**
Package files point to MIT. Meta data confirms MIT. 

**Resolution:**
https://github.com/mockito/mockito/blob/release/3.x/LICENSE

https://clearlydefined.io/file/fc37ea05c14706d13ec54d477a5c8c456aec1a5393779c683404b0151d04d7d7

**Affected definitions**:
- [mockito-all 1.10.8](https://clearlydefined.io/definitions/maven/mavencentral/org.mockito/mockito-all/1.10.8/1.10.8)