### PR TITLE
highcharts7.2.2

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -24,6 +24,9 @@ revisions:
   7.2.1:
     licensed:
       declared: OTHER
+  7.2.2:
+    licensed:
+      declared: OTHER
   8.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
highcharts7.2.2

**Details:**
Declaring OTHER for Highcharts commercial license.

**Resolution:**
NPM page: www.highcharts.com/license

Repo license on this page - https://github.com/highcharts/highcharts-dist/tree/v7.2.2

**Affected definitions**:
- [highcharts 7.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/7.2.2/7.2.2)