### PR TITLE
jersey-server 2.17

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.17':
+    licensed:
+      declared: CDDL-1.1 AND GPL-2.0-with-classpath-exception
   2.22.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-server.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   '2.17':
     licensed:
-      declared: CDDL-1.1 AND GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.22.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-server 2.17

**Details:**
ClearlyDefined Manifest file links to: ttp://glassfish.java.net/public/CDDL+GPL_1_1.html
Maven indicates CDDL and GPL 1.1
License link: https://javaee.github.io/glassfish/LICENSE is CDDL-1.1 and GPL with classpath exception

**Resolution:**
Declared license is: CDDL-1.1 AND GPL-2.0-with-classpath-exception
NOTE: The only drop down option for GPL with classpath is "GPL-2.0". I'm not sure if this is "2.0" or not.

**Affected definitions**:
- [jersey-server 2.17](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.core/jersey-server/2.17/2.17)