### PR TITLE
Declared License was missing for this FOSS component version.

### DIFF
--- a/curations/git/github/azure/go-autorest.yaml
+++ b/curations/git/github/azure/go-autorest.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: go-autorest
+  namespace: azure
+  provider: github
+  type: git
+revisions:
+  5432abe734f8d95c78340cd56712f912906e6514:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was missing for this FOSS component version.

**Details:**
The declared license was not found in CD URL.

**Resolution:**
Filled in the Declared License as "Apache-2.0". The license file for this component version can be found at https://github.com/Azure/go-autorest/blob/v8.3.1/LICENSE.

**Affected definitions**:
- [go-autorest 5432abe734f8d95c78340cd56712f912906e6514](https://clearlydefined.io/definitions/git/github/azure/go-autorest/5432abe734f8d95c78340cd56712f912906e6514/5432abe734f8d95c78340cd56712f912906e6514)