### PR TITLE
pandas v1.2.1

### DIFF
--- a/curations/pypi/pypi/-/pandas.yaml
+++ b/curations/pypi/pypi/-/pandas.yaml
@@ -39,3 +39,13 @@ revisions:
   1.2.0:
     licensed:
       declared: BSD-3-Clause
+  1.2.1:
+    described:
+      releaseDate: '2021-01-20'
+      sourceLocation:
+        name: pandas
+        namespace: pandas-dev
+        provider: github
+        revision: 9d598a5e1eee26df95b3910e3f2934890d062caa
+        type: git
+        url: 'https://github.com/pandas-dev/pandas/commit/9d598a5e1eee26df95b3910e3f2934890d062caa'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pandas v1.2.1

**Details:**
adding information for the latest pandas release

**Resolution:**
The information was taken from PyPI and https://github.com/pandas-dev/pandas/releases/tag/v1.2.1

**Affected definitions**:
- [pandas 1.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/pandas/1.2.1)