### PR TITLE
MongoDB.Driver 2.12.3

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Driver.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Driver.yaml
@@ -57,6 +57,9 @@ revisions:
   2.12.1:
     licensed:
       declared: Apache-2.0
+  2.12.3:
+    licensed:
+      declared: Apache-2.0
   2.12.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MongoDB.Driver 2.12.3

**Details:**
License in ClearlyDefined is Apache-2.0
Nuget license field links to Apache-2.0
Source code project license is Apache-2.0: https://github.com/mongodb/mongo-csharp-driver/blob/v2.12.3/License.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [MongoDB.Driver 2.12.3](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Driver/2.12.3/2.12.3)