### PR TITLE
Microsoft.WSMan.Runtime7.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.WSMan.Runtime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.WSMan.Runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.WSMan.Runtime
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.WSMan.Runtime7.0.2

**Details:**
Declare MIT found here (https://github.com/PowerShell/PowerShell/blob/v7.0.2/LICENSE.txt)

**Resolution:**
Matches License Info

**Affected definitions**:
- [Microsoft.WSMan.Runtime 7.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.WSMan.Runtime/7.0.2/7.0.2)