### PR TITLE
azureml-dataprep 2.6.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -93,6 +93,9 @@ revisions:
   2.4.5:
     licensed:
       declared: OTHER
+  2.6.1:
+    licensed:
+      declared: OTHER
   2.6.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.6.1

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.6.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.6.1/2.6.1)