### PR TITLE
junit-jupiter 5.7.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -13,3 +13,6 @@ revisions:
   5.6.2:
     licensed:
       declared: EPL-2.0
+  5.7.0:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter 5.7.0

**Details:**
ClearlyDefined license file is EPL-2.0
Maven license field indicates EPL
Source code project license is EPL-2.0 https://github.com/junit-team/junit5/blob/r5.7.0/LICENSE.md

**Resolution:**
Declared license is EPL-2.0

**Affected definitions**:
- [junit-jupiter 5.7.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.7.0/5.7.0)