### PR TITLE
jaxb-api 2.2.7

### DIFF
--- a/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.bind/jaxb-api.yaml
@@ -13,6 +13,9 @@ revisions:
   2.2.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  2.2.7:
+    licensed:
+      declared: CDDL-1.1 AND GPL-2.0-only
   2.3.0:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxb-api 2.2.7

**Details:**
ClearlyDefined license is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license field indicates CDDL-1.1 OR GPL-1.1 but license links at bottom are CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
Declared license is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

I'm not sure how to indicate the Classpath exception in the declared license field.

**Affected definitions**:
- [jaxb-api 2.2.7](https://clearlydefined.io/definitions/maven/mavencentral/javax.xml.bind/jaxb-api/2.2.7/2.2.7)