### PR TITLE
All files are BSD-3-Clause

### DIFF
--- a/curations/npm/npmjs/-/istanbul-lib-hook.yaml
+++ b/curations/npm/npmjs/-/istanbul-lib-hook.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: istanbul-lib-hook
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.2:
+    files:
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/index.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/hook.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
All files are BSD-3-Clause

**Details:**
The license is misindentified

**Resolution:**
Change the license to BSD-3-Clause

**Affected definitions**:
- [istanbul-lib-hook 1.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/istanbul-lib-hook/1.2.2/1.2.2)