### PR TITLE
Aspose.Email20.8.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Email.yaml
+++ b/curations/nuget/nuget/-/Aspose.Email.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  20.8.0:
+    licensed:
+      declared: OTHER
   5.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.Email20.8.0

**Details:**
Declaring OTHER for Aspose EULA

**Resolution:**
NuGet metadata: https://www.nuget.org/packages/Aspose.Email/20.8.0/License

Project page: https://products.aspose.com/words/net

**Affected definitions**:
- [Aspose.Email 20.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Email/20.8.0/20.8.0)