### PR TITLE
azureml-train 1.31.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -159,6 +159,9 @@ revisions:
   1.30.0:
     licensed:
       declared: OTHER
+  1.31.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train 1.31.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train 1.31.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train/1.31.0/1.31.0)