### PR TITLE
Sprache/2.1.0

### DIFF
--- a/curations/nuget/nuget/-/Sprache.yaml
+++ b/curations/nuget/nuget/-/Sprache.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.0.35:
     licensed:
       declared: MIT
+  2.1.0:
+    licensed:
+      declared: MIT
   2.3.0:
     licensed:
-      declared: MIT  
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Sprache/2.1.0

**Details:**
No info in package files. Meta data confirms MIT. 

**Resolution:**
https://github.com/sprache/Sprache/blob/master/licence.txt

**Affected definitions**:
- [Sprache 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Sprache/2.1.0/2.1.0)