### PR TITLE
AngularJS.Core 1.6.5

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Core.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Core.yaml
@@ -15,6 +15,9 @@ revisions:
   1.5.9:
     licensed:
       declared: MIT
+  1.6.5:
+    licensed:
+      declared: MIT
   1.6.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngularJS.Core 1.6.5

**Details:**
ClearlyDefined downloaded nuspec links to GitHub license is MIT: https://github.com/angular/angular.js/blob/v1.6.5/LICENSE
Nuget project links to same project website - MIT

**Resolution:**
MIT

**Affected definitions**:
- [AngularJS.Core 1.6.5](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Core/1.6.5/1.6.5)