### PR TITLE
Update StackExchange.Redis.StrongName 1.0.394 License

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.333:
     licensed:
       declared: MIT
+  1.0.394:
+    licensed:
+      declared: MIT
   1.0.414:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update StackExchange.Redis.StrongName 1.0.394 License

**Details:**
License: https://raw.githubusercontent.com/StackExchange/StackExchange.Redis/master/LICENSE

**Resolution:**
Update the License type to MIT

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.0.394](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.0.394/1.0.394)

