### PR TITLE
File expresses BSD 2-Clause

### DIFF
--- a/curations/npm/npmjs/-/normalize-package-data.yaml
+++ b/curations/npm/npmjs/-/normalize-package-data.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: normalize-package-data
+  provider: npmjs
+  type: npm
+revisions:
+  2.5.0:
+    files:
+      - attributions:
+          - Copyright (c) 2013 Meryn Stol
+        license: BSD 2-Clause
+        path: package/README.md

--- a/curations/npm/npmjs/-/normalize-package-data.yaml
+++ b/curations/npm/npmjs/-/normalize-package-data.yaml
@@ -7,5 +7,5 @@ revisions:
     files:
       - attributions:
           - Copyright (c) 2013 Meryn Stol
-        license: BSD 2-Clause
+        license: BSD-2-Clause
         path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File expresses BSD 2-Clause

**Details:**
File expresses BSD 2-Clause, but confusingly (and I believe unintentionally) links to MIT

**Resolution:**
Change to BSD 2-Clause

**Affected definitions**:
- [normalize-package-data 2.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/normalize-package-data/2.5.0/2.5.0)