### PR TITLE
System.Diagnostics.Tracer2.0.8

### DIFF
--- a/curations/nuget/nuget/-/System.Diagnostics.Tracer.yaml
+++ b/curations/nuget/nuget/-/System.Diagnostics.Tracer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Diagnostics.Tracer
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Diagnostics.Tracer2.0.8

**Details:**
Declare MIT found here (https://clearlydefined.io/definitions/nuget/nuget/-/System.Diagnostics.Tracer/2.0.8)

**Resolution:**
Matches license info

**Affected definitions**:
- [System.Diagnostics.Tracer 2.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Diagnostics.Tracer/2.0.8/2.0.8)