### PR TITLE
librdkafka.redist 1.4.0

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -27,6 +27,9 @@ revisions:
   1.3.0:
     licensed:
       declared: BSD-2-Clause
+  1.4.0:
+    licensed:
+      declared: BSD-2-Clause
   1.5.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkafka.redist 1.4.0

**Details:**
ClearlyDefined license is BSD-2-Clause
Nuget License field links to BSD-2-Clause
GitHub license is BSD-2-Clause: https://github.com/edenhill/librdkafka/blob/v1.4.0/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [librdkafka.redist 1.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.4.0/1.4.0)