### PR TITLE
azureml-pipeline 1.19.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline.yaml
@@ -60,6 +60,9 @@ revisions:
   1.18.0:
     licensed:
       declared: OTHER
+  1.19.0:
+    licensed:
+      declared: OTHER
   1.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline 1.19.0

**Details:**
PyPi license field indicates OTHER and links to https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline 1.19.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline/1.19.0/1.19.0)