### PR TITLE
System.Web.Http 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.Web.Http.yaml
+++ b/curations/nuget/nuget/-/System.Web.Http.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Web.Http
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Web.Http 4.0.0

**Details:**
Downloaded nuspec and no license information found but it states: "his is not the official Web API package from Microsoft"

**Resolution:**
Declared license is: NONE

**Affected definitions**:
- [System.Web.Http 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Web.Http/4.0.0/4.0.0)