### PR TITLE
 RazorGenerator.Testing 2.4.7

### DIFF
--- a/curations/nuget/nuget/-/RazorGenerator.Testing.yaml
+++ b/curations/nuget/nuget/-/RazorGenerator.Testing.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RazorGenerator.Testing
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 RazorGenerator.Testing 2.4.7

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/RazorGenerator/RazorGenerator/blob/master/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [RazorGenerator.Testing 2.4.7](https://clearlydefined.io/definitions/nuget/nuget/-/RazorGenerator.Testing/2.4.7/2.4.7)