### PR TITLE
semver2 3.4.2

### DIFF
--- a/curations/gem/rubygems/-/semver2.yaml
+++ b/curations/gem/rubygems/-/semver2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: semver2
+  provider: rubygems
+  type: gem
+revisions:
+  3.4.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
semver2 3.4.2

**Details:**
RubyGems license field indicates N/A
Source code project license is MIT: https://github.com/haf/semver/blob/07da8bf4d3ed698aab112864e6ecd37e007d4dc0/LICENSE.md

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [semver2 3.4.2](https://clearlydefined.io/definitions/gem/rubygems/-/semver2/3.4.2/3.4.2)