### PR TITLE
Discovered Licenses contained incorrect entries

### DIFF
--- a/curations/git/github/google/certificate-transparency-go.yaml
+++ b/curations/git/github/google/certificate-transparency-go.yaml
@@ -1,0 +1,38 @@
+coordinates:
+  name: certificate-transparency-go
+  namespace: google
+  provider: github
+  type: git
+revisions:
+  7618200f647971f5f6b0efc6e3498af5b0133a48:
+    files:
+      - attributions:
+          - 'Copyright (c) 2004, 2006 The Linux Foundation and its contributors.'
+        license: NONE
+        path: vendor/github.com/coreos/etcd/DCO
+      - attributions:
+          - Copyright 2014 Oleku Konko
+        license: MIT
+        path: vendor/github.com/coreos/etcd/cmd/vendor/github.com/olekukonko/tablewriter/csv.go
+      - attributions:
+          - Copyright 2014 Oleku Konko
+        license: MIT
+        path: vendor/github.com/coreos/etcd/cmd/vendor/github.com/olekukonko/tablewriter/table.go
+      - attributions:
+          - Copyright 2014 Oleku Konko
+        license: MIT
+        path: vendor/github.com/coreos/etcd/cmd/vendor/github.com/olekukonko/tablewriter/util.go
+      - attributions:
+          - Copyright 2014 Oleku Konko
+        license: MIT
+        path: vendor/github.com/coreos/etcd/cmd/vendor/github.com/olekukonko/tablewriter/wrap.go
+      - license: OTHER
+        path: vendor/github.com/coreos/etcd/cmd/vendor/golang.org/x/crypto/PATENTS
+      - license: OTHER
+        path: vendor/github.com/coreos/etcd/cmd/vendor/golang.org/x/net/PATENTS
+      - license: OTHER
+        path: vendor/github.com/coreos/etcd/cmd/vendor/golang.org/x/sys/PATENTS
+      - license: OTHER
+        path: vendor/github.com/coreos/etcd/cmd/vendor/golang.org/x/time/PATENTS
+      - license: OTHER
+        path: vendor/github.com/coreos/etcd/cmd/vendor/google.golang.org/grpc/PATENTS


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Discovered Licenses contained incorrect entries

**Details:**
1. File with Developer Certificate of Origin 1.1 reported NOASSERTION.
2. 4 files showed BSD 2.0-clause AND MIT but file headers indicated only MIT.
3. Google PATENT files reported NOASSERTION.

**Resolution:**
1. Marked the license with file containing Developer Certificate of Origin 1.1 as NONE.
2. Changed the 4 files showing BSD 2.0-clause AND MIT to reflect MIT only.
3. Marked the license with Google PATENT files as OTHER.

**Affected definitions**:
- [certificate-transparency-go 7618200f647971f5f6b0efc6e3498af5b0133a48](https://clearlydefined.io/definitions/git/github/google/certificate-transparency-go/7618200f647971f5f6b0efc6e3498af5b0133a48/7618200f647971f5f6b0efc6e3498af5b0133a48)