### PR TITLE
graceful-fs 3.0.6

### DIFF
--- a/curations/npm/npmjs/-/graceful-fs.yaml
+++ b/curations/npm/npmjs/-/graceful-fs.yaml
@@ -13,3 +13,6 @@ revisions:
   2.0.3:
     licensed:
       declared: BSD-2-Clause
+  3.0.6:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
graceful-fs 3.0.6

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field indicates BSD
Source code project license is BSD-2-Clause: https://github.com/isaacs/node-graceful-fs/blob/v3.0.6/LICENSE

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [graceful-fs 3.0.6](https://clearlydefined.io/definitions/npm/npmjs/-/graceful-fs/3.0.6/3.0.6)