### PR TITLE
NuGet.Packaging.Core 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging.Core 3.2.0

**Details:**
Looked in ClearlyDefined.  Nuspec license link is broken.
Nuget license link is broken
Project source code license is Apache-2.0:  https://github.com/NuGetArchive/NuGet.Packaging/blob/master/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Packaging.Core 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core/3.2.0/3.2.0)