### PR TITLE
 azureml-dataprep 2.20.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -111,6 +111,9 @@ revisions:
   2.2.5:
     licensed:
       declared: OTHER
+  2.20.1:
+    licensed:
+      declared: OTHER
   2.3.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 azureml-dataprep 2.20.1

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license


**Resolution:**
Declared license is OTHER


**Affected definitions**:
- [azureml-dataprep 2.20.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.20.1/2.20.1)