### PR TITLE
README declares MIT

### DIFF
--- a/curations/npm/npmjs/-/babel-loader.yaml
+++ b/curations/npm/npmjs/-/babel-loader.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: babel-loader
+  provider: npmjs
+  type: npm
+revisions:
+  8.0.4:
+    files:
+      - license: MIT
+        path: package/README.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
README declares MIT

**Details:**
The README declares MIT

**Resolution:**
Change the license on this file to MIT.

**Affected definitions**:
- [babel-loader 8.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/babel-loader/8.0.4/8.0.4)