### PR TITLE
azureml-pipeline-core 1.1.5

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -96,6 +96,9 @@ revisions:
   1.0.85.1:
     licensed:
       declared: OTHER
+  1.1.5:
+    licensed:
+      declared: OTHER
   1.10.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.1.5

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.1.5](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.1.5/1.1.5)