### PR TITLE
karma-chromium-edge-launcher 2.1.0

### DIFF
--- a/curations/npm/npmjs/@chiragrupani/karma-chromium-edge-launcher.yaml
+++ b/curations/npm/npmjs/@chiragrupani/karma-chromium-edge-launcher.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: karma-chromium-edge-launcher
+  namespace: '@chiragrupani'
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
karma-chromium-edge-launcher 2.1.0

**Details:**
ClearlyDefined license is a modified JSON
NPM license field indicates "MIT Based"
Source code project license is a modified JSON: https://github.com/ChiragRupani/karma-chromiumedge-launcher/blob/2.1.0/LICENSE

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [karma-chromium-edge-launcher 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/@chiragrupani/karma-chromium-edge-launcher/2.1.0/2.1.0)