### PR TITLE
debugpy 1.4.1

### DIFF
--- a/curations/pypi/pypi/-/debugpy.yaml
+++ b/curations/pypi/pypi/-/debugpy.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.1:
     licensed:
       declared: MIT
+  1.4.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
debugpy 1.4.1

**Details:**
The package's LICENSE file is MIT.  It appears EPL was included in the metadata because it is listed on the project's third party notices file.  However, the "declared" license here would just be MIT

**Resolution:**
MIT

**Affected definitions**:
- [debugpy 1.4.1](https://clearlydefined.io/definitions/pypi/pypi/-/debugpy/1.4.1/1.4.1)