### PR TITLE
Bond.Runtime.CSharp 7.0.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
@@ -68,6 +68,9 @@ revisions:
   6.0.0:
     licensed:
       declared: MIT
+  7.0.0:
+    licensed:
+      declared: MIT
   7.0.1:
     described:
       releaseDate: '2017-10-26'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Runtime.CSharp 7.0.0

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
Open source project license is MIT: https://github.com/microsoft/bond/blob/7.0.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [Bond.Runtime.CSharp 7.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Runtime.CSharp/7.0.0/7.0.0)