### PR TITLE
jersey-client 2.17

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-client.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.core/jersey-client.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.17':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.22.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-client 2.17

**Details:**
ClearlyDefined POM is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license link is same. https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-client/2.17
Maven POM is same

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-client 2.17](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.core/jersey-client/2.17/2.17)