### PR TITLE
rubyzip 1.2.3

### DIFF
--- a/curations/gem/rubygems/-/rubyzip.yaml
+++ b/curations/gem/rubygems/-/rubyzip.yaml
@@ -9,6 +9,9 @@ revisions:
   1.2.2:
     licensed:
       declared: BSD-2-Clause OR Ruby
+  1.2.3:
+    licensed:
+      declared: Ruby
   1.3.0:
     licensed:
       declared: BSD-2-Clause OR Ruby

--- a/curations/gem/rubygems/-/rubyzip.yaml
+++ b/curations/gem/rubygems/-/rubyzip.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: BSD-2-Clause OR Ruby
   1.2.3:
     licensed:
-      declared: Ruby
+      declared: BSD-2-Clause OR Ruby
   1.3.0:
     licensed:
       declared: BSD-2-Clause OR Ruby


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rubyzip 1.2.3

**Details:**
Looked in ClearlyDefined the Readme file indicates license is Ruby.
The Ruby license field indicates: BSD-2-Clause
The Ruby source code link has a Readme that indicates Ruby
https://github.com/rubyzip/rubyzip/tree/v1.2.3

**Resolution:**
Declared license is Ruby

**Affected definitions**:
- [rubyzip 1.2.3](https://clearlydefined.io/definitions/gem/rubygems/-/rubyzip/1.2.3/1.2.3)