### PR TITLE
System.Composition.Hosting 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.Hosting.yaml
+++ b/curations/nuget/nuget/-/System.Composition.Hosting.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Composition.Hosting 1.3.0

**Details:**
ClearlyDefined license is MIT
Nuget license field links to MIT
Source code project license is MIT: https://github.com/dotnet/corefx/blob/8e95f40402aed1ea4062a59b24b23d133d5bc54e/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Composition.Hosting 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Composition.Hosting/1.3.0/1.3.0)