### PR TITLE
npmconf 0.0.24

### DIFF
--- a/curations/npm/npmjs/-/npmconf.yaml
+++ b/curations/npm/npmjs/-/npmconf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: npmconf
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.24:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npmconf 0.0.24

**Details:**
ClearyDefined license is BSD-2-Clause
NPM license field indicates BSD
Open source project license is BSD-2-Clause: https://github.com/npm/npmconf/blob/v0.0.24/LICENSE

**Resolution:**
Declared license is BSD-2-Clause

**Affected definitions**:
- [npmconf 0.0.24](https://clearlydefined.io/definitions/npm/npmjs/-/npmconf/0.0.24/0.0.24)