### PR TITLE
jaxen 1.1.1

### DIFF
--- a/curations/maven/mavencentral/jaxen/jaxen.yaml
+++ b/curations/maven/mavencentral/jaxen/jaxen.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1.1.1:
     licensed:
-      declared: BSD-3-Clause OR Apache-2.0
+      declared: BSD-3-Clause
   1.1.6:
     licensed:
       declared: BSD-3-Clause

--- a/curations/maven/mavencentral/jaxen/jaxen.yaml
+++ b/curations/maven/mavencentral/jaxen/jaxen.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.1.1:
+    licensed:
+      declared: BSD-3-Clause OR Apache-2.0
   1.1.6:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxen 1.1.1

**Details:**
ClearlyDefined license.txt is BSD-3-Clause
Maven license field indicates Apache-2.0 but does not include a link: https://mvnrepository.com/artifact/jaxen/jaxen/1.1.1
POM didn't include license info

**Resolution:**
BSD-3-Clause OR Apache-2.0

**Affected definitions**:
- [jaxen 1.1.1](https://clearlydefined.io/definitions/maven/mavencentral/jaxen/jaxen/1.1.1/1.1.1)