### PR TITLE
 junit-jupiter 5.7.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -19,3 +19,6 @@ revisions:
   5.7.0:
     licensed:
       declared: EPL-2.0
+  5.7.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 junit-jupiter 5.7.2

**Details:**
ClearlyDefined license file is EPL-2.0
Maven license field is EPL-2.0
Maven license link is EPL-2.0

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter 5.7.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.7.2/5.7.2)