### PR TITLE
kendo-ooxml 1.6.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-ooxml.yaml
+++ b/curations/npm/npmjs/@progress/kendo-ooxml.yaml
@@ -16,6 +16,9 @@ revisions:
   1.6.0:
     licensed:
       declared: OTHER
+  1.6.1:
+    licensed:
+      declared: OTHER
   1.6.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-ooxml 1.6.1

**Details:**
learlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field see license
Source Code project link broken. 
 https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-ooxml 1.6.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-ooxml/1.6.1/1.6.1)