### PR TITLE
Microsoft.PowerShell.CoreCLR.Eventing7.0.2

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing.yaml
@@ -9,3 +9,6 @@ revisions:
   6.2.4:
     licensed:
       declared: MIT
+  7.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.CoreCLR.Eventing7.0.2

**Details:**
Declare MIT found here (https://github.com/PowerShell/PowerShell/blob/v7.0.2/LICENSE.txt)

**Resolution:**
matches license info

**Affected definitions**:
- [Microsoft.PowerShell.CoreCLR.Eventing 7.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.CoreCLR.Eventing/7.0.2/7.0.2)