### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/uid2.yaml
+++ b/curations/npm/npmjs/-/uid2.yaml
@@ -1,0 +1,23 @@
+coordinates:
+  name: uid2
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    described:
+      sourceLocation:
+        name: uid2
+        namespace: coreh
+        provider: github
+        revision: fde4a38680b88b46597c532c7bec62c94b9b7fea
+        type: git
+        url: 'https://github.com/coreh/uid2/commit/fde4a38680b88b46597c532c7bec62c94b9b7fea'
+  0.0.3:
+    described:
+      sourceLocation:
+        name: uid2
+        namespace: coreh
+        provider: github
+        revision: de1b40992074e01983dd1d145af369eb8bc41137
+        type: git
+        url: 'https://github.com/coreh/uid2/commit/de1b40992074e01983dd1d145af369eb8bc41137'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* uid2

**Affected definitions**:
- [uid2 0.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/uid2/0.0.3)