### PR TITLE
chardet4.0.0

### DIFF
--- a/curations/pypi/pypi/-/chardet.yaml
+++ b/curations/pypi/pypi/-/chardet.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.4:
     licensed:
       declared: LGPL-2.1-only
+  4.0.0:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
chardet4.0.0

**Details:**
Fixing the Declared License to LGPL 2.1 only

**Resolution:**
chardet/LICENSE at 4.0.0 · chardet/chardet (github.com)

**Affected definitions**:
- [chardet 4.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/chardet/4.0.0/4.0.0)