### PR TITLE
azureml-train-core 1.30.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-core.yaml
+++ b/curations/pypi/pypi/-/azureml-train-core.yaml
@@ -180,6 +180,9 @@ revisions:
   1.3.0.post1:
     licensed:
       declared: OTHER
+  1.30.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-core 1.30.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train-core 1.30.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-core/1.30.0/1.30.0)