### PR TITLE
azureml-core 1.29.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -342,6 +342,9 @@ revisions:
   1.28.0.post1:
     licensed:
       declared: OTHER
+  1.29.0:
+    licensed:
+      declared: OTHER
   1.29.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-core 1.29.0

**Details:**
PyPi license field indicates OTHER and links to https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-core 1.29.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.29.0/1.29.0)