### PR TITLE
inherits 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/inherits.yaml
+++ b/curations/npm/npmjs/-/inherits.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.0:
+    licensed:
+      declared: OTHER
   1.0.2:
     licensed:
       declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
inherits 1.0.0

**Details:**
NPM Indicates license is ISC but that appears to be the current license and not the license when package was last updated 10 years ago.  It appears the license at that time was: General Public Obviousness License - OTHER:  https://github.com/isaacs/inherits/blob/0b5b6e9964ca50307ee6018fcd24159bf79e0

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [inherits 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/inherits/1.0.0/1.0.0)