### PR TITLE
ServiceStack.Text/5.9.0

### DIFF
--- a/curations/nuget/nuget/-/ServiceStack.Text.yaml
+++ b/curations/nuget/nuget/-/ServiceStack.Text.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ServiceStack.Text
+  provider: nuget
+  type: nuget
+revisions:
+  5.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ServiceStack.Text/5.9.0

**Details:**
Package files points to proprietary license and meta data confirms. Curated as OTHER.

**Resolution:**
https://servicestack.net/terms

**Affected definitions**:
- [ServiceStack.Text 5.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/ServiceStack.Text/5.9.0/5.9.0)