### PR TITLE
NetMQ 4.0.1.6

### DIFF
--- a/curations/nuget/nuget/-/NetMQ.yaml
+++ b/curations/nuget/nuget/-/NetMQ.yaml
@@ -6,3 +6,6 @@ revisions:
   4.0.0.1:
     licensed:
       declared: LGPL-3.0-or-later WITH OTHER
+  4.0.1.6:
+    licensed:
+      declared: LGPL-3.0-or-later WITH OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NetMQ 4.0.1.6

**Details:**
Headers indicate this is "or-later" and project has LGPL-3.0 LICENSE file.  LICENSE file includes a "Special Exception" that does not have a matching SPDX.

**Resolution:**
So, curating as "LGPL-3.0-or-later WITH OTHER."

**Affected definitions**:
- [NetMQ 4.0.1.6](https://clearlydefined.io/definitions/nuget/nuget/-/NetMQ/4.0.1.6/4.0.1.6)