### PR TITLE
azureml-train 1.3.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -135,6 +135,9 @@ revisions:
   1.29.0:
     licensed:
       declared: OTHER
+  1.3.0:
+    licensed:
+      declared: OTHER
   1.5.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train 1.3.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train 1.3.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train/1.3.0/1.3.0)