### PR TITLE
Swashbuckle.SwaggerUi/6.0.0-beta902

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.SwaggerUi.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.SwaggerUi.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   6.0.0-beta902:
     licensed:
-      declared: MIT
+      declared: BSD-3-Clause

--- a/curations/nuget/nuget/-/Swashbuckle.SwaggerUi.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.SwaggerUi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle.SwaggerUi
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.0-beta902:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.SwaggerUi/6.0.0-beta902

**Details:**
Adding MIT
Commit ID: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/commit/c7b791090f89e7dacadec19530de4666b5ed66b7

**Resolution:**
Package lists domaindrivendev/Swashbuckle as the source repo, but the README atthe time the package was published states 6.0 is at domaindrivendev/Ahoy, which redirects to domaindrivendev/Swashbuckle.AspNetCore.

**Affected definitions**:
- [Swashbuckle.SwaggerUi 6.0.0-beta902](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.SwaggerUi/6.0.0-beta902/6.0.0-beta902)