### PR TITLE
azureml-dataprep 2.1.6

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -57,6 +57,9 @@ revisions:
   2.0.9:
     licensed:
       declared: OTHER
+  2.1.6:
+    licensed:
+      declared: OTHER
   2.1.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.1.6

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.1.6](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.1.6/2.1.6)