### PR TITLE
License states MIT

### DIFF
--- a/curations/npm/npmjs/-/config-chain.yaml
+++ b/curations/npm/npmjs/-/config-chain.yaml
@@ -10,5 +10,8 @@ revisions:
     licensed:
       declared: MIT
   1.1.12:
+    files:
+      - license: MIT
+        path: package/package.json
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License states MIT

**Details:**
The package.json file states MIT

**Resolution:**
Change the license to MIT

**Affected definitions**:
- [config-chain 1.1.12](https://clearlydefined.io/definitions/npm/npmjs/-/config-chain/1.1.12/1.1.12)