### PR TITLE
Fixed Source location

### DIFF
--- a/curations/crate/cratesio/-/slog.yaml
+++ b/curations/crate/cratesio/-/slog.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: slog
+  provider: cratesio
+  type: crate
+revisions:
+  2.7.0:
+    described:
+      sourceLocation:
+        name: slog
+        namespace: slog-rs
+        provider: github
+        revision: 87babc83ec27bd1ce6dba664dec57a403de7748f
+        type: git
+        url: 'https://github.com/slog-rs/slog/commit/87babc83ec27bd1ce6dba664dec57a403de7748f'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Fixed Source location

**Details:**
Source location was missing, because the associated git repo does not have a tag for the 2.7.0 version.

**Resolution:**
This PR specifies the source code URL for the 2.7.0 release via a git commit id.

I have raised an issue on the slog project regarding the missing tag for the 2.7.0 release: https://github.com/slog-rs/slog/issues/284

**Affected definitions**:
- [slog 2.7.0](https://clearlydefined.io/definitions/crate/cratesio/-/slog/2.7.0/2.7.0)