### PR TITLE
sp-lodash-subset 1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-lodash-subset.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-lodash-subset.yaml
@@ -88,3 +88,6 @@ revisions:
   1.8.2-plusbeta:
     licensed:
       declared: OTHER
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-lodash-subset 1.9.1

**Details:**
NPM License field refers to see license.
Readme indicates SharePoint Framework License:  https://unpkg.com/@microsoft/sp-core-library@1.8.2/EULA/Microsoft%20Sharepoint%20Framework%20-%20Standalone%20(free)%20Use%20Terms.docx

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [sp-lodash-subset 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-lodash-subset/1.9.1/1.9.1)