### PR TITLE
Aspose.Words19.8.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Words.yaml
+++ b/curations/nuget/nuget/-/Aspose.Words.yaml
@@ -6,6 +6,9 @@ revisions:
   17.4.0:
     licensed:
       declared: OTHER
+  19.8.0:
+    licensed:
+      declared: OTHER
   20.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.Words19.8.0

**Details:**
Declaring OTHER for Aspose EULA

**Resolution:**
NuGet license metadata: https://www.nuget.org/packages/Aspose.Words/19.8.0/License

Project page: https://products.aspose.com/words/net

**Affected definitions**:
- [Aspose.Words 19.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Words/19.8.0/19.8.0)