### PR TITLE
antlr4 4.8-1

### DIFF
--- a/curations/maven/mavencentral/org.antlr/antlr4.yaml
+++ b/curations/maven/mavencentral/org.antlr/antlr4.yaml
@@ -13,3 +13,6 @@ revisions:
   4.7.1:
     licensed:
       declared: BSD-3-Clause
+  4.8-1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
antlr4 4.8-1

**Details:**
POM indicates BSD-3-Clause
Maven license field indicates BSD: https://mvnrepository.com/artifact/org.antlr/antlr4-maven-plugin/4.8-1
Maven license link is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [antlr4 4.8-1](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/antlr4/4.8-1/4.8-1)