### PR TITLE
kobolabs/liblzma87b7682ce4b1c849504e2b3641cebaad62aaef87

### DIFF
--- a/curations/git/github/kobolabs/liblzma.yaml
+++ b/curations/git/github/kobolabs/liblzma.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: liblzma
+  namespace: kobolabs
+  provider: github
+  type: git
+revisions:
+  87b7682ce4b1c849504e2b3641cebaad62aaef87:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kobolabs/liblzma87b7682ce4b1c849504e2b3641cebaad62aaef87

**Details:**
Looking at the COPYING file, it seems the 'main' project license is "public domain," so curating as OTHER.

**Resolution:**
The COPYING file then lists other licenses that apply to certain files: https://github.com/kobolabs/liblzma/blob/87b7682ce4b1c849504e2b3641cebaad62aaef87/COPYING

**Affected definitions**:
- [liblzma 87b7682ce4b1c849504e2b3641cebaad62aaef87](https://clearlydefined.io/definitions/git/github/kobolabs/liblzma/87b7682ce4b1c849504e2b3641cebaad62aaef87/87b7682ce4b1c849504e2b3641cebaad62aaef87)