### PR TITLE
System.IO.Abstractions

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -18,6 +18,9 @@ revisions:
   3.0.10:
     licensed:
       declared: MIT
+  3.1.1:
+    licensed:
+      declared: MIT
   6.0.14:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions

**Details:**
ClearlyDefined nuspec file license links to MIT
Nuget license field links to MIT
Open Source Project license is MIT: https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v3.1.1/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.IO.Abstractions 3.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/3.1.1/3.1.1)