### PR TITLE
azureml-dataset-runtime 1.33.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -72,3 +72,6 @@ revisions:
   1.30.0:
     licensed:
       declared: OTHER
+  1.33.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime 1.33.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license



**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataset-runtime 1.33.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.33.0/1.33.0)