### PR TITLE
ServiceFabric.Mocks	4.1.5

### DIFF
--- a/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
+++ b/curations/nuget/nuget/-/ServiceFabric.Mocks.yaml
@@ -15,6 +15,9 @@ revisions:
   4.1.4:
     licensed:
       declared: MIT
+  4.1.5:
+    licensed:
+      declared: MIT
   4.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ServiceFabric.Mocks	4.1.5

**Details:**
Harvested license file indicates license is MIT

**Resolution:**
License file in repository also indicates license is MIT

**Affected definitions**:
- [ServiceFabric.Mocks 4.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/ServiceFabric.Mocks/4.1.5/4.1.5)