### PR TITLE
persistence-api 1.0.2

### DIFF
--- a/curations/maven/mavencentral/javax.persistence/persistence-api.yaml
+++ b/curations/maven/mavencentral/javax.persistence/persistence-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: persistence-api
+  namespace: javax.persistence
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.2:
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
persistence-api 1.0.2

**Details:**
ClearlyDefined license file is CDDL-1.0
Maven license field indicates CDDL-1.0
POM indicates CDDL-1.0

**Resolution:**
Declared license is CDDL-1.0

**Affected definitions**:
- [persistence-api 1.0.2](https://clearlydefined.io/definitions/maven/mavencentral/javax.persistence/persistence-api/1.0.2/1.0.2)