### PR TITLE
azureml-telemetry 1.35.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -201,6 +201,9 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.35.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-telemetry 1.35.0

**Details:**
PyPi license field indicates: https://aka.ms/azureml-sdk-license


**Resolution:**
OTHER

**Affected definitions**:
- [azureml-telemetry 1.35.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.35.0/1.35.0)