### PR TITLE
System.Spatial 5.0.0.50403

### DIFF
--- a/curations/nuget/nuget/-/System.Spatial.yaml
+++ b/curations/nuget/nuget/-/System.Spatial.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  5.0.0.50403:
+    licensed:
+      declared: NONE
   5.6.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Spatial 5.0.0.50403

**Details:**
ClearlyDefined nuspec license links to https://docs.microsoft.com/en-us/sql/connect/sql-data-developer?redirectedfrom=MSDN&view=sql-server-ver15
Nuget license links to links to same as above
Nuget open source project links to https://www.odata.org/

**Resolution:**
Declared license is NONE

**Affected definitions**:
- [System.Spatial 5.0.0.50403](https://clearlydefined.io/definitions/nuget/nuget/-/System.Spatial/5.0.0.50403/5.0.0.50403)