### PR TITLE
mockito-core 2.21.0

### DIFF
--- a/curations/maven/mavencentral/org.mockito/mockito-core.yaml
+++ b/curations/maven/mavencentral/org.mockito/mockito-core.yaml
@@ -22,6 +22,9 @@ revisions:
   2.19.0:
     licensed:
       declared: MIT
+  2.21.0:
+    licensed:
+      declared: MIT
   2.23.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mockito-core 2.21.0

**Details:**
ClearlyDefined license is MIT
Maven license field indicates MIT
Source code project license is MIT: https://github.com/mockito/mockito/blob/v2.21.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [mockito-core 2.21.0](https://clearlydefined.io/definitions/maven/mavencentral/org.mockito/mockito-core/2.21.0/2.21.0)