### PR TITLE
AzureFunctions.Extensions.DependencyInjection 1.1.3

### DIFF
--- a/curations/nuget/nuget/-/AzureFunctions.Extensions.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/AzureFunctions.Extensions.DependencyInjection.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AzureFunctions.Extensions.DependencyInjection
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.3:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AzureFunctions.Extensions.DependencyInjection 1.1.3

**Details:**
Nuspec license link was broken.  Was unable to find license information in the files.
Nuget license field link was broken
Source code project link was broken.
History indicates a license was added at v1.0.1

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [AzureFunctions.Extensions.DependencyInjection 1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/AzureFunctions.Extensions.DependencyInjection/1.1.3/1.1.3)