### PR TITLE
Update declared license

### DIFF
--- a/curations/npm/npmjs/-/ioslib.yaml
+++ b/curations/npm/npmjs/-/ioslib.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ioslib
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.13:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update declared license

**Details:**
Declared license was previously NOASSERTION, but project is licensed under Apache-2.0.

**Resolution:**
Updated declared license to Apache-2.0, in accordance with the declared license outlined in the project's LICENSE file. https://github.com/appcelerator/ioslib/blob/0.2.13/LICENSE

**Affected definitions**:
- [ioslib 0.2.13](https://clearlydefined.io/definitions/npm/npmjs/-/ioslib/0.2.13)