### PR TITLE
README expresses Apache-2.0

### DIFF
--- a/curations/npm/npmjs/-/node-environment-flags.yaml
+++ b/curations/npm/npmjs/-/node-environment-flags.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: node-environment-flags
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.5:
+    files:
+      - attributions:
+          - Copyright (c) 2018 Christopher Hiller.
+        license: Apache-2.0
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
README expresses Apache-2.0

**Details:**
File incorrectly shows NOASSERTION

**Resolution:**
Change to Apache-2.0

**Affected definitions**:
- [node-environment-flags 1.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/node-environment-flags/1.0.5/1.0.5)