### PR TITLE
animate.css 3.1.1

### DIFF
--- a/curations/npm/npmjs/-/animate.css.yaml
+++ b/curations/npm/npmjs/-/animate.css.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: animate.css
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
animate.css 3.1.1

**Details:**
ClearlyDefined Readme indicates MIT
NPM license field indicates MIT
GitHub Readme indicates MIT: https://github.com/animate-css/animate.css/blob/3.1.1/README.md

**Resolution:**
MIT

**Affected definitions**:
- [animate.css 3.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/animate.css/3.1.1/3.1.1)