### PR TITLE
TelerikMvcExtensions 2013.1.219

### DIFF
--- a/curations/nuget/nuget/-/TelerikMvcExtensions.yaml
+++ b/curations/nuget/nuget/-/TelerikMvcExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TelerikMvcExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  2013.1.219:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TelerikMvcExtensions 2013.1.219

**Details:**
Nuspec file license links to https://www.telerik.com/aspnet-mvc
Nuget license field links to https://www.telerik.com/aspnet-mvc
Upon research on site linked above found what appears to be the applicable license terms: https://www.telerik.com/purchase/license-agreement/kendo-ui

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [TelerikMvcExtensions 2013.1.219](https://clearlydefined.io/definitions/nuget/nuget/-/TelerikMvcExtensions/2013.1.219/2013.1.219)