### PR TITLE
scp 0.13.6

### DIFF
--- a/curations/pypi/pypi/-/scp.yaml
+++ b/curations/pypi/pypi/-/scp.yaml
@@ -6,3 +6,6 @@ revisions:
   0.13.3:
     licensed:
       declared: LGPL-2.1-or-later
+  0.13.6:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
scp 0.13.6

**Details:**
ClearlyDefined incorrectly listing GPL-3.0 in the declared field. 

**Resolution:**
LICENSE in package and setup.py indicate the license is LGPL-2.1-or-later

**Affected definitions**:
- [scp 0.13.6](https://clearlydefined.io/definitions/pypi/pypi/-/scp/0.13.6/0.13.6)