### PR TITLE
pytest-postgresql2.5.1

### DIFF
--- a/curations/pypi/pypi/-/pytest-postgresql.yaml
+++ b/curations/pypi/pypi/-/pytest-postgresql.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pytest-postgresql
+  provider: pypi
+  type: pypi
+revisions:
+  2.5.1:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pytest-postgresql2.5.1

**Details:**
Declaring LGPL-3.0 or later as mentioned on PyPI meta and per the license file in the package download. There is also a GPL-3.0 file in the package and GitHub repo but I think that would be a discovered license.

**Resolution:**
https://github.com/ClearcodeHQ/pytest-postgresql/blob/v2.5.1/src/pytest_postgresql/__init__.py

**Affected definitions**:
- [pytest-postgresql 2.5.1](https://clearlydefined.io/definitions/pypi/pypi/-/pytest-postgresql/2.5.1/2.5.1)