### PR TITLE
ws 0.4.31

### DIFF
--- a/curations/npm/npmjs/-/ws.yaml
+++ b/curations/npm/npmjs/-/ws.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.4.31:
+    licensed:
+      declared: MIT
   0.4.32:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ws 0.4.31

**Details:**
Readme includes MIT
NPM License field indicates MIT
Source code project Readme includes MIT: https://github.com/websockets/ws/blob/v0.4.31/README.md but not a license file at that time.  MIT was later added. 

**Resolution:**
MIT

**Affected definitions**:
- [ws 0.4.31](https://clearlydefined.io/definitions/npm/npmjs/-/ws/0.4.31/0.4.31)