### PR TITLE
pcf-scripts 1.5.5

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -9,6 +9,9 @@ revisions:
   1.4.4:
     licensed:
       declared: OTHER
+  1.5.5:
+    licensed:
+      declared: OTHER
   1.7.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.5.5

**Details:**
ClearlyDefined license file is MICROSOFT POWERAPPS CLI - OTHER: https://clearlydefined.io/file/dc0ec69f61019186d491e8d0f63bf194e06fb784ba7a2e3078d25d4d7a8a8dee

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pcf-scripts 1.5.5](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.5.5/1.5.5)