### PR TITLE
Newtonsoft.Json.Schema 3.0.14

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -32,7 +32,7 @@ revisions:
       declared: AGPL-3.0-only OR OTHER
   3.0.14:
     licensed:
-      declared: AGPL-3.0-only OR AGPL-3.0-or-later
+      declared: AGPL-3.0-only OR OTHER
   3.0.2:
     licensed:
       declared: AGPL-3.0-only OR OTHER

--- a/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.Schema.yaml
@@ -30,6 +30,9 @@ revisions:
   3.0.13:
     licensed:
       declared: AGPL-3.0-only OR OTHER
+  3.0.14:
+    licensed:
+      declared: AGPL-3.0-only OR AGPL-3.0-or-later
   3.0.2:
     licensed:
       declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json.Schema 3.0.14

**Details:**
Nuget license field links to: https://www.nuget.org/packages/Newtonsoft.Json.Schema/3.0.14/License

It states: "GNU Affero General Public License as published by the 
Free Software Foundation, either version 3 of the License" and also indicates it is available under a commercial license

**Resolution:**
Declared license is: AGPL-3.0-only OR AGPL-3.0-or-later OR OTHER

**Affected definitions**:
- [Newtonsoft.Json.Schema 3.0.14](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json.Schema/3.0.14/3.0.14)