### PR TITLE
Content includes some BSD-2-Clause

### DIFF
--- a/curations/npm/npmjs/-/ajv.yaml
+++ b/curations/npm/npmjs/-/ajv.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: ajv
+  provider: npmjs
+  type: npm
+revisions:
+  6.12.2:
+    files:
+      - attributions:
+          - (c) 2011 Gary Court.
+          - Copyright 2011 Gary Court.
+        license: BSD-2-Clause
+        path: package/dist/ajv.bundle.js

--- a/curations/npm/npmjs/-/ajv.yaml
+++ b/curations/npm/npmjs/-/ajv.yaml
@@ -8,5 +8,5 @@ revisions:
       - attributions:
           - (c) 2011 Gary Court.
           - Copyright 2011 Gary Court.
-        license: BSD-2-Clause
+        license: BSD-2-Clause-Views
         path: package/dist/ajv.bundle.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Content includes some BSD-2-Clause

**Details:**
ajv.bundle.js includes content that is BSD-2-Clause.

/** @license URI.js v4.2.1 (c) 2011 Gary Court. License: http://github.com/garycourt/uri-js */

The referenced repository indicates BSD-2-Clause.



**Resolution:**
Change the license of ajv.bundle.js to BSD-2-Clause

**Affected definitions**:
- [ajv 6.12.2](https://clearlydefined.io/definitions/npm/npmjs/-/ajv/6.12.2/6.12.2)