### PR TITLE
taffydb 2.6.2

### DIFF
--- a/curations/npm/npmjs/-/taffydb.yaml
+++ b/curations/npm/npmjs/-/taffydb.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.6.2:
     licensed:
-      declared: BSD-1-Clause
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
taffydb 2.6.2

**Details:**
Project maintainer clarified intent of package license is BSD-2-Clause (per issue number 166 in project repo).

**Resolution:**
Updating from BSD-1-Clause to BSD-2-Clause

**Affected definitions**:
- [taffydb 2.6.2](https://clearlydefined.io/definitions/npm/npmjs/-/taffydb/2.6.2/2.6.2)