### PR TITLE
mackron/dr_libsf123d965abc1eeb27792eab541de58

### DIFF
--- a/curations/git/github/mackron/dr_libs.yaml
+++ b/curations/git/github/mackron/dr_libs.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dr_libs
+  namespace: mackron
+  provider: github
+  type: git
+revisions:
+  f123d965abc1eeb27792eab541de58f4a9322062:
+    licensed:
+      declared: MIT-0 OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mackron/dr_libsf123d965abc1eeb27792eab541de58

**Details:**
I don't see a license file, but the top of the files say: “Choice of public domain or MIT-0.”

**Resolution:**
Since public domain is OTHER, the curation would be "MIT-0 OR OTHER."

**Affected definitions**:
- [dr_libs f123d965abc1eeb27792eab541de58f4a9322062](https://clearlydefined.io/definitions/git/github/mackron/dr_libs/f123d965abc1eeb27792eab541de58f4a9322062/f123d965abc1eeb27792eab541de58f4a9322062)