### PR TITLE
aspectjweaver 1.9.4

### DIFF
--- a/curations/maven/mavencentral/org.aspectj/aspectjweaver.yaml
+++ b/curations/maven/mavencentral/org.aspectj/aspectjweaver.yaml
@@ -13,6 +13,9 @@ revisions:
   1.9.3:
     licensed:
       declared: EPL-1.0
+  1.9.4:
+    licensed:
+      declared: EPL-1.0
   1.9.5:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
aspectjweaver 1.9.4

**Details:**
Maven license field indicates EPL-1.0
https://mvnrepository.com/artifact/org.aspectj/aspectjweaver/1.9.4
POM indicates EPL-1.0
https://repo1.maven.org/maven2/org/aspectj/aspectjweaver/1.9.4/aspectjweaver-1.9.4.pom
Maven license lins to EPL-1.0

**Resolution:**
Declared license is EPL-1.0

**Affected definitions**:
- [aspectjweaver 1.9.4](https://clearlydefined.io/definitions/maven/mavencentral/org.aspectj/aspectjweaver/1.9.4/1.9.4)