### PR TITLE
System.Data.SQLite.Core 1.0.112

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.102:
     licensed:
       declared: OTHER
+  1.0.112:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Other

**Summary:**
System.Data.SQLite.Core 1.0.112

**Details:**
Nuget license field links to https://www.sqlite.org/copyright.html
Declares Public Domain dedication but not a specific open source license. 

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.Data.SQLite.Core 1.0.112](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Core/1.0.112/1.0.112)