### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/-/azure-kusto-ingest.yaml
+++ b/curations/npm/npmjs/-/azure-kusto-ingest.yaml
@@ -1,0 +1,23 @@
+coordinates:
+  name: azure-kusto-ingest
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.9:
+    described:
+      sourceLocation:
+        name: azure-kusto-node
+        namespace: azure
+        provider: github
+        revision: 623d12522c478fc91664fc1f75de974c070abfff
+        type: git
+        url: 'https://github.com/azure/azure-kusto-node/commit/623d12522c478fc91664fc1f75de974c070abfff'
+  1.0.1:
+    described:
+      sourceLocation:
+        name: azure-kusto-node
+        namespace: azure
+        provider: github
+        revision: 55300226459a83910c1b7a182430cefd5eca3797
+        type: git
+        url: 'https://github.com/azure/azure-kusto-node/commit/55300226459a83910c1b7a182430cefd5eca3797'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
	* azure-kusto-ingest

**Affected definitions**:
- [azure-kusto-ingest 0.3.9](https://clearlydefined.io/definitions/npm/npmjs/-/azure-kusto-ingest/0.3.9)