### PR TITLE
azureml-pipeline-core 1.9.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -165,3 +165,6 @@ revisions:
   1.8.0:
     licensed:
       declared: OTHER
+  1.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.9.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.9.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.9.0/1.9.0)