### PR TITLE
SpecFlow 2.2.1

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.yaml
@@ -15,6 +15,9 @@ revisions:
   2.2.0:
     licensed:
       declared: BSD-3-Clause
+  2.2.1:
+    licensed:
+      declared: BSD-3-Clause
   2.4.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow 2.2.1

**Details:**
Looked in ClearlyDefined.  License is BSD-3-Clause
Nuget license links to BSD-3-Clause
Source code project is BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [SpecFlow 2.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow/2.2.1/2.2.1)