### PR TITLE
fenics 2019.1.0

### DIFF
--- a/curations/pypi/pypi/-/fenics.yaml
+++ b/curations/pypi/pypi/-/fenics.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fenics
+  provider: pypi
+  type: pypi
+revisions:
+  2019.1.0:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
fenics 2019.1.0

**Details:**
Looked in ClearlyDefined.  PKG-INFO file indicates LGPL-3.0-or-later
PyPi has no license field included
PyPi links to https://bitbucket.org/fenics-project/ and no license info found

**Resolution:**
Declared license is LGPL-3.0-or-later

**Affected definitions**:
- [fenics 2019.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/fenics/2019.1.0/2019.1.0)