### PR TITLE
debugpy 1.4.3

### DIFF
--- a/curations/pypi/pypi/-/debugpy.yaml
+++ b/curations/pypi/pypi/-/debugpy.yaml
@@ -12,3 +12,6 @@ revisions:
   1.4.1:
     licensed:
       declared: MIT
+  1.4.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
debugpy 1.4.3

**Details:**
The top level license is MIT.  The EPL reference is for PyDev.Debugger on the TPN.

**Resolution:**
Declared = MIT

**Affected definitions**:
- [debugpy 1.4.3](https://clearlydefined.io/definitions/pypi/pypi/-/debugpy/1.4.3/1.4.3)