### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/node-bin-setup.yaml
+++ b/curations/npm/npmjs/-/node-bin-setup.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: node-bin-setup
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.6:
+    described:
+      sourceLocation:
+        name: node-bin-setup
+        namespace: aredridel
+        provider: github
+        revision: ad56be2b72108028fc058c07665035e34f25c0e9
+        type: git
+        url: 'https://github.com/aredridel/node-bin-setup/commit/ad56be2b72108028fc058c07665035e34f25c0e9'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* node-bin-setup

**Affected definitions**:
- [node-bin-setup 1.0.6](https://clearlydefined.io/definitions/npm/npmjs/-/node-bin-setup/1.0.6)