### PR TITLE
File that is listed as MPL-2.0 isn't in the source

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents.client5/httpclient5.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: httpclient5
+  namespace: org.apache.httpcomponents.client5
+  provider: mavencentral
+  type: maven
+revisions:
+  5.0.3:
+    files:
+      - license: NONE
+        path: mozilla/public-suffix-list.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File that is listed as MPL-2.0 isn't in the source

**Details:**
I pulled the listed source JAR and the file that is listed as MPL-2.0 isn't in the source, AFAICT. I don't see the file in the [GitHub source](https://github.com/apache/httpcomponents-client/tree/3734aaa038a58c17af638e9fa29019cacb22e82c) either.

**Resolution:**
Mark the file as NONE. A better solution would be to remove it.

**Affected definitions**:
- [httpclient5 5.0.3](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.httpcomponents.client5/httpclient5/5.0.3/5.0.3)