### PR TITLE
sp-core-library 1.12.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-core-library.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-core-library.yaml
@@ -10,6 +10,9 @@ revisions:
   1.11.0:
     licensed:
       declared: OTHER
+  1.12.1:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-core-library 1.12.1

**Details:**
ClearlyDefined EULA is "SharePoint Framework Software License Terms. All available languages licenses are included.
NPM License field states see license
Source home page links to Overview of the SharePoint Framework

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [sp-core-library 1.12.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-core-library/1.12.1/1.12.1)