### PR TITLE
jQuery.UI.Combined 1.10.3

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.0:
     licensed:
       declared: MIT
+  1.10.3:
+    licensed:
+      declared: MIT
   1.10.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery.UI.Combined 1.10.3

**Details:**
Nuspec file license links to MIT
Nuget license field links to MIT
Source code project links to MIT: http://jquery.org/license/

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [jQuery.UI.Combined 1.10.3](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.10.3/1.10.3)