### PR TITLE
pylint 2.9.1

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -34,3 +34,6 @@ revisions:
   2.5.3:
     licensed:
       declared: GPL-2.0-only
+  2.9.1:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint 2.9.1

**Details:**
See License field here: https://github.com/PyCQA/pylint/blob/v2.9.1/setup.cfg

**Resolution:**
Per setup.cfg license metadata = GPL-2.0-or-later

**Affected definitions**:
- [pylint 2.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.9.1/2.9.1)