### PR TITLE
Set the declared license to match LICENSE file

### DIFF
--- a/curations/gem/rubygems/-/agi.yaml
+++ b/curations/gem/rubygems/-/agi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: agi
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.1:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Set the declared license to match LICENSE file

**Details:**
Missing declared LICENSE

**Resolution:**
THIS IS JUST A TEST DO NOT MERGE

**Affected definitions**:
- [agi 0.0.1](https://clearlydefined.io/definitions/gem/rubygems/-/agi/0.0.1)