### PR TITLE
Updating missing license for Google Packages

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-base.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-measurement-base
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.5.0:
+    licensed:
+      declared: Apache-2.0 AND BSD-3-Clause AND MIT AND NOASSERTION

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-base.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   16.5.0:
     licensed:
-      declared: Apache-2.0 AND BSD-3-Clause AND MIT AND NOASSERTION
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updating missing license for Google Packages

**Details:**
The following Google packages have a missing license (NOASSERTION).

**Resolution:**
License in pom and package URL point to Android Software Development Kit License: https://developer.android.com/studio/terms

**Affected definitions**:
- [play-services-measurement-base 16.5.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-measurement-base/16.5.0/16.5.0)