### PR TITLE
isomorphic-unfetch 3.0.0

### DIFF
--- a/curations/npm/npmjs/-/isomorphic-unfetch.yaml
+++ b/curations/npm/npmjs/-/isomorphic-unfetch.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.1:
     licensed:
       declared: MIT
+  3.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
isomorphic-unfetch 3.0.0

**Details:**
ClearlyDefined readme indicates MIT
NPM license field indicates MIT
Open source project license is MIT: https://github.com/developit/unfetch/blob/3.0.0/LICENSE.md

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [isomorphic-unfetch 3.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/isomorphic-unfetch/3.0.0/3.0.0)