### PR TITLE
commons-io 1.3.2

### DIFF
--- a/curations/maven/mavencentral/org.apache.commons/commons-io.yaml
+++ b/curations/maven/mavencentral/org.apache.commons/commons-io.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-io
+  namespace: org.apache.commons
+  provider: mavencentral
+  type: maven
+revisions:
+  1.3.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-io 1.3.2

**Details:**
ClearlyDefined license is Apache-2.0
Maven license field indicates Apache-2.0
Maven license links to Apache-2.0: http://www.apache.org/licenses/LICENSE-2.0.txt

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [commons-io 1.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.commons/commons-io/1.3.2/1.3.2)