### PR TITLE
corrected source for system.memory.data_1.0.2

### DIFF
--- a/curations/nuget/nuget/-/System.Memory.Data.yaml
+++ b/curations/nuget/nuget/-/System.Memory.Data.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: System.Memory.Data
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    described:
+      sourceLocation:
+        name: azure-sdk-for-net
+        namespace: azure
+        provider: github
+        revision: 7e3cf643977591e9041f4c628fd4d28237398e0b
+        type: git
+        url: 'https://github.com/azure/azure-sdk-for-net/commit/7e3cf643977591e9041f4c628fd4d28237398e0b'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
corrected source for system.memory.data_1.0.2

**Details:**
found the correct git commit. but the tag is unsually named, therefore the match didn't work

**Resolution:**
the PR corrects the source information for the package.

**Affected definitions**:
- [System.Memory.Data 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/System.Memory.Data/1.0.2/1.0.2)