### PR TITLE
http 0.0.1-security

### DIFF
--- a/curations/npm/npmjs/-/http.yaml
+++ b/curations/npm/npmjs/-/http.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: http
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1-security:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
http 0.0.1-security

**Details:**
No license info found in ClearlyDefined
NPM license field indicates NONE
No license field in GitHub: https://github.com/npm/security-holder

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [http 0.0.1-security](https://clearlydefined.io/definitions/npm/npmjs/-/http/0.0.1-security/0.0.1-security)