### PR TITLE
MSTest.TestFramework 2.2.4

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestFramework.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestFramework.yaml
@@ -26,3 +26,6 @@ revisions:
   2.1.2:
     licensed:
       declared: MIT
+  2.2.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSTest.TestFramework 2.2.4

**Details:**
Nuget License field links to MIT at: https://www.nuget.org/packages/MSTest.TestFramework/2.2.4/License

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [MSTest.TestFramework 2.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestFramework/2.2.4/2.2.4)