### PR TITLE
cssmin 0.3.2

### DIFF
--- a/curations/npm/npmjs/-/cssmin.yaml
+++ b/curations/npm/npmjs/-/cssmin.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   0.3.2:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-2-Clause
   0.4.3:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
cssmin 0.3.2

**Details:**
This was merged as "BSD-3-Clause," per the Troubleshooting guidelines, however, it looks like the author clarified he meant BSD-2-Clause on a later version (https://clearlydefined.io/definitions/npm/npmjs/-/cssmin/0.4.3). I think we can conclude he meant past versions to also be BSD-2-Clause.

**Resolution:**
Updating to BSD-2-Clause

**Affected definitions**:
- [cssmin 0.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/cssmin/0.3.2/0.3.2)