### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.2.0

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -111,3 +111,6 @@ revisions:
   2021.1.5:
     licensed:
       declared: OTHER
+  2021.2.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.2.0

**Details:**
NuGet license link goes to EULA style license - https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.2.0

**Resolution:**
EULA = OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.2.0/2021.2.0)