### PR TITLE
NUglify 1.13.10

### DIFF
--- a/curations/nuget/nuget/-/NUglify.yaml
+++ b/curations/nuget/nuget/-/NUglify.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.13.10:
+    licensed:
+      declared: BSD-2-Clause
   1.13.8:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NUglify 1.13.10

**Details:**
Source/project link license is BSD-2-Clause

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [NUglify 1.13.10](https://clearlydefined.io/definitions/nuget/nuget/-/NUglify/1.13.10/1.13.10)