### PR TITLE
azureml-pipeline-core 1.7.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -162,6 +162,9 @@ revisions:
   1.7.0:
     licensed:
       declared: OTHER
+  1.7.0.post1:
+    licensed:
+      declared: OTHER
   1.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.7.0.post1

**Details:**
PyPi license field indicates OTHER and links to https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.7.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.7.0.post1/1.7.0.post1)