### PR TITLE
tox missing source URL

### DIFF
--- a/curations/pypi/pypi/-/tox.yaml
+++ b/curations/pypi/pypi/-/tox.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: tox
+  provider: pypi
+  type: pypi
+revisions:
+  3.23.1:
+    described:
+      sourceLocation:
+        name: tox
+        namespace: tox-dev
+        provider: github
+        revision: d98f589197f033fa9846918f309bf66a645f905b
+        type: git
+        url: 'https://github.com/tox-dev/tox/commit/d98f589197f033fa9846918f309bf66a645f905b'


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
tox missing source URL

**Details:**
Missing Source URL

**Resolution:**
Added Source URL

**Affected definitions**:
- [tox 3.23.1](https://clearlydefined.io/definitions/pypi/pypi/-/tox/3.23.1)