### PR TITLE
pyzmq22.0.3

### DIFF
--- a/curations/pypi/pypi/-/pyzmq.yaml
+++ b/curations/pypi/pypi/-/pyzmq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pyzmq
+  provider: pypi
+  type: pypi
+revisions:
+  22.0.3:
+    licensed:
+      declared: BSD-3-Clause AND LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pyzmq22.0.3

**Details:**
Should be BSD-3-Clause and LGPL-v3-or-later found (https://clearlydefined.io/file/aef3b80570351d44e29c22d080d4e9e106b34f3fdbc5cdf9636994474c72b1a2) and (https://clearlydefined.io/file/aef3b80570351d44e29c22d080d4e9e106b34f3fdbc5cdf9636994474c72b1a2)

**Resolution:**
Also found in pyzmq-22.0.3.tar.gz in Download Files

**Affected definitions**:
- [pyzmq 22.0.3](https://clearlydefined.io/definitions/pypi/pypi/-/pyzmq/22.0.3/22.0.3)