### PR TITLE
SQLinq.Dapper 1.5.1-b5

### DIFF
--- a/curations/nuget/nuget/-/SQLinq.Dapper.yaml
+++ b/curations/nuget/nuget/-/SQLinq.Dapper.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.5.1-b5:
     licensed:
-      declared: LGPL-2.1-or-later
+      declared: LGPL-2.1-only

--- a/curations/nuget/nuget/-/SQLinq.Dapper.yaml
+++ b/curations/nuget/nuget/-/SQLinq.Dapper.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SQLinq.Dapper
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.1-b5:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SQLinq.Dapper 1.5.1-b5

**Details:**
Nuspec license links to LGPL-2.1-or-later
Nuget license field links to LGPL-2.1-or-later
GitHub is LGPL-2.1-or-later: https://github.com/crpietschmann/SQLinq/blob/master/LICENSE

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [SQLinq.Dapper 1.5.1-b5](https://clearlydefined.io/definitions/nuget/nuget/-/SQLinq.Dapper/1.5.1-b5/1.5.1-b5)