### PR TITLE
System.Composition.TypedParts 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.TypedParts.yaml
+++ b/curations/nuget/nuget/-/System.Composition.TypedParts.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Composition.TypedParts 1.3.0

**Details:**
ClearlyDefined license is MIT
Nuget
Nuget license field links to MIT
Source code project is MIT: https://github.com/dotnet/corefx

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Composition.TypedParts 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Composition.TypedParts/1.3.0/1.3.0)