### PR TITLE
rubyzip 1.1.7

### DIFF
--- a/curations/gem/rubygems/-/rubyzip.yaml
+++ b/curations/gem/rubygems/-/rubyzip.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  1.1.7:
+    licensed:
+      declared: BSD-2-Clause OR Ruby
   1.2.1:
     licensed:
       declared: BSD-2-Clause OR Ruby


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rubyzip 1.1.7

**Details:**
ClearlyDefined license is BSD-2-Clause OR Ruby
Ruby license field indicates BSD-2-Clause
Source code project license is same as Ruby: https://github.com/rubyzip/rubyzip/blob/v1.1.7/README.md

**Resolution:**
Declared license is BSD-2-Clause or Ruby

**Affected definitions**:
- [rubyzip 1.1.7](https://clearlydefined.io/definitions/gem/rubygems/-/rubyzip/1.1.7/1.1.7)