### PR TITLE
Updating Microsoft AzureML License for 1.16.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-native.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-native.yaml
@@ -21,3 +21,6 @@ revisions:
   22.0.0:
     licensed:
       declared: OTHER
+  23.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
@@ -9,6 +9,9 @@ revisions:
   1.1.1:
     licensed:
       declared: OTHER
+  1.1.2:
+    licensed:
+      declared: OTHER      
   1.2.0:
     licensed:
       declared: OTHER

--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -21,3 +21,6 @@ revisions:
   1.15.0:
     licensed:
       declared: OTHER
+  1.16.0:
+    licensed:
+      declared: OTHER

--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -18,3 +18,6 @@ revisions:
   1.13.0:
     licensed:
       declared: OTHER
+  1.16.0:
+    licensed:
+      declared: OTHER

--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -15,6 +15,12 @@ revisions:
   1.0.60:
     licensed:
       declared: OTHER
+  1.6.0:
+    licensed:
+      declared: OTHER
+  1.8.0:
+    licensed:
+      declared: OTHER
   1.10.0:
     licensed:
       declared: OTHER
@@ -28,12 +34,6 @@ revisions:
     licensed:
       declared: OTHER
   1.15.0:
-    licensed:
-      declared: OTHER
-  1.6.0:
-    licensed:
-      declared: OTHER
-  1.8.0:
     licensed:
       declared: OTHER
   1.16.0:

--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -36,3 +36,6 @@ revisions:
   1.8.0:
     licensed:
       declared: OTHER
+  1.16.0:
+    licensed:
+      declared: OTHER

--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -36,6 +36,9 @@ revisions:
   1.15.0:
     licensed:
       declared: OTHER
+  1.16.0:
+    licensed:
+      declared: OTHER      
   1.2.0:
     licensed:
       declared: OTHER

--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -18,3 +18,6 @@ revisions:
   1.15.0:
     licensed:
       declared: OTHER
+  1.16.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
Fixing this for our internal team. My team are the users of these packages, so the warnings impact us more then the producers of the package. 
Type: Missing

Summary:
azureml-dataprep-native 23.0.0
azureml-dataprep-rslex 1.1.2
azureml-dataset-runtime 1.16.0
azureml-pipeline-core 1.16.0
azureml-telemtry 1.16.0
azureml-train 1.16.0
azureml-train-automl-client 1.16.0

Details:
Add OTHER License

Resolution:
License Url:
https://aka.ms/azureml-sdk-license

Description:
Per metadata in pypi, and I am Microsoft employee familiar with this package. Work closely with the dev team, and am frequent user.

Pull request generated by Microsoft tooling.

Affected definitions:

azureml-dataprep-native 23.0.0
azureml-dataprep-rslex 1.1.2
azureml-dataset-runtime 1.16.0
azureml-pipeline-core 1.16.0
azureml-telemtry 1.16.0
azureml-train 1.16.0
azureml-train-automl-client 1.16.0
