### PR TITLE
slf4j-jdk14 1.5.6

### DIFF
--- a/curations/maven/mavencentral/org.slf4j/slf4j-jdk14.yaml
+++ b/curations/maven/mavencentral/org.slf4j/slf4j-jdk14.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: slf4j-jdk14
+  namespace: org.slf4j
+  provider: mavencentral
+  type: maven
+revisions:
+  1.5.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
slf4j-jdk14 1.5.6

**Details:**
Maven license field indicates MIT
Project is MIT: http://www.slf4j.org/license.html

**Resolution:**
MIT

**Affected definitions**:
- [slf4j-jdk14 1.5.6](https://clearlydefined.io/definitions/maven/mavencentral/org.slf4j/slf4j-jdk14/1.5.6/1.5.6)