### PR TITLE
NuGet.Build 2.12.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Build.yaml
+++ b/curations/nuget/nuget/-/NuGet.Build.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Build
+  provider: nuget
+  type: nuget
+revisions:
+  2.12.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Build 2.12.0

**Details:**
ClearlyDefined nuspec file license field links to Apache-2.0
Nuget license field links to Apache-2.0
Source code project license is Apache-2.0: https://github.com/NuGet/NuGet2/blob/2.12/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Build 2.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Build/2.12.0/2.12.0)