### PR TITLE
PyGithub 1.55

### DIFF
--- a/curations/pypi/pypi/-/PyGithub.yaml
+++ b/curations/pypi/pypi/-/PyGithub.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PyGithub
+  provider: pypi
+  type: pypi
+revisions:
+  '1.55':
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
PyGithub 1.55

**Details:**
Looking at the setup.py, I think the "declared" is LGPL-3.0-or-later (not GPL)

**Resolution:**
See above

**Affected definitions**:
- [PyGithub 1.55](https://clearlydefined.io/definitions/pypi/pypi/-/PyGithub/1.55/1.55)