### PR TITLE
escodegen 0.0.23

### DIFF
--- a/curations/npm/npmjs/-/escodegen.yaml
+++ b/curations/npm/npmjs/-/escodegen.yaml
@@ -6,6 +6,9 @@ revisions:
   0.0.21:
     licensed:
       declared: BSD-2-Clause
+  0.0.23:
+    licensed:
+      declared: BSD-2-Clause
   0.0.28:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
escodegen 0.0.23

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM License field indicates BSD-2-Clause
Open Source project license is BSD-2-Clause: https://github.com/estools/escodegen/blob/0.0.23/LICENSE.BSD

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [escodegen 0.0.23](https://clearlydefined.io/definitions/npm/npmjs/-/escodegen/0.0.23/0.0.23)