### PR TITLE
kendo-angular-dialog 3.12.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-dialog.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-dialog.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  3.12.1:
+    licensed:
+      declared: OTHER
   4.2.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-dialog 3.12.1

**Details:**
ClearlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field see license
Source Code project includes notice: https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-angular-dialog 3.12.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-dialog/3.12.1/3.12.1)