### PR TITLE
azureml-dataprep-native 32.0.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-native.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-native.yaml
@@ -48,6 +48,9 @@ revisions:
   30.0.0:
     licensed:
       declared: OTHER
+  32.0.0:
+    licensed:
+      declared: OTHER
   33.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-native 32.0.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-native 32.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-native/32.0.0/32.0.0)