### PR TITLE
azureml-dataprep 2.8.3

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -114,6 +114,9 @@ revisions:
   2.8.2:
     licensed:
       declared: OTHER
+  2.8.3:
+    licensed:
+      declared: OTHER
   2.9.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.8.3

**Details:**
PyPi license field indicates OTHER https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.8.3](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.8.3/2.8.3)