### PR TITLE
ag-grid-enterprise21.1.1

### DIFF
--- a/curations/npm/npmjs/-/ag-grid-enterprise.yaml
+++ b/curations/npm/npmjs/-/ag-grid-enterprise.yaml
@@ -18,6 +18,9 @@ revisions:
   21.1.0:
     licensed:
       declared: OTHER
+  21.1.1:
+    licensed:
+      declared: OTHER
   21.2.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ag-grid-enterprise21.1.1

**Details:**
Declaring OTHER for Commercial software

**Resolution:**
NPM page: "Commercial" 

https://github.com/ag-grid/ag-grid/blob/v21.1.0/LICENSE.txt - 

To view the commercial license for ag-grid-enterprise, see the file packages/ag-grid-enterprise/LICENSE.md

**Affected definitions**:
- [ag-grid-enterprise 21.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/ag-grid-enterprise/21.1.1/21.1.1)