### PR TITLE
System.Reactive.Compatibility .4.1

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.Compatibility.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.Compatibility.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Reactive.Compatibility
+  provider: nuget
+  type: nuget
+revisions:
+  4.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Reactive.Compatibility .4.1

**Details:**
Nuget license field links to MIT: https://github.com/dotnet/reactive/blob/main/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Reactive.Compatibility 4.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive.Compatibility/4.4.1/4.4.1)