### PR TITLE
request 2.34.0

### DIFF
--- a/curations/npm/npmjs/-/request.yaml
+++ b/curations/npm/npmjs/-/request.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: request
+  provider: npmjs
+  type: npm
+revisions:
+  2.34.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
request 2.34.0

**Details:**
ClearlyDefined license is Apache-2.0
NPM license field is Apache-2.0
Source code project license is Apache-2.0: https://github.com/request/request/blob/v2.34.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [request 2.34.0](https://clearlydefined.io/definitions/npm/npmjs/-/request/2.34.0/2.34.0)