### PR TITLE
charts-highcharts 3.5.1

### DIFF
--- a/curations/maven/mavencentral/io.gatling.highcharts/gatling-charts-highcharts.yaml
+++ b/curations/maven/mavencentral/io.gatling.highcharts/gatling-charts-highcharts.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: gatling-charts-highcharts
+  namespace: io.gatling.highcharts
+  provider: mavencentral
+  type: maven
+revisions:
+  3.5.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
charts-highcharts 3.5.1

**Details:**
OTHER: https://raw.githubusercontent.com/gatling/gatling-highcharts/master/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [gatling-charts-highcharts 3.5.1](https://clearlydefined.io/definitions/maven/mavencentral/io.gatling.highcharts/gatling-charts-highcharts/3.5.1/3.5.1)

