### PR TITLE
Point to source repository

### DIFF
--- a/curations/maven/mavencentral/org.jboss.test-audit/jboss-test-audit-api.yaml
+++ b/curations/maven/mavencentral/org.jboss.test-audit/jboss-test-audit-api.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: jboss-test-audit-api
+  namespace: org.jboss.test-audit
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.4.Final:
+    described:
+      sourceLocation:
+        name: jboss-test-audit
+        namespace: jboss
+        provider: github
+        revision: dba079c609c23eb63a9cd0f483751a83e49d29e4
+        type: git
+        url: 'https://github.com/jboss/jboss-test-audit/commit/dba079c609c23eb63a9cd0f483751a83e49d29e4'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Point to source repository

**Details:**
Point to the GitHub source

**Resolution:**
The source does not have a declared license, but file headers indicate Apache-2.0

**Affected definitions**:
- [jboss-test-audit-api 1.1.4.Final](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.test-audit/jboss-test-audit-api/1.1.4.Final/1.1.4.Final)