### PR TITLE
File does not express a license

### DIFF
--- a/curations/npm/npmjs/-/lockfile.yaml
+++ b/curations/npm/npmjs/-/lockfile.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: lockfile
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.4:
+    files:
+      - license: NONE
+        path: package/CHANGELOG.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File does not express a license

**Details:**
File is misidentified as NOASSERTION.

**Resolution:**
Change to NONE.

**Affected definitions**:
- [lockfile 1.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/lockfile/1.0.4/1.0.4)