### PR TITLE
fstream 1.0.4

### DIFF
--- a/curations/npm/npmjs/-/fstream.yaml
+++ b/curations/npm/npmjs/-/fstream.yaml
@@ -6,3 +6,6 @@ revisions:
   0.1.31:
     licensed:
       declared: BSD-2-Clause
+  1.0.4:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
fstream 1.0.4

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field indicates ISC
GitHub license is BSD-2-Clause: https://github.com/npm/fstream/blob/v1.0.4/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [fstream 1.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/fstream/1.0.4/1.0.4)