### PR TITLE
websocket-client0.58.0

### DIFF
--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: BSD-3-Clause
   0.58.0:
     licensed:
-      declared: LGPL-2.0-only
+      declared: LGPL-2.1-or-later

--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -6,3 +6,6 @@ revisions:
   0.56.0:
     licensed:
       declared: BSD-3-Clause
+  0.58.0:
+    licensed:
+      declared: LGPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
websocket-client0.58.0

**Details:**
Should be LGPL-2.1-only found in Files (https://clearlydefined.io/file/7c6699c75f87b52bdc542db26d6b1b92892577cda46e20eceb79e2790a1c291b) and source (https://github.com/websocket-client/websocket-client/blob/v0.58.0/LICENSE)

**Resolution:**
Change from GPL-3.0 to LGPL-2.1-only

**Affected definitions**:
- [websocket-client 0.58.0](https://clearlydefined.io/definitions/pypi/pypi/-/websocket-client/0.58.0/0.58.0)