### PR TITLE
false license discovered

### DIFF
--- a/curations/maven/mavencentral/org.apache.activemq/activemq-artemis-native.yaml
+++ b/curations/maven/mavencentral/org.apache.activemq/activemq-artemis-native.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: activemq-artemis-native
+  namespace: org.apache.activemq
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.1:
+    files:
+      - license: Apache-2.0
+        path: META-INF/DEPENDENCIES


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
false license discovered

**Details:**
The META-INF/maven/DEPENDENCIES file merely lists some dependencies of the component and their particular licenses. The JBoss Logging I18n Annotation Processor is licensed under LGPL 2.1 but is an optional dependency only.

**Resolution:**
The [source POM](https://github.com/apache/activemq-artemis-native/blob/1.0.1/pom.xml) clearly defines it as a build time dependency only. Thus, the LGPL should be removed from the discovered licenses list.

**Affected definitions**:
- [activemq-artemis-native 1.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.activemq/activemq-artemis-native/1.0.1/1.0.1)