### PR TITLE
block-stream 0.0.7

### DIFF
--- a/curations/npm/npmjs/-/block-stream.yaml
+++ b/curations/npm/npmjs/-/block-stream.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: block-stream
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.7:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
block-stream 0.0.7

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field indicates BSD
Open source project is BSD-2-Clause: https://github.com/isaacs/block-stream/blob/v0.0.7/LICENCE

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [block-stream 0.0.7](https://clearlydefined.io/definitions/npm/npmjs/-/block-stream/0.0.7/0.0.7)