### PR TITLE
ch.qos.logback/logback-core1.1.1

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: EPL-1.0 OR LGPL-2.1
+      declared: EPL-1.0 OR LGPL-2.1-only
   1.2.3:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only

--- a/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.1.1:
+    licensed:
+      declared: EPL-1.0 OR LGPL-2.1
   1.2.3:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ch.qos.logback/logback-core1.1.1

**Details:**
Adding EPL-1.0 to the Declared License 

(EPL-1.0 OR LGPL-2.1)

**Resolution:**
https://repo1.maven.org/maven2/ch/qos/logback/logback-core/1.1.1/logback-core-1.1.1.pom

**Affected definitions**:
- [logback-core 1.1.1](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-core/1.1.1/1.1.1)