### PR TITLE
pcf-scripts 1.6.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -12,6 +12,9 @@ revisions:
   1.5.5:
     licensed:
       declared: OTHER
+  1.6.6:
+    licensed:
+      declared: OTHER
   1.7.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.6.6

**Details:**
Looked in ClearlyDefined. License is Microsoft Software License Terms: MICROSOFT POWERAPPS CLI
NPM license field indicates see License

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pcf-scripts 1.6.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.6.6/1.6.6)