### PR TITLE
NuGet.Versioning 4.4.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -24,6 +24,9 @@ revisions:
   4.3.0:
     licensed:
       declared: Apache-2.0
+  4.4.0:
+    licensed:
+      declared: Apache-2.0
   4.5.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Versioning 4.4.0

**Details:**
ClearlyDefined nuspec file links to Apache-2.0: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt
Nuget license links to Apache-2.0
Open source project license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.4.0.4365/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Versioning 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/4.4.0/4.4.0)