### PR TITLE
Specify declared license for ios-deploy 1.8.7

### DIFF
--- a/curations/npm/npmjs/-/ios-deploy.yaml
+++ b/curations/npm/npmjs/-/ios-deploy.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.8.7:
     licensed:
-      declared: GPL-3.0-or-later+
+      declared: GPL-3.0-or-later

--- a/curations/npm/npmjs/-/ios-deploy.yaml
+++ b/curations/npm/npmjs/-/ios-deploy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ios-deploy
+  provider: npmjs
+  type: npm
+revisions:
+  1.8.7:
+    licensed:
+      declared: GPL-3.0-or-later+


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Specify declared license for ios-deploy 1.8.7

**Details:**
No declared license is specified for ios-deploy version 1.8.7

**Resolution:**
Specifying a declared license of GPL 3 or higher, per https://github.com/ios-control/ios-deploy/blob/1.8.7/LICENSE

**Affected definitions**:
- [ios-deploy 1.8.7](https://clearlydefined.io/definitions/npm/npmjs/-/ios-deploy/1.8.7)

