### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/polylabel.yaml
+++ b/curations/npm/npmjs/-/polylabel.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: polylabel
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.2:
+    described:
+      sourceLocation:
+        name: polylabel
+        namespace: mapbox
+        provider: github
+        revision: 64fe15722f380a53821286ee712abdd2ef79861a
+        type: git
+        url: 'https://github.com/mapbox/polylabel/commit/64fe15722f380a53821286ee712abdd2ef79861a'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* polylabel

**Affected definitions**:
- [polylabel 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/polylabel/1.0.2)