### PR TITLE
grunt-bbb-requirejs 0.1.0-alpha.8

### DIFF
--- a/curations/npm/npmjs/-/grunt-bbb-requirejs.yaml
+++ b/curations/npm/npmjs/-/grunt-bbb-requirejs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: grunt-bbb-requirejs
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0-alpha.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
grunt-bbb-requirejs 0.1.0-alpha.8

**Details:**
ClearlyDefined package.json links to project with MIT
NPN license field states NONE
GitHub is MIT: https://github.com/backbone-boilerplate/grunt-bbb-requirejs/blob/881ac263f185387092591940e696801df3dfb5dd/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [grunt-bbb-requirejs 0.1.0-alpha.8](https://clearlydefined.io/definitions/npm/npmjs/-/grunt-bbb-requirejs/0.1.0-alpha.8/0.1.0-alpha.8)