### PR TITLE
org.eclipse.jgit 4.5.7.201904151645-r

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.jgit/org.eclipse.jgit.yaml
+++ b/curations/maven/mavencentral/org.eclipse.jgit/org.eclipse.jgit.yaml
@@ -7,6 +7,9 @@ revisions:
   4.5.0.201609210915-r:
     licensed:
       declared: BSD-3-Clause
+  4.5.7.201904151645-r:
+    licensed:
+      declared: BSD-3-Clause
   5.1.3.201810200350-r:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.eclipse.jgit 4.5.7.201904151645-r

**Details:**
POM indicates: Eclipse Distribution License v1.0
Maven license field indicates BSD and EDL: https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit/4.5.7.201904151645-r

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [org.eclipse.jgit 4.5.7.201904151645-r](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.jgit/org.eclipse.jgit/4.5.7.201904151645-r/4.5.7.201904151645-r)