### PR TITLE
FTD2XX.Net 1.0.14

### DIFF
--- a/curations/nuget/nuget/-/FTD2XX.Net.yaml
+++ b/curations/nuget/nuget/-/FTD2XX.Net.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.14:
     licensed:
-      declared: NONE
+      declared: OTHER

--- a/curations/nuget/nuget/-/FTD2XX.Net.yaml
+++ b/curations/nuget/nuget/-/FTD2XX.Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FTD2XX.Net
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.14:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FTD2XX.Net 1.0.14

**Details:**
ClearlyDefined nuspec file did not contain link to license
Nuget license field is missing
Nuget open source project is a broken link

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [FTD2XX.Net 1.0.14](https://clearlydefined.io/definitions/nuget/nuget/-/FTD2XX.Net/1.0.14/1.0.14)