### PR TITLE
org.glassfish.tyrus.bundles/tyrus-standalone-client1.16

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.tyrus.bundles/tyrus-standalone-client.yaml
+++ b/curations/maven/mavencentral/org.glassfish.tyrus.bundles/tyrus-standalone-client.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tyrus-standalone-client
+  namespace: org.glassfish.tyrus.bundles
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.16':
+    licensed:
+      declared: NOASSERTION OR GPL-2.0-only

--- a/curations/maven/mavencentral/org.glassfish.tyrus.bundles/tyrus-standalone-client.yaml
+++ b/curations/maven/mavencentral/org.glassfish.tyrus.bundles/tyrus-standalone-client.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.16':
     licensed:
-      declared: NOASSERTION OR GPL-2.0-only
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.glassfish.tyrus.bundles/tyrus-standalone-client1.16

**Details:**
The whole thing should be: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
See file headers

**Affected definitions**:
- [tyrus-standalone-client 1.16](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.tyrus.bundles/tyrus-standalone-client/1.16/1.16)