### PR TITLE
azureml-pipeline 1.1.5

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline.yaml
@@ -39,6 +39,9 @@ revisions:
   1.1.2rc0:
     licensed:
       declared: OTHER
+  1.1.5:
+    licensed:
+      declared: OTHER
   1.10.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline 1.1.5

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline 1.1.5](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline/1.1.5/1.1.5)