### PR TITLE
OpenTracing0.12.1

### DIFF
--- a/curations/nuget/nuget/-/OpenTracing.yaml
+++ b/curations/nuget/nuget/-/OpenTracing.yaml
@@ -6,3 +6,6 @@ revisions:
   0.12.0:
     licensed:
       declared: Apache-2.0
+  0.12.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
OpenTracing0.12.1

**Details:**
Declare Apache-2.0 found here (https://github.com/opentracing/opentracing-csharp/blob/0.12.1/LICENSE)

**Resolution:**
Matches License Info

**Affected definitions**:
- [OpenTracing 0.12.1](https://clearlydefined.io/definitions/nuget/nuget/-/OpenTracing/0.12.1/0.12.1)