### PR TITLE
saucelabs 1.4.0

### DIFF
--- a/curations/npm/npmjs/-/saucelabs.yaml
+++ b/curations/npm/npmjs/-/saucelabs.yaml
@@ -6,6 +6,9 @@ revisions:
   1.3.0:
     licensed:
       declared: MIT
+  1.4.0:
+    licensed:
+      declared: MIT
   1.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
saucelabs 1.4.0

**Details:**
ClearlyDefined Readme includes MIT
NPM License field indicates Apache-2.0
Open source project Readme includes MIT: https://github.com/saucelabs/node-saucelabs/blob/v1.4.0/README.md

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [saucelabs 1.4.0](https://clearlydefined.io/definitions/npm/npmjs/-/saucelabs/1.4.0/1.4.0)