### PR TITLE
Microsoft.Diagnostics.Tracing.TraceEvent	2.0.58

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent.yaml
@@ -65,3 +65,6 @@ revisions:
         url: 'https://github.com/microsoft/perfview/commit/3c80832b1d71cae317ea1de45b043bd826eb99a5'
     licensed:
       declared: MIT
+  2.0.58:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Diagnostics.Tracing.TraceEvent	2.0.58

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site indicates license is MIT

**Affected definitions**:
- [Microsoft.Diagnostics.Tracing.TraceEvent 2.0.58](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Diagnostics.Tracing.TraceEvent/2.0.58/2.0.58)