### PR TITLE
azureml-dataprep-native 38.0.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep-native.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep-native.yaml
@@ -66,3 +66,6 @@ revisions:
   33.0.0:
     licensed:
       declared: OTHER
+  38.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep-native 38.0.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep-native 38.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep-native/38.0.0/38.0.0)