### PR TITLE
vscode-chrome-debug-core 6.8.11

### DIFF
--- a/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
+++ b/curations/npm/npmjs/-/vscode-chrome-debug-core.yaml
@@ -219,6 +219,9 @@ revisions:
   6.8.0:
     licensed:
       declared: MIT
+  6.8.11:
+    licensed:
+      declared: MIT
   6.8.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
vscode-chrome-debug-core 6.8.11

**Details:**
ClearlyDefined license is MIT
NPM license field indicates see license folder
Source code repository is MIT: https://github.com/microsoft/vscode-chrome-debug-core/blob/v6.8.11/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [vscode-chrome-debug-core 6.8.11](https://clearlydefined.io/definitions/npm/npmjs/-/vscode-chrome-debug-core/6.8.11/6.8.11)