### PR TITLE
azureml-automl-core 1.32.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -153,6 +153,9 @@ revisions:
   1.30.0:
     licensed:
       declared: OTHER
+  1.32.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.32.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-automl-core 1.32.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.32.0/1.32.0)