### PR TITLE
Declared license missing

### DIFF
--- a/curations/git/github/marian-nmt/marian.yaml
+++ b/curations/git/github/marian-nmt/marian.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: marian
+  namespace: marian-nmt
+  provider: github
+  type: git
+revisions:
+  63afe09901f10f8d7613307881559fde102126b4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license missing

**Details:**
The declared license according to LICENSE markdown file is MIT.

**Resolution:**
See: https://github.com/marian-nmt/marian/blob/63afe09901f10f8d7613307881559fde102126b4/LICENSE

**Affected definitions**:
- [marian 63afe09901f10f8d7613307881559fde102126b4](https://clearlydefined.io/definitions/git/github/marian-nmt/marian/63afe09901f10f8d7613307881559fde102126b4/63afe09901f10f8d7613307881559fde102126b4)