### PR TITLE
azureml-defaults 1.32.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-defaults.yaml
+++ b/curations/pypi/pypi/-/azureml-defaults.yaml
@@ -138,6 +138,9 @@ revisions:
   1.30.0:
     licensed:
       declared: OTHER
+  1.32.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-defaults 1.32.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-defaults 1.32.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-defaults/1.32.0/1.32.0)