### PR TITLE
azureml-telemetry 1.0.85

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -96,6 +96,9 @@ revisions:
   1.0.81:
     licensed:
       declared: OTHER
+  1.0.85:
+    licensed:
+      declared: OTHER
   1.0.85.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-telemetry 1.0.85

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-telemetry 1.0.85](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.0.85/1.0.85)