### PR TITLE
Adding XunitRetry license 

### DIFF
--- a/curations/nuget/nuget/-/XunitRetry.yaml
+++ b/curations/nuget/nuget/-/XunitRetry.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: XunitRetry
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding XunitRetry license 

**Details:**
License can be found here
https://github.com/giggio/xunit-retry/blob/master/LICENSE.txt

**Resolution:**
Adding the missing license

**Affected definitions**:
- [XunitRetry 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/XunitRetry/2.0.0)