### PR TITLE
Define source for Manatee.Json

### DIFF
--- a/curations/nuget/nuget/-/Manatee.Json.yaml
+++ b/curations/nuget/nuget/-/Manatee.Json.yaml
@@ -6,12 +6,12 @@ revisions:
   13.0.5:
     described:
       sourceLocation:
-        name: manatee.json
+        name: Manatee.Json
         namespace: gregsdennis
         provider: github
-        revision: b80a961
+        revision: b80a961bfa1214cb7744a44f04897aeb21ae26e2
         type: git
-        url: 'https://github.com/gregsdennis/manatee.json/commit/b80a961'
+        url: 'https://github.com/gregsdennis/Manatee.Json/commit/b80a961bfa1214cb7744a44f04897aeb21ae26e2'
   9.9.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Define source for Manatee.Json

**Details:**
Source code location wasn't provided.

**Resolution:**
Defines the source code location of the tool

**Affected definitions**:
- [Manatee.Json 13.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Manatee.Json/13.0.5)