### PR TITLE
mackron/dr_libsf123d965abc1eeb27792eab541de58f4

### DIFF
--- a/curations/git/github/mackron/dr_libs.yaml
+++ b/curations/git/github/mackron/dr_libs.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: MIT-0 OR OTHER
   f123d965abc1eeb27792eab541de58f4a9322062:
     licensed:
-      declared: MIT-0 OR OTHER
+      declared: MIT-0 OR Unlicense


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mackron/dr_libsf123d965abc1eeb27792eab541de58f4

**Details:**
There is no LICENSE file, however, the top of the files say: Choice of public domain or MIT-0. See license statements at the end of this file..  Looking at the end of the file, the public domain option is the Unlicense. So this should actually be "MIT-0 OR Unlicense."

**Resolution:**
See: https://github.com/mackron/dr_libs/blob/f123d965abc1eeb27792eab541de58f4a9322062/dr_mp3.h

**Affected definitions**:
- [dr_libs f123d965abc1eeb27792eab541de58f4a9322062](https://clearlydefined.io/definitions/git/github/mackron/dr_libs/f123d965abc1eeb27792eab541de58f4a9322062/f123d965abc1eeb27792eab541de58f4a9322062)