### PR TITLE
platform 3.4.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/platform.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: platform
+  namespace: net.java.dev.jna
+  provider: mavencentral
+  type: maven
+revisions:
+  3.4.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/net.java.dev.jna/platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/platform.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.4.0:
     licensed:
-      declared: Apache-2.0
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
platform 3.4.0

**Details:**
Searched Maven for net.java.dev.jna/platform 3.4.0 and found: https://search.maven.org/artifact/net.java.dev.jna/platform/3.4.0/jar    
License is LGPL-2.1-only


**Resolution:**
Declared license is LGPL-2.1-only

**Affected definitions**:
- [platform 3.4.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/platform/3.4.0/3.4.0)