### PR TITLE
ag-grid-enterprise24.1.0

### DIFF
--- a/curations/npm/npmjs/-/ag-grid-enterprise.yaml
+++ b/curations/npm/npmjs/-/ag-grid-enterprise.yaml
@@ -33,3 +33,6 @@ revisions:
   23.2.0:
     licensed:
       declared: OTHER
+  24.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ag-grid-enterprise24.1.0

**Details:**
Declaring OTHER for commercial license

**Resolution:**
AG-Grid-Enterprise requires a commercial license

https://github.com/ag-grid/ag-grid/blob/v24.1.0/LICENSE.txt

**Affected definitions**:
- [ag-grid-enterprise 24.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/ag-grid-enterprise/24.1.0/24.1.0)