### PR TITLE
SonarAnalyzer.CSharp	8.9.0.19135

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -15,3 +15,6 @@ revisions:
   8.4.0.15306:
     licensed:
       declared: LGPL-3.0-or-later
+  8.9.0.19135:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SonarAnalyzer.CSharp	8.9.0.19135

**Details:**
Harvested license file indicates license is LGPL 3.0 only

**Resolution:**
License file in repository also indicates license is LGPL 3.0 only

**Affected definitions**:
- [SonarAnalyzer.CSharp 8.9.0.19135](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/8.9.0.19135/8.9.0.19135)