### PR TITLE
argparse 1.2.1

### DIFF
--- a/curations/pypi/pypi/-/argparse.yaml
+++ b/curations/pypi/pypi/-/argparse.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  1.2.1:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: Python-2.0

--- a/curations/pypi/pypi/-/argparse.yaml
+++ b/curations/pypi/pypi/-/argparse.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: OTHER
   1.4.0:
     licensed:
-      declared: Python-2.0
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
argparse 1.2.1

**Details:**
ClearlyDefined license is OTHER: https://clearlydefined.io/file/c3a54c7cab0f15f2505942cfc6f13cdd08a5ba22acfd8dfeded7acd60cac67ee
PyPi license field indicates PSF
Google source code project: indicates OTHER: https://code.google.com/archive/p/argparse/

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [argparse 1.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/argparse/1.2.1/1.2.1)