### PR TITLE
Fixing lz4net.unsafe.netcore licensing info

### DIFF
--- a/curations/nuget/nuget/-/lz4net.unsafe.netcore.yaml
+++ b/curations/nuget/nuget/-/lz4net.unsafe.netcore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: lz4net.unsafe.netcore
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.15.93:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fixing lz4net.unsafe.netcore licensing info

**Details:**
lz4net (the parent project for this package) is licensed under BSD 2-Clause "Simplified" license

**Resolution:**
From license info for lz4net.unsafe.netcore:
https://www.nuget.org/packages/lz4net/1.0.15.93

The license info points to here:
https://github.com/MiloszKrajewski/lz4net/blob/master/LICENSE.md

**Affected definitions**:
- [lz4net.unsafe.netcore 1.0.15.93](https://clearlydefined.io/definitions/nuget/nuget/-/lz4net.unsafe.netcore/1.0.15.93/1.0.15.93)