### PR TITLE
azureml-dataprep-rslex 1.2.3

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
@@ -27,6 +27,9 @@ revisions:
   1.2.2:
     licensed:
       declared: OTHER
+  1.2.3:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-rslex 1.2.3

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-rslex 1.2.3](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-rslex/1.2.3/1.2.3)