### PR TITLE
Grpc.Core 1.19.0

### DIFF
--- a/curations/nuget/nuget/-/Grpc.Core.yaml
+++ b/curations/nuget/nuget/-/Grpc.Core.yaml
@@ -12,6 +12,9 @@ revisions:
   1.18.0:
     licensed:
       declared: Apache-2.0
+  1.19.0:
+    licensed:
+      declared: Apache-2.0
   1.7.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Grpc.Core 1.19.0

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license field links to Apache-2.0
Open source project license is Apache-2.0: https://github.com/grpc/grpc/blob/v1.19.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [Grpc.Core 1.19.0](https://clearlydefined.io/definitions/nuget/nuget/-/Grpc.Core/1.19.0/1.19.0)