### PR TITLE
tiny-queue 0.2.1

### DIFF
--- a/curations/npm/npmjs/-/tiny-queue.yaml
+++ b/curations/npm/npmjs/-/tiny-queue.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: tiny-queue
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tiny-queue 0.2.1

**Details:**
Looked in ClearlyDefined and license is Apache-2.0
NPM license field indicates Apache-2.0
Source Code Project includes Apache-2.0
https://github.com/nolanlawson/tiny-queue/blob/v0.2.1/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [tiny-queue 0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/tiny-queue/0.2.1/0.2.1)