### PR TITLE
No explicit license

### DIFF
--- a/curations/maven/mavencentral/org.jboss.weld.module/weld-jta.yaml
+++ b/curations/maven/mavencentral/org.jboss.weld.module/weld-jta.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: weld-jta
+  namespace: org.jboss.weld.module
+  provider: mavencentral
+  type: maven
+revisions:
+  4.0.0.Beta5:
+    files:
+      - license: NONE
+        path: META-INF/DEPENDENCIES.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
No explicit license

**Details:**
The file lists licenses for dependencies, but does not itself have an explicit license.

**Resolution:**
Change the license to NONE

**Affected definitions**:
- [weld-jta 4.0.0.Beta5](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.weld.module/weld-jta/4.0.0.Beta5/4.0.0.Beta5)