### PR TITLE
kendo-react-common 3.18.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-react-common.yaml
+++ b/curations/npm/npmjs/@progress/kendo-react-common.yaml
@@ -28,6 +28,9 @@ revisions:
   3.17.0:
     licensed:
       declared: OTHER
+  3.18.0:
+    licensed:
+      declared: OTHER
   4.3.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-react-common 3.18.0

**Details:**
ClearlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field COMMERCIAL
Source Code project includes notice: https://github.com/telerik/kendo-react/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-react-common 3.18.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-react-common/3.18.0/3.18.0)