### PR TITLE
ch.qos.logback.contrib/logback-json-core0.1.5

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback.contrib/logback-json-core.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback.contrib/logback-json-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: logback-json-core
+  namespace: ch.qos.logback.contrib
+  provider: mavencentral
+  type: maven
+revisions:
+  0.1.5:
+    licensed:
+      declared: EPL-1.0 OR LGPL-2.1

--- a/curations/maven/mavencentral/ch.qos.logback.contrib/logback-json-core.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback.contrib/logback-json-core.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   0.1.5:
     licensed:
-      declared: EPL-1.0 OR LGPL-2.1
+      declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ch.qos.logback.contrib/logback-json-core0.1.5

**Details:**
This component is dual-licensed - EPL-1.0 or LGPL-2.1

**Resolution:**
https://repo1.maven.org/maven2/ch/qos/logback/contrib/logback-json-core/0.1.5/logback-json-core-0.1.5.pom

**Affected definitions**:
- [logback-json-core 0.1.5](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback.contrib/logback-json-core/0.1.5/0.1.5)