### PR TITLE
System.Security.Permissions 4.4.0

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Permissions.yaml
+++ b/curations/nuget/nuget/-/System.Security.Permissions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.0:
+    licensed:
+      declared: MIT
   4.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Permissions 4.4.0

**Details:**
ClearlyDefined Readme indicates MIT
Nuget license field links to MIT
Nuget open source project links to: https://dotnet.microsoft.com/

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.Security.Permissions 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Permissions/4.4.0/4.4.0)