### PR TITLE
NuGet.CommandLine 4.6.4

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -30,6 +30,9 @@ revisions:
   4.6.2:
     licensed:
       declared: Apache-2.0
+  4.6.4:
+    licensed:
+      declared: Apache-2.0
   4.7.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.CommandLine 4.6.4

**Details:**
ClearlyDefined Nuspec file links to https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt Apache-2.0
Nuget license field links to Apache-2.0
Open source project license is Apache-2.0: https://github.com/NuGet/Home/blob/dev/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.CommandLine 4.6.4](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.6.4/4.6.4)