### PR TITLE
 jQuery.vsdoc 1.5.1

### DIFF
--- a/curations/nuget/nuget/-/jQuery.vsdoc.yaml
+++ b/curations/nuget/nuget/-/jQuery.vsdoc.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.5.1:
+    licensed:
+      declared: NONE
   1.6.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/jQuery.vsdoc.yaml
+++ b/curations/nuget/nuget/-/jQuery.vsdoc.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: NONE
   1.6.0:
     licensed:
-      declared: MIT
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jQuery.vsdoc 1.5.1

**Details:**
Nuget indicates package may be deprecated.  Nuget does not include source code project or license field links.  No license found in nuspec.

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [jQuery.vsdoc 1.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.vsdoc/1.5.1/1.5.1)