### PR TITLE
Microsoft.Bot.Streaming	4.10.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Streaming.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.10.0:
+    licensed:
+      declared: MIT
   4.6.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Streaming	4.10.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Streaming 4.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Streaming/4.10.0/4.10.0)