### PR TITLE
obspy1.2.2

### DIFF
--- a/curations/pypi/pypi/-/obspy.yaml
+++ b/curations/pypi/pypi/-/obspy.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.2.2:
     licensed:
-      declared: LGPL-3.0-only
+      declared: GPL-3.0-only AND LGPL-3.0-only

--- a/curations/pypi/pypi/-/obspy.yaml
+++ b/curations/pypi/pypi/-/obspy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: obspy
+  provider: pypi
+  type: pypi
+revisions:
+  1.2.2:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
obspy1.2.2

**Details:**
Fixing Declared license to LGPL-3.0-only

**Resolution:**
PyPI metadata/page references LGPL 3.0 - https://pypi.org/project/obspy/1.2.2/.

GitHub source license is also LGPL 3.0.

**Affected definitions**:
- [obspy 1.2.2](https://clearlydefined.io/definitions/pypi/pypi/-/obspy/1.2.2/1.2.2)