### PR TITLE
yaml/0.2.3

### DIFF
--- a/curations/npm/npmjs/-/yaml.yaml
+++ b/curations/npm/npmjs/-/yaml.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: yaml
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.3:
+    described:
+      sourceLocation:
+        name: js-yaml
+        namespace: tj
+        provider: github
+        revision: 8702385af98d4f814fc9254f0e93a0254df73d7b
+        type: git
+        url: 'https://github.com/tj/js-yaml/commit/8702385af98d4f814fc9254f0e93a0254df73d7b'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
yaml/0.2.3

**Details:**
Adding missing source location

**Resolution:**
The current GitHub repo and author are not the same as the author who published this version. I'm assuming TJ gave up the package name to someone else. The README for this version has the copyright of TJ Holowaychuk, who is github.com/tj. I found the source repo for this version in his repo list. 

**Affected definitions**:
- [yaml 0.2.3](https://clearlydefined.io/definitions/npm/npmjs/-/yaml/0.2.3/0.2.3)