### PR TITLE
NuGet.Packaging.Core 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
@@ -18,6 +18,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.8.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging.Core 4.8.0

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license links to Apache-2.0
Open Source project license is Apache-2.0

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [NuGet.Packaging.Core 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core/4.8.0/4.8.0)