### PR TITLE
thin 1.7.2

### DIFF
--- a/curations/gem/rubygems/-/thin.yaml
+++ b/curations/gem/rubygems/-/thin.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: thin
+  provider: rubygems
+  type: gem
+revisions:
+  1.7.2:
+    licensed:
+      declared: Ruby


### PR DESCRIPTION

**Type:** Missing

**Summary:**
thin 1.7.2

**Details:**
Looked in Clearly Defined.  Readme indicates Ruby
RubyGems license field indicates: GPLV2+, RUBY 1.8
Project source code includes Ruby in the Readme:  https://github.com/macournoyer/thin/tree/v1.7.2

**Resolution:**
Declared license is Ruby

**Affected definitions**:
- [thin 1.7.2](https://clearlydefined.io/definitions/gem/rubygems/-/thin/1.7.2/1.7.2)