### PR TITLE
azureml-automl-core 1.34.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -162,6 +162,9 @@ revisions:
   1.33.0:
     licensed:
       declared: OTHER
+  1.34.0:
+    licensed:
+      declared: OTHER
   1.34.0.post1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.34.0

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)
https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-automl-core 1.34.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.34.0/1.34.0)