### PR TITLE
tunnel 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/tunnel.yaml
+++ b/curations/npm/npmjs/-/tunnel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: tunnel
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tunnel 0.0.2

**Details:**
ClearlyDefined package.json is MIT
NPM license field is MIT
GItHub license is MIT: https://github.com/koichik/node-tunnel/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [tunnel 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/tunnel/0.0.2/0.0.2)