### PR TITLE
Unity.Abstractions 3.1.3

### DIFF
--- a/curations/nuget/nuget/-/Unity.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Unity.Abstractions.yaml
@@ -15,6 +15,9 @@ revisions:
   2.3.1:
     licensed:
       declared: Apache-2.0
+  3.1.3:
+    licensed:
+      declared: Apache-2.0
   3.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Abstractions 3.1.3

**Details:**
ClearlyDefined license is Apache-2.0
Nuget license field links to Apache-2.0
GitHub is Apache-2.0: https://github.com/unitycontainer/abstractions/blob/3.1.3.177/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Abstractions 3.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Abstractions/3.1.3/3.1.3)