### PR TITLE
Microsoft.Azure.DocumentDB2.11.5

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.DocumentDB.yaml
@@ -12,6 +12,9 @@ revisions:
   2.11.4:
     licensed:
       declared: MIT
+  2.11.5:
+    licensed:
+      declared: MIT
   2.11.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.DocumentDB2.11.5

**Details:**
Declare MIT found here at Master no tags and only update in 2015 declaring MIT (https://github.com/Azure/azure-cosmos-dotnet-v2/blob/master/LICENSE)

**Resolution:**
Matches license info

**Affected definitions**:
- [Microsoft.Azure.DocumentDB 2.11.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.DocumentDB/2.11.5/2.11.5)