### PR TITLE
License is MIT

### DIFF
--- a/curations/npm/npmjs/-/spdx-expression-parse.yaml
+++ b/curations/npm/npmjs/-/spdx-expression-parse.yaml
@@ -9,3 +9,7 @@ revisions:
   3.0.0:
     described:
       releaseDate: '2018-02-26'
+  3.0.1:
+    files:
+      - license: MIT
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is MIT

**Details:**
The flagged file references SPDX codes as part of the functionality that it provides. Based on the last line in the file, my interpretation is that the authors have contributed the functionality under the MIT

**Resolution:**
Change the license to MIT.

**Affected definitions**:
- [spdx-expression-parse 3.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/spdx-expression-parse/3.0.1/3.0.1)