### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.1.2

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -99,3 +99,6 @@ revisions:
   2021.1.1:
     licensed:
       declared: OTHER
+  2021.1.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.1.2

**Details:**
Nuget license field indicates OTHER and links to: https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.1.2/2021.1.2)