### PR TITLE
Sammy.js 0.7.5

### DIFF
--- a/curations/nuget/nuget/-/Sammy.js.yaml
+++ b/curations/nuget/nuget/-/Sammy.js.yaml
@@ -6,3 +6,6 @@ revisions:
   0.7.4:
     licensed:
       declared: MIT
+  0.7.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Sammy.js 0.7.5

**Details:**
ClearlyDefined license links to MIT
Nuget license filed links to MIT
GitHub includes MIT: https://www.nuget.org/packages/Sammy.js/0.7.5

**Resolution:**
MIT

**Affected definitions**:
- [Sammy.js 0.7.5](https://clearlydefined.io/definitions/nuget/nuget/-/Sammy.js/0.7.5/0.7.5)