### PR TITLE
 NuGet.Configuration 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Configuration.yaml
+++ b/curations/nuget/nuget/-/NuGet.Configuration.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 NuGet.Configuration 3.2.0

**Details:**
Looked in ClearlyDefined.  Nuspec license link is broken.
Nuget license links to Apache-2.0
Source code project includes Apache-2.0:  https://github.com/NuGetArchive/NuGet.Configuration/blob/master/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Configuration 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Configuration/3.2.0/3.2.0)