### PR TITLE
SpecFlow.Tools.MsBuild.Generation 3.0.188

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.Tools.MsBuild.Generation.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.Tools.MsBuild.Generation.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.0.188:
+    licensed:
+      declared: BSD-3-Clause
   3.0.225:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow.Tools.MsBuild.Generation 3.0.188

**Details:**
Looked in ClearlyDefined. Nuspec license links to BSD-3-Clause
Nuget license links is BSD-3-Clause
Source code project license is BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [SpecFlow.Tools.MsBuild.Generation 3.0.188](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow.Tools.MsBuild.Generation/3.0.188/3.0.188)