### PR TITLE
uuid-v4 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/uuid-v4.yaml
+++ b/curations/npm/npmjs/-/uuid-v4.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: uuid-v4
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
uuid-v4 0.1.0

**Details:**
ClearlyDefined readme indicates MIT
NPM license field indicates NONE
NPM Readme indicates MIT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [uuid-v4 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/uuid-v4/0.1.0/0.1.0)