### PR TITLE
MSTest.TestFramework 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestFramework.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestFramework.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: MIT
   2.1.0:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSTest.TestFramework 2.0.0

**Details:**
License link = MIT

**Resolution:**
MIT

**Affected definitions**:
- [MSTest.TestFramework 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestFramework/2.0.0/2.0.0)