### PR TITLE
librdkafka.redist	1.2.1

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -12,6 +12,9 @@ revisions:
   1.1.0:
     licensed:
       declared: BSD-2-Clause
+  1.2.1:
+    licensed:
+      declared: BSD-2-Clause
   1.2.2:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkafka.redist	1.2.1

**Details:**
Harvested readme file indicates license is BSD 2

**Resolution:**
 

**Affected definitions**:
- [librdkafka.redist 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.2.1/1.2.1)