### PR TITLE
Update license to CDDL+GPL

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-media-json-jackson
+  namespace: org.glassfish.jersey.media
+  provider: mavencentral
+  type: maven
+revisions:
+  2.23.2:
+    licensed:
+      declared: GPL-2.0 OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.23.2:
     licensed:
-      declared: GPL-2.0 OR CDDL-1.1
+      declared: GPL-2.0-only OR CDDL-1.1

--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   2.23.2:
     licensed:
-      declared: GPL-2.0-only OR CDDL-1.1
+      declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update license to CDDL+GPL

**Details:**
Declared license is NOASSERTION, while this library is released with GPL-2.0 OR CDDL-1.1

**Resolution:**
Sources: https://repo1.maven.org/maven2/org/glassfish/jersey/media/jersey-media-json-jackson/2.23.2/jersey-media-json-jackson-2.23.2-sources.jar

**Affected definitions**:
- [jersey-media-json-jackson 2.23.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/2.23.2/2.23.2)