### PR TITLE
Prism.Mvvm 1.1.1

### DIFF
--- a/curations/nuget/nuget/-/Prism.Mvvm.yaml
+++ b/curations/nuget/nuget/-/Prism.Mvvm.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: NONE
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/Prism.Mvvm.yaml
+++ b/curations/nuget/nuget/-/Prism.Mvvm.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Prism.Mvvm
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Mvvm 1.1.1

**Details:**
The license URL listed in the Nuspec file is broken.
Nuget license field link is broken.
Source code license link is broken.
Nuget states:  "The owner has unlisted this package. This could mean that the package is deprecated, has security vulnerabilities or shouldn't be used."

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [Prism.Mvvm 1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Mvvm/1.1.1/1.1.1)