### PR TITLE
jersey-test-framework-core 1.9

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-core.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-test-framework-core
+  namespace: com.sun.jersey.jersey-test-framework
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.9':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-test-framework-core 1.9

**Details:**
ClearlyDefined POM indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
https://mvnrepository.com/artifact/nl.bstoi.jersey.test-framework/jersey-spring-exposed-test-framework-core/2.19

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-test-framework-core 1.9](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-core/1.9/1.9)