### PR TITLE
File has no license information

### DIFF
--- a/curations/maven/mavencentral/org.jboss.weld.module/weld-jsf.yaml
+++ b/curations/maven/mavencentral/org.jboss.weld.module/weld-jsf.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: weld-jsf
+  namespace: org.jboss.weld.module
+  provider: mavencentral
+  type: maven
+revisions:
+  4.0.0.Beta5:
+    files:
+      - license: NONE
+        path: META-INF/DEPENDENCIES.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File has no license information

**Details:**
The file lists licenses for dependencies, but does not itself have an explicit license.

**Resolution:**
Change the license to NONE.

**Affected definitions**:
- [weld-jsf 4.0.0.Beta5](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.weld.module/weld-jsf/4.0.0.Beta5/4.0.0.Beta5)