### PR TITLE
preprocess 3.2.0

### DIFF
--- a/curations/npm/npmjs/-/preprocess.yaml
+++ b/curations/npm/npmjs/-/preprocess.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: preprocess
+  provider: npmjs
+  type: npm
+revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
preprocess 3.2.0

**Details:**
ClearlyDefined license is Apache-2.0
NPM license field indicates NONE
Open source project license is Apache-2.0: https://github.com/jsoverson/preprocess/blob/v3.2.0/LICENSE

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [preprocess 3.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/preprocess/3.2.0/3.2.0)