### PR TITLE
All content is BSD-3-Clause

### DIFF
--- a/curations/npm/npmjs/-/istanbul-lib-source-maps.yaml
+++ b/curations/npm/npmjs/-/istanbul-lib-source-maps.yaml
@@ -1,0 +1,23 @@
+coordinates:
+  name: istanbul-lib-source-maps
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.6:
+    files:
+      - attributions:
+          - 'Copyright 2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/transformer.js
+      - attributions:
+          - 'Copyright 2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/mapped.js
+      - attributions:
+          - 'Copyright 2012-2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/index.js
+      - attributions:
+          - 'Copyright 2015, Yahoo Inc.'
+        license: BSD-3-Clause
+        path: package/lib/map-store.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
All content is BSD-3-Clause

**Details:**
Content is misidentified as NOASSERTION

**Resolution:**
Change to BSD-3-Clause

**Affected definitions**:
- [istanbul-lib-source-maps 1.2.6](https://clearlydefined.io/definitions/npm/npmjs/-/istanbul-lib-source-maps/1.2.6/1.2.6)