### PR TITLE
Specify declared license for cordova-plugin-file 2.1.0

### DIFF
--- a/curations/npm/npmjs/-/cordova-plugin-file.yaml
+++ b/curations/npm/npmjs/-/cordova-plugin-file.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cordova-plugin-file
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Specify declared license for cordova-plugin-file 2.1.0

**Details:**
No declared license was specified for cordova-plugin-file 2.1.0.

**Resolution:**
Set declared license to Apache-2.0, per the following:
https://github.com/apache/cordova-plugin-file/blob/2.1.0/LICENSE

**Affected definitions**:
- [cordova-plugin-file 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/cordova-plugin-file/2.1.0)

