### PR TITLE
System.Data.SQLite.Core 1.0.110

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.109.2:
     licensed:
       declared: OTHER
+  1.0.110:
+    licensed:
+      declared: OTHER
   1.0.112:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.Core 1.0.110

**Details:**
Nuspec license links to OTHER (public domain) https://www.sqlite.org/copyright.html
Nuget License links to OTHER
Nuget source code project links to OTHER

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.Data.SQLite.Core 1.0.110](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Core/1.0.110/1.0.110)