### PR TITLE
Bootstrap.v3.Datetimepicker 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bootstrap.v3.Datetimepicker.yaml
+++ b/curations/nuget/nuget/-/Bootstrap.v3.Datetimepicker.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.0.0:
+    licensed:
+      declared: MIT
   4.15.35.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bootstrap.v3.Datetimepicker 4.0.0

**Details:**
Nuget links to source code project (no license field)
Source code project license is MIT: https://github.com/Eonasdan/tempus-dominus/blob/v4.0.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [Bootstrap.v3.Datetimepicker 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bootstrap.v3.Datetimepicker/4.0.0/4.0.0)