### PR TITLE
SimpleInjector.Integration.WebApi	3.3.1

### DIFF
--- a/curations/nuget/nuget/-/SimpleInjector.Integration.WebApi.yaml
+++ b/curations/nuget/nuget/-/SimpleInjector.Integration.WebApi.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.3.1:
+    licensed:
+      declared: MIT
   4.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SimpleInjector.Integration.WebApi	3.3.1

**Details:**
License link on Nuget site indicates license is MIT

**Resolution:**
Project site indicates license is MIT

**Affected definitions**:
- [SimpleInjector.Integration.WebApi 3.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/SimpleInjector.Integration.WebApi/3.3.1/3.3.1)