### PR TITLE
jQuery 1.8.0

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -95,6 +95,9 @@ revisions:
   1.7.2:
     licensed:
       declared: MIT
+  1.8.0:
+    licensed:
+      declared: MIT
   1.8.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery 1.8.0

**Details:**
Looked in ClearlyDefined.  Nuspec file license link is MIT
Nuget license field links to MIT
Nuget project source code links to Jquery home page.

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [jQuery 1.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/1.8.0/1.8.0)