### PR TITLE
pcf-start 1.6.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -12,6 +12,9 @@ revisions:
   1.5.5:
     licensed:
       declared: OTHER
+  1.6.6:
+    licensed:
+      declared: OTHER
   1.7.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 1.6.6

**Details:**
Looked in ClearlyDefined. License is Microsoft Software License Terms: MICROSOFT POWERAPPS CLI
NPM license field indicates see License

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pcf-start 1.6.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.6.6/1.6.6)