### PR TITLE
Did not discover license

### DIFF
--- a/curations/maven/mavencentral/com.github.peteroupc/numbers.yaml
+++ b/curations/maven/mavencentral/com.github.peteroupc/numbers.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: numbers
+  namespace: com.github.peteroupc
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.2:
+    licensed:
+      declared: CC0-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Did not discover license

**Details:**
The component's declared license has not been discovered properly.

**Resolution:**
Set declared license according to
https://github.com/peteroupc/Numbers/blob/v1.7.2/LICENSE.md

**Affected definitions**:
- [numbers 1.7.2](https://clearlydefined.io/definitions/maven/mavencentral/com.github.peteroupc/numbers/1.7.2)