### PR TITLE
io.netty/netty-buffer 4.1.52

### DIFF
--- a/curations/maven/mavencentral/io.netty/netty-buffer.yaml
+++ b/curations/maven/mavencentral/io.netty/netty-buffer.yaml
@@ -9,4 +9,14 @@ revisions:
       facets:
         dev:
           - buffer/**
+          - buffer/src/main/**
+        tests:
+          - buffer/src/test/**
       releaseDate: '2020-09-08'
+      sourceLocation:
+        name: netty
+        namespace: netty
+        provider: github
+        revision: ada9c38c0a96e593b895b93dd4600d5299e77cef
+        type: git
+        url: 'https://github.com/netty/netty/commit/ada9c38c0a96e593b895b93dd4600d5299e77cef'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
io.netty/netty-buffer 4.1.52

**Details:**
Missing source URL and wrong release date

**Resolution:**
Fix missing source URL and wrong release date

**Affected definitions**:
- [netty-buffer 4.1.52.Final](https://clearlydefined.io/definitions/maven/mavencentral/io.netty/netty-buffer/4.1.52.Final/4.1.52.Final)