### PR TITLE
azureml-telemetry 1.1.5

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -102,6 +102,9 @@ revisions:
   1.0.85.2:
     licensed:
       declared: OTHER
+  1.1.5:
+    licensed:
+      declared: OTHER
   1.1.5.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-telemetry 1.1.5

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER


**Affected definitions**:
- [azureml-telemetry 1.1.5](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.1.5/1.1.5)