### PR TITLE
NuGet.Versioning 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0
   3.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Versioning 3.2.0

**Details:**
Nuget license link broken but project site linked: https://github.com/NuGetArchive/NuGet.Versioning/blob/master/LICENSE.txt includes Apache-2.0

**Resolution:**
Conclusion:  Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Versioning 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/3.2.0/3.2.0)