### PR TITLE
junit-jupiter-params 5.7.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -19,6 +19,9 @@ revisions:
   5.6.3:
     licensed:
       declared: EPL-2.0
+  5.7.0:
+    licensed:
+      declared: EPL-2.0
   5.7.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter-params 5.7.0

**Details:**
ClearlyDefined license file is EPL-2.0:  https://clearlydefined.io/file/5aa4cd44c111add178d1c2e2fe36d58a484012c80167df925f826cd64d411bf0
Maven license field indicates EPL-2.0

**Resolution:**
Declared license is: EPL-2.0

**Affected definitions**:
- [junit-jupiter-params 5.7.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.7.0/5.7.0)