### PR TITLE
jersey-entity-filtering 2.17

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-entity-filtering
+  namespace: org.glassfish.jersey.ext
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.17':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-entity-filtering 2.17

**Details:**
ClearlyDefined no files
Maven license link is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-entity-filtering 2.17](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.ext/jersey-entity-filtering/2.17/2.17)