### PR TITLE
Define go dependency k8s.io/api which points to https://github.com/kubernetes/api v0.21.0

### DIFF
--- a/curations/git/github/kubernetes/api.yaml
+++ b/curations/git/github/kubernetes/api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: api
+  namespace: kubernetes
+  provider: github
+  type: git
+revisions:
+  5d0d5b56b51109a75225966be27ca7b6c6ca6dcd:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Define go dependency k8s.io/api which points to https://github.com/kubernetes/api v0.21.0

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>