### PR TITLE
security-framework/2.0.0

### DIFF
--- a/curations/crate/cratesio/-/security-framework.yaml
+++ b/curations/crate/cratesio/-/security-framework.yaml
@@ -6,3 +6,6 @@ revisions:
   0.4.4:
     licensed:
       declared: Apache-2.0 OR MIT
+  2.0.0:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
security-framework/2.0.0

**Details:**
Correcting license: https://github.com/kornelski/rust-security-framework/tree/v2.0.0#license

**Resolution:**
Apache-2.0 OR MIT

**Affected definitions**:
- [security-framework 2.0.0](https://clearlydefined.io/definitions/crate/cratesio/-/security-framework/2.0.0/2.0.0)