### PR TITLE
azureml-core 1.30.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -354,6 +354,9 @@ revisions:
   1.3.0.post2:
     licensed:
       declared: OTHER
+  1.30.0:
+    licensed:
+      declared: OTHER
   1.31.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-core 1.30.0

**Details:**
PyPi license field indicates OTHER  and includes a link to https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-core 1.30.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.30.0/1.30.0)