### PR TITLE
once 1.1.1

### DIFF
--- a/curations/npm/npmjs/-/once.yaml
+++ b/curations/npm/npmjs/-/once.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.1.1:
+    licensed:
+      declared: BSD-2-Clause
   1.3.1:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
once 1.1.1

**Details:**
Looked in ClearlyDefined.  License file is BSD-2-Clause
NPM license field indicates BSD
Source code project license is BSD-2-Clause:  https://github.com/isaacs/once/blob/v1.1.1/LICENSE

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [once 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/once/1.1.1/1.1.1)