### PR TITLE
Esprima 1.0.1258

### DIFF
--- a/curations/nuget/nuget/-/Esprima.yaml
+++ b/curations/nuget/nuget/-/Esprima.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.1246:
     licensed:
       declared: BSD-3-Clause
+  1.0.1258:
+    licensed:
+      declared: BSD-3-Clause
   1.0.1270:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Esprima 1.0.1258

**Details:**
ClearlyDefined license is BSD-3-Clause
Nuget license field links to BSD-3-Clause
Source Code project license is BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [Esprima 1.0.1258](https://clearlydefined.io/definitions/nuget/nuget/-/Esprima/1.0.1258/1.0.1258)