### PR TITLE
jersey-media-json-jackson 2.17

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.17':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.23.2:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-media-json-jackson 2.17

**Details:**
ClearlyDefined POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license link is same
https://mvnrepository.com/artifact/org.glassfish.jersey.media/jersey-media-json-jackson/2.17
Maven POM is same

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-media-json-jackson 2.17](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.media/jersey-media-json-jackson/2.17/2.17)