### PR TITLE
highcharts 9.3.0

### DIFF
--- a/curations/npm/npmjs/-/highcharts.yaml
+++ b/curations/npm/npmjs/-/highcharts.yaml
@@ -195,6 +195,9 @@ revisions:
   9.2.2:
     licensed:
       declared: OTHER
+  9.3.0:
+    licensed:
+      declared: OTHER
   9.3.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
highcharts 9.3.0

**Details:**
ClearlyDefined license indicates: License: [www.highcharts.com/license]
NPM License field links to same as above
GitHub is OTHER as noted in Readme: License: www.highcharts.com/license 

**Resolution:**
OTHER

**Affected definitions**:
- [highcharts 9.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts/9.3.0/9.3.0)