### PR TITLE
Ninject.Extensions.Logging 3.2.2

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.Logging.yaml
@@ -6,6 +6,9 @@ revisions:
   3.2.0:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.2.2:
+    licensed:
+      declared: Apache-2.0 OR MS-PL
   3.2.3:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Extensions.Logging 3.2.2

**Details:**
ClearlyDefined license is dual licensed Apache-2.0 OR MS-PL
Nuget license field links to Apache-2.0 OR MS-PL
Source code project license is Apache-2.0 OR MS-PL: https://github.com/ninject/ninject.extensions.logging/raw/master/LICENSE.txt (link from nuspec file)

**Resolution:**
Delcared license is Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.Extensions.Logging 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.Logging/3.2.2/3.2.2)