### PR TITLE
Microsoft.Azure.WebJobs.Host.Storage 3.0.14

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Host.Storage.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.WebJobs.Host.Storage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.Azure.WebJobs.Host.Storage
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.14:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.Azure.WebJobs.Host.Storage 3.0.14

**Details:**
NuGet license link = EULA

**Resolution:**
EULA = OTHER

**Affected definitions**:
- [Microsoft.Azure.WebJobs.Host.Storage 3.0.14](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.WebJobs.Host.Storage/3.0.14/3.0.14)