### PR TITLE
Bond.Core.CSharp 5.3.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
@@ -23,6 +23,9 @@ revisions:
   5.1.0:
     licensed:
       declared: MIT
+  5.3.0:
+    licensed:
+      declared: MIT
   5.3.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Core.CSharp 5.3.0

**Details:**
Declared license is MIT
Nuget license field links to MIT
Open source project license is MIT: https://github.com/microsoft/bond/blob/5.3.0/LICENSE

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [Bond.Core.CSharp 5.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Core.CSharp/5.3.0/5.3.0)