### PR TITLE
Microsoft.VisualStudio.Text.Data/16.6.255

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Text.Data.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Text.Data.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Text.Data
+  provider: nuget
+  type: nuget
+revisions:
+  16.6.255:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.VisualStudio.Text.Data/16.6.255

**Details:**
No info in package files. Meta data confirms proprietary license. Curated as OTHER. 

**Resolution:**
https://www.nuget.org/packages/Microsoft.VisualStudio.Text.Data/16.6.255/License

**Affected definitions**:
- [Microsoft.VisualStudio.Text.Data 16.6.255](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Text.Data/16.6.255/16.6.255)