### PR TITLE
forever-agent 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/forever-agent.yaml
+++ b/curations/npm/npmjs/-/forever-agent.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: forever-agent
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
forever-agent 0.2.0

**Details:**
ClearlyDefined package.json lins to GitHub
NPM license field indicates Apache-2.0
GitHub project is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [forever-agent 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/forever-agent/0.2.0/0.2.0)