### PR TITLE
XmlDoc2CmdletDoc0.2.5

### DIFF
--- a/curations/nuget/nuget/-/XmlDoc2CmdletDoc.yaml
+++ b/curations/nuget/nuget/-/XmlDoc2CmdletDoc.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: XmlDoc2CmdletDoc
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
XmlDoc2CmdletDoc0.2.5

**Details:**
Declaring BSD-3-Clause

**Resolution:**
NuGet metadata goes to GitHub repo. Version tags before and after include BSD-3-Clause license - https://github.com/red-gate/XmlDoc2CmdletDoc/blob/0.2.7/LICENSE.md

**Affected definitions**:
- [XmlDoc2CmdletDoc 0.2.5](https://clearlydefined.io/definitions/nuget/nuget/-/XmlDoc2CmdletDoc/0.2.5)