### PR TITLE
kendo-angular-popup 3.0.5

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
@@ -13,6 +13,9 @@ revisions:
   3.0.1:
     licensed:
       declared: OTHER
+  3.0.5:
+    licensed:
+      declared: OTHER
   3.0.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-popup 3.0.5

**Details:**
ClearlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field see license
Source Code project includes notice: https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-angular-popup 3.0.5](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-popup/3.0.5/3.0.5)