### PR TITLE
sp-build-common 1.11.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-build-common.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-build-common.yaml
@@ -7,6 +7,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-build-common 1.11.0

**Details:**
Looked in Clearly Defined.  EULA is Microsoft Sharepoint Framework - Standalone (free) Use Terms in all available languages
NPM license states see License file
Reference to more information links to SharePoint Framework home page

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [sp-build-common 1.11.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-build-common/1.11.0/1.11.0)