### PR TITLE
Bond.CSharp 7.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.CSharp.yaml
@@ -67,6 +67,9 @@ revisions:
   6.0.0:
     licensed:
       declared: MIT
+  7.0.0:
+    licensed:
+      declared: MIT
   7.0.1:
     described:
       releaseDate: '2017-10-26'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.CSharp 7.0.0

**Details:**
Looked in ClearlyDefined the Readme links to https://www.nuget.org/packages/Bond.CSharp/7.0.0
Nuget license field links to MIT
Source code project license is MIT
https://github.com/microsoft/bond/blob/7.0.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [Bond.CSharp 7.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.CSharp/7.0.0/7.0.0)