### PR TITLE
AspNetCore.HealthChecks.UI.Client/2.2.4

### DIFF
--- a/curations/nuget/nuget/-/AspNetCore.HealthChecks.UI.Client.yaml
+++ b/curations/nuget/nuget/-/AspNetCore.HealthChecks.UI.Client.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.3:
     licensed:
       declared: Apache-2.0
+  2.2.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AspNetCore.HealthChecks.UI.Client/2.2.4

**Details:**
Add Apache 2.0

**Resolution:**
Couldn't find version change commit. Closest commit I could find: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/43b12bd57431d5c06f28b9f530c330a7b6858e4f/LICENSE

**Affected definitions**:
- [AspNetCore.HealthChecks.UI.Client 2.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/AspNetCore.HealthChecks.UI.Client/2.2.4/2.2.4)