### PR TITLE
NPOI/2.3.0

### DIFF
--- a/curations/nuget/nuget/-/NPOI.yaml
+++ b/curations/nuget/nuget/-/NPOI.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.3.0:
+    licensed:
+      declared: Apache-2.0
   2.4.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NPOI/2.3.0

**Details:**
Add Apache 2.0

**Resolution:**
Included license file is Apache 2.0. Also, CodePlex archive states Apache 2.0.

**Affected definitions**:
- [NPOI 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/NPOI/2.3.0/2.3.0)