### PR TITLE
File has no license information

### DIFF
--- a/curations/npm/npmjs/-/readable-stream.yaml
+++ b/curations/npm/npmjs/-/readable-stream.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: readable-stream
+  provider: npmjs
+  type: npm
+revisions:
+  3.6.0:
+    files:
+      - license: NONE
+        path: package/CONTRIBUTING.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File has no license information

**Details:**
The file contains the developer's certificate of origin which may look like license, but is not (perhaps the scanner regards it as a potential license).

**Resolution:**
Change license from NOASSERTION to NONE.

**Affected definitions**:
- [readable-stream 3.6.0](https://clearlydefined.io/definitions/npm/npmjs/-/readable-stream/3.6.0/3.6.0)