### PR TITLE
License is MIT

### DIFF
--- a/curations/npm/npmjs/-/js-yaml.yaml
+++ b/curations/npm/npmjs/-/js-yaml.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: js-yaml
+  provider: npmjs
+  type: npm
+revisions:
+  3.13.1:
+    files:
+      - license: MIT
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
License is MIT

**Details:**
The file states that the license is MIT

**Resolution:**
Change the license from NOASSERTION to MIT.

**Affected definitions**:
- [js-yaml 3.13.1](https://clearlydefined.io/definitions/npm/npmjs/-/js-yaml/3.13.1/3.13.1)