### PR TITLE
jersey-test-framework-grizzly2 1.9

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-grizzly2.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-grizzly2.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.19':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.9':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-test-framework-grizzly2 1.9

**Details:**
Maven is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0:  https://www.findjar.com/jar/com/sun/jersey/jersey-test-framework/jersey-test-framework-grizzly/1.9-ea07/jersey-test-framework-grizzly-1.9-ea07.jar.html

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-test-framework-grizzly2 1.9](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-grizzly2/1.9/1.9)