### PR TITLE
SpecFlow.MsTest 3.0.188

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.MsTest.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.MsTest.yaml
@@ -6,6 +6,9 @@ revisions:
   2.4.1:
     licensed:
       declared: BSD-3-Clause
+  3.0.188:
+    licensed:
+      declared: BSD-3-Clause
   3.1.78:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow.MsTest 3.0.188

**Details:**
Looked in ClearlyDefined.  Nuspec license links to BSD-3-Clause
Nuget license links is BSD-3-Clause
Source code project license is BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [SpecFlow.MsTest 3.0.188](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow.MsTest/3.0.188/3.0.188)