### PR TITLE
azureml-dataprep-rslex 1.8.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-rslex.yaml
@@ -42,6 +42,9 @@ revisions:
   1.8.0:
     licensed:
       declared: OTHER
+  1.8.1:
+    licensed:
+      declared: OTHER
   1.9.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-rslex 1.8.1

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-rslex 1.8.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-rslex/1.8.1/1.8.1)