### PR TITLE
junit-interface 0.11

### DIFF
--- a/curations/maven/mavencentral/com.novocode/junit-interface.yaml
+++ b/curations/maven/mavencentral/com.novocode/junit-interface.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-interface
+  namespace: com.novocode
+  provider: mavencentral
+  type: maven
+revisions:
+  '0.11':
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-interface 0.11

**Details:**
Maven license field indicates BSD-3-Clause
Maven license link is BSD-2-Clause
GitHub license is BSD-2-Clause: https://github.com/sbt/junit-interface/blob/0.11/LICENSE.txt

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [junit-interface 0.11](https://clearlydefined.io/definitions/maven/mavencentral/com.novocode/junit-interface/0.11/0.11)