### PR TITLE
jdbc-postgres 42.1.4

### DIFF
--- a/curations/gem/rubygems/-/jdbc-postgres.yaml
+++ b/curations/gem/rubygems/-/jdbc-postgres.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jdbc-postgres
+  provider: rubygems
+  type: gem
+revisions:
+  42.1.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jdbc-postgres 42.1.4

**Details:**
ClearlyDefined license file is BSD-3-Clause
RubyGems license field indicates BSD
Source code project license is BSD-3-Clause:  https://github.com/jruby/activerecord-jdbc-adapter/blob/da9595b9bc0c08899f98f8066e78fa621d8382da/LICENSE.txt

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [jdbc-postgres 42.1.4](https://clearlydefined.io/definitions/gem/rubygems/-/jdbc-postgres/42.1.4/42.1.4)