### PR TITLE
Define golang dependency gopkg.in/yaml.v2 which points to https://github.com/go-yaml/yaml

### DIFF
--- a/curations/git/github/go-yaml/yaml.yaml
+++ b/curations/git/github/go-yaml/yaml.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: yaml
+  namespace: go-yaml
+  provider: github
+  type: git
+revisions:
+  7649d4548cb53a614db133b2a8ac1f31859dda8c:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Define golang dependency gopkg.in/yaml.v2 which points to https://github.com/go-yaml/yaml with version 2.4.0

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>