### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/golang/net.yaml
+++ b/curations/git/github/golang/net.yaml
@@ -4,9 +4,6 @@ coordinates:
   provider: github
   type: git
 revisions:
-  4876518f9e71663000c348837735820161a42df7:
-    licensed:
-      declared: BSD-3-Clause AND OTHER
   04defd469f4e290175cd2fb95a0e5f235f9bf173:
     licensed:
       declared: BSD-3-Clause AND OTHER
@@ -22,21 +19,27 @@ revisions:
   3b0461eec859c4b73bb64fdc8285971fd33e3938:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  4876518f9e71663000c348837735820161a42df7:
+    licensed:
+      declared: BSD-3-Clause AND OTHER
   7fd8e65b642006927f6cec5cb4241df7f98a2210:
     licensed:
       declared: BSD-3-Clause AND OTHER
   a5a99cb37ef4b68617775ab669177656090ab396:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  ab34263943818b32f575efc978a3d24e80b04bd7:
+    licensed:
+      declared: BSD-3-Clause AND NOASSERTION
   c89045814202410a2d67ec20ecf177ec77ceae7f:
     licensed:
       declared: BSD-3-Clause AND OTHER
   d8887717615a059821345a5c23649351b52a1c0b:
     licensed:
       declared: BSD-3-Clause AND OTHER
-  eb5bcb51f2a31c7d5141d810b70815c05d9c9146:
+  e18ecbb051101a46fc263334b127c89bc7bff7ea:
     licensed:
       declared: BSD-3-Clause AND OTHER
-  e18ecbb051101a46fc263334b127c89bc7bff7ea:
+  eb5bcb51f2a31c7d5141d810b70815c05d9c9146:
     licensed:
       declared: BSD-3-Clause AND OTHER

--- a/curations/git/github/golang/net.yaml
+++ b/curations/git/github/golang/net.yaml
@@ -30,7 +30,7 @@ revisions:
       declared: BSD-3-Clause AND OTHER
   ab34263943818b32f575efc978a3d24e80b04bd7:
     licensed:
-      declared: BSD-3-Clause AND NOASSERTION
+      declared: BSD-3-Clause AND OTHER
   c89045814202410a2d67ec20ecf177ec77ceae7f:
     licensed:
       declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The Declared License has one NOASSERTION for a PATENT file with no SPDX License as it is a customized License Text.

**Resolution:**
the PATENT License File is not a valid SPDX license it is being termed curated as OTHER instead of NOASSERTION. 

**Affected definitions**:
- [net ab34263943818b32f575efc978a3d24e80b04bd7](https://clearlydefined.io/definitions/git/github/golang/net/ab34263943818b32f575efc978a3d24e80b04bd7/ab34263943818b32f575efc978a3d24e80b04bd7)