### PR TITLE
System.Threading.Tasks.Extensions 4.6.0-preview.18571.3

### DIFF
--- a/curations/nuget/nuget/-/System.Threading.Tasks.Extensions.yaml
+++ b/curations/nuget/nuget/-/System.Threading.Tasks.Extensions.yaml
@@ -26,3 +26,6 @@ revisions:
         url: 'https://github.com/dotnet/corefx/commit/637a8d58f72f2b0f1a71187530c3cf433e95a75a'
     licensed:
       declared: MIT
+  4.6.0-preview.18571.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Threading.Tasks.Extensions 4.6.0-preview.18571.3

**Details:**
ClearlyDefined license file is MIT
Nuget license field links to MIT:  https://github.com/dotnet/corefx/blob/23f5ecd6a1231d286257d9cc2efda549efed949b/LICENSE.TXT
Nuget project links to .NET home page

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Threading.Tasks.Extensions 4.6.0-preview.18571.3](https://clearlydefined.io/definitions/nuget/nuget/-/System.Threading.Tasks.Extensions/4.6.0-preview.18571.3/4.6.0-preview.18571.3)