### PR TITLE
System.Composition 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.yaml
+++ b/curations/nuget/nuget/-/System.Composition.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Composition 1.3.0

**Details:**
ClearlyDefined license file is MIT
Nuget License field links to MIT
Source code project includes MIT and has a Patent file: https://github.com/dotnet/corefx/blob/8e95f40402aed1ea4062a59b24b23d133d5bc54e/PATENTS.TXT

**Resolution:**
Declared license is MIT AND OTHER

**Affected definitions**:
- [System.Composition 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Composition/1.3.0/1.3.0)