### PR TITLE
base64-js 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/base64-js.yaml
+++ b/curations/npm/npmjs/-/base64-js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: base64-js
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
base64-js 0.0.2

**Details:**
NPM license field indicates MIT 
Source code project includes MIT: https://github.com/beatgammit/base64-js/blob/master/LICENSE


**Resolution:**
Declared license is MIT

**Affected definitions**:
- [base64-js 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/base64-js/0.0.2/0.0.2)