### PR TITLE
Discovered Licenses contained NOASSERTIONS

### DIFF
--- a/curations/git/github/jetstack/cert-manager.yaml
+++ b/curations/git/github/jetstack/cert-manager.yaml
@@ -21,7 +21,7 @@ revisions:
       - attributions:
           - Copyright (c) 2015 Canonical Ltd.
           - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
-        license: LGPL-3.0
+        license: LGPL-3.0-only WITH LGPL-3.0-linking-exception
         path: vendor/github.com/juju/ratelimit/LICENSE
       - license: OTHER
         path: vendor/golang.org/x/crypto/PATENTS

--- a/curations/git/github/jetstack/cert-manager.yaml
+++ b/curations/git/github/jetstack/cert-manager.yaml
@@ -1,9 +1,36 @@
 coordinates:
-  type: git
   name: cert-manager
   namespace: jetstack
   provider: github
+  type: git
 revisions:
+  4dac8737f479ff0bcdaedcda62fb1ef7f84d9389:
+    files:
+      - attributions:
+          - 'Copyright (c) 2004, 2006 The Linux Foundation and its contributors.'
+        license: NONE
+        path: vendor/github.com/go-openapi/jsonpointer/.github/CONTRIBUTING.md
+      - attributions:
+          - 'Copyright (c) 2004, 2006 The Linux Foundation and its contributors.'
+        license: NONE
+        path: vendor/github.com/go-openapi/jsonreference/.github/CONTRIBUTING.md
+      - attributions:
+          - 'Copyright (c) 2004, 2006 The Linux Foundation and its contributors.'
+        license: NONE
+        path: vendor/github.com/go-openapi/swag/.github/CONTRIBUTING.md
+      - attributions:
+          - Copyright (c) 2015 Canonical Ltd.
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+        license: LGPL-3.0
+        path: vendor/github.com/juju/ratelimit/LICENSE
+      - license: OTHER
+        path: vendor/golang.org/x/crypto/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/net/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/sys/PATENTS
+      - license: OTHER
+        path: vendor/golang.org/x/text/PATENTS
   b26bd256f124d480fcb198e1464854f41b0d0d2c:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Discovered Licenses contained NOASSERTIONS

**Details:**
1. CONTRIBUTION Files reported NOASSERTION.
2. 1 LICENSE file showed NOASSERTION container LGPL-3.0 license text.
3. Google PATENT files reported NOASSERTION.

**Resolution:**
1. Marked the license with CONTRIBUTION Files as NONE.
2. Changed the license associated with the  LICENSE file to LGPL-3.0.
3. Marked the license with Google PATENT files as OTHER.

**Affected definitions**:
- [cert-manager 4dac8737f479ff0bcdaedcda62fb1ef7f84d9389](https://clearlydefined.io/definitions/git/github/jetstack/cert-manager/4dac8737f479ff0bcdaedcda62fb1ef7f84d9389/4dac8737f479ff0bcdaedcda62fb1ef7f84d9389)