### PR TITLE
jericho3.0.4

### DIFF
--- a/curations/pypi/pypi/-/jericho.yaml
+++ b/curations/pypi/pypi/-/jericho.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jericho
+  provider: pypi
+  type: pypi
+revisions:
+  3.0.4:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
jericho3.0.4

**Details:**
Declare GPLv2 or later found in PKG-INFO and setup-py

**Resolution:**
Agrees with https://pypi.org/project/jericho/3.0.4/#files

**Affected definitions**:
- [jericho 3.0.4](https://clearlydefined.io/definitions/pypi/pypi/-/jericho/3.0.4/3.0.4)