### PR TITLE
suds-community 0.8.5

### DIFF
--- a/curations/pypi/pypi/-/suds-community.yaml
+++ b/curations/pypi/pypi/-/suds-community.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: suds-community
+  provider: pypi
+  type: pypi
+revisions:
+  0.8.5:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
suds-community 0.8.5

**Details:**
There's a bug.  This looks like just LGPL-3.0-or-later per LICENSE and setup.py

**Resolution:**
See above

**Affected definitions**:
- [suds-community 0.8.5](https://clearlydefined.io/definitions/pypi/pypi/-/suds-community/0.8.5/0.8.5)