### PR TITLE
jsonfilter 1.1.2

### DIFF
--- a/curations/npm/npmjs/-/jsonfilter.yaml
+++ b/curations/npm/npmjs/-/jsonfilter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jsonfilter
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsonfilter 1.1.2

**Details:**
ClearlyDefined indicates BSD
NPM license field indicates BSD
Open source project does not include a license

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [jsonfilter 1.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/jsonfilter/1.1.2/1.1.2)