### PR TITLE
websocket-client 0.56.0

### DIFF
--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.56.0:
     licensed:
-      declared: BSD-3-Clause
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
websocket-client 0.56.0

**Details:**
The LICENSE file and metadata for the package is BSD-3-Clause.  However, per this Issue (https://github.com/websocket-client/websocket-client/issues/526), the project did not have the rights to change the license from LGPL to BSD.  Based on that, curating this as LGPL-2.1-or-later.

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [websocket-client 0.56.0](https://clearlydefined.io/definitions/pypi/pypi/-/websocket-client/0.56.0/0.56.0)