### PR TITLE
org.jsoup/jsoup/1.9.2

### DIFF
--- a/curations/maven/mavencentral/org.jsoup/jsoup.yaml
+++ b/curations/maven/mavencentral/org.jsoup/jsoup.yaml
@@ -19,3 +19,6 @@ revisions:
   1.8.3:
     licensed:
       declared: MIT
+  1.9.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jsoup/jsoup/1.9.2

**Details:**
Add MIT

**Resolution:**
Pom and source repo state MIT.
https://github.com/jhy/jsoup/blob/jsoup-1.9.2/LICENSE

**Affected definitions**:
- [jsoup 1.9.2](https://clearlydefined.io/definitions/maven/mavencentral/org.jsoup/jsoup/1.9.2/1.9.2)