### PR TITLE
Add license for NuGet.Repositories

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Repositories.yaml
+++ b/curations/nuget/nuget/-/NuGet.Repositories.yaml
@@ -12,3 +12,6 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.3.0-beta1-2418:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add license for NuGet.Repositories

**Details:**
Add license for NuGet.Repositories

**Resolution:**
License was retrieved from NuGet.org page for this version of the package.

**Affected definitions**:
- [NuGet.Repositories 4.3.0-beta1-2418](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Repositories/4.3.0-beta1-2418)