### PR TITLE
azureml-dataprep 2.4.3

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -90,6 +90,9 @@ revisions:
   2.4.2:
     licensed:
       declared: OTHER
+  2.4.3:
+    licensed:
+      declared: OTHER
   2.4.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.4.3

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.4.3](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.4.3/2.4.3)