### PR TITLE
Source Location and Declared License were missing for this FOSS component version

### DIFF
--- a/curations/npm/npmjs/@zxing/ngx-scanner.yaml
+++ b/curations/npm/npmjs/@zxing/ngx-scanner.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: ngx-scanner
+  namespace: '@zxing'
+  provider: npmjs
+  type: npm
+revisions:
+  3.0.0:
+    described:
+      sourceLocation:
+        name: ngx-scanner
+        namespace: zxing-js
+        provider: github
+        revision: a28b478530e9ed8b94b35ae0aa534b84385de5ce
+        type: git
+        url: 'https://github.com/zxing-js/ngx-scanner/commit/a28b478530e9ed8b94b35ae0aa534b84385de5ce'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source Location and Declared License were missing for this FOSS component version

**Details:**
Source Location and Declared License were missing for this FOSS component version.

**Resolution:**
Found and filled in the correct source code location (along with commit id) and the license from https://github.com/zxing-js/ngx-scanner/blob/a28b478530e9ed8b94b35ae0aa534b84385de5ce/LICENSE. 

**Affected definitions**:
- [ngx-scanner 3.0.0](https://clearlydefined.io/definitions/npm/npmjs/@zxing/ngx-scanner/3.0.0/3.0.0)