### PR TITLE
System.Data.SQLite.EF6 1.0.113

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.102:
     licensed:
       declared: OTHER
+  1.0.113:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.EF6 1.0.113

**Details:**
ClearlyDefined license is Public Domain
Nuget license field links to Public Domain
Open source project links to SQLite

**Resolution:**
Declared license is OTHER

**Affected definitions**:
- [System.Data.SQLite.EF6 1.0.113](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.EF6/1.0.113/1.0.113)