### PR TITLE
System.Runtime.CompilerServices.Unsafe 4.6.0-rc1.19456.4

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
@@ -27,3 +27,6 @@ revisions:
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT
+  4.6.0-rc1.19456.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Runtime.CompilerServices.Unsafe 4.6.0-rc1.19456.4

**Details:**
ClearlyDefined license is MIT
Nuget license field links to MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
Open Source project readme indicates it was MIT: https://github.com/dotnet/corefx/tree/release/2.0.0 Though it doesn't appear a license was included


**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Runtime.CompilerServices.Unsafe 4.6.0-rc1.19456.4](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe/4.6.0-rc1.19456.4/4.6.0-rc1.19456.4)