### PR TITLE
missing declared license

### DIFF
--- a/curations/maven/mavencentral/org.jboss.slf4j/slf4j-jboss-logging.yaml
+++ b/curations/maven/mavencentral/org.jboss.slf4j/slf4j-jboss-logging.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: slf4j-jboss-logging
+  namespace: org.jboss.slf4j
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.0.Final:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
missing declared license

**Details:**
The license is declared in the header of each file but not in the pom.xml

**Resolution:**
The headers declare the license to be LGPL 2.1 or later. See https://github.com/jboss-logging/slf4j-jboss-logging/blob/1.2.0.Final/pom.xml for an example

**Affected definitions**:
- [slf4j-jboss-logging 1.2.0.Final](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.slf4j/slf4j-jboss-logging/1.2.0.Final/1.2.0.Final)