### PR TITLE
System.Drawing.Common/4.5.0-preview1-25914-04

### DIFF
--- a/curations/nuget/nuget/-/System.Drawing.Common.yaml
+++ b/curations/nuget/nuget/-/System.Drawing.Common.yaml
@@ -6,6 +6,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview1-25914-04:
+    licensed:
+      declared: MIT
   4.5.0-preview2-26406-04:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Drawing.Common/4.5.0-preview1-25914-04

**Details:**
Add MIT

**Resolution:**
Included license file and license URL are MIT.

**Affected definitions**:
- [System.Drawing.Common 4.5.0-preview1-25914-04](https://clearlydefined.io/definitions/nuget/nuget/-/System.Drawing.Common/4.5.0-preview1-25914-04/4.5.0-preview1-25914-04)