### PR TITLE
Microsoft.PowerShell.Commands.Utility7.0.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.PowerShell.Commands.Utility.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerShell.Commands.Utility.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.PowerShell.Commands.Utility
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.PowerShell.Commands.Utility7.0.3

**Details:**
Declare MIT found here (https://github.com/PowerShell/PowerShell/blob/v7.0.3/LICENSE.txt)

**Resolution:**
Matches license info

**Affected definitions**:
- [Microsoft.PowerShell.Commands.Utility 7.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.PowerShell.Commands.Utility/7.0.3/7.0.3)