### PR TITLE
Pillow8.3.2

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -66,3 +66,6 @@ revisions:
   8.3.1:
     licensed:
       declared: HPND
+  8.3.2:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pillow8.3.2

**Details:**
Declared License is HPND

**Resolution:**
PyPI meta is HPND

Project license: https://pillow.readthedocs.io/en/stable/about.html#license

Source license is HPND: https://github.com/python-pillow/Pillow/blob/8.3.2/LICENSE

**Affected definitions**:
- [Pillow 8.3.2](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/8.3.2/8.3.2)