### PR TITLE
npm-user-validate 0.1.1

### DIFF
--- a/curations/npm/npmjs/-/npm-user-validate.yaml
+++ b/curations/npm/npmjs/-/npm-user-validate.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: npm-user-validate
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npm-user-validate 0.1.1

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field indicates BSD
GitHub license is BSD-2-Clause: https://github.com/npm/npm-user-validate/blob/v0.1.1/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [npm-user-validate 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/npm-user-validate/0.1.1/0.1.1)