### PR TITLE
highcharts-release 4.1.8

### DIFF
--- a/curations/npm/npmjs/-/highcharts-release.yaml
+++ b/curations/npm/npmjs/-/highcharts-release.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: highcharts-release
+  provider: npmjs
+  type: npm
+revisions:
+  4.1.8:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
highcharts-release 4.1.8

**Details:**
Some files are MIT, but a lot of the files point to the commercial license for highcharts: License: www.highcharts.com/license

**Resolution:**
OTHER for commercial license at www.highcharts.com/license

**Affected definitions**:
- [highcharts-release 4.1.8](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-release/4.1.8/4.1.8)