### PR TITLE
recursive-readdir 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/recursive-readdir.yaml
+++ b/curations/npm/npmjs/-/recursive-readdir.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: recursive-readdir
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
recursive-readdir 0.0.2

**Details:**
Nuspec links to source code project with MIT: github.com/jergason/recursive-readdir
NPM license field indicates MIT
Source code project is MIT but license was later than NPM package date


**Resolution:**
Declared license is MIT

**Affected definitions**:
- [recursive-readdir 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/recursive-readdir/0.0.2/0.0.2)