### PR TITLE
OpenTK.GLControl 1.1.2225

### DIFF
--- a/curations/nuget/nuget/-/OpenTK.GLControl.yaml
+++ b/curations/nuget/nuget/-/OpenTK.GLControl.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.2225:
+    licensed:
+      declared: MIT
   3.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
OpenTK.GLControl 1.1.2225

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license link is broken
Nuget project link is broken
Nuget page indicates source code is here: https://github.com/opentk/opentk which includes MIT license but was added after the date of the package

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [OpenTK.GLControl 1.1.2225](https://clearlydefined.io/definitions/nuget/nuget/-/OpenTK.GLControl/1.1.2225/1.1.2225)