### PR TITLE
Update declared license

### DIFF
--- a/curations/git/github/jsqlparser/jsqlparser.yaml
+++ b/curations/git/github/jsqlparser/jsqlparser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsqlparser
+  namespace: jsqlparser
+  provider: github
+  type: git
+revisions:
+  05761c552f52f15b6bde2e4a5fb25cb15c9e5791:
+    licensed:
+      declared: LGPL-2.1 OR Apache-2.0

--- a/curations/git/github/jsqlparser/jsqlparser.yaml
+++ b/curations/git/github/jsqlparser/jsqlparser.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   05761c552f52f15b6bde2e4a5fb25cb15c9e5791:
     licensed:
-      declared: LGPL-2.1 OR Apache-2.0
+      declared: LGPL-2.1-only OR Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update declared license

**Details:**
Declared license is currently NOASSERTION. 

**Resolution:**
The project repo says it is dual-licensed LGPLv2.1 OR Apache-2.0: 

https://github.com/jsqlparser/jsqlparser/tree/05761c552f52f15b6bde2e4a5fb25cb15c9e5791#license

**Affected definitions**:
- [jsqlparser 05761c552f52f15b6bde2e4a5fb25cb15c9e5791](https://clearlydefined.io/definitions/git/github/jsqlparser/jsqlparser/05761c552f52f15b6bde2e4a5fb25cb15c9e5791/05761c552f52f15b6bde2e4a5fb25cb15c9e5791)