### PR TITLE
azureml-pipeline-core 1.3.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -165,6 +165,9 @@ revisions:
   1.29.0:
     licensed:
       declared: OTHER
+  1.3.0:
+    licensed:
+      declared: OTHER
   1.30.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.3.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.3.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.3.0/1.3.0)