### PR TITLE
Declared license too broad

### DIFF
--- a/curations/pypi/pypi/-/docstring-to-markdown.yaml
+++ b/curations/pypi/pypi/-/docstring-to-markdown.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: docstring-to-markdown
+  provider: pypi
+  type: pypi
+revisions:
+  '0.7':
+    licensed:
+      declared: LGPL-2.1+

--- a/curations/pypi/pypi/-/docstring-to-markdown.yaml
+++ b/curations/pypi/pypi/-/docstring-to-markdown.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   '0.7':
     licensed:
-      declared: LGPL-2.1+
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license too broad

**Details:**
Claimed GPL 3, but is only LGPL v2.1 and later.

**Resolution:**
https://github.com/krassowski/docstring-to-markdown/blob/v0.7/LICENSE

**Affected definitions**:
- [docstring-to-markdown 0.7](https://clearlydefined.io/definitions/pypi/pypi/-/docstring-to-markdown/0.7/0.7)