### PR TITLE
azureml-dataprep-native 21.0.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-native.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-native.yaml
@@ -21,6 +21,9 @@ revisions:
   20.1.1:
     licensed:
       declared: OTHER
+  21.0.1:
+    licensed:
+      declared: OTHER
   21.0.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-native 21.0.1

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-native 21.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-native/21.0.1/21.0.1)