### PR TITLE
azureml-telemetry 1.32.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -186,10 +186,13 @@ revisions:
   1.3.0.post1:
     licensed:
       declared: OTHER
-  1.4.0:
+  1.30.0:
     licensed:
       declared: OTHER
-  1.30.0:
+  1.32.0:
+    licensed:
+      declared: OTHER
+  1.4.0:
     licensed:
       declared: OTHER
   1.4.0.post1:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-telemetry 1.32.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-telemetry 1.32.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.32.0/1.32.0)