### PR TITLE
loader-cased-file 1.11.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/loader-cased-file.yaml
+++ b/curations/npm/npmjs/@microsoft/loader-cased-file.yaml
@@ -7,6 +7,9 @@ revisions:
   1.10.0:
     licensed:
       declared: OTHER
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
loader-cased-file 1.11.0

**Details:**
ClearlyDefined EULA is "SharePoint Framework Software License Terms. All available languages licenses are included.
NPM License field states see license
Source home page links to Overview of the SharePoint Framework

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [loader-cased-file 1.11.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/loader-cased-file/1.11.0/1.11.0)