### PR TITLE
System.Security.Permissions 4.4.1

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Permissions.yaml
+++ b/curations/nuget/nuget/-/System.Security.Permissions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.1:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Permissions 4.4.1

**Details:**
ClearlyDefined license is MIT
Nuget license field links to MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Security.Permissions 4.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Permissions/4.4.1/4.4.1)