### PR TITLE
Roslyn.Services.CSharp1.2.20906.2

### DIFF
--- a/curations/nuget/nuget/-/Roslyn.Services.CSharp.yaml
+++ b/curations/nuget/nuget/-/Roslyn.Services.CSharp.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.2.20906.2:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Roslyn.Services.CSharp1.2.20906.2

**Details:**
Declared License should be OTHER

**Resolution:**
Fixing Declared License for PR #8472

No obvious license information in Clearly Defined
License link on Nuget site indicates license is OTHER
License file in repository was created after release of this version

License for package should be curated as OTHER

**Affected definitions**:
- [Roslyn.Services.CSharp 1.2.20906.2](https://clearlydefined.io/definitions/nuget/nuget/-/Roslyn.Services.CSharp/1.2.20906.2/1.2.20906.2)