### PR TITLE
promise.prototype.finally 1.0.

### DIFF
--- a/curations/npm/npmjs/-/promise.prototype.finally.yaml
+++ b/curations/npm/npmjs/-/promise.prototype.finally.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: promise.prototype.finally
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
promise.prototype.finally 1.0.

**Details:**
ClearlyDefined readme indicates MIT
NPM license field indicates MIT
Open source project includes MIT in Readme 

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [promise.prototype.finally 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/promise.prototype.finally/1.0.1/1.0.1)