### PR TITLE
Update regex.yaml

### DIFF
--- a/curations/pypi/pypi/-/regex.yaml
+++ b/curations/pypi/pypi/-/regex.yaml
@@ -24,3 +24,6 @@ revisions:
   2020.6.8:
     licensed:
       declared: Python-2.0
+  2020.7.14:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
Type: Missing

Summary:
regex 2020.7.14

Details:
Add MIT

Resolution:
License Url:
https://github.com/gitgik/regex/blob/master/LICENSE

Description:
License is included in GitHub Repo