### PR TITLE
lockfile 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/lockfile.yaml
+++ b/curations/npm/npmjs/-/lockfile.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-2-Clause
   1.0.4:
     files:
       - license: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
lockfile 1.0.0

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM indicates ISC
GitHub is BSD-2-Clause: https://github.com/npm/lockfile/blob/v1.0.0/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [lockfile 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/lockfile/1.0.0/1.0.0)