### PR TITLE
license of nwchem

### DIFF
--- a/curations/git/github/nwchemgit/nwchem.yaml
+++ b/curations/git/github/nwchemgit/nwchem.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: nwchem
+  namespace: nwchemgit
+  provider: github
+  type: git
+revisions:
+  735cdaa70c11dab5cef410424845a80f286dcfce:
+    licensed:
+      declared: ECL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
license of nwchem

**Details:**
license file is at https://github.com/nwchemgit/nwchem/blob/master/LICENSE.TXT

NWChem is an open-source computational chemistry package distributed under the terms of the Educational Community License (ECL) 2.0

**Resolution:**
Update the license information about the NWChem

**Affected definitions**:
- [nwchem 735cdaa70c11dab5cef410424845a80f286dcfce](https://clearlydefined.io/definitions/git/github/nwchemgit/nwchem/735cdaa70c11dab5cef410424845a80f286dcfce)