### PR TITLE
nokogiri1.12.5

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: nokogiri
+  provider: rubygems
+  type: gem
+revisions:
+  1.12.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri1.12.5

**Details:**
Fixing Declared license to be MIT

**Resolution:**
See Clearly Defined license file and https://github.com/sparklemotion/nokogiri/blob/v1.12.5/LICENSE.md

**Affected definitions**:
- [nokogiri 1.12.5](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.12.5/1.12.5)