### PR TITLE
librdkafka.redist 1.5.0

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -24,6 +24,9 @@ revisions:
   1.3.0:
     licensed:
       declared: BSD-2-Clause
+  1.5.0:
+    licensed:
+      declared: BSD-2-Clause
   1.5.2:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkafka.redist 1.5.0

**Details:**
ClearlyDefined license file is BSD-2-Clause: 
https://clearlydefined.io/file/ee5e38ac7f79a1e90fd0cc7821503af66ca21f6cc1d99d5ae2f97b57a2ac7a38

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [librdkafka.redist 1.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.5.0/1.5.0)