### PR TITLE
azureml-dataprep 2.2.4

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -75,6 +75,9 @@ revisions:
   2.2.3:
     licensed:
       declared: OTHER
+  2.2.4:
+    licensed:
+      declared: OTHER
   2.2.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.2.4

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.2.4](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.2.4/2.2.4)