### PR TITLE
azureml-pipeline-core 1.12.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -102,6 +102,9 @@ revisions:
   1.11.0:
     licensed:
       declared: OTHER
+  1.12.0:
+    licensed:
+      declared: OTHER
   1.13.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.12.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER


**Affected definitions**:
- [azureml-pipeline-core 1.12.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.12.0/1.12.0)