### PR TITLE
esprima-fb 13001.1001.0-dev-harmony-fb

### DIFF
--- a/curations/npm/npmjs/-/esprima-fb.yaml
+++ b/curations/npm/npmjs/-/esprima-fb.yaml
@@ -6,6 +6,9 @@ revisions:
   12001.1.0-dev-harmony-fb:
     licensed:
       declared: BSD-2-Clause
+  13001.1001.0-dev-harmony-fb:
+    licensed:
+      declared: BSD-2-Clause
   15001.1.0-dev-harmony-fb:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
esprima-fb 13001.1001.0-dev-harmony-fb

**Details:**
ClearlyDefined package.json links to license BSD-2-Clause
NPM license field indicates NONE
GitHub project is BSD-2-Clause: https://github.com/facebookarchive/esprima/blob/13001.1001.0-dev-harmony-fb/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [esprima-fb 13001.1001.0-dev-harmony-fb](https://clearlydefined.io/definitions/npm/npmjs/-/esprima-fb/13001.1001.0-dev-harmony-fb/13001.1001.0-dev-harmony-fb)