### PR TITLE
azureml-dataprep 2.18.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -102,6 +102,9 @@ revisions:
   2.15.1:
     licensed:
       declared: OTHER
+  2.18.0:
+    licensed:
+      declared: OTHER
   2.2.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.18.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.18.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.18.0/2.18.0)