### PR TITLE
System.IdentityModel.Tokens.Jwt 5.1.0

### DIFF
--- a/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
+++ b/curations/nuget/nuget/-/System.IdentityModel.Tokens.Jwt.yaml
@@ -21,6 +21,9 @@ revisions:
   5.0.0:
     licensed:
       declared: MIT
+  5.1.0:
+    licensed:
+      declared: MIT
   5.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IdentityModel.Tokens.Jwt 5.1.0

**Details:**
ClearlyDefined nuspec indicates MIT
Nuget license field links to MIT
Open source project is MIT but was added after the date of the Nuget package: https://github.com/AzureAD/azure-activedirectory-identitymodel-extensions-for-dotnet/blob/5.3.0/LICENSE.txt

**Resolution:**
Declared license is MIT

**Affected definitions**:
- [System.IdentityModel.Tokens.Jwt 5.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.IdentityModel.Tokens.Jwt/5.1.0/5.1.0)