### PR TITLE
System.IdentityModel.Tokens.Jwt 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
+++ b/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: OTHER
   4.0.2.206221351:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IdentityModel.Tokens.Jwt 1.0.0

**Details:**
Nuspec link to license is broken.
Nuget license field indicate Microsoft EULA but link is broken - OTHER

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.IdentityModel.Tokens.Jwt 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.IdentityModel.Tokens.Jwt/1.0.0/1.0.0)