### PR TITLE
istack-commons-tools 3.0.8

### DIFF
--- a/curations/maven/mavencentral/com.sun.istack/istack-commons-tools.yaml
+++ b/curations/maven/mavencentral/com.sun.istack/istack-commons-tools.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: istack-commons-tools
+  namespace: com.sun.istack
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.8:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
istack-commons-tools 3.0.8

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven license field and link indicates EDL-1.0 https://mvnrepository.com/artifact/com.sun.istack/istack-commons-tools/3.0.8
POM indicates BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [istack-commons-tools 3.0.8](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.istack/istack-commons-tools/3.0.8/3.0.8)