### PR TITLE
Declared license is missing

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.sshd/sshd-common.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.sshd/sshd-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sshd-common
+  namespace: org.apache.sshd
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is missing

**Details:**
The declared license has not been harvested properly

**Resolution:**
According to https://github.com/apache/mina-sshd/blob/sshd-2.3.0/LICENSE.txt the license is Apache 2.0

**Affected definitions**:
- [sshd-common 2.3.0](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.sshd/sshd-common/2.3.0/2.3.0)