### PR TITLE
cookie-jar 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/cookie-jar.yaml
+++ b/curations/npm/npmjs/-/cookie-jar.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cookie-jar
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cookie-jar 0.2.0

**Details:**
ClearlyDefined package.json links to project that has Apache-2.0
NPM license field states NONE
GitHub license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [cookie-jar 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/cookie-jar/0.2.0/0.2.0)