### PR TITLE
aopalliance-repackaged 2.4.0-b10

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   2.4.0-b10:
     licensed:
-      declared: CDDL-1.1 AND GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 AND GPL-2.0-only WITH Classpath-exception-2.0
   2.4.0-b34:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.4.0-b10:
+    licensed:
+      declared: CDDL-1.1 AND GPL-2.0-with-classpath-exception
   2.4.0-b34:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
aopalliance-repackaged 2.4.0-b10

**Details:**
ClearlyDefined no files
Maven license field indicates CDDL, GPL 1.1 and GPL 2.0.  The license link indicates 
CDDL + GPLv2 with classpath exception.  POM links: https://repo1.maven.org/maven2/org/glassfish/hk2/external/aopalliance-repackaged/2.4.0-b10/aopalliance-repackaged-2.4.0-b10.pom    

**Resolution:**
Declared license is CDDL-1.1 AND GPL-2.0-with-classpath-exception

**Affected definitions**:
- [aopalliance-repackaged 2.4.0-b10](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.hk2.external/aopalliance-repackaged/2.4.0-b10/2.4.0-b10)