### PR TITLE
Corrected license declarations for slog crates

### DIFF
--- a/curations/crate/cratesio/-/slog-async.yaml
+++ b/curations/crate/cratesio/-/slog-async.yaml
@@ -1,0 +1,29 @@
+coordinates:
+  name: slog-async
+  provider: cratesio
+  type: crate
+revisions:
+  2.6.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.5.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.4.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.2.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.1:
+    licensed:
+      declared: MPL-2.0
+  2.0.0:
+    licensed:
+      declared: MPL-2.0

--- a/curations/crate/cratesio/-/slog-scope.yaml
+++ b/curations/crate/cratesio/-/slog-scope.yaml
@@ -29,19 +29,19 @@ revisions:
       declared: MPL-2.0 OR MIT OR Apache-2.0
   3.0.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.3.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.2.2:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.2.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.1.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0

--- a/curations/crate/cratesio/-/slog-scope.yaml
+++ b/curations/crate/cratesio/-/slog-scope.yaml
@@ -1,0 +1,47 @@
+coordinates:
+  name: slog-scope
+  provider: cratesio
+  type: crate
+revisions:
+  4.4.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.2.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.1.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.1.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.0.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  3.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.2.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.2.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0

--- a/curations/crate/cratesio/-/slog-stdlog.yaml
+++ b/curations/crate/cratesio/-/slog-stdlog.yaml
@@ -23,19 +23,19 @@ revisions:
       declared: MPL-2.0 OR MIT OR Apache-2.0
   2.0.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.1.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.0.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.0.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.7.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.6.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0

--- a/curations/crate/cratesio/-/slog-stdlog.yaml
+++ b/curations/crate/cratesio/-/slog-stdlog.yaml
@@ -1,0 +1,41 @@
+coordinates:
+  name: slog-stdlog
+  provider: cratesio
+  type: crate
+revisions:
+  4.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  4.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  3.0.5:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  3.0.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  3.0.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  3.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.0.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.7.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.6.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0

--- a/curations/crate/cratesio/-/slog-term.yaml
+++ b/curations/crate/cratesio/-/slog-term.yaml
@@ -1,0 +1,92 @@
+coordinates:
+  name: slog-term
+  provider: cratesio
+  type: crate
+revisions:
+  2.8.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.7.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.6.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.5.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.4.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.4.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.4.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.2.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.4:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.3:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.1:
+    licensed:
+      declared: MPL-2.0
+  2.0.0:
+    licensed:
+      declared: MPL-2.0
+  1.5.0:
+    licensed:
+      declared: MPL-2.0
+  1.4.0:
+    licensed:
+      declared: MPL-2.0
+  1.3.5:
+    licensed:
+      declared: MPL-2.0
+  1.3.4:
+    licensed:
+      declared: MPL-2.0
+  1.3.3:
+    licensed:
+      declared: MPL-2.0
+  1.3.2:
+    licensed:
+      declared: MPL-2.0
+  1.3.1:
+    licensed:
+      declared: MPL-2.0
+  1.3.0:
+    licensed:
+      declared: MPL-2.0
+  1.2.0:
+    licensed:
+      declared: MPL-2.0
+  1.1.0:
+    licensed:
+      declared: MPL-2.0
+  1.0.0:
+    licensed:
+      declared: MPL-2.0
+  0.7.0:
+    licensed:
+      declared: MPL-2.0
+  0.6.0:
+    licensed:
+      declared: MPL-2.0
+  0.5.0:
+    licensed:
+      declared: MPL-2.0

--- a/curations/crate/cratesio/-/slog-term.yaml
+++ b/curations/crate/cratesio/-/slog-term.yaml
@@ -38,10 +38,10 @@ revisions:
       declared: MPL-2.0 OR MIT OR Apache-2.0
   2.0.3:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.2:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.1:
     licensed:
       declared: MPL-2.0

--- a/curations/crate/cratesio/-/slog.yaml
+++ b/curations/crate/cratesio/-/slog.yaml
@@ -71,19 +71,19 @@ revisions:
       declared: MPL-2.0 OR MIT OR Apache-2.0
   2.0.4:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.3:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.2:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   2.0.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.7.1:
     licensed:
       declared: MPL-2.0
@@ -95,61 +95,61 @@ revisions:
       declared: MPL-2.0
   1.5.2:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.5.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.5.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.4.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.4.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.3.2:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.3.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.3.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.2.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.2.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.1.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.0.1:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   1.0.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.7.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.6.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.5.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.4.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.3.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.2.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0
   0.1.0:
     licensed:
-      declared: MPL-2.0 OR MIT OR Apache-2.0
+      declared: MPL-2.0

--- a/curations/crate/cratesio/-/slog.yaml
+++ b/curations/crate/cratesio/-/slog.yaml
@@ -1,0 +1,155 @@
+coordinates:
+  name: slog
+  provider: cratesio
+  type: crate
+revisions:
+  2.7.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.5.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.5.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.5.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.4.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.4.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.3.3:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.3.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.3.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.2.3:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.2.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.2.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.1.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.12:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.11:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.10:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.9:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.8:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.6:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.5:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.4:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.3:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  2.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.7.1:
+    licensed:
+      declared: MPL-2.0
+  1.7.0:
+    licensed:
+      declared: MPL-2.0
+  1.6.0:
+    licensed:
+      declared: MPL-2.0
+  1.5.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.5.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.5.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.4.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.4.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.3.2:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.3.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.2.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.2.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.0.1:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  1.0.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.7.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.6.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.5.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.4.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.3.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.2.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0
+  0.1.0:
+    licensed:
+      declared: MPL-2.0 OR MIT OR Apache-2.0


### PR DESCRIPTION
License corrections for `slog` and related feature crates.

`clearlydefined` is currently declaring these incorrectly.  I have raised an issue on the `clearlydefined` service to try to resolve the underlying issue.
https://github.com/clearlydefined/service/issues/856