### PR TITLE
ELD: set correct declared license

### DIFF
--- a/curations/git/github/git-for-windows/git.yaml
+++ b/curations/git/github/git-for-windows/git.yaml
@@ -9,6 +9,9 @@ revisions:
       releaseDate: '2019-02-26'
     licensed:
       declared: GPL-2.0-only
+  77982caf269b7ee713a76da2bcf260c34d3bf7a7:
+    licensed:
+      declared: GPL-2.0-only
   907ab1011dce9112700498e034b974ba60f8b407:
     licensed:
       declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ELD: set correct declared license

**Details:**
This material is licensed under the GPL v2 (see https://github.com/git-for-windows/git/blob/v2.28.0.windows.1/COPYING and file /git-2.28.0.windows.1/COPYING

**Resolution:**
This material is licensed under the GPL v2 (see https://github.com/git-for-windows/git/blob/v2.28.0.windows.1/COPYING and file /git-2.28.0.windows.1/COPYING

**Affected definitions**:
- [git 77982caf269b7ee713a76da2bcf260c34d3bf7a7](https://clearlydefined.io/definitions/git/github/git-for-windows/git/77982caf269b7ee713a76da2bcf260c34d3bf7a7/77982caf269b7ee713a76da2bcf260c34d3bf7a7)