### PR TITLE
NLog.Schema4.7.2

### DIFF
--- a/curations/nuget/nuget/-/NLog.Schema.yaml
+++ b/curations/nuget/nuget/-/NLog.Schema.yaml
@@ -105,3 +105,6 @@ revisions:
   4.6.2:
     licensed:
       declared: BSD-3-Clause
+  4.7.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Schema4.7.2

**Details:**
Declare BSD-3-Clause found here (https://github.com/NLog/NLog/blob/v4.7.2/LICENSE.txt)

**Resolution:**
Matches License Info

**Affected definitions**:
- [NLog.Schema 4.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Schema/4.7.2/4.7.2)