### PR TITLE
NuGet.CommandLine 1.0.11220.26

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.11220.26:
+    licensed:
+      declared: Apache-2.0
   3.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.CommandLine 1.0.11220.26

**Details:**
Nuget open source project linked to CodePlex which redirected to GitHub.  License Apache-2.0:  https://github.com/NuGetArchive/NuGet.CommandLine/blob/master/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.CommandLine 1.0.11220.26](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/1.0.11220.26/1.0.11220.26)