### PR TITLE
Pillow8.4.0

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -69,3 +69,6 @@ revisions:
   8.3.2:
     licensed:
       declared: HPND
+  8.4.0:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Pillow8.4.0

**Details:**
Fixing Declared license to HPND

**Resolution:**
https://pypi.org/project/Pillow/8.4.0/
https://github.com/python-pillow/Pillow/blob/8.4.x/LICENSE


**Affected definitions**:
- [Pillow 8.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/Pillow/8.4.0/8.4.0)