### PR TITLE
ldjson-stream 1.2.1

### DIFF
--- a/curations/npm/npmjs/-/ldjson-stream.yaml
+++ b/curations/npm/npmjs/-/ldjson-stream.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ldjson-stream
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ldjson-stream 1.2.1

**Details:**
ClearlyDefined Readme file indicates BSD 
NPM license field indicates BSD
Open source project linked from Readme is BSD-3-Clause as indicated in Readme: https://github.com/maxogden/ndjson

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [ldjson-stream 1.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/ldjson-stream/1.2.1/1.2.1)