### PR TITLE
Add Apache as declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/org.yaml/snakeyaml.yaml
+++ b/curations/sourcearchive/mavencentral/org.yaml/snakeyaml.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: snakeyaml
+  namespace: org.yaml
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '1.27':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add Apache as declared license

**Details:**
The Declared License was NOASSERTION

**Resolution:**
After reviewing the discovered files, and the license text at https://bitbucket.org/asomov/snakeyaml/src/master/LICENSE.txt I found them all to be licensed as Apache.

The one exception was Base64Coder which has multiple licenses, including Apache listed as licensed under.

**Affected definitions**:
- [snakeyaml 1.27](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.yaml/snakeyaml/1.27/1.27)