### PR TITLE
node-modules1.0.0

### DIFF
--- a/curations/npm/npmjs/-/node-modules.yaml
+++ b/curations/npm/npmjs/-/node-modules.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: node-modules
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
node-modules1.0.0

**Details:**
Declaring MIT

**Resolution:**
NPM page has MIT

Directs to GitHub, version specific license also noted on homepage and in ReadMe:
https://github.com/mafintosh/node-modules-cli/blob/v1.0.0/README.md

**Affected definitions**:
- [node-modules 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/node-modules/1.0.0)