### PR TITLE
eslint-config-google 0.6.0

### DIFF
--- a/curations/npm/npmjs/-/eslint-config-google.yaml
+++ b/curations/npm/npmjs/-/eslint-config-google.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: eslint-config-google
+  provider: npmjs
+  type: npm
+revisions:
+  0.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
eslint-config-google 0.6.0

**Details:**
Looked in ClearlyDefined.  License is Apache-2.0
NPM license field indicates Apache-2.0
Source Code Project includes Apache-2.0: https://github.com/google/eslint-config-google/blob/v0.6.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [eslint-config-google 0.6.0](https://clearlydefined.io/definitions/npm/npmjs/-/eslint-config-google/0.6.0/0.6.0)