### PR TITLE
System.Composition.Runtime 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.Runtime.yaml
+++ b/curations/nuget/nuget/-/System.Composition.Runtime.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Composition.Runtime 1.3.0

**Details:**
ClearlyDefined license is MIT
Nuget license field links to MIT
Source code project license is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Composition.Runtime 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Composition.Runtime/1.3.0/1.3.0)