### PR TITLE
Unity.WebApi.5.1 5.2.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.WebApi.5.1.yaml
+++ b/curations/nuget/nuget/-/Unity.WebApi.5.1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Unity.WebApi.5.1
+  provider: nuget
+  type: nuget
+revisions:
+  5.2.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Unity.WebApi.5.1.yaml
+++ b/curations/nuget/nuget/-/Unity.WebApi.5.1.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   5.2.0:
     licensed:
-      declared: MIT
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.WebApi.5.1 5.2.0

**Details:**
Looked in ClearlyDefined and no license info found.
Nuget did not include license field or link to source code project
Search on GitHub and this appears to be the correct project with MIT license:  https://github.com/devtrends/Unity.WebAPI/blob/master/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [Unity.WebApi.5.1 5.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.WebApi.5.1/5.2.0/5.2.0)