### PR TITLE
mysqlclient 2.0.3

### DIFF
--- a/curations/pypi/pypi/-/mysqlclient.yaml
+++ b/curations/pypi/pypi/-/mysqlclient.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mysqlclient
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.3:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mysqlclient 2.0.3

**Details:**
LICENSE is GPL and not finding evidence of "or later," so doing GPL-2.0-only

**Resolution:**
See above

**Affected definitions**:
- [mysqlclient 2.0.3](https://clearlydefined.io/definitions/pypi/pypi/-/mysqlclient/2.0.3/2.0.3)