### PR TITLE
azureml-dataprep-rslex 1.11.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
@@ -15,6 +15,9 @@ revisions:
   1.1.3:
     licensed:
       declared: OTHER
+  1.11.2:
+    licensed:
+      declared: OTHER
   1.12.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-rslex 1.11.2

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-rslex 1.11.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-rslex/1.11.2/1.11.2)