### PR TITLE
Declared license was "ISC AND MIT"

### DIFF
--- a/curations/git/github/jsstyles/jss.yaml
+++ b/curations/git/github/jsstyles/jss.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jss
+  namespace: jsstyles
+  provider: github
+  type: git
+revisions:
+  2ed79e0139cfc06922ef74a6e5745f219d23ee80:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license was "ISC AND MIT"

**Details:**
1. Declared license was "ISC AND MIT" which is actually "MIT" only. This information can be found at https://github.com/cssinjs/jss/blob/v10.1.1/LICENSE.
2. Furthermore, the Discovered license looks ambiguous. Should be "ISC AND MIT" instead of what is found currently.

**Resolution:**
1. Changed the Declared License to "MIT". 

**Affected definitions**:
- [jss 2ed79e0139cfc06922ef74a6e5745f219d23ee80](https://clearlydefined.io/definitions/git/github/jsstyles/jss/2ed79e0139cfc06922ef74a6e5745f219d23ee80/2ed79e0139cfc06922ef74a6e5745f219d23ee80)