### PR TITLE
Swashbuckle.OData/3.4.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.OData.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.OData.yaml
@@ -6,6 +6,9 @@ revisions:
   2.19.0:
     licensed:
       declared: MIT
+  3.4.0:
+    licensed:
+      declared: MIT
   3.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.OData/3.4.0

**Details:**
Add MIT

**Resolution:**
License includes CC info for documentation but I didn't see any documentation in the package. Only curating MIT for the code.

**Affected definitions**:
- [Swashbuckle.OData 3.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.OData/3.4.0/3.4.0)