### PR TITLE
libzip.redist 1.1.2.7

### DIFF
--- a/curations/nuget/nuget/-/libzip.redist.yaml
+++ b/curations/nuget/nuget/-/libzip.redist.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: libzip.redist
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.2.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
libzip.redist 1.1.2.7

**Details:**
ClearlyDefined nuspec links to BSD-3-Clause
Nuget license field links to BSD-3-Clause
Open source project license is BSD-3-Clause: https://github.com/nih-at/libzip/blob/rel-1-1-2/LICENSE

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [libzip.redist 1.1.2.7](https://clearlydefined.io/definitions/nuget/nuget/-/libzip.redist/1.1.2.7/1.1.2.7)