### PR TITLE
Declared license was "Apache 2.0 AND NOASSERTION" which is incorrect

### DIFF
--- a/curations/git/github/coreos/etcd.yaml
+++ b/curations/git/github/coreos/etcd.yaml
@@ -23,7 +23,7 @@ revisions:
       - attributions:
           - Copyright (c) 2011-2014 - Canonical Inc.
           - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
-        license: LGPL-3.0
+        license: LGPL-3.0-only WITH LGPL-3.0-linking-exception
         path: cmd/vendor/gopkg.in/yaml.v2/LICENSE
     licensed:
       declared: Apache-2.0

--- a/curations/git/github/coreos/etcd.yaml
+++ b/curations/git/github/coreos/etcd.yaml
@@ -4,6 +4,29 @@ coordinates:
   provider: github
   type: git
 revisions:
+  0f4a535c2fb7a2920e13e2e19b9eaf6b2e9285e5:
+    files:
+      - attributions:
+          - 'Copyright (c) 2004, 2006 The Linux Foundation and its contributors.'
+        license: NONE
+        path: DCO
+      - license: OTHER
+        path: cmd/vendor/golang.org/x/crypto/PATENTS
+      - license: OTHER
+        path: cmd/vendor/golang.org/x/net/PATENTS
+      - license: OTHER
+        path: cmd/vendor/golang.org/x/sys/PATENTS
+      - license: OTHER
+        path: cmd/vendor/golang.org/x/time/PATENTS
+      - license: OTHER
+        path: cmd/vendor/google.golang.org/grpc/PATENTS
+      - attributions:
+          - Copyright (c) 2011-2014 - Canonical Inc.
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+        license: LGPL-3.0
+        path: cmd/vendor/gopkg.in/yaml.v2/LICENSE
+    licensed:
+      declared: Apache-2.0
   98d308426819d892e149fe45f6fd542464cb1f9d:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license was "Apache 2.0 AND NOASSERTION" which is incorrect

**Details:**
Declared License was "Apache 2.0 AND NOASSERTION" but the component is distributed under Apache-2.0 alone

**Resolution:**
Corrected the Declared License to Apache-2.0 alone. Also corrected the Discovered Licenses flagged as NOASSERTION.

**Affected definitions**:
- [etcd 0f4a535c2fb7a2920e13e2e19b9eaf6b2e9285e5](https://clearlydefined.io/definitions/git/github/coreos/etcd/0f4a535c2fb7a2920e13e2e19b9eaf6b2e9285e5/0f4a535c2fb7a2920e13e2e19b9eaf6b2e9285e5)