### PR TITLE
Microsoft.PowerShell.MarkdownRender	7.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.MarkdownRender.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.MarkdownRender.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.MarkdownRender
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.MarkdownRender	7.0.2

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.PowerShell.MarkdownRender 7.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.MarkdownRender/7.0.2/7.0.2)