### PR TITLE
levenshtein 1.0.2

### DIFF
--- a/curations/npm/npmjs/-/levenshtein.yaml
+++ b/curations/npm/npmjs/-/levenshtein.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: levenshtein
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.2:
+    licensed:
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
levenshtein 1.0.2

**Details:**
ClearlyDefined readme indicates Unlicense
NPM License field indicates Public Domain
Open Source project license is Unlicense but was added to the project after the date of the NPM project:  https://github.com/gf3/Levenshtein/blob/35f1c9f6cfbf1747f8b95d871e297f66df32c9e9/UNLICENSE

**Resolution:**
Declared license is Unlicense

**Affected definitions**:
- [levenshtein 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/levenshtein/1.0.2/1.0.2)