### PR TITLE
Microsoft.Bot.Builder.Dialogs	4.5.3

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.5.3:
+    licensed:
+      declared: MIT
   4.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Bot.Builder.Dialogs	4.5.3

**Details:**
License file in repository indicates license is MIT

**Resolution:**
 

**Affected definitions**:
- [Microsoft.Bot.Builder.Dialogs 4.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Bot.Builder.Dialogs/4.5.3/4.5.3)