### PR TITLE
No license data in files marked NOASSERTION

### DIFF
--- a/curations/npm/npmjs/-/rx-lite.yaml
+++ b/curations/npm/npmjs/-/rx-lite.yaml
@@ -7,5 +7,14 @@ revisions:
     licensed:
       declared: Apache-2.0
   4.0.8:
+    files:
+      - attributions:
+          - 'Copyright (c) Microsoft Open Technologies, Inc.'
+        license: NONE
+        path: package/rx.lite.min.js
+      - attributions:
+          - Copyright (c) Microsoft
+        license: NONE
+        path: package/rx.lite.js
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
No license data in files marked NOASSERTION

**Details:**
These files refer to the LICENSE.txt file for license information, but do not otherwise contain any indication of the license.

**Resolution:**
Change the license to NONE.

**Affected definitions**:
- [rx-lite 4.0.8](https://clearlydefined.io/definitions/npm/npmjs/-/rx-lite/4.0.8/4.0.8)