### PR TITLE
Correction of NOASSERTION in Discovered license

### DIFF
--- a/curations/git/github/angular-translate/angular-translate.yaml
+++ b/curations/git/github/angular-translate/angular-translate.yaml
@@ -1,0 +1,10 @@
+coordinates:
+  name: angular-translate
+  namespace: angular-translate
+  provider: github
+  type: git
+revisions:
+  fdb55bda5551223760a881d92afa2d6a38f35200:
+    files:
+      - license: NONE
+        path: src/service/sanitization.js


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correction of NOASSERTION in Discovered license

**Details:**
Discovered license included NOASSERTION because of the file sanitization.js.

**Resolution:**
No licensed information was found in https://github.com/angular-translate/angular-translate/blob/fdb55bda5551223760a881d92afa2d6a38f35200/src/service/sanitization.js, so marked the license field as NONE.

**Affected definitions**:
- [angular-translate fdb55bda5551223760a881d92afa2d6a38f35200](https://clearlydefined.io/definitions/git/github/angular-translate/angular-translate/fdb55bda5551223760a881d92afa2d6a38f35200/fdb55bda5551223760a881d92afa2d6a38f35200)