### PR TITLE
ReSharper.Annotations 7.1.3.130415

### DIFF
--- a/curations/nuget/nuget/-/ReSharper.Annotations.yaml
+++ b/curations/nuget/nuget/-/ReSharper.Annotations.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ReSharper.Annotations
+  provider: nuget
+  type: nuget
+revisions:
+  7.1.3.130415:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ReSharper.Annotations 7.1.3.130415

**Details:**
Nuget license field links is broken but navigates to JetBrains. Review of JetBrains site indicates the license is OTHER: https://www.jetbrains.com/legal/docs/toolbox/user.html

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [ReSharper.Annotations 7.1.3.130415](https://clearlydefined.io/definitions/nuget/nuget/-/ReSharper.Annotations/7.1.3.130415/7.1.3.130415)