### PR TITLE
io.netty/netty-common 4.1.52.Final

### DIFF
--- a/curations/maven/mavencentral/io.netty/netty-common.yaml
+++ b/curations/maven/mavencentral/io.netty/netty-common.yaml
@@ -1,0 +1,21 @@
+coordinates:
+  name: netty-common
+  namespace: io.netty
+  provider: mavencentral
+  type: maven
+revisions:
+  4.1.52.Final:
+    described:
+      facets:
+        dev:
+          - common/src/main/**
+        tests:
+          - common/src/test/**
+      releaseDate: '2020-09-08'
+      sourceLocation:
+        name: netty
+        namespace: netty
+        provider: github
+        revision: ada9c38c0a96e593b895b93dd4600d5299e77cef
+        type: git
+        url: 'https://github.com/netty/netty/commit/ada9c38c0a96e593b895b93dd4600d5299e77cef'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
io.netty/netty-common 4.1.52.Final

**Details:**
Missing source URL and wrong release date

**Resolution:**
Fix missing source URL and wrong release date

**Affected definitions**:
- [netty-common 4.1.52.Final](https://clearlydefined.io/definitions/maven/mavencentral/io.netty/netty-common/4.1.52.Final/4.1.52.Final)