### PR TITLE
Bogus/29.0.2

### DIFF
--- a/curations/nuget/nuget/-/Bogus.yaml
+++ b/curations/nuget/nuget/-/Bogus.yaml
@@ -6,6 +6,9 @@ revisions:
   22.0.8:
     licensed:
       declared: MIT
+  29.0.2:
+    licensed:
+      declared: MIT AND BSD-3-Clause
   30.0.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Bogus.yaml
+++ b/curations/nuget/nuget/-/Bogus.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: MIT
   29.0.2:
     licensed:
-      declared: MIT AND BSD-3-Clause
+      declared: MIT 
   30.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bogus/29.0.2

**Details:**
Meta data points to both MIT and BSD 3 Clause. 

**Resolution:**
https://raw.githubusercontent.com/bchavez/Bogus/master/LICENSE

**Affected definitions**:
- [Bogus 29.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Bogus/29.0.2/29.0.2)