### PR TITLE
jaxen 1.2.0

### DIFF
--- a/curations/maven/mavencentral/jaxen/jaxen.yaml
+++ b/curations/maven/mavencentral/jaxen/jaxen.yaml
@@ -7,3 +7,6 @@ revisions:
   1.1.6:
     licensed:
       declared: BSD-3-Clause
+  1.2.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxen 1.2.0

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven license field states BSD-2-Clause but links to BSD-3-Clause
Source code project license is BSD-3-Clause: https://github.com/jaxen-xpath/jaxen/blob/v1.2.0/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jaxen 1.2.0](https://clearlydefined.io/definitions/maven/mavencentral/jaxen/jaxen/1.2.0/1.2.0)