### PR TITLE
Code license is MIT

### DIFF
--- a/curations/git/github/davegamble/cjson.yaml
+++ b/curations/git/github/davegamble/cjson.yaml
@@ -7,3 +7,6 @@ revisions:
   7db005e0281b140a13c93c9aeda4f1ee1bd8e740:
     licensed:
       declared: MIT
+  d2735278ed1c2e4556f53a7a782063b31331dbf7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Code license is MIT

**Details:**
Some JSON related tests use the Apache license, but none of the core code does.

**Resolution:**
Test with Apache license:

https://github.com/DaveGamble/cJSON/tree/master/tests/json-patch-tests

**Affected definitions**:
- [cjson d2735278ed1c2e4556f53a7a782063b31331dbf7](https://clearlydefined.io/definitions/git/github/davegamble/cjson/d2735278ed1c2e4556f53a7a782063b31331dbf7)

