### PR TITLE
Adding missing declared license

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.Tools.yaml
@@ -9,6 +9,9 @@ revisions:
   3.10.0:
     licensed:
       declared: BSD-3-Clause
+  3.10.1:
+    licensed:
+      declared: BSD-3-Clause
   3.11.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding missing declared license

**Details:**
No license was declared to Google.Protobud.Tools 3.10.1

**Resolution:**
Added BSD-3-Clause license

**Affected definitions**:
- [Google.Protobuf.Tools 3.10.1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf.Tools/3.10.1)