### PR TITLE
azureml-dataprep 1.3.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.1:
     licensed:
       declared: OTHER
+  1.3.2:
+    licensed:
+      declared: OTHER
   1.3.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 1.3.2

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 1.3.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/1.3.2/1.3.2)