### PR TITLE
html2text/2020.1.16

### DIFF
--- a/curations/pypi/pypi/-/html2text.yaml
+++ b/curations/pypi/pypi/-/html2text.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: html2text
+  provider: pypi
+  type: pypi
+revisions:
+  2020.1.16:
+    files:
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+        license: GPL-3.0-only
+        path: html2text-2020.1.16/COPYING
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
html2text/2020.1.16

**Details:**
Cleaning up COPYING file and "Declared" field to be "GPL-3.0-only."

**Resolution:**
GPL-3.0-only

**Affected definitions**:
- [html2text 2020.1.16](https://clearlydefined.io/definitions/pypi/pypi/-/html2text/2020.1.16/2020.1.16)