### PR TITLE
azureml-pipeline 1.24.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline.yaml
@@ -72,6 +72,9 @@ revisions:
   1.23.0:
     licensed:
       declared: OTHER
+  1.24.0:
+    licensed:
+      declared: OTHER
   1.25.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline 1.24.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline 1.24.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline/1.24.0/1.24.0)