### PR TITLE
Radzen.Blazor 2.11.13

### DIFF
--- a/curations/nuget/nuget/-/Radzen.Blazor.yaml
+++ b/curations/nuget/nuget/-/Radzen.Blazor.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.11.13:
     licensed:
-      declared: MIT
+      declared: X11
   2.17.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Radzen.Blazor 2.11.13

**Details:**
Merged incorrectly - this is a match for "X11"

**Resolution:**
Compare license file (https://www.nuget.org/packages/Radzen.Blazor/2.11.13/License) with https://spdx.org/licenses/X11.html

**Affected definitions**:
- [Radzen.Blazor 2.11.13](https://clearlydefined.io/definitions/nuget/nuget/-/Radzen.Blazor/2.11.13/2.11.13)