### PR TITLE
System-Web-Helpers.dll 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/System-Web-Helpers.dll.yaml
+++ b/curations/nuget/nuget/-/System-Web-Helpers.dll.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System-Web-Helpers.dll
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System-Web-Helpers.dll 1.0.0

**Details:**
ClearlyDefined downloaded component and no license info found. 
Nuget no license field included
Nuget no project included

**Resolution:**
NONE

**Affected definitions**:
- [System-Web-Helpers.dll 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System-Web-Helpers.dll/1.0.0/1.0.0)