### PR TITLE
SpecFlow.MsTest 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.MsTest.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.MsTest.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.2.0:
+    licensed:
+      declared: BSD-3-Clause
   2.4.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION
**Type:** Missing

**Summary:**
SpecFlow.MsTest 2.2.0

**Details:**
Looked in ClearlyDefined. Nuspec license links to BSD-3-Clause
Nuget license links is BSD-3-Clause
Source code project license is BSD-3-Clause:  https://github.com/SpecFlowOSS/SpecFlow/blob/V2.2.0/LICENSE.txt

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [SpecFlow.MsTest 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow.MsTest/2.2.0/2.2.0)