### PR TITLE
hk2-locator 2.4.0-b10

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.hk2/hk2-locator.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2/hk2-locator.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   2.4.0-b10:
     licensed:
-      declared: CDDL-1.1 AND GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.4.0-b34:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.glassfish.hk2/hk2-locator.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2/hk2-locator.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.4.0-b10:
+    licensed:
+      declared: CDDL-1.1 AND GPL-2.0-with-classpath-exception
   2.4.0-b34:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hk2-locator 2.4.0-b10

**Details:**
ClearlyDefined no files
Maven license field indicates CDDL AND GPLv2 and GPLv1.1
Maven license links to: https://glassfish.java.net/nonav/public/CDDL+GPL_1_1.html

**Resolution:**
Declared license is CDDL-1.1 AND GPL-2.0-with-classpath-exception

**Affected definitions**:
- [hk2-locator 2.4.0-b10](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.hk2/hk2-locator/2.4.0-b10/2.4.0-b10)