### PR TITLE
Accord 3.7.0

### DIFF
--- a/curations/nuget/nuget/-/Accord.yaml
+++ b/curations/nuget/nuget/-/Accord.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.7.0:
     licensed:
-      declared: LGPL-2.1-or-later+
+      declared: LGPL-2.1-or-later
   3.8.0:
     licensed:
       declared: LGPL-2.1-or-later

--- a/curations/nuget/nuget/-/Accord.yaml
+++ b/curations/nuget/nuget/-/Accord.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.7.0:
     licensed:
-      declared: LGPL-2.1+
+      declared: LGPL-2.1-or-later+
   3.8.0:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Accord 3.7.0

**Details:**
Correcting from deprecated SPDX identifier (LGPL-2.1+) to correct/current identifier of "LGPL-2.1-or-later.'

**Resolution:**
"LGPL-2.1-or-later'

**Affected definitions**:
- [Accord 3.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Accord/3.7.0/3.7.0)