### PR TITLE
Specify declared license for ios-deploy 1.8.7

### DIFF
--- a/curations/git/github/ios-control/ios-deploy.yaml
+++ b/curations/git/github/ios-control/ios-deploy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ios-deploy
+  namespace: ios-control
+  provider: github
+  type: git
+revisions:
+  436cb4b593509602817b2a8ba94b42d76586dcce:
+    licensed:
+      declared: GPL-3.0-or-later+


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Specify declared license for ios-deploy 1.8.7

**Details:**
No declared license specified for ios-deploy 1.8.7.

**Resolution:**
Adding a declared license of GPL version 3 or above, per https://github.com/ios-control/ios-deploy/blob/1.8.7/LICENSE

**Affected definitions**:
- [ios-deploy 436cb4b593509602817b2a8ba94b42d76586dcce](https://clearlydefined.io/definitions/git/github/ios-control/ios-deploy/436cb4b593509602817b2a8ba94b42d76586dcce)

