### PR TITLE
SpecFlow 3.0.188

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.yaml
@@ -21,6 +21,9 @@ revisions:
   2.4.1:
     licensed:
       declared: BSD-3-Clause
+  3.0.188:
+    licensed:
+      declared: BSD-3-Clause
   3.0.225:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow 3.0.188

**Details:**
Looked in ClearlyDefined. Nuspec license links to BSD-3-Clause
Nuget license links is BSD-3-Clause
Source code project license is BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [SpecFlow 3.0.188](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow/3.0.188/3.0.188)