### PR TITLE
paramiko 2.8.0

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -12,3 +12,6 @@ revisions:
   2.7.2:
     licensed:
       declared: LGPL-2.1-or-later
+  2.8.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko 2.8.0

**Details:**
Based on package LICENSE file and setup.py this is LGPL-2.1-or-later

**Resolution:**
https://clearlydefined.io/file/314143819976253855ee5f86b8d62dc0ecb230c16493e6ead5d06652291ebf70

**Affected definitions**:
- [paramiko 2.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.8.0/2.8.0)