### PR TITLE
frozendict 2.0.6

### DIFF
--- a/curations/pypi/pypi/-/frozendict.yaml
+++ b/curations/pypi/pypi/-/frozendict.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: frozendict
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.6:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
frozendict 2.0.6

**Details:**
Tooling seems to be incorrectly pulling in GPL-3.0

**Resolution:**
LGPL-3.0-only

**Affected definitions**:
- [frozendict 2.0.6](https://clearlydefined.io/definitions/pypi/pypi/-/frozendict/2.0.6/2.0.6)