### PR TITLE
Unity.ServiceLocator 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.ServiceLocator.yaml
+++ b/curations/nuget/nuget/-/Unity.ServiceLocator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Unity.ServiceLocator
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.ServiceLocator 2.0.0

**Details:**
ClearlyDefined no license info found
Nuget no license field
Nuget no open source project link

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [Unity.ServiceLocator 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.ServiceLocator/2.0.0/2.0.0)