### PR TITLE
azureml-train 1.9.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -141,3 +141,6 @@ revisions:
   1.7.0:
     licensed:
       declared: OTHER
+  1.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train 1.9.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train 1.9.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train/1.9.0/1.9.0)