### PR TITLE
LamarCodeGeneration 1.4.0

### DIFF
--- a/curations/nuget/nuget/-/LamarCodeGeneration.yaml
+++ b/curations/nuget/nuget/-/LamarCodeGeneration.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.4.0:
+    licensed:
+      declared: MIT
   2.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LamarCodeGeneration 1.4.0

**Details:**
Looked in ClearlyDefined.  The license file indicates MIT.
Nuget license field links to MIT
Nuget source code links to Lamar home page.
Project Source code includes MIT license: https://github.com/JasperFx/lamar/blob/master/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [LamarCodeGeneration 1.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/LamarCodeGeneration/1.4.0/1.4.0)