### PR TITLE
SimpleInjector.Extensions.ExecutionContextScoping3.3.1

### DIFF
--- a/curations/nuget/nuget/-/SimpleInjector.Extensions.ExecutionContextScoping.yaml
+++ b/curations/nuget/nuget/-/SimpleInjector.Extensions.ExecutionContextScoping.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SimpleInjector.Extensions.ExecutionContextScoping
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SimpleInjector.Extensions.ExecutionContextScoping3.3.1

**Details:**
Declare MIT found at Master via project site, Edit on Github, source, legal to (https://github.com/simpleinjector/SimpleInjector/blob/master/LICENSE)(3.3.1 tag  broken) 

**Resolution:**
matches license info

**Affected definitions**:
- [SimpleInjector.Extensions.ExecutionContextScoping 3.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/SimpleInjector.Extensions.ExecutionContextScoping/3.3.1/3.3.1)