### PR TITLE
websocket-client0.56.0

### DIFF
--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: websocket-client
+  provider: pypi
+  type: pypi
+revisions:
+  0.56.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
websocket-client0.56.0

**Details:**
Should be BSD-3-Clause found at Files (https://clearlydefined.io/file/a47b06717e8a3cf01d1307141287b1b4fa17fe4bb8785633d2fc6f57cb71d05e) and Project description (https://pypi.org/project/websocket-client/0.56.0/)

**Resolution:**
and at Source (https://github.com/websocket-client/websocket-client/blob/v0.56.0/LICENSE) - Change to BSD-3-Clause

**Affected definitions**:
- [websocket-client 0.56.0](https://clearlydefined.io/definitions/pypi/pypi/-/websocket-client/0.56.0/0.56.0)