### PR TITLE
Declared license has not been discovered

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -10,3 +10,6 @@ revisions:
   20.2.0:
     licensed:
       declared: UPL-1.0
+  20.3.1:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license has not been discovered

**Details:**
The SDK component seems to be released under the UPL-1.0 license as can be seen here:
https://github.com/oracle/graal/blob/vm-20.3.1/sdk/LICENSE.md

**Resolution:**
Add the missing declared license

**Affected definitions**:
- [graal-sdk 20.3.1](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/20.3.1)