### PR TITLE
System.Data.DataSetExtensions 4.6.0-preview3.19128.7 17Harvested

### DIFF
--- a/curations/nuget/nuget/-/System.Data.DataSetExtensions.yaml
+++ b/curations/nuget/nuget/-/System.Data.DataSetExtensions.yaml
@@ -6,3 +6,6 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.6.0-preview3.19128.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.DataSetExtensions 4.6.0-preview3.19128.7 17Harvested

**Details:**
ClearlyDefined license.txt file is MIT
Nuget license field links to MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
Source code project license is MIT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Data.DataSetExtensions 4.6.0-preview3.19128.7](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.DataSetExtensions/4.6.0-preview3.19128.7/4.6.0-preview3.19128.7)