### PR TITLE
hsqldb 1.8.0.10

### DIFF
--- a/curations/maven/mavencentral/hsqldb/hsqldb.yaml
+++ b/curations/maven/mavencentral/hsqldb/hsqldb.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hsqldb
+  namespace: hsqldb
+  provider: mavencentral
+  type: maven
+revisions:
+  1.8.0.10:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hsqldb 1.8.0.10

**Details:**
ClearlyDefined no license info found
Maven license field missing
Maven license links to BSD-3-Clause: http://hsqldb.org/web/hsqlLicense.html
POM indicates HSQLDB License, a BSD open source license

**Resolution:**
Declared license is BSD-3-Clause

**Affected definitions**:
- [hsqldb 1.8.0.10](https://clearlydefined.io/definitions/maven/mavencentral/hsqldb/hsqldb/1.8.0.10/1.8.0.10)