### PR TITLE
Discovered license is incorrect

### DIFF
--- a/curations/maven/mavencentral/org.infinispan/infinispan-client-hotrod.yaml
+++ b/curations/maven/mavencentral/org.infinispan/infinispan-client-hotrod.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: infinispan-client-hotrod
+  namespace: org.infinispan
+  provider: mavencentral
+  type: maven
+revisions:
+  12.0.2.Final:
+    licensed:
+      declared: Apache-2.0 AND CDDL-1.1


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Discovered license is incorrect

**Details:**
The GPL-2.0-only license does not apply here because the dependency that it comes from (jboss-transaction-api_1.2_spec) is licensed under either CDDL or GPL 2.0 as can be seen here: https://github.com/jboss/jboss-transaction-api_spec/tree/jboss-transaction-api_1.2_spec-1.1.1.Final

**Resolution:**
Set declared and discovered license to Apache-2.0 AND CDDL-1.1

**Affected definitions**:
- [infinispan-client-hotrod 12.0.2.Final](https://clearlydefined.io/definitions/maven/mavencentral/org.infinispan/infinispan-client-hotrod/12.0.2.Final/12.0.2.Final)