### PR TITLE
mongoose 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/mongoose.yaml
+++ b/curations/npm/npmjs/-/mongoose.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mongoose
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mongoose 1.0.0

**Details:**
ClearlyDefined Readme file includes MIT license
NPM license field indicates MIT
Source Code project license is MIT but license was added later than the NPM published date

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [mongoose 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/mongoose/1.0.0/1.0.0)