### PR TITLE
httpcomponents-client 5.0.2

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
@@ -20,3 +20,19 @@ revisions:
         url: 'https://github.com/apache/httpcomponents-client/commit/44e464ac200a15da3b6a73ddc39e48d12cdaf865'
     licensed:
       declared: Apache-2.0
+  5.0.2:
+    described:
+      facets:
+        dev:
+          - httpclient5/src/main/**
+        examples:
+          - httpclient5/src/test/**
+      sourceLocation:
+        name: httpcomponents-client
+        namespace: apache
+        provider: github
+        revision: 09525137f826e89a911992b40d0490f136f7f0d5
+        type: git
+        url: 'https://github.com/apache/httpcomponents-client/commit/09525137f826e89a911992b40d0490f136f7f0d5'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
httpcomponents-client 5.0.2

**Details:**
Missing source URL and declared license.

**Resolution:**
Add missing source URL and declared license.

**Affected definitions**:
- [httpclient5 5.0.2](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.0.2/5.0.2)