### PR TITLE
scp0.13.3

### DIFF
--- a/curations/pypi/pypi/-/scp.yaml
+++ b/curations/pypi/pypi/-/scp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: scp
+  provider: pypi
+  type: pypi
+revisions:
+  0.13.3:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
scp0.13.3

**Details:**
Should be LGPL-2.1-or-later as seen in the "tar" file in the downloaded component and also Files license file here (https://clearlydefined.io/file/2455cf0fc78e13772bf10ef5f209e7eb8625706d671b2f420cc8add37d548c1c) 

**Resolution:**
Also in license file on GitHub here (https://github.com/jbardin/scp.py/blob/v0.13.3/LICENSE.txt)

**Affected definitions**:
- [scp 0.13.3](https://clearlydefined.io/definitions/pypi/pypi/-/scp/0.13.3/0.13.3)