### PR TITLE
MvcDonutCaching 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/MvcDonutCaching.yaml
+++ b/curations/nuget/nuget/-/MvcDonutCaching.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MvcDonutCaching
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MvcDonutCaching 1.3.0

**Details:**
Nuspec file license links to MIT
Nuget license field links to MIT
Source code project license is MIT: https://github.com/moonpyk/mvcdonutcaching/blob/v1.3.0/LICENSE.txt

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [MvcDonutCaching 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/MvcDonutCaching/1.3.0/1.3.0)