### PR TITLE
read 1.0.5

### DIFF
--- a/curations/npm/npmjs/-/read.yaml
+++ b/curations/npm/npmjs/-/read.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: read
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.5:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
read 1.0.5

**Details:**
Looked in ClearlyDefined.  License is BSD-2-Clause
NPM license field indicates BSD
Source code project license is BSD-2-Clause: https://github.com/npm/read/blob/v1.0.5/LICENCE

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [read 1.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/read/1.0.5/1.0.5)