### PR TITLE
kendo-angular-dropdowns 4.2.7

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-dropdowns.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-dropdowns.yaml
@@ -13,6 +13,9 @@ revisions:
   4.2.0:
     licensed:
       declared: OTHER
+  4.2.7:
+    licensed:
+      declared: OTHER
   4.4.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-dropdowns 4.2.7

**Details:**
ClearlyDefined license links to Telerik website which includes license: https://www.telerik.com/purchase/license-agreement/kendo-ui
NPM license field see license
Source Code project link broken.
https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [kendo-angular-dropdowns 4.2.7](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-dropdowns/4.2.7/4.2.7)