### PR TITLE
tf2onnx 1.6.3

### DIFF
--- a/curations/pypi/pypi/-/tf2onnx.yaml
+++ b/curations/pypi/pypi/-/tf2onnx.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: MIT
   1.6.3:
     licensed:
-      declared: Apache-2.0
+      declared: MIT

--- a/curations/pypi/pypi/-/tf2onnx.yaml
+++ b/curations/pypi/pypi/-/tf2onnx.yaml
@@ -9,3 +9,6 @@ revisions:
   1.5.3:
     licensed:
       declared: MIT
+  1.6.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tf2onnx 1.6.3

**Details:**
Add Apache-2.0 license

**Resolution:**
License Url: https://github.com/onnx/tensorflow-onnx/blob/master/LICENSE

Pypi url: https://pypi.org/project/tf2onnx/

**Affected definitions**:
- [tf2onnx 1.6.3](https://clearlydefined.io/definitions/pypi/pypi/-/tf2onnx/1.6.3/1.6.3)