### PR TITLE
json-stringify-safe 3.0.0

### DIFF
--- a/curations/npm/npmjs/-/json-stringify-safe.yaml
+++ b/curations/npm/npmjs/-/json-stringify-safe.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  3.0.0:
+    licensed:
+      declared: BSD-2-Clause
   4.0.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
json-stringify-safe 3.0.0

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field states ISC
GitHub license is BSD-2-Clause: https://github.com/moll/json-stringify-safe/blob/v3.0.0/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [json-stringify-safe 3.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/json-stringify-safe/3.0.0/3.0.0)