### PR TITLE
kwant 1.4.1

### DIFF
--- a/curations/pypi/pypi/-/kwant.yaml
+++ b/curations/pypi/pypi/-/kwant.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: kwant
+  provider: pypi
+  type: pypi
+revisions:
+  1.4.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kwant 1.4.1

**Details:**
Looked in Clearly Defined.  License is BSD-2-Clause.  
PyPi license field indicates BSD
Source code project includes BSD-2-Clause

**Resolution:**
Declared license is BSD-2-Clause
Note: "(CEA = Commissariat à l'énergie atomique et aux énergies alternatives)" translates to name of entity with copyright: CEA = French Atomic Energy and Alternative Energies Commission

**Affected definitions**:
- [kwant 1.4.1](https://clearlydefined.io/definitions/pypi/pypi/-/kwant/1.4.1/1.4.1)