### PR TITLE
platform 3.5.1

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/platform.yaml
@@ -7,3 +7,6 @@ revisions:
   3.4.0:
     licensed:
       declared: LGPL-2.1-or-later
+  3.5.1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
platform 3.5.1

**Details:**
ClearlyDefined indicates LGPL
Maven license is LGPL-2.1-or-later: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html

**Resolution:**
Declared license is LGPL-2.1-or-later

**Affected definitions**:
- [platform 3.5.1](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/platform/3.5.1/3.5.1)