### PR TITLE
License is MIT

### DIFF
--- a/curations/npm/npmjs/-/streamsearch.yaml
+++ b/curations/npm/npmjs/-/streamsearch.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: streamsearch
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.2:
+    files:
+      - license: MIT
+        path: package/package.json


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is MIT

**Details:**
The file expresses MIT licensing.

Note that the file is metadata. Strictly speaking, the expression of license is about the content in general, not specifically the file itself. I believe that this is just splitting hairs...

**Resolution:**
Change the license from NOASSERTION to MIT.

**Affected definitions**:
- [streamsearch 0.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/streamsearch/0.1.2/0.1.2)