### PR TITLE
facebook/zstde4558ffd1dc49399faf4ee5d85abed4386b4dcf5

### DIFF
--- a/curations/git/github/facebook/zstd.yaml
+++ b/curations/git/github/facebook/zstd.yaml
@@ -22,6 +22,9 @@ revisions:
   b706286adbba780006a47ef92df0ad7a785666b6:
     licensed:
       declared: BSD-3-Clause OR GPL-2.0-only
+  e4558ffd1dc49399faf4ee5d85abed4386b4dcf5:
+    licensed:
+      declared: BSD-3-Clause OR GPL-2.0-only
   f800e72a3c04604475dcfbb337c4fe0cdd430ead:
     licensed:
       declared: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
facebook/zstde4558ffd1dc49399faf4ee5d85abed4386b4dcf5

**Details:**
Dual licensed means OR

**Resolution:**
License
Zstandard is dual-licensed under BSD and GPLv2.

**Affected definitions**:
- [zstd e4558ffd1dc49399faf4ee5d85abed4386b4dcf5](https://clearlydefined.io/definitions/git/github/facebook/zstd/e4558ffd1dc49399faf4ee5d85abed4386b4dcf5/e4558ffd1dc49399faf4ee5d85abed4386b4dcf5)