### PR TITLE
CommandLineParser20/2.0.0

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser20.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser20.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CommandLineParser20
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommandLineParser20/2.0.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://raw.githubusercontent.com/cosmo0/commandline/master/doc/LICENSE

**Affected definitions**:
- [CommandLineParser20 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser20/2.0.0/2.0.0)