### PR TITLE
pcf-start 1.9.9

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -9,10 +9,10 @@ revisions:
   1.1.6:
     licensed:
       declared: OTHER
-  1.3.6:
+  1.2.6:
     licensed:
       declared: OTHER
-  1.2.6:
+  1.3.6:
     licensed:
       declared: OTHER
   1.4.4:
@@ -31,5 +31,8 @@ revisions:
     licensed:
       declared: OTHER
   1.8.6:
+    licensed:
+      declared: OTHER
+  1.9.9:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 1.9.9

**Details:**
ClearlyDefined license is OTHER: MICROSOFT SOFTWARE LICENSE TERMS MICROSOFT POWERAPPS CLI
NPM license field indicates OTHER: https://www.npmjs.com/package/pcf-start 

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-start 1.9.9](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.9.9/1.9.9)