### PR TITLE
xerces/xercesImpl 2.11.0

### DIFF
--- a/curations/maven/mavencentral/xerces/xercesImpl.yaml
+++ b/curations/maven/mavencentral/xerces/xercesImpl.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.11.0:
+    licensed:
+      declared: Apache-2.0
   2.9.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xerces/xercesImpl 2.11.0

**Details:**
Maven indicates Apache-2.0
https://search.maven.org/artifact/xerces/xercesImpl/2.12.1/jar

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [xercesImpl 2.11.0](https://clearlydefined.io/definitions/maven/mavencentral/xerces/xercesImpl/2.11.0/2.11.0)