### PR TITLE
NuGet.Packaging 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.yaml
@@ -15,6 +15,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.8.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging 4.8.0

**Details:**
ClearlyDefined nuspec links to Apache-2.0
Nuget license field links to Apache-2.0
Open source project license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/01526febb05abca3b0004781c21c386bbe1b1286/LICENSE.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Packaging 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging/4.8.0/4.8.0)