### PR TITLE
com.sun.jersey/jersey-client1.19.1

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-client.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-client.yaml
@@ -9,7 +9,7 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.19.1:
     licensed:
-      declared: GPL-2.0-only
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.9':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Other

**Summary:**
com.sun.jersey/jersey-client1.19.1

**Details:**
Just correcting https://github.com/clearlydefined/curated-data/pull/12013

**Resolution:**
See above

**Affected definitions**:
- [jersey-client 1.19.1](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-client/1.19.1/1.19.1)