### PR TITLE
debug_inspector 0.0.2

### DIFF
--- a/curations/gem/rubygems/-/debug_inspector.yaml
+++ b/curations/gem/rubygems/-/debug_inspector.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: debug_inspector
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
debug_inspector 0.0.2

**Details:**
ClearlyDefined Readme indicates MIT
RubyGems license field indicates N/A
Source code project Readme license is MIT: https://github.com/banister/debug_inspector/tree/v0.0.2

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [debug_inspector 0.0.2](https://clearlydefined.io/definitions/gem/rubygems/-/debug_inspector/0.0.2/0.0.2)