### PR TITLE
HeaderPropagation 3.0.2

### DIFF
--- a/curations/nuget/nuget/-/HeaderPropagation.yaml
+++ b/curations/nuget/nuget/-/HeaderPropagation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: HeaderPropagation
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HeaderPropagation 3.0.2

**Details:**
ClearlyDefined license file indicates Apache-2.0
Nuget license field links to Apache-2.0
Open source project license is Apache-2.0: https://github.com/alefranz/HeaderPropagation/blob/3.0.2/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [HeaderPropagation 3.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/HeaderPropagation/3.0.2/3.0.2)