### PR TITLE
azureml-train 1.33.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-train.yaml
+++ b/curations/pypi/pypi/-/azureml-train.yaml
@@ -165,6 +165,9 @@ revisions:
   1.32.0:
     licensed:
       declared: OTHER
+  1.33.1:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train 1.33.1

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)
https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-train 1.33.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train/1.33.1/1.33.1)