### PR TITLE
NuGet.Build.Tasks.Pack 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Build.Tasks.Pack.yaml
+++ b/curations/nuget/nuget/-/NuGet.Build.Tasks.Pack.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Build.Tasks.Pack
+  provider: nuget
+  type: nuget
+revisions:
+  4.8.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Build.Tasks.Pack 4.8.0

**Details:**
An earlier version of the component is licensed under Apache-2.0
https://github.com/NuGet/Home/blob/dev/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Build.Tasks.Pack 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Build.Tasks.Pack/4.8.0/4.8.0)