### PR TITLE
azureml-dataprep 2.0.6

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -66,6 +66,9 @@ revisions:
   2.0.5:
     licensed:
       declared: OTHER
+  2.0.6:
+    licensed:
+      declared: OTHER
   2.0.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.0.6

**Details:**
PyPi license field indicates OTHER (https://aka.ms/azureml-sdk-license)


**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [azureml-dataprep 2.0.6](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.0.6/2.0.6)