### PR TITLE
dotnet/runtime38017c3935de95d0335bac04f4901ddfc2718656

### DIFF
--- a/curations/git/github/dotnet/runtime.yaml
+++ b/curations/git/github/dotnet/runtime.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   38017c3935de95d0335bac04f4901ddfc2718656:
     licensed:
-      declared: MIT
+      declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
dotnet/runtime38017c3935de95d0335bac04f4901ddfc2718656

**Details:**
Adding OTHER for the Patent license in the repo

**Resolution:**
https://github.com/dotnet/runtime/blob/38017c3935de95d0335bac04f4901ddfc2718656/PATENTS.TXT

**Affected definitions**:
- [runtime 38017c3935de95d0335bac04f4901ddfc2718656](https://clearlydefined.io/definitions/git/github/dotnet/runtime/38017c3935de95d0335bac04f4901ddfc2718656/38017c3935de95d0335bac04f4901ddfc2718656)