### PR TITLE
mdn-data 1.1.4

### DIFF
--- a/curations/npm/npmjs/-/mdn-data.yaml
+++ b/curations/npm/npmjs/-/mdn-data.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.4:
     licensed:
-      declared: MPL-2.0-no-copyleft-exception
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mdn-data 1.1.4

**Details:**
Correcting prior curation. Not finding an indication this project elected Exhibit B.  Appears to just be part of the LICENSE template.

**Resolution:**
Therefore, this would be curated simply as "MPL-2.0" and not "MPL-2.0-no-copyleft-exception."

**Affected definitions**:
- [mdn-data 1.1.4](https://clearlydefined.io/definitions/npm/npmjs/-/mdn-data/1.1.4/1.1.4)