### PR TITLE
azureml-dataprep 2.22.3

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -120,6 +120,9 @@ revisions:
   2.22.2:
     licensed:
       declared: OTHER
+  2.22.3:
+    licensed:
+      declared: OTHER
   2.23.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.22.3

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.22.3](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.22.3/2.22.3)