### PR TITLE
Ninject 3.0.1.10

### DIFF
--- a/curations/nuget/nuget/-/Ninject.yaml
+++ b/curations/nuget/nuget/-/Ninject.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0.15:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.0.1.10:
+    licensed:
+      declared: Apache-2.0 OR MS-PL
   3.2.0:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject 3.0.1.10

**Details:**
ClearlyDefined license is dual licensed Apache-2.0 OR MS-PL
Nuget license field links to Apache-2.0 OR MS-PL
Open source project license is Apache-2.0 OR MS-PL: https://github.com/ninject/Ninject/blob/3.0.1/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject 3.0.1.10](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject/3.0.1.10/3.0.1.10)