### PR TITLE
Pillow 8.3.0

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -48,12 +48,15 @@ revisions:
   8.1.0:
     licensed:
       declared: HPND
-  8.1.2:
-    licensed:
-      declared: HPND
   8.1.1:
     licensed:
       declared: HPND
+  8.1.2:
+    licensed:
+      declared: HPND
   8.2.0:
+    licensed:
+      declared: HPND
+  8.3.0:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pillow 8.3.0

**Details:**
Pillow project states it is HPND.  Unclear where crawler got CPL from.

**Resolution:**
HPND

**Affected definitions**:
- [Pillow 8.3.0](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/8.3.0/8.3.0)