### PR TITLE
 inference-schema 1.1.0

### DIFF
--- a/curations/pypi/pypi/-/inference-schema.yaml
+++ b/curations/pypi/pypi/-/inference-schema.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: inference-schema
+  provider: pypi
+  type: pypi
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 inference-schema 1.1.0

**Details:**
ClearlyDefined - no files.
PyPi license field indicates MIT
PyPi project description includes MIT: https://pypi.org/project/inference-schema/1.1.0/

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [inference-schema 1.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/inference-schema/1.1.0/1.1.0)