### PR TITLE
pleeease-filters 3.0.1

### DIFF
--- a/curations/npm/npmjs/-/pleeease-filters.yaml
+++ b/curations/npm/npmjs/-/pleeease-filters.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  3.0.1:
+    licensed:
+      declared: MIT
   4.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pleeease-filters 3.0.1

**Details:**
ClearlyDefined Readme includes MIT
NPM license field indicates NONE
GitHub license is MIT included in the Readme: https://github.com/iamvdo/pleeease-filters/blob/3.0.0/README.md 

**Resolution:**
MIT

**Affected definitions**:
- [pleeease-filters 3.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/pleeease-filters/3.0.1/3.0.1)