### PR TITLE
nib/0.8.2

### DIFF
--- a/curations/npm/npmjs/-/nib.yaml
+++ b/curations/npm/npmjs/-/nib.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: nib
+  provider: npmjs
+  type: npm
+revisions:
+  0.8.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nib/0.8.2

**Details:**
Add MIT

**Resolution:**
License in README is MIT

**Affected definitions**:
- [nib 0.8.2](https://clearlydefined.io/definitions/npm/npmjs/-/nib/0.8.2/0.8.2)