### PR TITLE
azureml-dataprep 1.7.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -18,6 +18,9 @@ revisions:
   1.6.3:
     licensed:
       declared: OTHER
+  1.7.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 1.7.0

**Details:**
PyPi license field indicates OTHER 
https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 1.7.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/1.7.0/1.7.0)