### PR TITLE
WebApiThrottle 1.5.2.1

### DIFF
--- a/curations/nuget/nuget/-/WebApiThrottle.yaml
+++ b/curations/nuget/nuget/-/WebApiThrottle.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.5.2.1:
+    licensed:
+      declared: MIT
   1.5.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WebApiThrottle 1.5.2.1

**Details:**
Nuspec links to project that includes MIT: https://github.com/stefanprodan/WebApiThrottle/blob/v1.5.2/LICENSE.md
Nuget project license links to same as above.
Nuget license field is missing

**Resolution:**
MIT

**Affected definitions**:
- [WebApiThrottle 1.5.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/WebApiThrottle/1.5.2.1/1.5.2.1)