### PR TITLE
NuGet.Frameworks 4.6.4

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -18,6 +18,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.6.4:
+    licensed:
+      declared: Apache-2.0
   4.7.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Frameworks 4.6.4

**Details:**
ClearlyDefined nuspec license link is Apache-2.0
Nuget license field is Apache-2.0
GitHub is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/01526febb05abca3b0004781c21c386bbe1b1286/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Frameworks 4.6.4](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Frameworks/4.6.4/4.6.4)