### PR TITLE
System.Composition.AttributedModel 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.AttributedModel.yaml
+++ b/curations/nuget/nuget/-/System.Composition.AttributedModel.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Composition.AttributedModel 1.3.0

**Details:**
Looked in ClearlyDefined.  License file is MIT.
Nuget license field links to MIT:  https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
Source Code Project indicates in Readme MIT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Composition.AttributedModel 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Composition.AttributedModel/1.3.0/1.3.0)