### PR TITLE
javax.servlet 3.1

### DIFF
--- a/curations/maven/mavencentral/org.glassfish/javax.servlet.yaml
+++ b/curations/maven/mavencentral/org.glassfish/javax.servlet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.servlet
+  namespace: org.glassfish
+  provider: mavencentral
+  type: maven
+revisions:
+  '3.1':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.servlet 3.1

**Details:**
ClearlyDefined license is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license link is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
Declared license is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.servlet 3.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish/javax.servlet/3.1/3.1)