### PR TITLE
bytes 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/bytes.yaml
+++ b/curations/npm/npmjs/-/bytes.yaml
@@ -6,6 +6,9 @@ revisions:
   0.1.0:
     licensed:
       declared: MIT
+  0.2.0:
+    licensed:
+      declared: MIT
   0.2.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bytes 0.2.0

**Details:**
Looked in ClearlyDefined.  The Readme file indicates MIT
NPM license field indicates MIT
Source code project includes MIT: https://github.com/visionmedia/bytes.js/tree/0.2.0

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [bytes 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/bytes/0.2.0/0.2.0)