### PR TITLE
Ninject.Extensions.Logging.Log4net 3.2.2

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.Logging.Log4net.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.Logging.Log4net.yaml
@@ -6,6 +6,9 @@ revisions:
   3.2.0:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.2.2:
+    licensed:
+      declared: Apache-2.0 AND MS-PL
   3.2.3:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Extensions.Logging.Log4net 3.2.2

**Details:**
Looked in ClearlyDefined. Nuspec license links to dual licensed Apache-2.0 and MS-PL
Nuget license field links to license links to dual licensed Apache-2.0 and MS-PL
Source code projects links to license links to dual licensed Apache-2.0 and MS-PL

**Resolution:**
Declared license is dual licensed Apache-2.0 and MS-PL
https://github.com/ninject/Ninject/blob/3.2.2/LICENSE.txt

**Affected definitions**:
- [Ninject.Extensions.Logging.Log4net 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.Logging.Log4net/3.2.2/3.2.2)