### PR TITLE
Declared license is missing

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -76,3 +76,6 @@ revisions:
   21.0.0:
     licensed:
       declared: UPL-1.0
+  21.2.0:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is missing

**Details:**
The artifact's declared license is missing

**Resolution:**
According to the artifact's GitHub repo at https://github.com/oracle/graal/tree/vm-21.2.0/sdk the license is UPL-1.0

**Affected definitions**:
- [graal-sdk 21.2.0](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/21.2.0/21.2.0)