### PR TITLE
 moodle-mod_questionnaire.3.10.1-Set declared license

### DIFF
--- a/curations/git/github/poetos/moodle-mod_questionnaire.yaml
+++ b/curations/git/github/poetos/moodle-mod_questionnaire.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   a5d2b59271a5273d621c88f5221c982b22737b37:
     licensed:
-      declared: GPL-3.0+
+      declared: GPL-3.0-or-later

--- a/curations/git/github/poetos/moodle-mod_questionnaire.yaml
+++ b/curations/git/github/poetos/moodle-mod_questionnaire.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: moodle-mod_questionnaire
+  namespace: poetos
+  provider: github
+  type: git
+revisions:
+  a5d2b59271a5273d621c88f5221c982b22737b37:
+    licensed:
+      declared: GPL-3.0+


### PR DESCRIPTION
**Type:** Other

**Summary:**
Set declared license

**Details:**
The declared license shows spdx with GPL-3.0 and MIT suggestions.
The project declares GPL-3.0+.

**Resolution:**
Setting valid spdx license identifier

**Affected definitions**:
- [moodle-mod_questionnaire a5d2b59271a5273d621c88f5221c982b22737b37](https://clearlydefined.io/definitions/git/github/poetos/moodle-mod_questionnaire/a5d2b59271a5273d621c88f5221c982b22737b37)