### PR TITLE
send 0.1.1

### DIFF
--- a/curations/npm/npmjs/-/send.yaml
+++ b/curations/npm/npmjs/-/send.yaml
@@ -6,6 +6,9 @@ revisions:
   0.0.4:
     licensed:
       declared: MIT
+  0.1.1:
+    licensed:
+      declared: MIT
   0.1.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
send 0.1.1

**Details:**
ClearlyDefined readme file includes MIT
NPM license field indicates MIT
Open source project license is MIT: https://github.com/pillarjs/send/tree/0.1.1

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [send 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/send/0.1.1/0.1.1)