### PR TITLE
System.Linq.Dynamic.Core 1.0.18

### DIFF
--- a/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
+++ b/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.12:
     licensed:
       declared: Apache-2.0
+  1.0.18:
+    licensed:
+      declared: Apache-2.0
   1.0.19:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Linq.Dynamic.Core 1.0.18

**Details:**
ClearlyDefined nuspec links to Apache-2.0
Nuget license field links to Apache-2.0
Open Source Project license is Apache-2.0: https://github.com/zzzprojects/System.Linq.Dynamic.Core/blob/1.0.18.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [System.Linq.Dynamic.Core 1.0.18](https://clearlydefined.io/definitions/nuget/nuget/-/System.Linq.Dynamic.Core/1.0.18/1.0.18)