### PR TITLE
zlib_native.redist/1.2.11

### DIFF
--- a/curations/nuget/nuget/-/zlib_native.redist.yaml
+++ b/curations/nuget/nuget/-/zlib_native.redist.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: zlib_native.redist
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.11:
+    licensed:
+      declared: Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
zlib_native.redist/1.2.11

**Details:**
No info in package files. Meta data confirms zlib. 

**Resolution:**
https://zlib.net/zlib_license.html

**Affected definitions**:
- [zlib_native.redist 1.2.11](https://clearlydefined.io/definitions/nuget/nuget/-/zlib_native.redist/1.2.11/1.2.11)