### PR TITLE
added source link

### DIFF
--- a/curations/npm/npmjs/-/nearley.yaml
+++ b/curations/npm/npmjs/-/nearley.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: nearley
+  provider: npmjs
+  type: npm
+revisions:
+  2.19.7:
+    described:
+      sourceLocation:
+        name: nearley
+        namespace: kach
+        provider: github
+        revision: 7c0fd952b85b833a1b6ff377b7f4366c633204df
+        type: git
+        url: 'https://github.com/kach/nearley/commit/7c0fd952b85b833a1b6ff377b7f4366c633204df'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
added source link

**Details:**
added missing source link

**Resolution:**
found it in the commits, when the package.json file was changed to 2.19.7

**Affected definitions**:
- [nearley 2.19.7](https://clearlydefined.io/definitions/npm/npmjs/-/nearley/2.19.7/2.19.7)