### PR TITLE
azureml-pipeline-core 1.35.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -183,6 +183,9 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.35.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.35.0

**Details:**
ClearlyDefined has no files
PyPi license field indicates OTHER: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.35.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.35.0/1.35.0)