### PR TITLE
 F 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/F.yaml
+++ b/curations/nuget/nuget/-/F.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: F
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 F 1.0.0

**Details:**
ClearlyDefined downloaded package Nuspec didn't include any license info and found no license info in other files
Nuget license field is missing
Nuget source code project license link is missing

**Resolution:**
NONE

**Affected definitions**:
- [F 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/F/1.0.0/1.0.0)