### PR TITLE
org.eclipse.jdt/core3.1.1

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.jdt/core.yaml
+++ b/curations/maven/mavencentral/org.eclipse.jdt/core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: core
+  namespace: org.eclipse.jdt
+  provider: mavencentral
+  type: maven
+revisions:
+  3.1.1:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.eclipse.jdt/core3.1.1

**Details:**
Declare EPL-1.0 found here (https://repo1.maven.org/maven2/org/eclipse/jdt/core/3.1.1/core-3.1.1.pom)

**Resolution:**
Matches Repository found here (https://mvnrepository.com/artifact/org.eclipse.jdt/core/3.1.1)

**Affected definitions**:
- [core 3.1.1](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.jdt/core/3.1.1/3.1.1)