### PR TITLE
Handlebars.js 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/Handlebars.js.yaml
+++ b/curations/nuget/nuget/-/Handlebars.js.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.3.0:
+    licensed:
+      declared: MIT
   2.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Handlebars.js 1.3.0

**Details:**
ClearlyDefined nuspec license link is MIT
Nuget license field links to MIT
Project license is MIT: https://raw.githubusercontent.com/wycats/handlebars.js/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Handlebars.js 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Handlebars.js/1.3.0/1.3.0)