### PR TITLE
File expresses MIT

### DIFF
--- a/curations/npm/npmjs/-/parse5.yaml
+++ b/curations/npm/npmjs/-/parse5.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: parse5
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.1:
+    files:
+      - license: MIT
+        path: package/package.json


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
File expresses MIT

**Details:**
File incorrectly shows as NOASSERTION

**Resolution:**
Change to MIT

**Affected definitions**:
- [parse5 1.5.1](https://clearlydefined.io/definitions/npm/npmjs/-/parse5/1.5.1/1.5.1)