### PR TITLE
gulp-buffer 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/gulp-buffer.yaml
+++ b/curations/npm/npmjs/-/gulp-buffer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: gulp-buffer
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gulp-buffer 0.0.2

**Details:**
ClearlyDefined Readme includes MIT
NPM license field indicates NONE
Open source project includes MIT in Readme: https://github.com/jeromew/gulp-buffer

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [gulp-buffer 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/gulp-buffer/0.0.2/0.0.2)