### PR TITLE
azureml-train-restclients-hyperdrive 1.31.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -168,6 +168,9 @@ revisions:
   1.30.0:
     licensed:
       declared: OTHER
+  1.31.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-restclients-hyperdrive 1.31.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.31.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.31.0/1.31.0)