### PR TITLE
org.eclipse.collections/eclipse-collections-api11.0.0.M3

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.collections/eclipse-collections-api.yaml
+++ b/curations/maven/mavencentral/org.eclipse.collections/eclipse-collections-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  11.0.0.M3:
+    licensed:
+      declared: BSD-3-Clause OR EPL-1.0
   9.2.0:
     licensed:
       declared: EPL-1.0 AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.eclipse.collections/eclipse-collections-api11.0.0.M3

**Details:**
Incorrectly has AND instead of OR

**Resolution:**
See Q&A 33 here https://www.eclipse.org/legal/eplfaq.php

**Affected definitions**:
- [eclipse-collections-api 11.0.0.M3](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.collections/eclipse-collections-api/11.0.0.M3/11.0.0.M3)