### PR TITLE
License is incorrect

### DIFF
--- a/curations/maven/mavencentral/org.jboss.weld.module/weld-ejb.yaml
+++ b/curations/maven/mavencentral/org.jboss.weld.module/weld-ejb.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: weld-ejb
+  namespace: org.jboss.weld.module
+  provider: mavencentral
+  type: maven
+revisions:
+  4.0.0.Beta5:
+    files:
+      - license: NONE
+        path: META-INF/DEPENDENCIES.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is incorrect

**Details:**
The DEPENDENCIES.text file lists licenses, but has no expression of it's own license.

**Resolution:**
Change license to NONE.

**Affected definitions**:
- [weld-ejb 4.0.0.Beta5](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.weld.module/weld-ejb/4.0.0.Beta5/4.0.0.Beta5)