### PR TITLE
emojione 3.1.7

### DIFF
--- a/curations/npm/npmjs/-/emojione.yaml
+++ b/curations/npm/npmjs/-/emojione.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: emojione
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
emojione 3.1.7

**Details:**
ClearlyDefined license indicates MIT except for artwork which is under Free license: emojione.com/developers/free-license 
Premium license: emojione.com/developers/premium-license
NPM license field indicates NONE
Source code project license indicates MIT: https://github.com/joypixels/emojione/blob/9

**Resolution:**
Source code is licensed under MIT

**Affected definitions**:
- [emojione 3.1.7](https://clearlydefined.io/definitions/npm/npmjs/-/emojione/3.1.7/3.1.7)