### PR TITLE
node-uuid 1.4.0

### DIFF
--- a/curations/npm/npmjs/-/node-uuid.yaml
+++ b/curations/npm/npmjs/-/node-uuid.yaml
@@ -6,3 +6,6 @@ revisions:
   1.3.3:
     licensed:
       declared: MIT OR GPL-1.0-or-later
+  1.4.0:
+    licensed:
+      declared: MIT OR GPL-1.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
node-uuid 1.4.0

**Details:**
ClearlyDefined license states Dual licensed under the MIT and GPL licenses
NPM license field states NONE
NPM link to open source repository: https://github.com/broofa/node-uuid/tree/v1.4.0 indicates Dual licensed under the MIT and GPL licenses

**Resolution:**
MIT OR GPL-1.0-or-later

Per curation guidelines: If the only license information is “GPL,” with no COPYING license file, code the license as “GPL-1.0-or-later.”

**Affected definitions**:
- [node-uuid 1.4.0](https://clearlydefined.io/definitions/npm/npmjs/-/node-uuid/1.4.0/1.4.0)