### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/eslint-plugin-rulesdir.yaml
+++ b/curations/npm/npmjs/-/eslint-plugin-rulesdir.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: eslint-plugin-rulesdir
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    described:
+      sourceLocation:
+        name: eslint-plugin-rulesdir
+        namespace: not-an-aardvark
+        provider: github
+        revision: 0678a8bc7358856e3c9ecdbb3ba31db587094121
+        type: git
+        url: 'https://github.com/not-an-aardvark/eslint-plugin-rulesdir/commit/0678a8bc7358856e3c9ecdbb3ba31db587094121'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* eslint-plugin-rulesdir

**Affected definitions**:
- [eslint-plugin-rulesdir 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/eslint-plugin-rulesdir/0.2.0)