### PR TITLE
Confluent.Kafka 1.5.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -68,6 +68,9 @@ revisions:
   1.4.0:
     licensed:
       declared: Apache-2.0
+  1.5.0:
+    licensed:
+      declared: Apache-2.0
   1.5.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Confluent.Kafka 1.5.0

**Details:**
ClearlyDefined license file indicates Apache-2.0
Nuget License field links to Apache-2.0
Source code project license is Apache-2.0: https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.5.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [Confluent.Kafka 1.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.5.0/1.5.0)