### PR TITLE
License expressed is LGPL-2.0-or-later 

### DIFF
--- a/curations/npm/npmjs/-/jsdom.yaml
+++ b/curations/npm/npmjs/-/jsdom.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: jsdom
+  provider: npmjs
+  type: npm
+revisions:
+  9.12.0:
+    files:
+      - attributions:
+          - Copyright (c) 2000 Lars Knoll (knoll@kde.org)
+          - 'Copyright (c) 2003, 2004, 2005, 2006, 2007, 2008, 2009, 2010, 2011 Apple Inc.'
+        license: LGPL-2.0-or-later
+        path: package/lib/jsdom/browser/default-stylesheet.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License expressed is LGPL-2.0-or-later 

**Details:**
LGPL-2.0+ AND LGPL-2.0-or-later seems a bit redundant...

**Resolution:**
Change license to LGPL-2.0-or-later 

**Affected definitions**:
- [jsdom 9.12.0](https://clearlydefined.io/definitions/npm/npmjs/-/jsdom/9.12.0/9.12.0)