### PR TITLE
Note license for cbor

### DIFF
--- a/curations/maven/mavencentral/com.upokecenter/cbor.yaml
+++ b/curations/maven/mavencentral/com.upokecenter/cbor.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cbor
+  namespace: com.upokecenter
+  provider: mavencentral
+  type: maven
+revisions:
+  4.2.0:
+    licensed:
+      declared: CC0-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Note license for cbor

**Details:**
Note that the license for cbor-Java is CC0 (alternatively Public Domain)

**Resolution:**
My CBOR library at https://github.com/peteroupc/CBOR-Java has a declared license of CC0 1.0, but this has not been noted automatically by ClearlyDefined.

**Affected definitions**:
- [cbor 4.2.0](https://clearlydefined.io/definitions/maven/mavencentral/com.upokecenter/cbor/4.2.0/4.2.0)