### PR TITLE
NLog.Extensions.Logging1.3.0

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.3.0:
+    licensed:
+      declared: BSD-2-Clause
   1.4.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Extensions.Logging1.3.0

**Details:**
Declare BSD-2-Clause found here (https://github.com/NLog/NLog.Extensions.Logging/blob/v1.3.0/LICENSE)

**Resolution:**
matches license info

**Affected definitions**:
- [NLog.Extensions.Logging 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.3.0/1.3.0)