### PR TITLE
PhantomJS 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/PhantomJS.yaml
+++ b/curations/nuget/nuget/-/PhantomJS.yaml
@@ -6,6 +6,9 @@ revisions:
   1.9.8:
     licensed:
       declared: BSD-3-Clause
+  2.0.0:
+    licensed:
+      declared: BSD-3-Clause
   2.1.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PhantomJS 2.0.0

**Details:**
ClearlyDefined nuspec license links to BSD-3-Clause
Nuget license field BSD-3-Clause
Open source project license is BSD-3-Clause


**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [PhantomJS 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/PhantomJS/2.0.0/2.0.0)