### PR TITLE
tunnel-agent 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/tunnel-agent.yaml
+++ b/curations/npm/npmjs/-/tunnel-agent.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: tunnel-agent
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tunnel-agent 0.2.0

**Details:**
NPM License field indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/request/tunnel-agent/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [tunnel-agent 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/tunnel-agent/0.2.0/0.2.0)