### PR TITLE
Pillow 8.3.1, 5.4.0 dev0, 8.3.0

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -12,6 +12,9 @@ revisions:
   5.3.0:
     licensed:
       declared: HPND
+  5.4.0.dev0:
+    licensed:
+      declared: HPND
   5.4.1:
     licensed:
       declared: HPND
@@ -48,12 +51,18 @@ revisions:
   8.1.0:
     licensed:
       declared: HPND
-  8.1.2:
-    licensed:
-      declared: HPND
   8.1.1:
     licensed:
       declared: HPND
+  8.1.2:
+    licensed:
+      declared: HPND
   8.2.0:
+    licensed:
+      declared: HPND
+  8.3.0:
+    licensed:
+      declared: HPND
+  8.3.1:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pillow 8.3.1, 5.4.0 dev0, 8.3.0

**Details:**
Correcting all the pillow packages that say "CAL" to HPND.

**Resolution:**
Pillow is HPND

**Affected definitions**:
- [Pillow 8.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/8.3.1)