### PR TITLE
once 1.3.1

### DIFF
--- a/curations/npm/npmjs/-/once.yaml
+++ b/curations/npm/npmjs/-/once.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: once
+  provider: npmjs
+  type: npm
+revisions:
+  1.3.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
once 1.3.1

**Details:**
Looked in ClearlyDefined.  License is BSD-2-Clause
NPM license indicates BSD
Source code project is BSD-2-Clause: https://github.com/isaacs/once/blob/v1.3.1/LICENSE

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [once 1.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/once/1.3.1/1.3.1)