### PR TITLE
stdole16.7.30508.193

### DIFF
--- a/curations/nuget/nuget/-/stdole.yaml
+++ b/curations/nuget/nuget/-/stdole.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: Other
   16.7.30508.193:
     licensed:
-      declared: NONE
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
stdole16.7.30508.193

**Details:**
Declared License should be "OTHER"

**Resolution:**
Fixing Declared License for PR# 8473

License file on Clearly Defined indicates license is OTHER
License link on Nuget site indicates same
License file in package indicates same

License for package should be curated as OTHER

**Affected definitions**:
- [stdole 16.7.30508.193](https://clearlydefined.io/definitions/nuget/nuget/-/stdole/16.7.30508.193/16.7.30508.193)