### PR TITLE
react-tween-state 0.1.5

### DIFF
--- a/curations/npm/npmjs/-/react-tween-state.yaml
+++ b/curations/npm/npmjs/-/react-tween-state.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: react-tween-state
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
react-tween-state 0.1.5

**Details:**
ClearlyDefined license is BSD-3-Clause
NPM license field is BSD
Source code project license is BSD-3-Clause: https://github.com/chenglou/react-tween-state/blob/v0.1.5/LICENSE.txt

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [react-tween-state 0.1.5](https://clearlydefined.io/definitions/npm/npmjs/-/react-tween-state/0.1.5/0.1.5)