### PR TITLE
com.github.jnr/jnr-posix3.1.4

### DIFF
--- a/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
+++ b/curations/maven/mavencentral/com.github.jnr/jnr-posix.yaml
@@ -7,3 +7,6 @@ revisions:
   3.0.45:
     licensed:
       declared: EPL-1.0 OR CPL-1.0 OR GPL-2.0 OR LGPL-2.1
+  3.1.4:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.github.jnr/jnr-posix3.1.4

**Details:**
POM lists 3 licenses and in the repo, it is explained this is tri-licensed: https://github.com/jnr/jnr-posix/blob/master/LICENSE.txt

**Resolution:**
see above

**Affected definitions**:
- [jnr-posix 3.1.4](https://clearlydefined.io/definitions/maven/mavencentral/com.github.jnr/jnr-posix/3.1.4/3.1.4)