### PR TITLE
pcf-start 0.4.3

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.4.3:
+    licensed:
+      declared: OTHER
   1.1.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 0.4.3

**Details:**
Looked in ClearlyDefined. License is Microsoft Software License Terms
NPM license field indicates see License

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pcf-start 0.4.3](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/0.4.3/0.4.3)