### PR TITLE
ldap3 2.9

### DIFF
--- a/curations/pypi/pypi/-/ldap3.yaml
+++ b/curations/pypi/pypi/-/ldap3.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ldap3
+  provider: pypi
+  type: pypi
+revisions:
+  '2.9':
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ldap3 2.9

**Details:**
LICENSE file and setup.py indicate LGPL 3.0 or later (not GPL)

**Resolution:**
Correcting per above 

**Affected definitions**:
- [ldap3 2.9](https://clearlydefined.io/definitions/pypi/pypi/-/ldap3/2.9/2.9)