### PR TITLE
Discovered Licenses contained NOASSERTIONS

### DIFF
--- a/curations/git/github/zalando/connexion.yaml
+++ b/curations/git/github/zalando/connexion.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: connexion
+  namespace: zalando
+  provider: github
+  type: git
+revisions:
+  f846126d42fb97d1526da0cc62e6e7a2d716840c:
+    files:
+      - license: NONE
+        path: examples/enforcedefaults/README.rst
+      - license: MIT
+        path: connexion/vendor/swagger-ui/lib/jquery-1.8.0.min.js
+      - license: BSD-3-Clause
+        path: connexion/vendor/swagger-ui/lib/highlight.9.1.0.pack.js
+      - license: MIT
+        path: connexion/vendor/swagger-ui/lib/lodash.min.js


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Discovered Licenses contained NOASSERTIONS

**Details:**
NOASSERTION was flagged for 4 files that did not contain the license text of any FOSS license. Only license name or a link to license text was mentioned. So, CD could not figure out the correct license.

**Resolution:**
Put the correct license for each case of Discovered License reported as NOASSERTION.

**Affected definitions**:
- [connexion f846126d42fb97d1526da0cc62e6e7a2d716840c](https://clearlydefined.io/definitions/git/github/zalando/connexion/f846126d42fb97d1526da0cc62e6e7a2d716840c/f846126d42fb97d1526da0cc62e6e7a2d716840c)