### PR TITLE
System.Net.Security 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.Net.Security.yaml
+++ b/curations/nuget/nuget/-/System.Net.Security.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.0.0:
     licensed:
-      declared: NOASSERTION
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Net.Security 4.0.0

**Details:**
NuGet license info link goes to a EULA

**Resolution:**
EULA + OTHER

**Affected definitions**:
- [System.Net.Security 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Net.Security/4.0.0/4.0.0)