### PR TITLE
Microsoft.IdentityModel.Protocols.OpenIdConnect 5.3.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.OpenIdConnect.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Protocols.OpenIdConnect.yaml
@@ -9,6 +9,9 @@ revisions:
   5.2.0:
     licensed:
       declared: MIT
+  5.3.0:
+    licensed:
+      declared: MIT
   5.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.IdentityModel.Protocols.OpenIdConnect 5.3.0

**Details:**
NuGet license link and repo = MIT

**Resolution:**
MIT

**Affected definitions**:
- [Microsoft.IdentityModel.Protocols.OpenIdConnect 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.IdentityModel.Protocols.OpenIdConnect/5.3.0/5.3.0)