### PR TITLE
mackron/dr_libsac9a8ef455d1170655883e346b35fc1db7

### DIFF
--- a/curations/git/github/mackron/dr_libs.yaml
+++ b/curations/git/github/mackron/dr_libs.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   ac9a8ef455d1170655883e346b35fc1db7effb73:
     licensed:
-      declared: MIT-0 OR OTHER
+      declared: MIT-0 OR Unlicense
   f123d965abc1eeb27792eab541de58f4a9322062:
     licensed:
       declared: MIT-0 OR OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mackron/dr_libsac9a8ef455d1170655883e346b35fc1db7

**Details:**
There is no LICENSE file, however, the top of the files say: "Choice of public domain or MIT-0. See license statements at the end of this file." Looking at the end of the file, the public domain option is the Unlicense. So this should actually be "MIT-0 OR Unlicense."

**Resolution:**
Example file: https://github.com/mackron/dr_libs/blob/ac9a8ef455d1170655883e346b35fc1db7effb73/dr_flac.h

**Affected definitions**:
- [dr_libs ac9a8ef455d1170655883e346b35fc1db7effb73](https://clearlydefined.io/definitions/git/github/mackron/dr_libs/ac9a8ef455d1170655883e346b35fc1db7effb73/ac9a8ef455d1170655883e346b35fc1db7effb73)