### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/prepend-selector-webpack-plugin.yaml
+++ b/curations/npm/npmjs/-/prepend-selector-webpack-plugin.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: prepend-selector-webpack-plugin
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    described:
+      sourceLocation:
+        name: prepend-selector-webpack-plugin
+        namespace: stutrek
+        provider: github
+        revision: db54f71f523349a7ed5000a101caabf40477fbc3
+        type: git
+        url: 'https://github.com/stutrek/prepend-selector-webpack-plugin/commit/db54f71f523349a7ed5000a101caabf40477fbc3'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* prepend-selector-webpack-plugin

**Affected definitions**:
- [prepend-selector-webpack-plugin 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/prepend-selector-webpack-plugin/1.0.0)