### PR TITLE
jersey-guava 2.17

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.bundles.repackaged/jersey-guava.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.bundles.repackaged/jersey-guava.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.17':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.22.2:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-guava 2.17

**Details:**
ClearlyDefined POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license link is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
https://mvnrepository.com/artifact/org.glassfish.jersey.bundles.repackaged/jersey-guava/2.17
Maven POM is same as above

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-guava 2.17](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.bundles.repackaged/jersey-guava/2.17/2.17)