### PR TITLE
Functionality references licenses

### DIFF
--- a/curations/npm/npmjs/-/spdx-license-ids.yaml
+++ b/curations/npm/npmjs/-/spdx-license-ids.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: spdx-license-ids
+  provider: npmjs
+  type: npm
+revisions:
+  3.0.5:
+    files:
+      - license: NONE
+        path: package/deprecated.json
+      - license: CC0-1.0
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Functionality references licenses

**Details:**
The functionality references licenses by SPDX code in functionality; these codes are not intended to apply to the functionality itself. 

**Resolution:**
Update the licenses to reflect what's stated (or not stated)

**Affected definitions**:
- [spdx-license-ids 3.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/spdx-license-ids/3.0.5/3.0.5)