### PR TITLE
File has no license statement

### DIFF
--- a/curations/maven/mavencentral/org.jboss.weld/weld-core-impl.yaml
+++ b/curations/maven/mavencentral/org.jboss.weld/weld-core-impl.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: weld-core-impl
+  namespace: org.jboss.weld
+  provider: mavencentral
+  type: maven
+revisions:
+  4.0.0.Beta5:
+    files:
+      - license: NONE
+        path: META-INF/DEPENDENCIES.txt


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File has no license statement

**Details:**
The file lists licenses for dependencies, but does not itself have an explicit license.

**Resolution:**
Change the license to NONE.

**Affected definitions**:
- [weld-core-impl 4.0.0.Beta5](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.weld/weld-core-impl/4.0.0.Beta5/4.0.0.Beta5)