### PR TITLE
Resolve NOASSERTION cases

### DIFF
--- a/curations/git/github/peterh/liner.yaml
+++ b/curations/git/github/peterh/liner.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: liner
+  namespace: peterh
+  provider: github
+  type: git
+revisions:
+  5a0dfa99e2aa1d433a9642e863da51402e609376:
+    files:
+      - attributions:
+          - Copyright (c) 2012 Peter Harris
+        license: MIT
+        path: COPYING
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve NOASSERTION cases

**Details:**
Declared license is MIT 

**Resolution:**
Curate declared license as MIT

**Affected definitions**:
- [liner 5a0dfa99e2aa1d433a9642e863da51402e609376](https://clearlydefined.io/definitions/git/github/peterh/liner/5a0dfa99e2aa1d433a9642e863da51402e609376/5a0dfa99e2aa1d433a9642e863da51402e609376)