### PR TITLE
hunspell-spellchecker 1.0.2

### DIFF
--- a/curations/npm/npmjs/-/hunspell-spellchecker.yaml
+++ b/curations/npm/npmjs/-/hunspell-spellchecker.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hunspell-spellchecker
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hunspell-spellchecker 1.0.2

**Details:**
Looked in ClearlyDefined the package.json file indicates Apache-2.0
NPM license field indicates Apache-2.0
Source code project indicates Apache-2.0
https://github.com/GitbookIO/hunspell-spellchecker/blob/1.0.2/package.json
Although the license file wasn't added until later

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [hunspell-spellchecker 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/hunspell-spellchecker/1.0.2/1.0.2)