### PR TITLE
azureml-pipeline-steps 1.30.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
@@ -165,6 +165,9 @@ revisions:
   1.3.0:
     licensed:
       declared: OTHER
+  1.30.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-steps 1.30.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline-steps 1.30.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-steps/1.30.0/1.30.0)