### PR TITLE
azureml-pipeline-steps 1.33.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
@@ -174,6 +174,9 @@ revisions:
   1.32.0:
     licensed:
       declared: OTHER
+  1.33.0:
+    licensed:
+      declared: OTHER
   1.34.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-steps 1.33.0

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)
https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-pipeline-steps 1.33.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-steps/1.33.0/1.33.0)