### PR TITLE
cross-unzip 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/cross-unzip.yaml
+++ b/curations/npm/npmjs/-/cross-unzip.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cross-unzip
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: LGPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cross-unzip 0.0.2

**Details:**
ClearlyDefined file downloaded indicates LGPL
NPM license field indicates LGPL
Open source project does not include a license: https://github.com/fritx/cross-unzip

**Resolution:**
Declared license is LGPL-2.0-or later
Per curation guidelines:
If the only license information is “LGPL” with no COPYING license file, code the license as “LGPL-2.0-or later.”

**Affected definitions**:
- [cross-unzip 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/cross-unzip/0.0.2/0.0.2)