### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.1.3

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -97,7 +97,7 @@ revisions:
     licensed:
       declared: OTHER
   2021.1.1:
-       licensed:
+    licensed:
       declared: OTHER
   2021.1.3:
     licensed:

--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -99,3 +99,6 @@ revisions:
   2021.1.1:
     licensed:
       declared: OTHER
+  2021.1.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.1.3

**Details:**
Nuget license field indicates OTHER and links to https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.1.3/2021.1.3)