### PR TITLE
Fixing psycopg2-binary 2.8.4

### DIFF
--- a/curations/pypi/pypi/-/psycopg2-binary.yaml
+++ b/curations/pypi/pypi/-/psycopg2-binary.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.8.4:
     licensed:
-      declared: LGPL-3.0-or-later
+      declared: LGPL-3.0-or-later WITH OTHER
   2.8.5:
     licensed:
       declared: LGPL-3.0-or-later WITH OTHER

--- a/curations/pypi/pypi/-/psycopg2-binary.yaml
+++ b/curations/pypi/pypi/-/psycopg2-binary.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  2.8.4:
+    licensed:
+      declared: LGPL-3.0-or-later
   2.8.5:
     licensed:
       declared: LGPL-3.0-or-later WITH OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing psycopg2-binary 2.8.4

**Details:**
Declared is incorrectly GPL when it should be LGPL.  See LICENSE file in "Files" section. 

**Resolution:**
Curated:  LGPL-3.0-or-later  (Note:  a BSD license applies to some files, but I think that would be considered a "Discovered" license).  Thoughts?

**Affected definitions**:
- [psycopg2-binary 2.8.4](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2-binary/2.8.4/2.8.4)