### PR TITLE
Adding missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting
+  provider: nuget
+  type: nuget
+revisions:
+  4.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared license

**Details:**
License missing for this package. The license is found on the git repo here:

https://github.com/chsakell/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting/blob/master/LICENSE

I was not able to edit the source for some reason.

**Resolution:**
It adds the MIT license as declared.

**Affected definitions**:
- [Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore.SwaggerGen.ConventionalRouting/4.2.0/4.2.0)