### PR TITLE
kendo-angular-pdf-export 2.0.3

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-pdf-export.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-pdf-export.yaml
@@ -10,6 +10,9 @@ revisions:
   1.3.1:
     licensed:
       declared: OTHER
+  2.0.3:
+    licensed:
+      declared: OTHER
   2.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-pdf-export 2.0.3

**Details:**
ClearlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field see license
Source Code project includes notice: https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-angular-pdf-export 2.0.3](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-pdf-export/2.0.3/2.0.3)