### PR TITLE
asm 6.1.1

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -18,6 +18,9 @@ revisions:
   '6.0':
     licensed:
       declared: BSD-3-Clause
+  6.1.1:
+    licensed:
+      declared: BSD-3-Clause
   '6.2':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
asm 6.1.1

**Details:**
Maven license field links to BSD-3-Clause: https://asm.ow2.io/license.html
POM links to BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [asm 6.1.1](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm/6.1.1/6.1.1)