### PR TITLE
highcharts8.2.2

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -42,3 +42,6 @@ revisions:
   8.2.0:
     licensed:
       declared: OTHER
+  8.2.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
highcharts8.2.2

**Details:**
Declaring OTHER for Highcharts license

**Resolution:**
NPM page license metadata: www.highcharts.com/license

**Affected definitions**:
- [highcharts 8.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/8.2.2/8.2.2)