### PR TITLE
System.Data.SQLite.Core 1.0.109.2

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.102:
     licensed:
       declared: OTHER
+  1.0.109.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.Core 1.0.109.2

**Details:**
The Nuget license field links to: https://www.sqlite.org/copyright.html which indicates public domain.

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.Data.SQLite.Core 1.0.109.2](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Core/1.0.109.2/1.0.109.2)