### PR TITLE
bbb 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/bbb.yaml
+++ b/curations/npm/npmjs/-/bbb.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: bbb
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bbb 0.2.0

**Details:**
ClearlyDefined package.json links to GitHub with MIT
NPM license field indicates NONE
GitHub is MIT as listed in Readme: https://github.com/backbone-boilerplate/grunt-bbb/tree/0.2.0

**Resolution:**
MIT

**Affected definitions**:
- [bbb 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/bbb/0.2.0/0.2.0)