### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.2.2

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -117,3 +117,6 @@ revisions:
   2021.2.1:
     licensed:
       declared: OTHER
+  2021.2.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.2.2

**Details:**
Looked in ClearlyDefined and license is JETBRAINS USER AGREEMENT
Nuget license field links to JETBRAINS USER AGREEMENT

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.2.2/2021.2.2)