### PR TITLE
RESTFulSense/1.9.0

### DIFF
--- a/curations/nuget/nuget/-/RESTFulSense.yaml
+++ b/curations/nuget/nuget/-/RESTFulSense.yaml
@@ -12,3 +12,6 @@ revisions:
   1.8.0:
     licensed:
       declared: MIT
+  1.9.0:
+    licensed:
+      declared: MIT AND CC-BY-3.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RESTFulSense/1.9.0

**Details:**
Adding MIT AND CC-BY-3.0

**Resolution:**
License states documentation is under Creative Commons Attribution 3.0 United States (Unported) License but links to 3.0 Unported. Included CC-BY-3.0 since the package as 1 png file. Not sure if that is correct

**Affected definitions**:
- [RESTFulSense 1.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/RESTFulSense/1.9.0/1.9.0)