### PR TITLE
azureml-train-restclients-hyperdrive 1.33.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -168,6 +168,9 @@ revisions:
   1.30.0:
     licensed:
       declared: OTHER
+  1.33.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER

--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -173,7 +173,7 @@ revisions:
       declared: OTHER
   1.32.0:
     licensed:
-      declared: 
+      declared: OTHER
   1.33.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-restclients-hyperdrive 1.33.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.33.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.33.0/1.33.0)