### PR TITLE
azureml-dataset-runtime 1.35.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -84,3 +84,6 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.35.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime 1.35.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER: https://aka.ms/azureml-sdk-license
GitHub is OTHER: https://github.com/Azure/MachineLearningNotebooks/blob/azureml-sdk-1.35.0/Licenses/sdk-license/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataset-runtime 1.35.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.35.0/1.35.0)