### PR TITLE
sp-dialog 1.9.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-dialog.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-dialog.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sp-dialog
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.9.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-dialog 1.9.1

**Details:**
ClearlyDefined EULA is "SharePoint Framework Software License Terms. All available languages licenses are included.
NPM License field states Unlicensed
Source home page links to Overview of the SharePoint Framework

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [sp-dialog 1.9.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-dialog/1.9.1/1.9.1)