### PR TITLE
batch 0.5.0

### DIFF
--- a/curations/npm/npmjs/-/batch.yaml
+++ b/curations/npm/npmjs/-/batch.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.5.0:
+    licensed:
+      declared: MIT
   0.5.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
batch 0.5.0

**Details:**
NPM license field indicates MIT
The current source code project license is MIT: https://github.com/visionmedia/batch/blob/e21e1aee35c31822bbdaf3c43a32939ef7d02775/LICENSE
There doesn't appear to be a license in the project at the time of the package.

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [batch 0.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/batch/0.5.0/0.5.0)