### PR TITLE
Bootstrap.v3.Datetimepicker.CSS 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bootstrap.v3.Datetimepicker.CSS.yaml
+++ b/curations/nuget/nuget/-/Bootstrap.v3.Datetimepicker.CSS.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.0.0:
+    licensed:
+      declared: MIT
   4.15.35:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bootstrap.v3.Datetimepicker.CSS 4.0.0

**Details:**
Nuget did not include a license field but links to source code project that has MIT license: https://github.com/Eonasdan/tempus-dominus/blob/v4.0.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [Bootstrap.v3.Datetimepicker.CSS 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bootstrap.v3.Datetimepicker.CSS/4.0.0/4.0.0)