### PR TITLE
System.Data.SQLite.EF6 1.0.102

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Data.SQLite.EF6
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.102:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.EF6 1.0.102

**Details:**
ClearlyDefined license indicates Public Domain
Nuget license field links to: https://www.sqlite.org/copyright.html - Public Domain

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.Data.SQLite.EF6 1.0.102](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.EF6/1.0.102/1.0.102)