### PR TITLE
 asm 3.3.1

### DIFF
--- a/curations/maven/mavencentral/asm/asm.yaml
+++ b/curations/maven/mavencentral/asm/asm.yaml
@@ -10,3 +10,6 @@ revisions:
   '3.2':
     licensed:
       declared: BSD-3-Clause
+  3.3.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 asm 3.3.1

**Details:**
No license info found in ClearlyDefined
Maven indicates BSD: https://mvnrepository.com/artifact/asm/asm/3.3.1
License linked: http://asm.objectweb.org/license.html is BSD-3-Clause

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [asm 3.3.1](https://clearlydefined.io/definitions/maven/mavencentral/asm/asm/3.3.1/3.3.1)