### PR TITLE
Source location was missing for this FOSS component version.

### DIFF
--- a/curations/npm/npmjs/@phosphor/widgets.yaml
+++ b/curations/npm/npmjs/@phosphor/widgets.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: widgets
+  namespace: '@phosphor'
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.0:
+    described:
+      sourceLocation:
+        name: phosphor
+        namespace: phosphorjs
+        provider: github
+        revision: 39d54e8a5863f4e96b80dc05404e07367af5e638
+        type: git
+        url: 'https://github.com/phosphorjs/phosphor/commit/39d54e8a5863f4e96b80dc05404e07367af5e638'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source location was missing for this FOSS component version.

**Details:**
The "Source Location" field was empty.

**Resolution:**
Provided the correct homepage (with commit id) of the FOSS component version, @phosphor/widgets:1.5.0.

**Affected definitions**:
- [widgets 1.5.0](https://clearlydefined.io/definitions/npm/npmjs/@phosphor/widgets/1.5.0/1.5.0)