### PR TITLE
System.Configuration 2.0.5

### DIFF
--- a/curations/nuget/nuget/-/System.Configuration.yaml
+++ b/curations/nuget/nuget/-/System.Configuration.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Configuration
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.5:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Configuration 2.0.5

**Details:**
Downloaded nuspec and couldn't find any licensing information.  No license information on Nuget page by this author

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [System.Configuration 2.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/System.Configuration/2.0.5/2.0.5)