### PR TITLE
jainslee-api 1.1

### DIFF
--- a/curations/maven/mavencentral/javax.slee/jainslee-api.yaml
+++ b/curations/maven/mavencentral/javax.slee/jainslee-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jainslee-api
+  namespace: javax.slee
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavencentral/javax.slee/jainslee-api.yaml
+++ b/curations/maven/mavencentral/javax.slee/jainslee-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.1':
     licensed:
-      declared: OTHER
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jainslee-api 1.1

**Details:**
POM includes URL: http://jcp.org/en/jsr/detail?id=240 that indicates OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [jainslee-api 1.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.slee/jainslee-api/1.1/1.1)