### PR TITLE
Compiled classes with no license information being misidentified

### DIFF
--- a/curations/maven/mavencentral/org.apache.tomcat/coyote.yaml
+++ b/curations/maven/mavencentral/org.apache.tomcat/coyote.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: coyote
+  namespace: org.apache.tomcat
+  provider: mavencentral
+  type: maven
+revisions:
+  6.0.51:
+    files:
+      - license: NONE
+        path: org/apache/jk/core/MsgContext.class
+      - license: NONE
+        path: org/apache/tomcat/util/net/SocketProperties.class
+      - license: NONE
+        path: org/apache/tomcat/util/descriptor/XmlErrorHandler.class
+      - license: NONE
+        path: org/apache/tomcat/util/digester/Digester.class


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Compiled classes with no license information being misidentified

**Details:**
The source pointer for this record is wrong. It appears that the harvester has run on the compiled form and misidentified several compiled files that do not have any human readable text as having a license. 

**Resolution:**
Change the files identified as NOASSERTION to NONE.

**Affected definitions**:
- [coyote 6.0.51](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.tomcat/coyote/6.0.51/6.0.51)