### PR TITLE
soloader 0.6.0

### DIFF
--- a/curations/maven/mavencentral/com.facebook.soloader/soloader.yaml
+++ b/curations/maven/mavencentral/com.facebook.soloader/soloader.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.6.0:
+    licensed:
+      declared: Apache-2.0
   0.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
soloader 0.6.0

**Details:**
Looked in Clearly Defined no license info found.
Maven includes license field with label "BSD" but links to Apache-2.0
Maven includes link to project source code:  https://github.com/facebook/soloader
License is Apache-2.0
https://github.com/facebook/SoLoader/blob/v0.6.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [soloader 0.6.0](https://clearlydefined.io/definitions/maven/mavencentral/com.facebook.soloader/soloader/0.6.0/0.6.0)