### PR TITLE
org.slf4j/slf4j-nop/1.5.3

### DIFF
--- a/curations/maven/mavencentral/org.slf4j/slf4j-nop.yaml
+++ b/curations/maven/mavencentral/org.slf4j/slf4j-nop.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.5.3:
     licensed:
-      declared: ICU
+      declared: MIT

--- a/curations/maven/mavencentral/org.slf4j/slf4j-nop.yaml
+++ b/curations/maven/mavencentral/org.slf4j/slf4j-nop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: slf4j-nop
+  namespace: org.slf4j
+  provider: mavencentral
+  type: maven
+revisions:
+  1.5.3:
+    licensed:
+      declared: ICU


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.slf4j/slf4j-nop/1.5.3

**Details:**
Add ICU

**Resolution:**
3 of the 4 source files have ICU license.

**Affected definitions**:
- [slf4j-nop 1.5.3](https://clearlydefined.io/definitions/maven/mavencentral/org.slf4j/slf4j-nop/1.5.3/1.5.3)