### PR TITLE
Define go dependency k8s.io/apimachinery which points to https://github.com/kubernetes/apimachinery v0.21.0

### DIFF
--- a/curations/git/github/kubernetes/apimachinery.yaml
+++ b/curations/git/github/kubernetes/apimachinery.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: apimachinery
+  namespace: kubernetes
+  provider: github
+  type: git
+revisions:
+  e337f44144a6ffeee2758c80dea17dd53fa6cbf4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Define go dependency k8s.io/apimachinery which points to https://github.com/kubernetes/apimachinery v0.21.0

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>