### PR TITLE
xom 1.0

### DIFF
--- a/curations/maven/mavencentral/xom/xom.yaml
+++ b/curations/maven/mavencentral/xom/xom.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xom
+  namespace: xom
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xom 1.0

**Details:**
Maven license field indicates LGPL: https://mvnrepository.com/artifact/xom/xom/1.0
POM indicates LGPL
POM URL links to this home page with a license link: http://www.xom.nu/license.xhtml which is LGPL-2.1-only

**Resolution:**
LGPL-2.1-only

**Affected definitions**:
- [xom 1.0](https://clearlydefined.io/definitions/maven/mavencentral/xom/xom/1.0/1.0)