### PR TITLE
send 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/send.yaml
+++ b/curations/npm/npmjs/-/send.yaml
@@ -6,6 +6,9 @@ revisions:
   0.0.4:
     licensed:
       declared: MIT
+  0.1.0:
+    licensed:
+      declared: MIT
   0.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
send 0.1.0

**Details:**
ClearlyDefined Readme includes MIT
NPM License field indicates MIT
GitHub Readme includes MIT: https://github.com/pillarjs/send/blob/0.1.0/Readme.md

**Resolution:**
MIT

**Affected definitions**:
- [send 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/send/0.1.0/0.1.0)