### PR TITLE
E:D: stack deploy

### DIFF
--- a/curations/git/github/requirejs/requirejs.yaml
+++ b/curations/git/github/requirejs/requirejs.yaml
@@ -7,6 +7,9 @@ revisions:
   4316f8f19f981c726eb32b5335c36237e0125948:
     licensed:
       declared: MIT
+  57c48253e42133a61075da67809b91ea34f89811:
+    licensed:
+      declared: MIT
   5e5c633e32903841fc0270acd493eb1f994fa7d4:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
E:D: stack deploy

**Details:**
Set Declared license to MIT

**Resolution:**
This material is licensed under the MIT License (see https://github.com/requirejs/requirejs/blob/2.3.5/LICENSE and file /requirejs-2.3.5/LICENSE)

**Affected definitions**:
- [requirejs 57c48253e42133a61075da67809b91ea34f89811](https://clearlydefined.io/definitions/git/github/requirejs/requirejs/57c48253e42133a61075da67809b91ea34f89811/57c48253e42133a61075da67809b91ea34f89811)