### PR TITLE
MathNet.Numerics.Signed/4.7.0

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.Signed.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.Signed.yaml
@@ -12,6 +12,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.7.0:
+    licensed:
+      declared: MIT
   4.8.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MathNet.Numerics.Signed/4.7.0

**Details:**
Add MIT

**Resolution:**
https://github.com/mathnet/mathnet-numerics/blob/v4.7.0/LICENSE.md

**Affected definitions**:
- [MathNet.Numerics.Signed 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics.Signed/4.7.0/4.7.0)