### PR TITLE
@types/adlib 3.0.1

### DIFF
--- a/curations/npm/npmjs/@types/adlib.yaml
+++ b/curations/npm/npmjs/@types/adlib.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: adlib
+  namespace: '@types'
+  provider: npmjs
+  type: npm
+revisions:
+  3.0.1:
+    licensed:
+      declared: MIT AND Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Revise from MIT to MIT AND Apache-2.0

**Details:**
Apache 2.0 asserted on the type definition files not expressed in the declared license


**Resolution:**
Definition files:

https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/adlib/adlib-tests.ts
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/f7ec78508c6797e42f87a4390735bc2c650a1bfd/types/adlib/index.d.ts

**Affected definitions**:
- [adlib 3.0.1](https://clearlydefined.io/definitions/npm/npmjs/@types/adlib/3.0.1/3.0.1)