### PR TITLE
Confluent.Kafka 0.11.1

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -6,6 +6,12 @@ revisions:
   0.11.0:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause
+  0.11.1:
+    files:
+      - attributions:
+          - 'Copyright 2016-2017 Confluent Inc., Andreas Heider Kafka Confluent'
+        license: Apache-2.0 AND BSD-2-Clause
+        path: Confluent.Kafka.nuspec
   0.11.2:
     licensed:
       declared: Apache-2.0 AND BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Confluent.Kafka 0.11.1

**Details:**
Missing BSD-2-Clause on the license file as a "discovered" license, so adding this info to the nuspec.  See license file - https://github.com/confluentinc/confluent-kafka-dotnet/blob/v0.11.1/LICENSE

**Resolution:**
Curating nuspec to be "Apache-2.0 AND BSD-2-Clause."

**Affected definitions**:
- [Confluent.Kafka 0.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/0.11.1/0.11.1)