### PR TITLE
Microsoft.ApplicationInsights.Profiler.Core/2.0.0-beta4

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Profiler.Core.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ApplicationInsights.Profiler.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.ApplicationInsights.Profiler.Core
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0-beta4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.ApplicationInsights.Profiler.Core/2.0.0-beta4

**Details:**
Package files points to proprietary license. Meta data confirmed. Curated as OTHER. 

**Resolution:**
https://github.com/Microsoft/ApplicationInsights-Profiler-AspNetCore/blob/master/EULA-prerelease.md

**Affected definitions**:
- [Microsoft.ApplicationInsights.Profiler.Core 2.0.0-beta4](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ApplicationInsights.Profiler.Core/2.0.0-beta4/2.0.0-beta4)