### PR TITLE
pytest-dev/pytest source url

### DIFF
--- a/curations/pypi/pypi/-/pytest.yaml
+++ b/curations/pypi/pypi/-/pytest.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: pytest
+  provider: pypi
+  type: pypi
+revisions:
+  6.2.5:
+    described:
+      sourceLocation:
+        name: pytest
+        namespace: pytest-dev
+        provider: github
+        revision: 1569fac603d9a50022e1474b494eebf970a2a3af
+        type: git
+        url: 'https://github.com/pytest-dev/pytest/commit/1569fac603d9a50022e1474b494eebf970a2a3af'


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
pytest-dev/pytest source url

**Details:**
source url missing

**Resolution:**
add source url

**Affected definitions**:
- [pytest 6.2.5](https://clearlydefined.io/definitions/pypi/pypi/-/pytest/6.2.5)