### PR TITLE
cookie 0.0.5

### DIFF
--- a/curations/npm/npmjs/-/cookie.yaml
+++ b/curations/npm/npmjs/-/cookie.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cookie
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cookie 0.0.5

**Details:**
No license info found in ClearlyDefined
NPM license field indicates MIT
Source code project license is MIT
The NPM package indicates it was published 9 years ago and that was prior to the first license being added to the project:  https://github.com/jshttp/cookie/blob/ac3b71a3386888dad0db631685b9c17

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [cookie 0.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/cookie/0.0.5/0.0.5)