### PR TITLE
Update YACLP 1.0.46 description and license

### DIFF
--- a/curations/nuget/nuget/-/YACLP.yaml
+++ b/curations/nuget/nuget/-/YACLP.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: YACLP
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.46:
+    described:
+      sourceLocation:
+        name: yaclp
+        namespace: uglybugger
+        provider: github
+        revision: d2c7ced03c24db287996ac53119d05d45b1e6ae2
+        type: git
+        url: 'https://github.com/uglybugger/yaclp/commit/d2c7ced03c24db287996ac53119d05d45b1e6ae2'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update YACLP 1.0.46 description and license

**Details:**
nuget: https://www.nuget.org/packages/Yaclp/1.0.46
git: https://github.com/uglybugger/Yaclp


**Resolution:**
Update description and license

**Affected definitions**:
- [YACLP 1.0.46](https://clearlydefined.io/definitions/nuget/nuget/-/YACLP/1.0.46/1.0.46)

