### PR TITLE
Pillow8.1.1

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -48,6 +48,9 @@ revisions:
   8.1.0:
     licensed:
       declared: HPND
+  8.1.1:
+    licensed:
+      declared: HPND
   8.2.0:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pillow8.1.1

**Details:**
Fixing Declared license to HPND

**Resolution:**
PyPI meta is HPND

https://pillow.readthedocs.io/en/stable/about.html#license

**Affected definitions**:
- [Pillow 8.1.1](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/8.1.1/8.1.1)