### PR TITLE
Roslyn.Compilers.CSharp1.2.20906.2

### DIFF
--- a/curations/nuget/nuget/-/Roslyn.Compilers.CSharp.yaml
+++ b/curations/nuget/nuget/-/Roslyn.Compilers.CSharp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Roslyn.Compilers.CSharp
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.20906.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Roslyn.Compilers.CSharp1.2.20906.2

**Details:**
Declare OTHER under MS EULA found here (https://docs.microsoft.com/en-us/previous-versions/jj150688(v=msdn.10)?redirectedfrom=MSDN)

**Resolution:**
Matches license info

**Affected definitions**:
- [Roslyn.Compilers.CSharp 1.2.20906.2](https://clearlydefined.io/definitions/nuget/nuget/-/Roslyn.Compilers.CSharp/1.2.20906.2/1.2.20906.2)