### PR TITLE
popper.js 1.12.9

### DIFF
--- a/curations/nuget/nuget/-/popper.js.yaml
+++ b/curations/nuget/nuget/-/popper.js.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.12.9:
+    licensed:
+      declared: MIT
   1.14.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
popper.js 1.12.9

**Details:**
Looked in ClearlyDefined and no license info found.
Nuget license field is missing
Nuget project link to Popper site included link to Nuget which includes a MIT license: https://github.com/popperjs/popper-core/blob/v1.12.9/LICENSE.md

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [popper.js 1.12.9](https://clearlydefined.io/definitions/nuget/nuget/-/popper.js/1.12.9/1.12.9)