### PR TITLE
Declared license was "Apache 2.0 AND NOASSERTION" which is incorrect

### DIFF
--- a/curations/git/github/go-swagger/go-swagger.yaml
+++ b/curations/git/github/go-swagger/go-swagger.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: go-swagger
+  namespace: go-swagger
+  provider: github
+  type: git
+revisions:
+  8dfd9cdaac6292e37023827f9618397f495d62f3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license was "Apache 2.0 AND NOASSERTION" which is incorrect

**Details:**
Declared license was "Apache 2.0 AND NOASSERTION" which is actually "Apache 2.0" only.

**Resolution:**
Changed the Declared License to "Apache 2.0". License information can be found at https://github.com/go-swagger/go-swagger/blob/8dfd9cdaac6292e37023827f9618397f495d62f3/LICENSE.

**Affected definitions**:
- [go-swagger 8dfd9cdaac6292e37023827f9618397f495d62f3](https://clearlydefined.io/definitions/git/github/go-swagger/go-swagger/8dfd9cdaac6292e37023827f9618397f495d62f3/8dfd9cdaac6292e37023827f9618397f495d62f3)