### PR TITLE
License info is missing

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -73,3 +73,6 @@ revisions:
   20.3.1:
     licensed:
       declared: UPL-1.0
+  21.0.0:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
License info is missing

**Details:**
The license information has not been harvested properly

**Resolution:**
The license is UPL 1.0 according to https://github.com/oracle/graal/blob/vm-21.0.0/sdk/LICENSE.md

**Affected definitions**:
- [graal-sdk 21.0.0](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/21.0.0/21.0.0)