### PR TITLE
HtmlAgilityPack.NetCore 1.5.0.1

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.NetCore.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.NetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: HtmlAgilityPack.NetCore
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.0.1:
+    licensed:
+      declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack.NetCore 1.5.0.1

**Details:**
Nuget links to source code project site that has been deprecated.  The new site did not have a license at the date the Nuget was last updated.  The current license is dual license MIT AND OTHER:  https://github.com/zzzprojects/html-agility-pack/blob/87a8592ba3aae0f3b0033eb05800aba768ee1e7e/LICENSE

**Resolution:**
Declared license is MIT AND OTHER

**Affected definitions**:
- [HtmlAgilityPack.NetCore 1.5.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack.NetCore/1.5.0.1/1.5.0.1)