### PR TITLE
win-spawn 2.0.0

### DIFF
--- a/curations/npm/npmjs/-/win-spawn.yaml
+++ b/curations/npm/npmjs/-/win-spawn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: win-spawn
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
win-spawn 2.0.0

**Details:**
ClearlyDefined package.json indicates BSD-3-Clause
NPM license field indicates BSD
GitHub no license file but in package.json indicates BSD-3-Clause: https://github.com/ForbesLindesay-Unmaintained/win-spawn/search?q=license

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [win-spawn 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/win-spawn/2.0.0/2.0.0)