### PR TITLE
bootstrap 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/bootstrap.yaml
+++ b/curations/nuget/nuget/-/bootstrap.yaml
@@ -12,6 +12,9 @@ revisions:
   3.0.2:
     licensed:
       declared: Apache-2.0
+  3.2.0:
+    licensed:
+      declared: MIT
   3.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bootstrap 3.2.0

**Details:**
Looked in ClearlyDefined. Nuspec file license URL links to MIT
Nuget license field links to MIT
Source code project license is MIT: https://github.com/twbs/bootstrap/blob/v3.2.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [bootstrap 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/bootstrap/3.2.0/3.2.0)