### PR TITLE
SQLinq 3.0.1-b5

### DIFF
--- a/curations/nuget/nuget/-/SQLinq.yaml
+++ b/curations/nuget/nuget/-/SQLinq.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.0.1-b5:
     licensed:
-      declared: LGPL-2.1-or-later
+      declared: LGPL-2.1-only

--- a/curations/nuget/nuget/-/SQLinq.yaml
+++ b/curations/nuget/nuget/-/SQLinq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SQLinq
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.1-b5:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SQLinq 3.0.1-b5

**Details:**
Nuspec links to project file with LGPL-2.1-or-later
Nuget license field links to LGPL-2.1-or-later
GitHub is LGPL-2.1-or-later: https://github.com/crpietschmann/SQLinq/blob/master/LICENSE

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [SQLinq 3.0.1-b5](https://clearlydefined.io/definitions/nuget/nuget/-/SQLinq/3.0.1-b5/3.0.1-b5)