### PR TITLE
xmldom 0.1.16

### DIFF
--- a/curations/npm/npmjs/-/xmldom.yaml
+++ b/curations/npm/npmjs/-/xmldom.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   0.1.16:
     licensed:
-      declared: MIT OR LGPL-3.0-only
+      declared: LGPL-2.0-or-later
   0.1.19:
     licensed:
       declared: MIT OR LGPL-2.0-or-later

--- a/curations/npm/npmjs/-/xmldom.yaml
+++ b/curations/npm/npmjs/-/xmldom.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.1.16:
+    licensed:
+      declared: MIT OR LGPL-3.0-only
   0.1.19:
     licensed:
       declared: MIT OR LGPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xmldom 0.1.16

**Details:**
ClearlyDefined indicates license is LGPL
NPM license field indicate MIT
Open Source Project license is MIT OR LGPL-3.0-only: http://www.gnu.org/licenses/lgpl.html

**Resolution:**
Declared license is MIT OR LGPL-3.0-only

**Affected definitions**:
- [xmldom 0.1.16](https://clearlydefined.io/definitions/npm/npmjs/-/xmldom/0.1.16/0.1.16)