### PR TITLE
Updated Declared license

### DIFF
--- a/curations/git/github/ajaxorg/ace.yaml
+++ b/curations/git/github/ajaxorg/ace.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ace
+  namespace: ajaxorg
+  provider: github
+  type: git
+revisions:
+  0b7504dae1efe06e058c7fba777e3485cd9294ec:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updated Declared license

**Details:**
The declared license was missing from this component and it should be BSD 3 Clause.
Here is the license file https://github.com/ajaxorg/ace/blob/0b7504dae1efe06e058c7fba777e3485cd9294ec/LICENSE

**Resolution:**
Updating Declared license to BSD 3 Clause.

**Affected definitions**:
- [ace 0b7504dae1efe06e058c7fba777e3485cd9294ec](https://clearlydefined.io/definitions/git/github/ajaxorg/ace/0b7504dae1efe06e058c7fba777e3485cd9294ec/0b7504dae1efe06e058c7fba777e3485cd9294ec)