### PR TITLE
Pillow 8.3.2

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -66,3 +66,6 @@ revisions:
   8.3.1:
     licensed:
       declared: HPND
+  8.3.2:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pillow 8.3.2

**Details:**
Tooling incorrectly classifying this as CAL.  It's HPND

**Resolution:**
HPND

**Affected definitions**:
- [Pillow 8.3.2](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/8.3.2/8.3.2)