### PR TITLE
Declared license was "Apache 2.0 AND NOASSERTION" which is incorrect

### DIFF
--- a/curations/git/github/go-swagger/go-swagger.yaml
+++ b/curations/git/github/go-swagger/go-swagger.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: go-swagger
+  namespace: go-swagger
+  provider: github
+  type: git
+revisions:
+  b015bda48dfc648fdd95e7bc81dbb5cefc17c975:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license was "Apache 2.0 AND NOASSERTION" which is incorrect

**Details:**
Declared license was "Apache 2.0 AND NOASSERTION" which is actually "Apache 2.0" only.

**Resolution:**
License information can be found at https://github.com/go-swagger/go-swagger/blob/b015bda48dfc648fdd95e7bc81dbb5cefc17c975/LICENSE.

**Affected definitions**:
- [go-swagger b015bda48dfc648fdd95e7bc81dbb5cefc17c975](https://clearlydefined.io/definitions/git/github/go-swagger/go-swagger/b015bda48dfc648fdd95e7bc81dbb5cefc17c975/b015bda48dfc648fdd95e7bc81dbb5cefc17c975)