### PR TITLE
escodegen 1.3.1

### DIFF
--- a/curations/npm/npmjs/-/escodegen.yaml
+++ b/curations/npm/npmjs/-/escodegen.yaml
@@ -18,6 +18,9 @@ revisions:
   1.2.0:
     licensed:
       declared: BSD-2-Clause
+  1.3.1:
+    licensed:
+      declared: BSD-2-Clause
   1.3.3:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
escodegen 1.3.1

**Details:**
ClearlyDefined license file is BSD-2-Clause
NPM license field indicates BSD-2-Clause
GitHub license is BSD-2-Clause: https://github.com/estools/escodegen/blob/1.3.1/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [escodegen 1.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/escodegen/1.3.1/1.3.1)