### PR TITLE
M2Mqtt4.3.0

### DIFF
--- a/curations/nuget/nuget/-/M2Mqtt.yaml
+++ b/curations/nuget/nuget/-/M2Mqtt.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.3.0:
     licensed:
-      declared: NONE
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
M2Mqtt4.3.0

**Details:**
Fixing Declared License to EPL-1.0

**Resolution:**
There's no license with the NuGet, and project moved from Codeplex to GitHub. https://github.com/salmanebah/m2mqtt/blob/a374780296cd404a1358644c3b5613b981471d71/LICENSE

**Affected definitions**:
- [M2Mqtt 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/M2Mqtt/4.3.0/4.3.0)

