### PR TITLE
Microsoft.IdentityModel.Protocols.OpenIdConnect5.4.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.OpenIdConnect.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.OpenIdConnect.yaml
@@ -9,3 +9,6 @@ revisions:
   5.2.0:
     licensed:
       declared: MIT
+  5.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.IdentityModel.Protocols.OpenIdConnect5.4.0

**Details:**
Declaring MIT

**Resolution:**
NuGet metadata goes to GitHub repo. License for tagged version:
https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/5.4.0/LICENSE.txt

**Affected definitions**:
- [Microsoft.IdentityModel.Protocols.OpenIdConnect 5.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocols.OpenIdConnect/5.4.0)