### PR TITLE
OpenTK 1.1.2225

### DIFF
--- a/curations/nuget/nuget/-/OpenTK.yaml
+++ b/curations/nuget/nuget/-/OpenTK.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.2225:
+    licensed:
+      declared: MIT
   3.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
OpenTK 1.1.2225

**Details:**
License link in Nuspec is broken
License link in Nuget is broken
Source Code project referenced at the bottom of the Nuget readme section is MIT: https://github.com/ppy/osuTK/blob/master/License.txt

**Resolution:**
MIT

**Affected definitions**:
- [OpenTK 1.1.2225](https://clearlydefined.io/definitions/nuget/nuget/-/OpenTK/1.1.2225/1.1.2225)