### PR TITLE
License is MPL-1.1

### DIFF
--- a/curations/npm/npmjs/-/html-minifier.yaml
+++ b/curations/npm/npmjs/-/html-minifier.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: html-minifier
+  provider: npmjs
+  type: npm
+revisions:
+  3.5.21:
+    files:
+      - license: MPL-1.1
+        path: package/src/htmlparser.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is MPL-1.1

**Details:**
I believe that the "MPL" content cited in the header is from here: https://gist.github.com/xgz123/3c039d60bdeab36bc9082f134c2d1953 (which is licensed MPL-1.1)

**Resolution:**
Change the license on this one file to MPL-1.1.

**Affected definitions**:
- [html-minifier 3.5.21](https://clearlydefined.io/definitions/npm/npmjs/-/html-minifier/3.5.21/3.5.21)