### PR TITLE
xunit.console 2.4.1

### DIFF
--- a/curations/nuget/nuget/-/xunit.console.yaml
+++ b/curations/nuget/nuget/-/xunit.console.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: xunit.console
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.console 2.4.1

**Details:**
Looked in Clearly Defined.  Nuspec license link is broken.
Nuget license field links to Apache-2.0
Source Code project includes Apache-2.0

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [xunit.console 2.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.console/2.4.1/2.4.1)