### PR TITLE
JWT 7.2.1

### DIFF
--- a/curations/nuget/nuget/-/JWT.yaml
+++ b/curations/nuget/nuget/-/JWT.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   7.2.1:
     licensed:
-      declared: OTHER
+      declared: CC0-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
JWT 7.2.1

**Details:**
Was curated OTHER for public domain, however the public domain license it points to is CC0-1.0, which has a SPDX

**Resolution:**
Updating to CC0-1.0

**Affected definitions**:
- [JWT 7.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/JWT/7.2.1/7.2.1)