### PR TITLE
azure-core 0.1.14

### DIFF
--- a/curations/gem/rubygems/-/azure-core.yaml
+++ b/curations/gem/rubygems/-/azure-core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.1.14:
+    licensed:
+      declared: Apache-2.0
   0.1.15:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azure-core 0.1.14

**Details:**
Looked in ClearlyDefined. No license info found
RubyGems license field indicates Apache-2.0
Source code project indicates Apache-2.0.  See: https://github.com/Azure/azure-ruby-asm-core/blob/master/azure-core.gemspec

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [azure-core 0.1.14](https://clearlydefined.io/definitions/gem/rubygems/-/azure-core/0.1.14/0.1.14)