### PR TITLE
Microsoft.PowerShell.Commands.Diagnostics	7.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.Commands.Diagnostics.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.Commands.Diagnostics.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  7.0.2:
+    licensed:
+      declared: MIT
   7.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.Commands.Diagnostics	7.0.2

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.PowerShell.Commands.Diagnostics 7.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.Commands.Diagnostics/7.0.2/7.0.2)