### PR TITLE
pywin32 302

### DIFF
--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   '223':
     licensed:
-      declared: Python-2.0
+      declared: PSF-2.0
   '224':
     licensed:
       declared: PSF-2.0
@@ -14,7 +14,7 @@ revisions:
       declared: PSF-2.0
   '226':
     licensed:
-      declared: PSF-2.0 AND BSD-3-Clause
+      declared: PSF-2.0
   '227':
     licensed:
       declared: PSF-2.0
@@ -29,4 +29,4 @@ revisions:
       declared: PSF-2.0
   '302':
     licensed:
-      declared: OTHER
+      declared: PSF-2.0

--- a/curations/pypi/pypi/-/pywin32.yaml
+++ b/curations/pypi/pypi/-/pywin32.yaml
@@ -27,3 +27,6 @@ revisions:
   '301':
     licensed:
       declared: PSF-2.0
+  '302':
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pywin32 302

**Details:**
No files in ClearlyDefined.
PyPi license field indicates PSF
Source Code project did not include a license

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [pywin32 302](https://clearlydefined.io/definitions/pypi/pypi/-/pywin32/302/302)