### PR TITLE
inference-schema 1.3.0

### DIFF
--- a/curations/pypi/pypi/-/inference-schema.yaml
+++ b/curations/pypi/pypi/-/inference-schema.yaml
@@ -6,3 +6,6 @@ revisions:
   1.1.0:
     licensed:
       declared: MIT
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
inference-schema 1.3.0

**Details:**
ClearlyDefined no files
PyPi license field indicates MIT
PyPi page includes MIT

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [inference-schema 1.3.0](https://clearlydefined.io/definitions/pypi/pypi/-/inference-schema/1.3.0/1.3.0)