### PR TITLE
Update the source information

### DIFF
--- a/curations/npm/npmjs/@npmcli/node-gyp.yaml
+++ b/curations/npm/npmjs/@npmcli/node-gyp.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: node-gyp
+  namespace: '@npmcli'
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    described:
+      sourceLocation:
+        name: node-gyp
+        namespace: npm
+        provider: github
+        revision: 391b87a3b45e7457b31211c952bd4693d6c5c243
+        type: git
+        url: 'https://github.com/npm/node-gyp/commit/391b87a3b45e7457b31211c952bd4693d6c5c243'
+  1.0.2:
+    described:
+      sourceLocation:
+        name: node-gyp
+        namespace: npm
+        provider: github
+        revision: 6ab304a5afffb9b116c2b00c798ee1c5f33684a0
+        type: git
+        url: 'https://github.com/npm/node-gyp/commit/6ab304a5afffb9b116c2b00c798ee1c5f33684a0'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update the source information

**Details:**
With the rise in supply chain attacks and OSS dependencies being used as a attack vector, Microsoft is working with our ecosystem partners, such as the Linux Foundation's OpenSSF, to enable OSS consumers to track packages back to their public sources.

**Resolution:**
This PR was created to add this value, ensuring future releases will include this provenance information.
Published NPM packages with repository information:
* @npmcli/node-gyp

**Affected definitions**:
- [node-gyp 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/@npmcli/node-gyp/1.0.1)