### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/spectrum-colorpicker.yaml
+++ b/curations/npm/npmjs/-/spectrum-colorpicker.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: spectrum-colorpicker
+  provider: npmjs
+  type: npm
+revisions:
+  1.8.0:
+    described:
+      sourceLocation:
+        name: spectrum
+        namespace: bgrins
+        provider: github
+        revision: 98454b55521cfb495f628db28af01100c029ef76
+        type: git
+        url: 'https://github.com/bgrins/spectrum/commit/98454b55521cfb495f628db28af01100c029ef76'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* spectrum-colorpicker

**Affected definitions**:
- [spectrum-colorpicker 1.8.0](https://clearlydefined.io/definitions/npm/npmjs/-/spectrum-colorpicker/1.8.0)