### PR TITLE
 jQuery 1.9.0

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -107,6 +107,9 @@ revisions:
   1.8.3:
     licensed:
       declared: MIT
+  1.9.0:
+    licensed:
+      declared: MIT
   1.9.1:
     files:
       - license: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jQuery 1.9.0

**Details:**
Nuspec file license links to MIT
Nuget license field links to MIT
Source code project links to MIT: http://jquery.org/license/

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [jQuery 1.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/1.9.0/1.9.0)