### PR TITLE
jackson-datatype-protobuf 0.9.10-jackson2.9-proto2

### DIFF
--- a/curations/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf.yaml
+++ b/curations/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jackson-datatype-protobuf
+  namespace: com.hubspot.jackson
+  provider: mavencentral
+  type: maven
+revisions:
+  0.9.10-jackson2.9-proto2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jackson-datatype-protobuf 0.9.10-jackson2.9-proto2

**Details:**
POM indicates Apache-2.0
Maven license links indicate Apache-2.0
Open source project license is Apache-2.0: https://github.com/HubSpot/jackson-datatype-protobuf/blob/fe6e67f14300b7565a109bda3052493a2f6cbc9a/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jackson-datatype-protobuf 0.9.10-jackson2.9-proto2](https://clearlydefined.io/definitions/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf/0.9.10-jackson2.9-proto2/0.9.10-jackson2.9-proto2)