### PR TITLE
pcf-scripts 1.3.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -6,6 +6,9 @@ revisions:
   1.1.6:
     licensed:
       declared: OTHER
+  1.3.6:
+    licensed:
+      declared: OTHER
   1.4.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.3.6

**Details:**
Looked in ClearlyDefined. License is Microsoft Software License Terms: MICROSOFT POWERAPPS CLI
NPM license field indicates see License

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pcf-scripts 1.3.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.3.6/1.3.6)