### PR TITLE
es6-module-transpiler/0.2.0

### DIFF
--- a/curations/npm/npmjs/-/es6-module-transpiler.yaml
+++ b/curations/npm/npmjs/-/es6-module-transpiler.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: es6-module-transpiler
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
es6-module-transpiler/0.2.0

**Details:**
Add Apache 2.0

**Resolution:**
Included license file and source repo is Apache 2.0.
https://github.com/esnext/es6-module-transpiler/blob/v0.2.0/LICENSE

**Affected definitions**:
- [es6-module-transpiler 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/es6-module-transpiler/0.2.0/0.2.0)