### PR TITLE
javax.persistence-api 2.2

### DIFF
--- a/curations/maven/mavencentral/javax.persistence/javax.persistence-api.yaml
+++ b/curations/maven/mavencentral/javax.persistence/javax.persistence-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.persistence-api
+  namespace: javax.persistence
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.2':
+    licensed:
+      declared: EPL-1.0 OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.persistence-api 2.2

**Details:**
ClearlyDefined pom states Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0
Maven license links to Eclipse Public License v1.0 and Eclipse Distribution License v. 1.0

**Resolution:**
EPL-1.0 OR BSD-3-Clause

**Affected definitions**:
- [javax.persistence-api 2.2](https://clearlydefined.io/definitions/maven/mavencentral/javax.persistence/javax.persistence-api/2.2/2.2)