### PR TITLE
TestStack.BDDfy 4.3.2

### DIFF
--- a/curations/nuget/nuget/-/TestStack.BDDfy.yaml
+++ b/curations/nuget/nuget/-/TestStack.BDDfy.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: MIT
   4.3.2:
     licensed:
-      declared: NONE
+      declared: MIT

--- a/curations/nuget/nuget/-/TestStack.BDDfy.yaml
+++ b/curations/nuget/nuget/-/TestStack.BDDfy.yaml
@@ -9,3 +9,6 @@ revisions:
   4.2.0:
     licensed:
       declared: MIT
+  4.3.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TestStack.BDDfy 4.3.2

**Details:**
No license info found in nuspec or files
Nuget does not include a license field or source code project link.  Did not find package on GitHub.

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [TestStack.BDDfy 4.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/TestStack.BDDfy/4.3.2/4.3.2)