### PR TITLE
azureml-dataprep 1.5.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -15,6 +15,9 @@ revisions:
   1.4.6:
     licensed:
       declared: OTHER
+  1.5.0:
+    licensed:
+      declared: OTHER
   1.6.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 1.5.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 1.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/1.5.0/1.5.0)