### PR TITLE
debugpy1.5.0

### DIFF
--- a/curations/pypi/pypi/-/debugpy.yaml
+++ b/curations/pypi/pypi/-/debugpy.yaml
@@ -15,3 +15,6 @@ revisions:
   1.4.3:
     licensed:
       declared: MIT
+  1.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
debugpy1.5.0

**Details:**
Fixing curation and Declaring MIT

**Resolution:**
I don't see the EPL-1.0 license other than it's noted on the PyPI meta. This package / version has a MIT license and there's also MIT in the homepage project repo:
https://github.com/microsoft/debugpy/blob/v1.5.0/LICENSE

**Affected definitions**:
- [debugpy 1.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/debugpy/1.5.0/1.5.0)