### PR TITLE
clang 11.0

### DIFF
--- a/curations/pypi/pypi/-/clang.yaml
+++ b/curations/pypi/pypi/-/clang.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: clang
+  provider: pypi
+  type: pypi
+revisions:
+  '11.0':
+    files:
+      - license: Apache-2.0 WITH LLVM-exception
+        path: clang-11.0/clang/__init__.py
+      - license: Apache-2.0 WITH LLVM-exception
+        path: clang-11.0/clang/cindex.py
+      - license: Apache-2.0 WITH LLVM-exception
+        path: clang-11.0/clang/enumerations.py


### PR DESCRIPTION

**Type:** Missing

**Summary:**
clang 11.0

**Details:**
Adding Apache-2.0 WITH LLVM-exception info to .py files

**Resolution:**
See above

**Affected definitions**:
- [clang 11.0](https://clearlydefined.io/definitions/pypi/pypi/-/clang/11.0/11.0)