### PR TITLE
azureml-dataprep 2.3.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -123,6 +123,9 @@ revisions:
   2.23.2:
     licensed:
       declared: OTHER
+  2.3.2:
+    licensed:
+      declared: OTHER
   2.3.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.3.2

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.3.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.3.2/2.3.2)