### PR TITLE
System.IO.Abstractions.TestingHelpers 3.1.1

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
@@ -12,6 +12,9 @@ revisions:
   2.1.0.178:
     licensed:
       declared: MIT
+  3.1.1:
+    licensed:
+      declared: MIT
   7.0.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions.TestingHelpers 3.1.1

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
Open source project license is MIT: https://github.com/System-IO-Abstractions/System.IO.Abstractions/blob/v3.1.1/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.IO.Abstractions.TestingHelpers 3.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions.TestingHelpers/3.1.1/3.1.1)