### PR TITLE
Update declared license

### DIFF
--- a/curations/git/github/jenkinsci/token-macro-plugin.yaml
+++ b/curations/git/github/jenkinsci/token-macro-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: token-macro-plugin
+  namespace: jenkinsci
+  provider: github
+  type: git
+revisions:
+  92ba403e2ff135dba048ad3cc0e5071d07d98b58:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Update declared license

**Details:**
Declared license is "NOASSERTION", however the project's POM.xml appears to hold some useful information about what license is applicable.

**Resolution:**
Update declared to MIT license as noted in https://github.com/jenkinsci/token-macro-plugin/blob/92ba403e2ff135dba048ad3cc0e5071d07d98b58/pom.xml

**Affected definitions**:
- [token-macro-plugin 92ba403e2ff135dba048ad3cc0e5071d07d98b58](https://clearlydefined.io/definitions/git/github/jenkinsci/token-macro-plugin/92ba403e2ff135dba048ad3cc0e5071d07d98b58/92ba403e2ff135dba048ad3cc0e5071d07d98b58)