### PR TITLE
Xceed.FileSystem 6.7.19075.7501

### DIFF
--- a/curations/nuget/nuget/-/Xceed.FileSystem.yaml
+++ b/curations/nuget/nuget/-/Xceed.FileSystem.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  6.7.19075.7501:
+    licensed:
+      declared: OTHER
   6.7.19076.18060:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xceed.FileSystem 6.7.19075.7501

**Details:**
Looked in ClearlyDefined. Nuspec license links to Xceed Software License Agreement.
Nuget license field links to Xceed Software License Agreement:
http://xceed.com/xceed-software-license-agreement/
Source code project links to Exceed Software home page.

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [Xceed.FileSystem 6.7.19075.7501](https://clearlydefined.io/definitions/nuget/nuget/-/Xceed.FileSystem/6.7.19075.7501/6.7.19075.7501)