### PR TITLE
jna 4.0.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -7,6 +7,9 @@ revisions:
   3.4.0:
     licensed:
       declared: LGPL-2.1-or-later
+  4.0.0:
+    licensed:
+      declared: Apache-2.0
   4.1.0:
     licensed:
       declared: Apache-2.0 AND LGPL-2.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jna 4.0.0

**Details:**
Maven license field indicates: Apache-2.0 OR LGPL-2.1-or-late
Maven pom indicates Apache-2.0
Source Code Project license states in Readme: "This library is licensed under the LGPL, version 2.1 or later, and (from version 4.0 onward) the Apache Software License, version 2.0."
 


**Resolution:**
Declared license is Apache-2.0
https://github.com/java-native-access/jna/tree/4.0  

The Readme file stated: "This library is licensed under the LGPL, version 2.1 or later, and (from version 4.0 onward) the Apache Software License, version 2.0. Commercial license arrangements are negotiable."

**Affected definitions**:
- [jna 4.0.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/4.0.0/4.0.0)