### PR TITLE
Release date was off by ~19 years

### DIFF
--- a/curations/maven/mavencentral/com.puppycrawl.tools/checkstyle.yaml
+++ b/curations/maven/mavencentral/com.puppycrawl.tools/checkstyle.yaml
@@ -7,3 +7,6 @@ revisions:
   '6.12':
     licensed:
       declared: LGPL-2.1-only
+  '8.29':
+    described:
+      releaseDate: '2020-01-26'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Release date was off by ~19 years

**Details:**
The release date was listed as '2001-08-29'. but Maven Jan 26, 2020, which seems much more reasonable. 

**Resolution:**
Updated the release date to match maven: 
https://mvnrepository.com/artifact/com.puppycrawl.tools/checkstyle/8.29

**Affected definitions**:
- [checkstyle 8.29](https://clearlydefined.io/definitions/maven/mavencentral/com.puppycrawl.tools/checkstyle/8.29)