### PR TITLE
System.Reactive.Interfaces 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.Interfaces.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.Interfaces.yaml
@@ -10,12 +10,14 @@ revisions:
     described:
       releaseDate: '2016-11-21'
       sourceLocation:
+        name: Rx.NET
+        namespace: Reactive-Extensions
         provider: github
         revision: e0b6af3e204feb8aa13841a8a873d78ae6c43467
         type: git
-        url: >-
-          https://github.com/Reactive-Extensions/Rx.NET/commit/e0b6af3e204feb8aa13841a8a873d78ae6c43467
-        name: Rx.NET
-        namespace: Reactive-Extensions
+        url: 'https://github.com/Reactive-Extensions/Rx.NET/commit/e0b6af3e204feb8aa13841a8a873d78ae6c43467'
+    licensed:
+      declared: Apache-2.0
+  4.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Reactive.Interfaces 4.0.0

**Details:**
License link in the Nuspec goes to MIT: http://go.microsoft.com/fwlink/?LinkID=261272
Nuget license field links to MIT
GitHub license at time of package was Apache-2.0 and later changed to MIT

**Resolution:**
Apache-2.0

**Affected definitions**:
- [System.Reactive.Interfaces 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive.Interfaces/4.0.0/4.0.0)