### PR TITLE
Add missing source location and declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.sshd/sshd-sftp.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.sshd/sshd-sftp.yaml
@@ -1,0 +1,22 @@
+coordinates:
+  name: sshd-sftp
+  namespace: org.apache.sshd
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.6.0:
+    described:
+      facets:
+        dev:
+          - sshd-sftp/src/main/**
+        tests:
+          - sshd-sftp/src/test/**
+      sourceLocation:
+        name: mina-sshd
+        namespace: apache
+        provider: github
+        revision: a0bbdf9d37fb7a453d4354e93c9e6c02c013a85d
+        type: git
+        url: 'https://github.com/apache/mina-sshd/commit/a0bbdf9d37fb7a453d4354e93c9e6c02c013a85d'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing source location and declared license

**Details:**
missing source location and declared license

**Resolution:**
Add missing source location and declared license

**Affected definitions**:
- [sshd-sftp 2.6.0](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.sshd/sshd-sftp/2.6.0/2.6.0)