### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.2.1

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -111,3 +111,6 @@ revisions:
   2021.1.5:
     licensed:
       declared: OTHER
+  2021.2.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.2.1

**Details:**
NuGet license goes to a EULA style license

**Resolution:**
EULA license = OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.2.1/2021.2.1)