### PR TITLE
procfs 0.9.1

### DIFF
--- a/curations/crate/cratesio/-/procfs.yaml
+++ b/curations/crate/cratesio/-/procfs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: procfs
+  provider: cratesio
+  type: crate
+revisions:
+  0.9.1:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
procfs 0.9.1

**Details:**
The netadata (https://crates.io/crates/procfs/0.9.1) is Apache-2.0 OR MIT.  Same on license file in source (https://github.com/eminence/procfs/blob/v0.9.1/COPYRIGHT.txt).  Rest would be "discovered."

**Resolution:**
Apache-2.0 OR MIT

**Affected definitions**:
- [procfs 0.9.1](https://clearlydefined.io/definitions/crate/cratesio/-/procfs/0.9.1/0.9.1)