### PR TITLE
Unidecode1.2.0

### DIFF
--- a/curations/pypi/pypi/-/Unidecode.yaml
+++ b/curations/pypi/pypi/-/Unidecode.yaml
@@ -24,4 +24,4 @@ revisions:
       declared: GPL-2.0-or-later
   1.2.0:
     licensed:
-      declared: LGPL-2.0-or-later
+      declared: GPL-2.0-or-later

--- a/curations/pypi/pypi/-/Unidecode.yaml
+++ b/curations/pypi/pypi/-/Unidecode.yaml
@@ -22,3 +22,6 @@ revisions:
   1.1.1:
     licensed:
       declared: GPL-2.0-or-later
+  1.2.0:
+    licensed:
+      declared: LGPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Unidecode1.2.0

**Details:**
Should be LGPL-2.0-or-later found in Files (https://clearlydefined.io/file/8177f97513213526df2cf6184d8ff986c675afb514d4e68a404010521b880643) and License file in Download Files at Unidecode-1.2.0-py2.py3-none-any.whl

**Resolution:**
Update to LGPL-2.0-or later

**Affected definitions**:
- [Unidecode 1.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/Unidecode/1.2.0/1.2.0)