### PR TITLE
mackron/dr_libsac9a8ef455d1170655883e346b35fc1d

### DIFF
--- a/curations/git/github/mackron/dr_libs.yaml
+++ b/curations/git/github/mackron/dr_libs.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dr_libs
+  namespace: mackron
+  provider: github
+  type: git
+revisions:
+  ac9a8ef455d1170655883e346b35fc1db7effb73:
+    licensed:
+      declared: MIT-0 OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mackron/dr_libsac9a8ef455d1170655883e346b35fc1d

**Details:**
I don't see a license file, but the top of the files say: “Choice of public domain or MIT-0.”  

**Resolution:**
Since public domain is OTHER, the curation would be "MIT-0 OR OTHER."

**Affected definitions**:
- [dr_libs ac9a8ef455d1170655883e346b35fc1db7effb73](https://clearlydefined.io/definitions/git/github/mackron/dr_libs/ac9a8ef455d1170655883e346b35fc1db7effb73/ac9a8ef455d1170655883e346b35fc1db7effb73)