### PR TITLE
aws-sign 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/aws-sign.yaml
+++ b/curations/npm/npmjs/-/aws-sign.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: aws-sign
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
aws-sign 0.2.0

**Details:**
ClearlyDefined package.json includes links to project with Apache-2.0 license: https://github.com/request/aws-sign/blob/master/LICENSE
NPM license field indicates MIT
Link to project is: https://github.com/egorFiNE/node-aws-sign/blob/master/LICENSE - is MIT but not same as project above

**Resolution:**
Apache-2.0

**Affected definitions**:
- [aws-sign 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/aws-sign/0.2.0/0.2.0)