### PR TITLE
debug 0.8.0

### DIFF
--- a/curations/npm/npmjs/-/debug.yaml
+++ b/curations/npm/npmjs/-/debug.yaml
@@ -6,6 +6,9 @@ revisions:
   0.7.4:
     licensed:
       declared: MIT
+  0.8.0:
+    licensed:
+      declared: MIT
   0.8.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
debug 0.8.0

**Details:**
ClearlyDefined Readme file includes MIT
NPN license field is MIT
GitHub license in Readme is MIT: https://github.com/visionmedia/debug/tree/0.8.0

**Resolution:**
MIT

**Affected definitions**:
- [debug 0.8.0](https://clearlydefined.io/definitions/npm/npmjs/-/debug/0.8.0/0.8.0)