### PR TITLE
jersey-guava 2.25.1

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.bundles.repackaged/jersey-guava.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.bundles.repackaged/jersey-guava.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1
   2.25.1:
     licensed:
-      declared: CDDL-1.1 OR GPL-2-only WITH Classpath-exception-2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-guava 2.25.1

**Details:**
Manifest indicates CDDL-1.1 OR GPL-2-only WITH Classpath-exception-2.0
Maven indicates CDDL AND GPL 1.1:  https://mvnrepository.com/artifact/org.glassfish.jersey.bundles.repackaged/jersey-guava/2.25.1
The POM indicates:  
CDDL-1.1 OR GPL-2-only WITH Classpath-exception-2.0

**Resolution:**
Declared license is CDDL-1.1 OR GPL-2-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-guava 2.25.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.bundles.repackaged/jersey-guava/2.25.1/2.25.1)