### PR TITLE
Updated Declared license

### DIFF
--- a/curations/git/github/hector-client/hector.yaml
+++ b/curations/git/github/hector-client/hector.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hector
+  namespace: hector-client
+  provider: github
+  type: git
+revisions:
+  6c75206381f8b4987fecfc37f4aa944730c9495a:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updated Declared license

**Details:**
The declared license was marked as "No Assertion" but it is found out to be MIT License.
Here is the license file - 
https://github.com/hector-client/hector/blob/6c75206381f8b4987fecfc37f4aa944730c9495a/LICENSE

**Resolution:**
Updating Declared license to MIT.

**Affected definitions**:
- [hector 6c75206381f8b4987fecfc37f4aa944730c9495a](https://clearlydefined.io/definitions/git/github/hector-client/hector/6c75206381f8b4987fecfc37f4aa944730c9495a/6c75206381f8b4987fecfc37f4aa944730c9495a)