### PR TITLE
NuGet.Resolver 4.9.4

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Resolver.yaml
+++ b/curations/nuget/nuget/-/NuGet.Resolver.yaml
@@ -6,3 +6,6 @@ revisions:
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0
+  4.9.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Resolver 4.9.4

**Details:**
Looked in Clearly Defined.  Nuspec license links to Apache-2.0
Nuget license links to Apache-2.0
Source code project includes Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/01526febb05abca3b0004781c21c386bbe1b1286/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Resolver 4.9.4](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Resolver/4.9.4/4.9.4)