### PR TITLE
LamarCodeGeneration 2.3.0

### DIFF
--- a/curations/nuget/nuget/-/LamarCodeGeneration.yaml
+++ b/curations/nuget/nuget/-/LamarCodeGeneration.yaml
@@ -6,6 +6,9 @@ revisions:
   1.4.0:
     licensed:
       declared: MIT
+  2.3.0:
+    licensed:
+      declared: MIT
   2.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LamarCodeGeneration 2.3.0

**Details:**
ClearlyDefined license is MIT
Nuget license field links to MIT
Source code project license is MIT: https://github.com/JasperFX/lamar/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [LamarCodeGeneration 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/LamarCodeGeneration/2.3.0/2.3.0)