### PR TITLE
Content is all under BSD-3-Clause

### DIFF
--- a/curations/npm/npmjs/-/istanbul-lib-coverage.yaml
+++ b/curations/npm/npmjs/-/istanbul-lib-coverage.yaml
@@ -1,0 +1,19 @@
+coordinates:
+  name: istanbul-lib-coverage
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.1:
+    files:
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/index.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/file.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/coverage-map.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Content is all under BSD-3-Clause

**Details:**
Content is misidentified as NOASSERTION

**Resolution:**
Change license to BSD-3-Clause

**Affected definitions**:
- [istanbul-lib-coverage 1.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/istanbul-lib-coverage/1.2.1/1.2.1)