### PR TITLE
DotNetSeleniumExtras.WaitHelpers3.11.0

### DIFF
--- a/curations/nuget/nuget/-/DotNetSeleniumExtras.WaitHelpers.yaml
+++ b/curations/nuget/nuget/-/DotNetSeleniumExtras.WaitHelpers.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.11.0:
     licensed:
-      declared: NONE
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
DotNetSeleniumExtras.WaitHelpers3.11.0

**Details:**
Declaring Apache 2.0

**Resolution:**
License noted on this file: https://github.com/DotNetSeleniumTools/DotNetSeleniumExtras/blob/master/src/WaitHelpers/ExpectedConditions.cs

**Affected definitions**:
- [DotNetSeleniumExtras.WaitHelpers 3.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetSeleniumExtras.WaitHelpers/3.11.0)