### PR TITLE
Added license type.

### DIFF
--- a/curations/nuget/nuget/-/PGK.Extensions.yaml
+++ b/curations/nuget/nuget/-/PGK.Extensions.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: PGK.Extensions
+  provider: nuget
+  type: nuget
+revisions:
+  2011.6.0:
+    described:
+      facets:
+        data: []
+      sourceLocation:
+        name: .net-extensions
+        namespace: joysky
+        provider: github
+        revision: 479a2ed
+        type: git
+        url: 'https://github.com/joysky/.net-extensions/commit/479a2ed'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Other

**Summary:**
Added license type.

**Details:**
License type was not declared.

**Resolution:**
Attached license type, which is declared as "Apache 2.0" in the GitHub repo.

**Affected definitions**:
- [PGK.Extensions 2011.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/PGK.Extensions/2011.6.0/2011.6.0)