### PR TITLE
TopologicalSorting.netstandard 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/TopologicalSorting.netstandard.yaml
+++ b/curations/nuget/nuget/-/TopologicalSorting.netstandard.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TopologicalSorting.netstandard
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TopologicalSorting.netstandard 1.0.3

**Details:**
Nuget license field is Apache-2.0
Source code project license is Apache-2.0:  https://github.com/machonky/TopologicalSorting.netstandard/blob/master/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [TopologicalSorting.netstandard 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/TopologicalSorting.netstandard/1.0.3/1.0.3)