### PR TITLE
Files express no explicit license

### DIFF
--- a/curations/npm/npmjs/-/rx-lite-aggregates.yaml
+++ b/curations/npm/npmjs/-/rx-lite-aggregates.yaml
@@ -4,5 +4,14 @@ coordinates:
   type: npm
 revisions:
   4.0.8:
+    files:
+      - attributions:
+          - Copyright (c) Microsoft
+        license: NONE
+        path: package/rx.lite.aggregates.js
+      - attributions:
+          - 'Copyright (c) Microsoft Open Technologies, Inc.'
+        license: NONE
+        path: package/rx.lite.aggregates.min.js
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Files express no explicit license

**Details:**
File headers refer to the license file.

**Resolution:**
Change to NONE

**Affected definitions**:
- [rx-lite-aggregates 4.0.8](https://clearlydefined.io/definitions/npm/npmjs/-/rx-lite-aggregates/4.0.8/4.0.8)