### PR TITLE
azureml-dataprep 1.1.38

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  1.1.38:
+    licensed:
+      declared: OTHER
   1.10.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 1.1.38

**Details:**
PyPi license field indicates OTHER 
https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 1.1.38](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/1.1.38/1.1.38)