### PR TITLE
dominate2.5.1

### DIFF
--- a/curations/pypi/pypi/-/dominate.yaml
+++ b/curations/pypi/pypi/-/dominate.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dominate
+  provider: pypi
+  type: pypi
+revisions:
+  2.5.1:
+    licensed:
+      declared: LGPL-3.0

--- a/curations/pypi/pypi/-/dominate.yaml
+++ b/curations/pypi/pypi/-/dominate.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.5.1:
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dominate2.5.1

**Details:**
Correct license is LGPLv3 found here (https://clearlydefined.io/definitions/pypi/pypi/-/dominate/2.5.1)

**Resolution:**
Updated to LGPLv3

**Affected definitions**:
- [dominate 2.5.1](https://clearlydefined.io/definitions/pypi/pypi/-/dominate/2.5.1/2.5.1)