### PR TITLE
Microsoft.AspNet.SignalR.Client2.4.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.AspNet.SignalR.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.AspNet.SignalR.Client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.AspNet.SignalR.Client
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.AspNet.SignalR.Client2.4.1

**Details:**
Declaring Apache 2.0

**Resolution:**
NuGet metadata: https://raw.githubusercontent.com/SignalR/SignalR/2.3.0/LICENSE.txt

GitHub project, tagged license: https://github.com/SignalR/SignalR/blob/2.4.1/LICENSE.txt

**Affected definitions**:
- [Microsoft.AspNet.SignalR.Client 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.AspNet.SignalR.Client/2.4.1)