### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.1.5

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -99,9 +99,12 @@ revisions:
   2021.1.1:
     licensed:
       declared: OTHER
+  2021.1.2:
+    licensed:
+      declared: OTHER
   2021.1.3:
     licensed:
       declared: OTHER
-  2021.1.2:
+  2021.1.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.1.5

**Details:**
Nuget License field links to Jet Brains User Agreement: https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.1.5/2021.1.5)