### PR TITLE
Define go dependency k8s.io/client-go which points to https://github.com/kubernetes/client-go v0.21.0

### DIFF
--- a/curations/git/github/kubernetes/client-go.yaml
+++ b/curations/git/github/kubernetes/client-go.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: client-go
+  namespace: kubernetes
+  provider: github
+  type: git
+revisions:
+  b09a9ce3bf3b6a4e288530e952cf2d74902394d2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Define go dependency k8s.io/client-go which points to https://github.com/kubernetes/client-go v0.21.0

Signed-off-by: Oleksandr Andriienko <oandriie@redhat.com>