### PR TITLE
assert-plus 0.1.2

### DIFF
--- a/curations/npm/npmjs/-/assert-plus.yaml
+++ b/curations/npm/npmjs/-/assert-plus.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.1.2:
+    licensed:
+      declared: MIT
   0.1.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
assert-plus 0.1.2

**Details:**
NPM License field indicates MIT
ClearlyDefined README.MD indicates MIT
Source code project appears to now have a license when package was last updated.  However, the current license is MIT: https://github.com/joyent/node-assert-plus/blob/master/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [assert-plus 0.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/assert-plus/0.1.2/0.1.2)