### PR TITLE
System.Data.SQLite.Linq 1.0.102

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Linq.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Linq.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Data.SQLite.Linq
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.102:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
**Type:** Missing

**Summary:**
System.Data.SQLite.Linq 1.0.102

**Details:**
ClearlyDefined license is public domain OTHER
Nuget license field links to Public Domain: https://www.sqlite.org/copyright.html
Project Website is OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.Linq 1.0.102](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Linq/1.0.102/1.0.102)