### PR TITLE
azureml-inference-server-http 0.3.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-inference-server-http.yaml
+++ b/curations/pypi/pypi/-/azureml-inference-server-http.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: azureml-inference-server-http
+  provider: pypi
+  type: pypi
+revisions:
+  0.3.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-inference-server-http 0.3.1

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-inference-server-http 0.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-inference-server-http/0.3.1/0.3.1)