### PR TITLE
DocumentFormat.OpenXml2.7.2

### DIFF
--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: MIT
   2.7.2:
     licensed:
-      declared: NONE
+      declared: Apache-2.0
   2.8.1:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.5.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.7.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
DocumentFormat.OpenXml2.7.2

**Details:**
Declaring Apache 2.0

**Resolution:**
GitHub repo license for tagged version is Apache 2.0: https://github.com/OfficeDev/Open-XML-SDK/blob/v2.7.2/LICENSE.txt

License was later changed to MIT as documented on NuGet page.

**Affected definitions**:
- [DocumentFormat.OpenXml 2.7.2](https://clearlydefined.io/definitions/nuget/nuget/-/DocumentFormat.OpenXml/2.7.2)