### PR TITLE
websocket-client 1.1.0

### DIFF
--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -9,3 +9,6 @@ revisions:
   0.58.0:
     licensed:
       declared: LGPL-2.1-or-later
+  1.1.0:
+    licensed:
+      declared: LGPL-3.0-or-later

--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: LGPL-2.1-or-later
   1.1.0:
     licensed:
-      declared: LGPL-3.0-or-later
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
websocket-client 1.1.0

**Details:**
Scanners identified wrong license.  This is LGPL and source files indicate "or later."

**Resolution:**
Thanks

**Affected definitions**:
- [websocket-client 1.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/websocket-client/1.1.0/1.1.0)