### PR TITLE
NodaTime 2.4.13-corrected

### DIFF
--- a/curations/nuget/nuget/-/NodaTime.yaml
+++ b/curations/nuget/nuget/-/NodaTime.yaml
@@ -6,3 +6,6 @@ revisions:
   2.4.11:
     licensed:
       declared: Apache-2.0
+  2.4.11:
+    licensed:
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/NodaTime.yaml
+++ b/curations/nuget/nuget/-/NodaTime.yaml
@@ -6,6 +6,6 @@ revisions:
   2.4.11:
     licensed:
       declared: Apache-2.0
-  2.4.11:
+  2.4.13:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION
**Type:** Missing

**Summary:** 
NodaTime 2.4.13

**Details:** 
Add Apache-2.0 License

**Resolution:** 
License Url: https://github.com/nodatime/nodatime/blob/2.4.13/LICENSE.txt

**Description**:
License defined in the source repository for 2.4.13 release tag

**Affected definitions**:
* [NodaTime 2.4.13](https://clearlydefined.io/definitions/nuget/nuget/-/NodaTime/2.4.13)