### PR TITLE
Add missing license information for libjpeg-turbo 

### DIFF
--- a/curations/git/github/libjpeg-turbo/libjpeg-turbo.yaml
+++ b/curations/git/github/libjpeg-turbo/libjpeg-turbo.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: BSD-3-Clause AND IJG AND Zlib
   ad8330af72aefe5f07f79f6922fb5aa9ed209d18:
     licensed:
-      declared: 'BSD-3-Clause '
+      declared: BSD-3-Clause AND IJG AND Zlib

--- a/curations/git/github/libjpeg-turbo/libjpeg-turbo.yaml
+++ b/curations/git/github/libjpeg-turbo/libjpeg-turbo.yaml
@@ -7,3 +7,6 @@ revisions:
   166e34213e4f4e2363ce058a7bcc69fd03e38b76:
     licensed:
       declared: BSD-3-Clause AND IJG AND Zlib
+  ad8330af72aefe5f07f79f6922fb5aa9ed209d18:
+    licensed:
+      declared: 'BSD-3-Clause '


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing license information for libjpeg-turbo 

**Details:**
The license details for libjpeg-turbo ad8330af72aefe5f07f79f6922fb5aa9ed209d18 were missing. I have added the same details from libjpeg-turbo 166e34213e4f4e2363ce058a7bcc69fd03e38b76.

**Resolution:**
The license for libjpeg-turbo ad8330af72aefe5f07f79f6922fb5aa9ed209d18 can be found here:
https://github.com/libjpeg-turbo/libjpeg-turbo/blob/ad8330af72aefe5f07f79f6922fb5aa9ed209d18/LICENSE.md

**Affected definitions**:
- [libjpeg-turbo ad8330af72aefe5f07f79f6922fb5aa9ed209d18](https://clearlydefined.io/definitions/git/github/libjpeg-turbo/libjpeg-turbo/ad8330af72aefe5f07f79f6922fb5aa9ed209d18)