### PR TITLE
NuGet.Packaging.Core.Types 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.Types.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.Types.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging.Core.Types 3.2.0

**Details:**
Looked in ClearlyDefined.  Nuspec file did not include license info
Nuget did not include a source code project link or license link for this version.  However, for a later version it links to source code project: https://github.com/NuGet/NuGet.Client
Which includes an Apache-2.0 at the time of pkg

**Resolution:**
Declared license is Apache-2.0
https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Affected definitions**:
- [NuGet.Packaging.Core.Types 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core.Types/3.2.0/3.2.0)