### PR TITLE
azureml-train 1.11.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -84,6 +84,9 @@ revisions:
   1.0.81:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.13.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train 1.11.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train 1.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train/1.11.0/1.11.0)