### PR TITLE
pcf-scripts 1.9.9

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -30,3 +30,6 @@ revisions:
   1.8.6:
     licensed:
       declared: OTHER
+  1.9.9:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.9.9

**Details:**
ClearlyDefined license file is OTHER: Microsoft Software License Terms MICROSOFT POWERAPPS CLI
NPM license field indicates see license folder
Project links to Microsoft Power Apps site

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-scripts 1.9.9](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.9.9/1.9.9)