### PR TITLE
oauth-sign 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/oauth-sign.yaml
+++ b/curations/npm/npmjs/-/oauth-sign.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: oauth-sign
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
oauth-sign 0.2.0

**Details:**
ClearlyDefined project links to https://github.com/request/oauth-sign/blob/master/LICENSE
NPM license field indicates Apache-2-0
GitHub includes Apache-2.0: https://github.com/request/oauth-sign/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [oauth-sign 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/oauth-sign/0.2.0/0.2.0)