### PR TITLE
Newtonsoft.Json 5.0.1

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -40,6 +40,9 @@ revisions:
   4.5.6:
     licensed:
       declared: MIT
+  5.0.1:
+    licensed:
+      declared: MIT
   5.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json 5.0.1

**Details:**
Nuspec license link was broken
Nuget license field is MIT
GitHub is MIT: https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Newtonsoft.Json 5.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/5.0.1/5.0.1)