### PR TITLE
highcharts-angular 2.8.0

### DIFF
--- a/curations/npm/npmjs/-/highcharts-angular.yaml
+++ b/curations/npm/npmjs/-/highcharts-angular.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: highcharts-angular
+  provider: npmjs
+  type: npm
+revisions:
+  2.8.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
highcharts-angular 2.8.0

**Details:**
The license file in the package is MIT.  It does reference Highcharts is under a commercial license, but this particular package is MIT.

**Resolution:**
MIT

**Affected definitions**:
- [highcharts-angular 2.8.0](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-angular/2.8.0/2.8.0)