### PR TITLE
JetBrains.ReSharper.CommandLineTools 9.1.20150408.154812

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -117,9 +117,9 @@ revisions:
   2021.2.1:
     licensed:
       declared: OTHER
-  9.1.20150408.154812:
+  2021.2.2:
     licensed:
       declared: OTHER
-  2021.2.2:
+  9.1.20150408.154812:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 9.1.20150408.154812

**Details:**
ClearlyDefined not able to download package
Nuget license field links to JetBrains website
Source Code project links to JetBrains website

**Resolution:**
Declared license is OTHER
https://resources.jetbrains.com/sales-config/config/agreements/TB/eua.html

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 9.1.20150408.154812](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/9.1.20150408.154812/9.1.20150408.154812)