### PR TITLE
aws-sdk-v1 1.65.0

### DIFF
--- a/curations/gem/rubygems/-/aws-sdk-v1.yaml
+++ b/curations/gem/rubygems/-/aws-sdk-v1.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  1.65.0:
+    licensed:
+      declared: Apache-2.0
   1.67.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
aws-sdk-v1 1.65.0

**Details:**
ClearlyDefined license is Apache-2.0
RubyGems license field indicates Apache-2.0
Source code project license is Apache-2.0: https://github.com/aws/aws-sdk-ruby/blob/v1.65.0/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [aws-sdk-v1 1.65.0](https://clearlydefined.io/definitions/gem/rubygems/-/aws-sdk-v1/1.65.0/1.65.0)