### PR TITLE
System.Reactive.Linq 4.1.2

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.Linq.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.Linq.yaml
@@ -20,7 +20,7 @@ revisions:
       declared: Apache-2.0
   4.0.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   4.1.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Reactive.Linq 4.1.2

**Details:**
Nuspec license links to MIT
Nuget license field links to MIT
Source code project license at time of Nuget package is Apache-2.0 (was changed to MIT on 3/28/20

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [System.Reactive.Linq 4.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive.Linq/4.1.2/4.1.2)