### PR TITLE
Hangfire.SqlServer1.7.9

### DIFF
--- a/curations/nuget/nuget/-/Hangfire.SqlServer.yaml
+++ b/curations/nuget/nuget/-/Hangfire.SqlServer.yaml
@@ -9,3 +9,6 @@ revisions:
   1.7.11:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER
+  1.7.9:
+    licensed:
+      declared: LGPL-3.0-or-later OR OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Hangfire.SqlServer1.7.9

**Details:**
Declaring LGPL-3.0-or-later OR OTHER (to include the commercial license)

**Resolution:**
https://raw.githubusercontent.com/HangfireIO/Hangfire/master/LICENSE.md

**Affected definitions**:
- [Hangfire.SqlServer 1.7.9](https://clearlydefined.io/definitions/nuget/nuget/-/Hangfire.SqlServer/1.7.9/1.7.9)

