### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/cordova-plugin-network-information.yaml
+++ b/curations/npm/npmjs/-/cordova-plugin-network-information.yaml
@@ -4,6 +4,14 @@ coordinates:
   type: npm
 revisions:
   1.0.0:
+    described:
+      sourceLocation:
+        name: cordova-plugin-network-information
+        namespace: apache
+        provider: github
+        revision: 30d51f8f320fe0421c9bacdc16a090a7b1232914
+        type: git
+        url: 'https://github.com/apache/cordova-plugin-network-information/commit/30d51f8f320fe0421c9bacdc16a090a7b1232914'
     licensed:
       declared: Apache-2.0
   1.2.0:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* cordova-plugin-network-information

**Affected definitions**:
- [cordova-plugin-network-information 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/cordova-plugin-network-information/1.0.0)