### PR TITLE
Hl7.Fhir.ElementModel/1.7.0

### DIFF
--- a/curations/nuget/nuget/-/Hl7.Fhir.ElementModel.yaml
+++ b/curations/nuget/nuget/-/Hl7.Fhir.ElementModel.yaml
@@ -14,3 +14,6 @@ revisions:
         url: 'https://github.com/firelyteam/fhir-net-api/commit/5dd79b45f272822e2030e330a46425ed5452e374'
     licensed:
       declared: BSD-3-Clause
+  1.7.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Hl7.Fhir.ElementModel/1.7.0

**Details:**
No info in package files. Meta data confirms BSD 3 Clause. 

**Resolution:**
https://www.nuget.org/packages/Hl7.Fhir.ElementModel/1.7.0/License

**Affected definitions**:
- [Hl7.Fhir.ElementModel 1.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Hl7.Fhir.ElementModel/1.7.0/1.7.0)