### PR TITLE
multipledispatch/0.6.0

### DIFF
--- a/curations/pypi/pypi/-/multipledispatch.yaml
+++ b/curations/pypi/pypi/-/multipledispatch.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: multipledispatch
+  provider: pypi
+  type: pypi
+revisions:
+  0.6.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
multipledispatch/0.6.0

**Details:**
No info in package files. Meta data confirm BSD 3 Clause. 

**Resolution:**
https://github.com/mrocklin/multipledispatch/blob/0.6.0/LICENSE.txt

**Affected definitions**:
- [multipledispatch 0.6.0](https://clearlydefined.io/definitions/pypi/pypi/-/multipledispatch/0.6.0/0.6.0)