### PR TITLE
hande use LGPL 2.1

### DIFF
--- a/curations/git/github/hande-qmc/hande.yaml
+++ b/curations/git/github/hande-qmc/hande.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hande
+  namespace: hande-qmc
+  provider: github
+  type: git
+revisions:
+  0cd750354e5a04678e04bf0b7a04945cb5e0b58a:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
hande use LGPL 2.1

**Details:**
license file is at https://github.com/hande-qmc/hande/blob/main/COPYING

**Resolution:**
change to LGPL 2.1

**Affected definitions**:
- [hande 0cd750354e5a04678e04bf0b7a04945cb5e0b58a](https://clearlydefined.io/definitions/git/github/hande-qmc/hande/0cd750354e5a04678e04bf0b7a04945cb5e0b58a)