### PR TITLE
ELD: update overall declared license

### DIFF
--- a/curations/git/github/git-for-windows/git.yaml
+++ b/curations/git/github/git-for-windows/git.yaml
@@ -12,6 +12,9 @@ revisions:
   77982caf269b7ee713a76da2bcf260c34d3bf7a7:
     licensed:
       declared: GPL-2.0-only
+  7c71c859c97853ed057da5cbab12f3c13b5554df:
+    licensed:
+      declared: GPL-2.0-only
   907ab1011dce9112700498e034b974ba60f8b407:
     licensed:
       declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ELD: update overall declared license

**Details:**
component: git v2.25.0.windows.1


**Resolution:**
Update overall declared license - This material is licensed under the GPL v2 (see file /git-2.25.0.windows.1/COPYING).

**Affected definitions**:
- [git 7c71c859c97853ed057da5cbab12f3c13b5554df](https://clearlydefined.io/definitions/git/github/git-for-windows/git/7c71c859c97853ed057da5cbab12f3c13b5554df/7c71c859c97853ed057da5cbab12f3c13b5554df)