### PR TITLE
 overrides 1.9

### DIFF
--- a/curations/pypi/pypi/-/overrides.yaml
+++ b/curations/pypi/pypi/-/overrides.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  '1.9':
+    licensed:
+      declared: Apache-2.0
   3.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 overrides 1.9

**Details:**
ClearlyDefined license is Apache-2.0
PyPi license field is Apache-2.0
Source code project license is Apache-2.0

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [overrides 1.9](https://clearlydefined.io/definitions/pypi/pypi/-/overrides/1.9/1.9)