### PR TITLE
xunit	1.9.1

### DIFF
--- a/curations/nuget/nuget/-/xunit.yaml
+++ b/curations/nuget/nuget/-/xunit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.9.1:
+    licensed:
+      declared: Apache-2.0
   1.9.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit	1.9.1

**Details:**
License information is not available for this version, but license file in repository indicates license for later versions is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [xunit 1.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/xunit/1.9.1/1.9.1)