### PR TITLE
Aspose.PDF21.10.1

### DIFF
--- a/curations/nuget/nuget/-/Aspose.PDF.yaml
+++ b/curations/nuget/nuget/-/Aspose.PDF.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Aspose.PDF
+  provider: nuget
+  type: nuget
+revisions:
+  21.10.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.PDF21.10.1

**Details:**
Declaring OTHER for Aspose EULA

**Resolution:**
https://www.nuget.org/packages/Aspose.PDF/21.10.1/License

**Affected definitions**:
- [Aspose.PDF 21.10.1](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.PDF/21.10.1/21.10.1)