### PR TITLE
Prism.Interactivity 5.0.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.Interactivity.yaml
+++ b/curations/nuget/nuget/-/Prism.Interactivity.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Prism.Interactivity
+  provider: nuget
+  type: nuget
+revisions:
+  5.0.0:
+    licensed:
+      declared: NONE

--- a/curations/nuget/nuget/-/Prism.Interactivity.yaml
+++ b/curations/nuget/nuget/-/Prism.Interactivity.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   5.0.0:
     licensed:
-      declared: NONE
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Interactivity 5.0.0

**Details:**
ClearlyDefined Nuspec license and project links are broken. No license info found in files.
Nuget License link is broken
Nuget project link is broken

**Resolution:**
NONE

**Affected definitions**:
- [Prism.Interactivity 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Interactivity/5.0.0/5.0.0)