### PR TITLE
httpcomponents-client 5.0.1

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
@@ -1,0 +1,22 @@
+coordinates:
+  name: httpclient5
+  namespace: org.apache.httpcomponents.client5
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  5.0.1:
+    described:
+      facets:
+        dev:
+          - httpclient5/src/main/**
+        tests:
+          - httpclient5/src/test/**
+      sourceLocation:
+        name: httpcomponents-client
+        namespace: apache
+        provider: github
+        revision: 44e464ac200a15da3b6a73ddc39e48d12cdaf865
+        type: git
+        url: 'https://github.com/apache/httpcomponents-client/commit/44e464ac200a15da3b6a73ddc39e48d12cdaf865'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
httpcomponents-client 5.0.1

**Details:**
Missing source URL and declare license

**Resolution:**
Add missing source URL and declare license

**Affected definitions**:
- [httpclient5 5.0.1](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.0.1/5.0.1)