### PR TITLE
commons-logging:commons-logging-api	1.1

### DIFF
--- a/curations/maven/mavencentral/commons-logging/commons-logging-api.yaml
+++ b/curations/maven/mavencentral/commons-logging/commons-logging-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-logging-api
+  namespace: commons-logging
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-logging:commons-logging-api	1.1

**Details:**
License file in package indicates license is Apache 2.0

**Resolution:**
 

**Affected definitions**:
- [commons-logging-api 1.1](https://clearlydefined.io/definitions/maven/mavencentral/commons-logging/commons-logging-api/1.1/1.1)