### PR TITLE
Akka1.3.15

### DIFF
--- a/curations/nuget/nuget/-/Akka.yaml
+++ b/curations/nuget/nuget/-/Akka.yaml
@@ -6,3 +6,6 @@ revisions:
   1.3.10:
     licensed:
       declared: Apache-2.0
+  1.3.15:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka1.3.15

**Details:**
Declare Apache-2.0 found here at 1.3.12 (https://github.com/akkadotnet/akka.net/blob/v.1.3.12/LICENSE) and same at 1.14.0 - beta1 (no tag at 1.3.15)

**Resolution:**
Matches license info

**Affected definitions**:
- [Akka 1.3.15](https://clearlydefined.io/definitions/nuget/nuget/-/Akka/1.3.15/1.3.15)