### PR TITLE
FFmpeg.AutoGen4.2.2.2

### DIFF
--- a/curations/nuget/nuget/-/FFmpeg.AutoGen.yaml
+++ b/curations/nuget/nuget/-/FFmpeg.AutoGen.yaml
@@ -6,3 +6,6 @@ revisions:
   4.2.0:
     licensed:
       declared: LGPL-3.0-only
+  4.2.2.2:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FFmpeg.AutoGen4.2.2.2

**Details:**
Declared LGPL-3.0-only found at license under Files (https://clearlydefined.io/file/ea7d049c7705dc13afc202dd18e1827f3484f8212fd3fa7b82fc4a0c363432c9)

**Resolution:**
Matches Project site (https://github.com/Ruslan-B/FFmpeg.AutoGen/blob/master/LICENSE.txt) and License info (https://www.nuget.org/packages/FFmpeg.AutoGen/4.2.2.2/License)

**Affected definitions**:
- [FFmpeg.AutoGen 4.2.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/FFmpeg.AutoGen/4.2.2.2/4.2.2.2)