### PR TITLE
AutoItX.Dotnet 3.3.14.

### DIFF
--- a/curations/nuget/nuget/-/AutoItX.Dotnet.yaml
+++ b/curations/nuget/nuget/-/AutoItX.Dotnet.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.3.14.2:
+    licensed:
+      declared: OTHER
   3.3.14.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AutoItX.Dotnet 3.3.14.

**Details:**
Downloaded and license is a modified 0BSD
Nuget license field is missing
Project page indicates "Freeware" https://www.autoitscript.com/site/

**Resolution:**
OTHER

**Affected definitions**:
- [AutoItX.Dotnet 3.3.14.2](https://clearlydefined.io/definitions/nuget/nuget/-/AutoItX.Dotnet/3.3.14.2/3.3.14.2)