### PR TITLE
Declared license is Apache-2.0

### DIFF
--- a/curations/maven/mavencentral/org.osgi/org.osgi.core.yaml
+++ b/curations/maven/mavencentral/org.osgi/org.osgi.core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: org.osgi.core
+  namespace: org.osgi
+  provider: mavencentral
+  type: maven
+revisions:
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license is Apache-2.0

**Details:**
The license file indicates Apache-2.0

**Resolution:**
Change the declared license to Apache-2.0

**Affected definitions**:
- [org.osgi.core 4.1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.osgi/org.osgi.core/4.1.0/4.1.0)