### PR TITLE
System.Numerics.Vectors 4.6.0-preview 5.19224.8

### DIFF
--- a/curations/nuget/nuget/-/System.Numerics.Vectors.yaml
+++ b/curations/nuget/nuget/-/System.Numerics.Vectors.yaml
@@ -17,3 +17,6 @@ revisions:
         url: 'https://github.com/dotnet/corefx/commit/30ab651fcb4354552bd4891619a0bdd81e0ebdbf'
     licensed:
       declared: MIT
+  4.6.0-preview5.19224.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Numerics.Vectors 4.6.0-preview 5.19224.8

**Details:**
Nuget license field links to MIT: https://github.com/dotnet/runtime/blob/381372f6f12884caee5bb90f52649040827e19cc/LICENSE.TXT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Numerics.Vectors 4.6.0-preview5.19224.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Numerics.Vectors/4.6.0-preview5.19224.8/4.6.0-preview5.19224.8)