### PR TITLE
Add declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/com.microsoft.azure.iot/proton-j-azure-iot.yaml
+++ b/curations/sourcearchive/mavencentral/com.microsoft.azure.iot/proton-j-azure-iot.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: proton-j-azure-iot
+  namespace: com.microsoft.azure.iot
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  0.12.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add declared license

**Details:**
The declared license on the source-archive was empty. The binary definition (https://clearlydefined.io/definitions/maven/mavencentral/com.microsoft.azure.iot/proton-j-azure-iot/0.12.2) has a declared license of "Apache-2.0". Further verified by going to Maven itself and checking the source package.

**Resolution:**
Source package: https://repo1.maven.org/maven2/com/microsoft/azure/iot/proton-j-azure-iot/0.12.2/proton-j-azure-iot-0.12.2-sources.jar

Path: META-INF\LICENSE

**Affected definitions**:
- [proton-j-azure-iot 0.12.2](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.microsoft.azure.iot/proton-j-azure-iot/0.12.2/0.12.2)