### PR TITLE
Add source URL for com.google.code.gson:gson 2.8.6

### DIFF
--- a/curations/maven/mavencentral/com.google.code.gson/gson.yaml
+++ b/curations/maven/mavencentral/com.google.code.gson/gson.yaml
@@ -1,0 +1,18 @@
+coordinates:
+  name: gson
+  namespace: com.google.code.gson
+  provider: mavencentral
+  type: maven
+revisions:
+  2.8.6:
+    described:
+      facets:
+        dev: []
+        tests: []
+      sourceLocation:
+        name: gson
+        namespace: google
+        provider: github
+        revision: 29c93895bbcaed02178abc9e3d47b73878aaca73
+        type: git
+        url: 'https://github.com/google/gson/commit/29c93895bbcaed02178abc9e3d47b73878aaca73'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add source URL for com.google.code.gson:gson 2.8.6

**Details:**
Missing source URL for com.google.code.gson:gson 2.8.6

**Resolution:**
Add source URL for com.google.code.gson:gson 2.8.6

**Affected definitions**:
- [gson 2.8.6](https://clearlydefined.io/definitions/maven/mavencentral/com.google.code.gson/gson/2.8.6/2.8.6)