### PR TITLE
highcharts6.0.7

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -6,6 +6,9 @@ revisions:
   6.0.1:
     licensed:
       declared: OTHER
+  6.0.7:
+    licensed:
+      declared: OTHER
   6.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
highcharts6.0.7

**Details:**
Declaring OTHER for Highcharts commercial license

**Resolution:**
Licensing: www.highcharts.com/license

**Affected definitions**:
- [highcharts 6.0.7](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/6.0.7/6.0.7)