### PR TITLE
Prism.Unity 8.1.97

### DIFF
--- a/curations/nuget/nuget/-/Prism.Unity.yaml
+++ b/curations/nuget/nuget/-/Prism.Unity.yaml
@@ -15,3 +15,6 @@ revisions:
   7.2.0.1422:
     licensed:
       declared: MIT
+  8.1.97:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Unity 8.1.97

**Details:**
The NuGet license link goes directly to hosted MIT license - https://www.nuget.org/packages/Prism.Unity/8.1.97/License

**Resolution:**
MIT

**Affected definitions**:
- [Prism.Unity 8.1.97](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Unity/8.1.97/8.1.97)