### PR TITLE
semver 3.0.1

### DIFF
--- a/curations/npm/npmjs/-/semver.yaml
+++ b/curations/npm/npmjs/-/semver.yaml
@@ -9,6 +9,9 @@ revisions:
   2.3.2:
     licensed:
       declared: BSD-2-Clause
+  3.0.1:
+    licensed:
+      declared: BSD-2-Clause
   4.3.2:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
semver 3.0.1

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field indicates BSD
Source code project license is BSD-2-Clause: https://github.com/npm/node-semver/blob/v3.0.1/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [semver 3.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/semver/3.0.1/3.0.1)