### PR TITLE
azureml-train 1.4.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -84,19 +84,19 @@ revisions:
   1.0.81:
     licensed:
       declared: OTHER
-  1.12.0:
-    licensed:
-      declared: OTHER
-  1.10.0:
+  1.0.85:
     licensed:
       declared: OTHER
   1.1.5:
     licensed:
       declared: OTHER
+  1.10.0:
+    licensed:
+      declared: OTHER
   1.11.0:
     licensed:
       declared: OTHER
-  1.0.85:
+  1.12.0:
     licensed:
       declared: OTHER
   1.13.0:
@@ -157,6 +157,9 @@ revisions:
     licensed:
       declared: OTHER
   1.30.0:
+    licensed:
+      declared: OTHER
+  1.4.0:
     licensed:
       declared: OTHER
   1.5.0:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train 1.4.0

**Details:**
PyPi license field indicates OTHER: https://aka.ms/azureml-sdk-license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train 1.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train/1.4.0/1.4.0)