### PR TITLE
ipykernel5.4.3

### DIFF
--- a/curations/pypi/pypi/-/ipykernel.yaml
+++ b/curations/pypi/pypi/-/ipykernel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ipykernel
+  provider: pypi
+  type: pypi
+revisions:
+  5.4.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ipykernel5.4.3

**Details:**
Fixing curation to BSD-3-Clause

**Resolution:**
Copying file in PyPI package download is BSD-3-Clause and GitHub repo license is BSD-3-Clause -
https://github.com/ipython/ipykernel/blob/5.4.3/COPYING.md

**Affected definitions**:
- [ipykernel 5.4.3](https://clearlydefined.io/definitions/pypi/pypi/-/ipykernel/5.4.3)