### PR TITLE
package.json expresses MIT

### DIFF
--- a/curations/npm/npmjs/-/prelude-ls.yaml
+++ b/curations/npm/npmjs/-/prelude-ls.yaml
@@ -4,5 +4,8 @@ coordinates:
   type: npm
 revisions:
   1.1.2:
+    files:
+      - license: MIT
+        path: package/package.json
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
package.json expresses MIT

**Details:**
File is mislabeled NOASSERTION

**Resolution:**
Change to MIT

**Affected definitions**:
- [prelude-ls 1.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/prelude-ls/1.1.2/1.1.2)