### PR TITLE
Adding missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -75,6 +75,9 @@ revisions:
   3.18.0:
     licensed:
       declared: BSD-3-Clause
+  3.18.1:
+    licensed:
+      declared: BSD-3-Clause
   3.3.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared license

**Details:**
Google protobuf 3.18.1 is missing declared license.

**Resolution:**
Changed the declared license to BSD-3-Clause as shown here:

https://github.com/protocolbuffers/protobuf/blob/0dab03ba7bc438d7ba3eac2b2c1eb39ed520f928/csharp/src/Google.Protobuf/ByteString.cs

**Affected definitions**:
- [Google.Protobuf 3.18.1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.18.1)