### PR TITLE
azureml-dataprep-native 14.2.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-native.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-native.yaml
@@ -6,6 +6,9 @@ revisions:
   14.1.0:
     licensed:
       declared: OTHER
+  14.2.0:
+    licensed:
+      declared: OTHER
   14.2.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-native 14.2.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-native 14.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-native/14.2.0/14.2.0)