### PR TITLE
azureml-dataprep-rslex 1.0.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.1:
     licensed:
       declared: OTHER
+  1.0.2:
+    licensed:
+      declared: OTHER
   1.1.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-rslex 1.0.2

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-rslex 1.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-rslex/1.0.2/1.0.2)