### PR TITLE
adding missing link to github page

### DIFF
--- a/curations/pypi/pypi/-/deodr.yaml
+++ b/curations/pypi/pypi/-/deodr.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: deodr
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.19:
+    described:
+      releaseDate: '2021-01-04'
+      sourceLocation:
+        name: deodr
+        namespace: martinresearch
+        provider: github
+        revision: 968cea26d85346a71791c482a19056fde899f5ce
+        type: git
+        url: 'https://github.com/martinresearch/deodr/commit/968cea26d85346a71791c482a19056fde899f5ce'

--- a/curations/pypi/pypi/-/deodr.yaml
+++ b/curations/pypi/pypi/-/deodr.yaml
@@ -10,6 +10,6 @@ revisions:
         name: deodr
         namespace: martinresearch
         provider: github
-        revision: 968cea26d85346a71791c482a19056fde899f5ce
+        revision: cd59689e56566077e217ac5987fddc71a0914d3f
         type: git
-        url: 'https://github.com/martinresearch/deodr/commit/968cea26d85346a71791c482a19056fde899f5ce'
+        url: 'https://github.com/martinResearch/DEODR/commit/cd59689e56566077e217ac5987fddc71a0914d3f'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
adding missing link to github page

**Details:**
missing link to github page

**Resolution:**
adding missing link to github page

**Affected definitions**:
- [deodr 0.1.19](https://clearlydefined.io/definitions/pypi/pypi/-/deodr/0.1.19)