### PR TITLE
Grpc.Core.Api 1.19.0

### DIFF
--- a/curations/nuget/nuget/-/Grpc.Core.Api.yaml
+++ b/curations/nuget/nuget/-/Grpc.Core.Api.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Grpc.Core.Api
+  provider: nuget
+  type: nuget
+revisions:
+  1.19.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Grpc.Core.Api 1.19.0

**Details:**
ClearlyDefined nuspec license link is: https://github.com/grpc/grpc/blob/master/LICENSE Apache-2.0
Nuget license field links to Apache-2.0
Open source project license: https://github.com/grpc/grpc/blob/v1.19.0/LICENSE is Apache-2.0

**Resolution:**
Declared license is Apache-2.0

**Affected definitions**:
- [Grpc.Core.Api 1.19.0](https://clearlydefined.io/definitions/nuget/nuget/-/Grpc.Core.Api/1.19.0/1.19.0)