### PR TITLE
 httpmime 4.3.3

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents/httpmime.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents/httpmime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: httpmime
+  namespace: org.apache.httpcomponents
+  provider: mavencentral
+  type: maven
+revisions:
+  4.3.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 httpmime 4.3.3

**Details:**
ClearlyDefined license is Apache-2.0
Maven license field indicates Apache-2.0
POM license is Apache-2.0
https://mvnrepository.com/artifact/org.apache.httpcomponents/httpmime/4.3.3

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [httpmime 4.3.3](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.httpcomponents/httpmime/4.3.3/4.3.3)