### PR TITLE
Discovered Licenses contained NOASSERTIONS

### DIFF
--- a/curations/git/github/containers/image.yaml
+++ b/curations/git/github/containers/image.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: image
+  namespace: containers
+  provider: github
+  type: git
+revisions:
+  e5b5d45390c655df9d2e451c508634afa5cf55a1:
+    files:
+      - attributions:
+          - 'Copyright (c) 2004, 2006 The Linux Foundation and its contributors.'
+        license: NONE
+        path: CONTRIBUTING.md


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Discovered Licenses contained NOASSERTIONS

**Details:**
NOASSERTION was flagged in CONTRIBUTING.md file with text of Developer Certificate of Origin Version 1.1.

**Resolution:**
Since CONTRIBUTING.md did not contain any FOSS license text, marked the license as NONE.

**Affected definitions**:
- [image e5b5d45390c655df9d2e451c508634afa5cf55a1](https://clearlydefined.io/definitions/git/github/containers/image/e5b5d45390c655df9d2e451c508634afa5cf55a1/e5b5d45390c655df9d2e451c508634afa5cf55a1)