### PR TITLE
Xceed.Compression.Formats 6.7.19075.7501

### DIFF
--- a/curations/nuget/nuget/-/Xceed.Compression.Formats.yaml
+++ b/curations/nuget/nuget/-/Xceed.Compression.Formats.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xceed.Compression.Formats
+  provider: nuget
+  type: nuget
+revisions:
+  6.7.19075.7501:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xceed.Compression.Formats 6.7.19075.7501

**Details:**
Looked in ClearlyDefined. Nuspec license links to Xceed Software License Agreement.
Nuget license field links to Xceed Software License Agreement:
http://xceed.com/xceed-software-license-agreement/
Source code project links to Exceed Software home page.

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [Xceed.Compression.Formats 6.7.19075.7501](https://clearlydefined.io/definitions/nuget/nuget/-/Xceed.Compression.Formats/6.7.19075.7501/6.7.19075.7501)