### PR TITLE
ag-grid-enterprise23.2.1

### DIFF
--- a/curations/npm/npmjs/-/ag-grid-enterprise.yaml
+++ b/curations/npm/npmjs/-/ag-grid-enterprise.yaml
@@ -33,3 +33,6 @@ revisions:
   23.2.0:
     licensed:
       declared: OTHER
+  23.2.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ag-grid-enterprise23.2.1

**Details:**
Declaring OTHER for commercial license

**Resolution:**
NPM License - "Commercial"

Repo license - https://github.com/ag-grid/ag-grid/blob/v23.2.1/LICENSE.txt

**Affected definitions**:
- [ag-grid-enterprise 23.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/ag-grid-enterprise/23.2.1/23.2.1)