### PR TITLE
Content is all BSD-3-Clause

### DIFF
--- a/curations/npm/npmjs/-/istanbul-lib-report.yaml
+++ b/curations/npm/npmjs/-/istanbul-lib-report.yaml
@@ -1,0 +1,39 @@
+coordinates:
+  name: istanbul-lib-report
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.5:
+    files:
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/index.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/summarizer.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/file-writer.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/context.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/watermarks.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/path.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/xml-writer.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/tree.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Content is all BSD-3-Clause

**Details:**
The harvested data incorrectly lists the license as NOASSERTION.

**Resolution:**
Change the license to BSD-3-Clause

**Affected definitions**:
- [istanbul-lib-report 1.1.5](https://clearlydefined.io/definitions/npm/npmjs/-/istanbul-lib-report/1.1.5/1.1.5)