### PR TITLE
runtime.win-x64.Microsoft.NETCore.DotNetAppHost2.1.22

### DIFF
--- a/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetAppHost.yaml
+++ b/curations/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetAppHost.yaml
@@ -6,6 +6,9 @@ revisions:
   2.1.0:
     licensed:
       declared: MIT
+  2.1.22:
+    licensed:
+      declared: MIT
   2.1.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
runtime.win-x64.Microsoft.NETCore.DotNetAppHost2.1.22

**Details:**
Declare MIT found in Files under LICENSE.TXT here (https://clearlydefined.io/file/ff26c8fb716d2381357faa7584901159f70cab3fce65fdc642794cafff3a554b)

**Resolution:**
matches license info

**Affected definitions**:
- [runtime.win-x64.Microsoft.NETCore.DotNetAppHost 2.1.22](https://clearlydefined.io/definitions/nuget/nuget/-/runtime.win-x64.Microsoft.NETCore.DotNetAppHost/2.1.22/2.1.22)