### PR TITLE
Fix missing license type in AdaptiveExpressions@4.12.1

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveExpressions.yaml
+++ b/curations/nuget/nuget/-/AdaptiveExpressions.yaml
@@ -15,6 +15,9 @@ revisions:
   4.11.1:
     licensed:
       declared: MIT
+  4.12.1:
+    licensed:
+      declared: MIT
   4.9.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Fix missing license type

**Details:**
Add MIT license which is consistent with previous versions.

**Resolution:**
https://github.com/microsoft/botframework-sdk/blob/master/LICENSE

**Affected definitions**:
- [AdaptiveExpressions 4.12.1](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveExpressions/4.12.1/4.12.1)