### PR TITLE
source location is missing

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.sshd/sshd-common.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.sshd/sshd-common.yaml
@@ -5,5 +5,13 @@ coordinates:
   type: sourcearchive
 revisions:
   2.3.0:
+    described:
+      sourceLocation:
+        name: mina-sshd
+        namespace: apache
+        provider: github
+        revision: 4f83fff0e6b8f8ab2ec18c04621381606f01d585
+        type: git
+        url: 'https://github.com/apache/mina-sshd/commit/4f83fff0e6b8f8ab2ec18c04621381606f01d585'
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
source location is missing

**Details:**
Source location on GitHub is not available

**Resolution:**
Add source location on GitHub for 2.3.0 tag

**Affected definitions**:
- [sshd-common 2.3.0](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.sshd/sshd-common/2.3.0/2.3.0)