### PR TITLE
hk2-api 2.4.0-b10

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.hk2/hk2-api.yaml
+++ b/curations/maven/mavencentral/org.glassfish.hk2/hk2-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.4.0-b10:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.4.0-b34:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hk2-api 2.4.0-b10

**Details:**
ClearlyDefined no files
Maven license link is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
https://mvnrepository.com/artifact/org.glassfish.hk2/hk2-api/2.4.0-b10
POM is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [hk2-api 2.4.0-b10](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.hk2/hk2-api/2.4.0-b10/2.4.0-b10)