### PR TITLE
coremltools 4.0

### DIFF
--- a/curations/pypi/pypi/-/coremltools.yaml
+++ b/curations/pypi/pypi/-/coremltools.yaml
@@ -9,3 +9,6 @@ revisions:
   '3.4':
     licensed:
       declared: BSD-3-Clause
+  '4.0':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
coremltools 4.0

**Details:**
Add BSD 3-clause license.

**Resolution:**
License URL: https://github.com/apple/coremltools/blob/main/LICENSE.txt

Pypi URL: https://pypi.org/project/coremltools/

**Affected definitions**:
- [coremltools 4.0](https://clearlydefined.io/definitions/pypi/pypi/-/coremltools/4.0/4.0)