### PR TITLE
ELD: stack sol deploy

### DIFF
--- a/curations/git/github/knockout/knockout.yaml
+++ b/curations/git/github/knockout/knockout.yaml
@@ -10,3 +10,6 @@ revisions:
   7a83820efc96d47742e2f8c9b4fcd2459c81dd21:
     licensed:
       declared: MIT
+  aad712123b2a9f5373d2eeb71cd63227fe5c7bd8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ELD: stack sol deploy

**Details:**
Set Declared license to MIT

**Resolution:**
This material is licensed under the MIT License (see https://github.com/knockout/knockout/blob/v3.5.1/LICENSE and file /knockout-3.5.1/LICENSE)

**Affected definitions**:
- [knockout aad712123b2a9f5373d2eeb71cd63227fe5c7bd8](https://clearlydefined.io/definitions/git/github/knockout/knockout/aad712123b2a9f5373d2eeb71cd63227fe5c7bd8/aad712123b2a9f5373d2eeb71cd63227fe5c7bd8)