### PR TITLE
Updated Declared license

### DIFF
--- a/curations/git/github/prometheus/client_golang.yaml
+++ b/curations/git/github/prometheus/client_golang.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: client_golang
+  namespace: prometheus
+  provider: github
+  type: git
+revisions:
+  c317fb74746eac4fc65fe3909195f4cf67c5562a:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updated Declared license

**Details:**
The declared license should be Apache 2.0. Here is the link to the license file -https://github.com/prometheus/client_golang/blob/c317fb74746eac4fc65fe3909195f4cf67c5562a/LICENSE

**Resolution:**
Updated the declared license to Apache 2.0

**Affected definitions**:
- [client_golang c317fb74746eac4fc65fe3909195f4cf67c5562a](https://clearlydefined.io/definitions/git/github/prometheus/client_golang/c317fb74746eac4fc65fe3909195f4cf67c5562a/c317fb74746eac4fc65fe3909195f4cf67c5562a)