### PR TITLE
JetBrains.ReSharper.CommandLineTools 9.1.20150408.154812

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -117,3 +117,6 @@ revisions:
   2021.2.1:
     licensed:
       declared: OTHER
+  9.1.20150408.154812:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 9.1.20150408.154812

**Details:**
Nuspec links to JetBrains site
Nuget links to JetBrains site
Source code project links to JetBrains site
https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 9.1.20150408.154812](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/9.1.20150408.154812/9.1.20150408.154812)