### PR TITLE
escope 1.0.1

### DIFF
--- a/curations/npm/npmjs/-/escope.yaml
+++ b/curations/npm/npmjs/-/escope.yaml
@@ -6,3 +6,6 @@ revisions:
   0.0.16:
     licensed:
       declared: BSD-2-Clause
+  1.0.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
escope 1.0.1

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field states BSD-2-Clause
GitHub license is BSD-2-Clause: https://github.com/estools/escope/blob/1.0.0/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [escope 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/escope/1.0.1/1.0.1)