### PR TITLE
FFmpeg.AutoGen4.3.1

### DIFF
--- a/curations/nuget/nuget/-/FFmpeg.AutoGen.yaml
+++ b/curations/nuget/nuget/-/FFmpeg.AutoGen.yaml
@@ -6,3 +6,6 @@ revisions:
   4.2.0:
     licensed:
       declared: LGPL-3.0-only
+  4.3.1:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FFmpeg.AutoGen4.3.1

**Details:**
Declare LGPL-3.0-only found at License Info (https://www.nuget.org/packages/FFmpeg.AutoGen/4.3.1/License) and under Files - License on Clearly Defined (https://clearlydefined.io/file/ea7d049c7705dc13afc202dd18e1827f3484f8212fd3fa7b82fc4a0c363432c9)

**Resolution:**
Latest in Project site is 4.3.0.3 is also LGPL-3.0-Only

**Affected definitions**:
- [FFmpeg.AutoGen 4.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/FFmpeg.AutoGen/4.3.1/4.3.1)