### PR TITLE
Pkcs12ProtectedConfigurationProvider 1.0.1

### DIFF
--- a/curations/nuget/nuget/-/Pkcs12ProtectedConfigurationProvider.yaml
+++ b/curations/nuget/nuget/-/Pkcs12ProtectedConfigurationProvider.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Pkcs12ProtectedConfigurationProvider
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Pkcs12ProtectedConfigurationProvider 1.0.1

**Details:**
Looked in ClearlyDefined.  Nuspec license link and source code project links are broken.
Nuget license field link is broken
Nuget source code link is broken
Searched GitHub and MSDN and did not find component.

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [Pkcs12ProtectedConfigurationProvider 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Pkcs12ProtectedConfigurationProvider/1.0.1/1.0.1)