### PR TITLE
azureml-dataprep-native 13.2.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-native.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-native.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  13.2.0:
+    licensed:
+      declared: OTHER
   14.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-native 13.2.0

**Details:**
Pypi indicates OTHER: 
 https://pypi.org/project/azureml-dataprep-native/13.2.0/

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-native 13.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-native/13.2.0/13.2.0)