### PR TITLE
websocket-client1.1.1

### DIFF
--- a/curations/pypi/pypi/-/websocket-client.yaml
+++ b/curations/pypi/pypi/-/websocket-client.yaml
@@ -12,3 +12,6 @@ revisions:
   1.1.0:
     licensed:
       declared: LGPL-2.1-or-later
+  1.1.1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
websocket-client1.1.1

**Details:**
Unclear where tooling is pulling GPL-3.0.  LICENSE file is LGPL-2.1 and setup.py indicates "or later."

**Resolution:**
Thanks

**Affected definitions**:
- [websocket-client 1.1.1](https://clearlydefined.io/definitions/pypi/pypi/-/websocket-client/1.1.1/1.1.1)