### PR TITLE
jaxen 1.1.6

### DIFF
--- a/curations/maven/mavencentral/jaxen/jaxen.yaml
+++ b/curations/maven/mavencentral/jaxen/jaxen.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jaxen
+  namespace: jaxen
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.6:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxen 1.1.6

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven license field is blank: https://mvnrepository.com/artifact/jaxen/jaxen/1.1.6 and link to license is broken
Open source project license is BSD-3-Clause: https://github.com/codehaus/jaxen/blob/V_1_1_6_Final/jaxen/LICENSE.txt

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [jaxen 1.1.6](https://clearlydefined.io/definitions/maven/mavencentral/jaxen/jaxen/1.1.6/1.1.6)