### PR TITLE
MSTest.TestFramework 2.1.1

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestFramework.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestFramework.yaml
@@ -17,6 +17,9 @@ revisions:
   2.1.0-beta2:
     licensed:
       declared: MIT
+  2.1.1:
+    licensed:
+      declared: MIT
   2.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSTest.TestFramework 2.1.1

**Details:**
NuGet links to hosted MIT web page

**Resolution:**
MIT

**Affected definitions**:
- [MSTest.TestFramework 2.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestFramework/2.1.1/2.1.1)