### PR TITLE
azureml-train-automl-client 1.6.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -135,6 +135,9 @@ revisions:
   1.5.0.post1:
     licensed:
       declared: OTHER
+  1.6.0:
+    licensed:
+      declared: OTHER
   1.6.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client 1.6.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train-automl-client 1.6.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.6.0/1.6.0)