### PR TITLE
sha 1.3.0

### DIFF
--- a/curations/npm/npmjs/-/sha.yaml
+++ b/curations/npm/npmjs/-/sha.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sha
+  provider: npmjs
+  type: npm
+revisions:
+  1.3.0:
+    licensed:
+      declared: BSD-2-Clause OR MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sha 1.3.0

**Details:**
ClearlyDefined license file is BSD-2-Clause OR MIT
NPM license field indicates BSD
https://www.npmjs.com/package/sha/v/1.3.0
Source code project page indicates BSD-2-Clause OR MIT: https://github.com/ForbesLindesay/sha/blob/1.3.0/LICENSE

**Resolution:**
Declared license is BSD-2-Clause OR MIT

**Affected definitions**:
- [sha 1.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/sha/1.3.0/1.3.0)