### PR TITLE
Google.Protobuf.Tools 3.13.0

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
@@ -27,6 +27,9 @@ revisions:
   3.12.3:
     licensed:
       declared: BSD-3-Clause
+  3.13.0:
+    licensed:
+      declared: BSD-3-Clause
   3.14.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf.Tools 3.13.0

**Details:**
Looked in ClearlyDefined. No license info in license file.
Nuget license field links to BSD-3-Clause
Source code project includes BSD-3-Clause: https://github.com/protocolbuffers/protobuf/blob/v3.13.0/LICENSE

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [Google.Protobuf.Tools 3.13.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf.Tools/3.13.0/3.13.0)