### PR TITLE
Radzen.Blazor 2.18.6

### DIFF
--- a/curations/nuget/nuget/-/Radzen.Blazor.yaml
+++ b/curations/nuget/nuget/-/Radzen.Blazor.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: OTHER
   2.18.6:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Radzen.Blazor 2.18.6

**Details:**
Correcting

**Resolution:**
Modified license file - should be OTHER

**Affected definitions**:
- [Radzen.Blazor 2.18.6](https://clearlydefined.io/definitions/nuget/nuget/-/Radzen.Blazor/2.18.6/2.18.6)