### PR TITLE
utcstring 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/utcstring.yaml
+++ b/curations/npm/npmjs/-/utcstring.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: utcstring
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
utcstring 0.1.0

**Details:**
Declared includes "MPL-2.0-no-copyleft-exception," which I think is wrong.  I think Exhibit B of the MPL license is just part of the template and not actually being applied. 

**Resolution:**
This looks like regular "MPL-2.0"

**Affected definitions**:
- [utcstring 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/utcstring/0.1.0/0.1.0)