### PR TITLE
qs 0.6.5

### DIFF
--- a/curations/npm/npmjs/-/qs.yaml
+++ b/curations/npm/npmjs/-/qs.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: MIT
   0.6.5:
     licensed:
-      declared: BSD-3-Clause
+      declared: MIT
   0.6.6:
     licensed:
       declared: MIT

--- a/curations/npm/npmjs/-/qs.yaml
+++ b/curations/npm/npmjs/-/qs.yaml
@@ -9,6 +9,9 @@ revisions:
   0.5.6:
     licensed:
       declared: MIT
+  0.6.5:
+    licensed:
+      declared: BSD-3-Clause
   0.6.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
qs 0.6.5

**Details:**
NPM license field indicates BSD-3-Clause.  License in source code project is also BSD-3-Clause.

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [qs 0.6.5](https://clearlydefined.io/definitions/npm/npmjs/-/qs/0.6.5/0.6.5)