### PR TITLE
component version is wrong

### DIFF
--- a/curations/git/github/apache/qpid-dispatch.yaml
+++ b/curations/git/github/apache/qpid-dispatch.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: qpid-dispatch
+  namespace: apache
+  provider: github
+  type: git
+revisions:
+  525291a9b5b86e2dcc9e957c189a5cc73262de1d:
+    described:
+      facets:
+        tests:
+          - /tests/**/*
+          - /tests/*


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
component version is wrong

**Details:**
This entry seems to have been automatically harvested from the GitHub tag. However, the tag name has not been used as the artifact version (1.14.0) but the corresponding Git revision.

**Resolution:**
Set the artifact version to 1.14.0

**Affected definitions**:
- [qpid-dispatch 525291a9b5b86e2dcc9e957c189a5cc73262de1d](https://clearlydefined.io/definitions/git/github/apache/qpid-dispatch/525291a9b5b86e2dcc9e957c189a5cc73262de1d/525291a9b5b86e2dcc9e957c189a5cc73262de1d)