### PR TITLE
Roslyn1.2.20906.2

### DIFF
--- a/curations/nuget/nuget/-/Roslyn.yaml
+++ b/curations/nuget/nuget/-/Roslyn.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: OTHER
   1.2.20906.2:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Roslyn1.2.20906.2

**Details:**
Declared license should be "OTHER"

**Resolution:**
Fixing Declared License for PR #8469

No obvious license information on Clearly Defined
License link on Nuget site indicates license is OTHER
License files in repository are after release are after release

License for package should be curated as OTHER

**Affected definitions**:
- [Roslyn 1.2.20906.2](https://clearlydefined.io/definitions/nuget/nuget/-/Roslyn/1.2.20906.2/1.2.20906.2)