### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/golang/net.yaml
+++ b/curations/git/github/golang/net.yaml
@@ -8,11 +8,8 @@ revisions:
     licensed:
       declared: BSD-3-Clause AND OTHER
   0ba52f642ac2f9371a88bfdde41f4b4e195a37c0:
-    files:
-      - license: OTHER
-        path: PATENTS
     licensed:
-      declared: BSD-3-Clause AND NOASSERTION
+      declared: BSD-3-Clause AND OTHER
   1e06a53dbb7e2ed46e91183f219db23c6943c532:
     licensed:
       declared: BSD-3-Clause AND OTHER

--- a/curations/git/github/golang/net.yaml
+++ b/curations/git/github/golang/net.yaml
@@ -4,12 +4,15 @@ coordinates:
   provider: github
   type: git
 revisions:
-  4876518f9e71663000c348837735820161a42df7:
-    licensed:
-      declared: BSD-3-Clause AND OTHER
   04defd469f4e290175cd2fb95a0e5f235f9bf173:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  0ba52f642ac2f9371a88bfdde41f4b4e195a37c0:
+    files:
+      - license: OTHER
+        path: PATENTS
+    licensed:
+      declared: BSD-3-Clause AND NOASSERTION
   1e06a53dbb7e2ed46e91183f219db23c6943c532:
     licensed:
       declared: BSD-3-Clause AND OTHER
@@ -20,6 +23,9 @@ revisions:
     licensed:
       declared: BSD-3-Clause AND OTHER
   3b0461eec859c4b73bb64fdc8285971fd33e3938:
+    licensed:
+      declared: BSD-3-Clause AND OTHER
+  4876518f9e71663000c348837735820161a42df7:
     licensed:
       declared: BSD-3-Clause AND OTHER
   7fd8e65b642006927f6cec5cb4241df7f98a2210:
@@ -34,9 +40,9 @@ revisions:
   d8887717615a059821345a5c23649351b52a1c0b:
     licensed:
       declared: BSD-3-Clause AND OTHER
-  eb5bcb51f2a31c7d5141d810b70815c05d9c9146:
+  e18ecbb051101a46fc263334b127c89bc7bff7ea:
     licensed:
       declared: BSD-3-Clause AND OTHER
-  e18ecbb051101a46fc263334b127c89bc7bff7ea:
+  eb5bcb51f2a31c7d5141d810b70815c05d9c9146:
     licensed:
       declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The Declared and Discovered License has one NOASSERTION for a PATENT file with no SPDX License as it is a customized License Text

**Resolution:**
Since the Patent file is not a valid SPDX License, it is being curated as OTHER instead of NOASSERTION in both Declared and Discovered Licenses.

https://github.com/golang/net/blob/ab34263943818b32f575efc978a3d24e80b04bd7/PATENTS

**Affected definitions**:
- [net 0ba52f642ac2f9371a88bfdde41f4b4e195a37c0](https://clearlydefined.io/definitions/git/github/golang/net/0ba52f642ac2f9371a88bfdde41f4b4e195a37c0/0ba52f642ac2f9371a88bfdde41f4b4e195a37c0)