### PR TITLE
azureml-telemetry 1.9.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -192,3 +192,6 @@ revisions:
   1.8.0:
     licensed:
       declared: OTHER
+  1.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-telemetry 1.9.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-telemetry 1.9.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.9.0/1.9.0)