### PR TITLE
node-forge/0.6.23

### DIFF
--- a/curations/npm/npmjs/-/node-forge.yaml
+++ b/curations/npm/npmjs/-/node-forge.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.6.23:
+    licensed:
+      declared: BSD-3-Clause OR GPL-2.0-only
   0.6.33:
     licensed:
       declared: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
node-forge/0.6.23

**Details:**
Add BSD-3-Clause OR GPL-2.0-only

**Resolution:**
I couldn't find anything that stated "or later".

https://github.com/digitalbazaar/forge/blob/0.6.23/LICENSE

**Affected definitions**:
- [node-forge 0.6.23](https://clearlydefined.io/definitions/npm/npmjs/-/node-forge/0.6.23/0.6.23)