### PR TITLE
kendo-ooxml 1.5.0

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-ooxml.yaml
+++ b/curations/npm/npmjs/@progress/kendo-ooxml.yaml
@@ -13,6 +13,9 @@ revisions:
   1.4.2:
     licensed:
       declared: OTHER
+  1.5.0:
+    licensed:
+      declared: OTHER
   1.6.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-ooxml 1.5.0

**Details:**
ClearlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field see license
Source Code project link broken.
https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-ooxml 1.5.0](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-ooxml/1.5.0/1.5.0)