### PR TITLE
jedediah/0.1.1

### DIFF
--- a/curations/npm/npmjs/-/jedediah.yaml
+++ b/curations/npm/npmjs/-/jedediah.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jedediah
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jedediah/0.1.1

**Details:**
Add BSD-3-Clause

**Resolution:**
Could only find "BSD" as the license info. Curating as BSD-3-Clause per curation guidelines.

**Affected definitions**:
- [jedediah 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/jedediah/0.1.1/0.1.1)