### PR TITLE
Hyperion	0.9.8

### DIFF
--- a/curations/nuget/nuget/-/Hyperion.yaml
+++ b/curations/nuget/nuget/-/Hyperion.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Hyperion
+  provider: nuget
+  type: nuget
+revisions:
+  0.9.8:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Hyperion	0.9.8

**Details:**
License file in repository indicates license is Apache 2.0

**Resolution:**
License link on Nuget site indicates license is Apache 2.0

**Affected definitions**:
- [Hyperion 0.9.8](https://clearlydefined.io/definitions/nuget/nuget/-/Hyperion/0.9.8/0.9.8)