### PR TITLE
System.Composition.Convention 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/System.Composition.Convention.yaml
+++ b/curations/nuget/nuget/-/System.Composition.Convention.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: MIT
   1.3.0:
     licensed:
-      declared: OTHER
+      declared: MIT

--- a/curations/nuget/nuget/-/System.Composition.Convention.yaml
+++ b/curations/nuget/nuget/-/System.Composition.Convention.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Composition.Convention 1.3.0

**Details:**
ClearlyDefined license is MIT
Nuget license field links to MIT
Open source project MIT WITH a patent file: MIT: https://github.com/dotnet/corefx/blob/8e95f40402aed1ea4062a59b24b23d133d5bc54e/LICENSE
Patent: https://github.com/dotnet/corefx/blob/8e95f40402aed1ea4062a59b24b23d133d5bc54e/PATENTS.TXT

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.Composition.Convention 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Composition.Convention/1.3.0/1.3.0)