### PR TITLE
mkdirp 0.3.4

### DIFF
--- a/curations/npm/npmjs/-/mkdirp.yaml
+++ b/curations/npm/npmjs/-/mkdirp.yaml
@@ -6,3 +6,6 @@ revisions:
   0.3.0:
     licensed:
       declared: MIT
+  0.3.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mkdirp 0.3.4

**Details:**
ClearlyDefined license is MIT
NPM License field indicates MIT/X11
Source code project license is MIT: https://github.com/isaacs/node-mkdirp/blob/0.3.4/LICENSE


**Resolution:**
Declared license is MIT

**Affected definitions**:
- [mkdirp 0.3.4](https://clearlydefined.io/definitions/npm/npmjs/-/mkdirp/0.3.4/0.3.4)