### PR TITLE
Astroid license is LGPL only

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -9,3 +9,6 @@ revisions:
   2.3.3:
     licensed:
       declared: LGPL-2.1-only
+  2.7.3:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Astroid license is LGPL only

**Details:**
Astroid license is LGPL only

**Resolution:**
Astroid license is LGPL only

**Affected definitions**:
- [astroid 2.7.3](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.7.3/2.7.3)