### PR TITLE
Microsoft.Bot.Connector	4.10.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Connector.yaml
@@ -6,6 +6,9 @@ revisions:
   3.15.2.2:
     licensed:
       declared: MIT
+  4.10.0:
+    licensed:
+      declared: MIT
   4.10.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Connector	4.10.0

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License link on Nuget site indicates license is MIT

**Affected definitions**:
- [Microsoft.Bot.Connector 4.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Connector/4.10.0/4.10.0)