### PR TITLE
Adding XunitRetry license 

### DIFF
--- a/curations/git/github/giggio/xunit-retry.yaml
+++ b/curations/git/github/giggio/xunit-retry.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: xunit-retry
+  namespace: giggio
+  provider: github
+  type: git
+revisions:
+  7a99f99f678fab808a846a305140afd81329a00d:
+    described:
+      facets:
+        doc: []
+        tests: []
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding XunitRetry license 

**Details:**
XunitRetry license is GPL-2.0-only

**Resolution:**
License definition can be found here
https://github.com/giggio/xunit-retry/blob/master/LICENSE.txt

**Affected definitions**:
- [xunit-retry 7a99f99f678fab808a846a305140afd81329a00d](https://clearlydefined.io/definitions/git/github/giggio/xunit-retry/7a99f99f678fab808a846a305140afd81329a00d/7a99f99f678fab808a846a305140afd81329a00d)