### PR TITLE
htmlunit-core-js 2.15

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.htmlunit/htmlunit-core-js.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.htmlunit/htmlunit-core-js.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.15':
+    licensed:
+      declared: MPL-2.0
   '2.17':
     licensed:
       declared: MPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
htmlunit-core-js 2.15

**Details:**
No license info found in ClearlyDefined
Maven license field indicates MPL-2.0
POM indicates MPL-2.0 and links to https://www.mozilla.org/en-US/MPL/2.0/

**Resolution:**
Declared license is MPL-2.0

**Affected definitions**:
- [htmlunit-core-js 2.15](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.htmlunit/htmlunit-core-js/2.15/2.15)