### PR TITLE
Hangfire.AspNetCore1.7.9

### DIFF
--- a/curations/nuget/nuget/-/Hangfire.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Hangfire.AspNetCore.yaml
@@ -9,3 +9,6 @@ revisions:
   1.7.12:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER
+  1.7.9:
+    licensed:
+      declared: LGPL-3.0-or-later OR OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Hangfire.AspNetCore1.7.9

**Details:**
Declaring LGPL-3.0-or-later OR OTHER (to include the commercial license)

**Resolution:**
https://raw.githubusercontent.com/HangfireIO/Hangfire/master/LICENSE.md

**Affected definitions**:
- [Hangfire.AspNetCore 1.7.9](https://clearlydefined.io/definitions/nuget/nuget/-/Hangfire.AspNetCore/1.7.9/1.7.9)

