### PR TITLE
intel 1.2.0

### DIFF
--- a/curations/npm/npmjs/-/intel.yaml
+++ b/curations/npm/npmjs/-/intel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: intel
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.0:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
intel 1.2.0

**Details:**
I dont see that Exhibit B was elected.  I think the tooling is picking that up from the regular MPL license template. 

**Resolution:**
This PR is to delete "MPL-2.0-no-copyleft-exception" from the declared field. 

**Affected definitions**:
- [intel 1.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/intel/1.2.0/1.2.0)