### PR TITLE
Aspose.Words21.10.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Words.yaml
+++ b/curations/nuget/nuget/-/Aspose.Words.yaml
@@ -39,3 +39,6 @@ revisions:
   21.1.0:
     licensed:
       declared: OTHER
+  21.10.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.Words21.10.0

**Details:**
Declaring OTHER for Aspose EULA

**Resolution:**
https://www.nuget.org/packages/Aspose.Words/21.10.0/License

**Affected definitions**:
- [Aspose.Words 21.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Words/21.10.0/21.10.0)