### PR TITLE
jsoup 1.10.3

### DIFF
--- a/curations/maven/mavencentral/org.jsoup/jsoup.yaml
+++ b/curations/maven/mavencentral/org.jsoup/jsoup.yaml
@@ -7,6 +7,9 @@ revisions:
   1.10.1:
     licensed:
       declared: MIT
+  1.10.3:
+    licensed:
+      declared: MIT
   1.11.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsoup 1.10.3

**Details:**
ClearlyDefined license is MIT
Maven license field is MIT: https://mvnrepository.com/artifact/org.jsoup/jsoup/1.10.2
POM is MIT

**Resolution:**
MIT

**Affected definitions**:
- [jsoup 1.10.3](https://clearlydefined.io/definitions/maven/mavencentral/org.jsoup/jsoup/1.10.3/1.10.3)