### PR TITLE
Add missing declared license

### DIFF
--- a/curations/git/github/moby/hyperkit.yaml
+++ b/curations/git/github/moby/hyperkit.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hyperkit
+  namespace: moby
+  provider: github
+  type: git
+revisions:
+  06c3cf7ec253534b2d81f61ee3c85c5c9aafa4ee:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing declared license

**Details:**
The declared license was missing.

**Resolution:**
According to the README, the applicable license is BSD-2-Clause.

See: https://github.com/moby/hyperkit/tree/06c3cf7ec253534b2d81f61ee3c85c5c9aafa4ee#copyright-and-license

**Affected definitions**:
- [hyperkit 06c3cf7ec253534b2d81f61ee3c85c5c9aafa4ee](https://clearlydefined.io/definitions/git/github/moby/hyperkit/06c3cf7ec253534b2d81f61ee3c85c5c9aafa4ee/06c3cf7ec253534b2d81f61ee3c85c5c9aafa4ee)