### PR TITLE
junit-jupiter-params 5.7.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -25,6 +25,9 @@ revisions:
   5.7.0:
     licensed:
       declared: EPL-2.0
+  5.7.1:
+    licensed:
+      declared: ECL-2.0
   5.7.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter-params 5.7.1

**Details:**
Looked in ClearlyDefined.  License is EPL-2.0
Maven license field indicates EPL-2.0
POM indicates EPL-2.0

**Resolution:**
Declared license is EPL-2.0

**Affected definitions**:
- [junit-jupiter-params 5.7.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.7.1/5.7.1)