### PR TITLE
rhino 1.7.7.1

### DIFF
--- a/curations/maven/mavencentral/org.mozilla/rhino.yaml
+++ b/curations/maven/mavencentral/org.mozilla/rhino.yaml
@@ -7,6 +7,9 @@ revisions:
   1.7.10:
     licensed:
       declared: MPL-2.0
+  1.7.7.1:
+    licensed:
+      declared: MPL-2.0
   1.7.7.2:
     licensed:
       declared: MPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rhino 1.7.7.1

**Details:**
Looked in ClearlyDefined.  License is MPL-2.0
Maven license field indicates MPL-2.0
POM indicates MPL-2.0

**Resolution:**
Declared license is MPL-2.0

**Affected definitions**:
- [rhino 1.7.7.1](https://clearlydefined.io/definitions/maven/mavencentral/org.mozilla/rhino/1.7.7.1/1.7.7.1)