### PR TITLE
Stubble.Core 1.6.3

### DIFF
--- a/curations/nuget/nuget/-/Stubble.Core.yaml
+++ b/curations/nuget/nuget/-/Stubble.Core.yaml
@@ -13,6 +13,11 @@ revisions:
     licensed:
       declared: MIT
   1.6.3:
+    files:
+      - attributions:
+          - Copyright (c) 2017
+        license: MIT AND BSD-2-Clause
+        path: Stubble.Core.nuspec
     licensed:
       declared: MIT
   1.7.2:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Stubble.Core 1.6.3

**Details:**
Declared license is MIT, however a discovered license should be BSD-2-Clause as found on the license file

**Resolution:**
To add BSD-2-Clause as a discovered license, I am curating the nuspec file with this PR.  Thanks

**Affected definitions**:
- [Stubble.Core 1.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/Stubble.Core/1.6.3/1.6.3)