### PR TITLE
Aspose.Slides.NET19.8.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Slides.NET.yaml
+++ b/curations/nuget/nuget/-/Aspose.Slides.NET.yaml
@@ -6,3 +6,6 @@ revisions:
   17.12.0:
     licensed:
       declared: OTHER
+  19.8.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.Slides.NET19.8.0

**Details:**
Declaring OTHER for Aspose EULA

**Resolution:**
NuGet license info: https://www.nuget.org/packages/Aspose.Slides.NET/19.8.0/License

Project page: https://products.aspose.com/slides

**Affected definitions**:
- [Aspose.Slides.NET 19.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Slides.NET/19.8.0/19.8.0)