### PR TITLE
junit-jupiter-params 5.4.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -10,6 +10,9 @@ revisions:
   5.3.1:
     licensed:
       declared: EPL-2.0
+  5.4.2:
+    licensed:
+      declared: ECL-2.0
   5.5.2:
     licensed:
       declared: EPL-2.0

--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -12,7 +12,7 @@ revisions:
       declared: EPL-2.0
   5.4.2:
     licensed:
-      declared: ECL-2.0
+      declared: EPL-2.0
   5.5.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter-params 5.4.2

**Details:**
ClearlyDefined license file is EPL-2.0
Maven: https://search.maven.org/artifact/org.junit.jupiter/junit-jupiter-params/5.4.2/jar
Includes EPL-2.0: http://www.eclipse.org/legal/epl-v20.html

**Resolution:**
Declared license is EPL-2.0

**Affected definitions**:
- [junit-jupiter-params 5.4.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.4.2/5.4.2)