### PR TITLE
dom4j 2.1.3

### DIFF
--- a/curations/maven/mavencentral/org.dom4j/dom4j.yaml
+++ b/curations/maven/mavencentral/org.dom4j/dom4j.yaml
@@ -7,3 +7,6 @@ revisions:
   2.1.1:
     licensed:
       declared: Plexus
+  2.1.3:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/org.dom4j/dom4j.yaml
+++ b/curations/maven/mavencentral/org.dom4j/dom4j.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: Plexus
   2.1.3:
     licensed:
-      declared: BSD-3-Clause
+      declared: Plexus


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dom4j 2.1.3

**Details:**
Maven license field indicates BSD-3-Clause
Source code project is BSD-3-Clause: https://github.com/dom4j/dom4j/blob/version-2.1.3/LICENSE

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [dom4j 2.1.3](https://clearlydefined.io/definitions/maven/mavencentral/org.dom4j/dom4j/2.1.3/2.1.3)