### PR TITLE
NetMQ 4.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/NetMQ.yaml
+++ b/curations/nuget/nuget/-/NetMQ.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.0.0.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
NetMQ 4.0.0.1

**Details:**
Updating to the WITH OTHER format = LGPL-3.0-or-later WITH OTHER 

**Resolution:**
OTHER is for the "Special exception" at the bottom of the file.  It is very close to the classpath exception, but with some edits. 

**Affected definitions**:
- [NetMQ 4.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/NetMQ/4.0.0.1)