### PR TITLE
pcf-scripts 0.4.3

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.4.3:
+    licensed:
+      declared: OTHER
   1.1.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 0.4.3

**Details:**
Looked in ClearlyDefined. License is Microsoft Software License Terms: MICROSOFT POWERAPPS CLI
NPM license field indicates see License

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pcf-scripts 0.4.3](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/0.4.3/0.4.3)