### PR TITLE
onnxoptimizer 0.2.6

### DIFF
--- a/curations/pypi/pypi/-/onnxoptimizer.yaml
+++ b/curations/pypi/pypi/-/onnxoptimizer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: onnxoptimizer
+  provider: pypi
+  type: pypi
+revisions:
+  0.2.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
onnxoptimizer 0.2.6

**Details:**
Add Apache-2.0 license

**Resolution:**
License Url: https://github.com/onnx/optimizer/blob/master/LICENSE

**Affected definitions**:
- [onnxoptimizer 0.2.6](https://clearlydefined.io/definitions/pypi/pypi/-/onnxoptimizer/0.2.6/0.2.6)