### PR TITLE
Aspose.Words20.9.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Words.yaml
+++ b/curations/nuget/nuget/-/Aspose.Words.yaml
@@ -9,3 +9,6 @@ revisions:
   20.8.0:
     licensed:
       declared: OTHER
+  20.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.Words20.9.0

**Details:**
Declaring OTHER for Aspose EULA

**Resolution:**
NuGet metadata: https://www.nuget.org/packages/Aspose.Words/20.9.0/License

Project page: https://products.aspose.com/words/net

**Affected definitions**:
- [Aspose.Words 20.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Words/20.9.0/20.9.0)