### PR TITLE
jna 3.4.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.4.0:
+    licensed:
+      declared: LGPL-2.1-or-later
   4.1.0:
     licensed:
       declared: Apache-2.0 AND LGPL-2.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jna 3.4.0

**Details:**
Maven indicates LGPL-2.1
https://mvnrepository.com/artifact/net.java.dev.jna/jna/3.4.0
Source Code project Readme states LGPL-2.1-or-later
License is: LGPL-2.1-or-later

**Resolution:**
Declared license is LGPL-2.1-or-later

**Affected definitions**:
- [jna 3.4.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/3.4.0/3.4.0)