### PR TITLE
log-driver 1.2.1

### DIFF
--- a/curations/npm/npmjs/-/log-driver.yaml
+++ b/curations/npm/npmjs/-/log-driver.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.2.1:
+    licensed:
+      declared: ISC
   1.2.5:
     licensed:
       declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
log-driver 1.2.1

**Details:**
ClearlyDefined links to open source project with ISC license
NPM license field indicates ISC
GitHub license is ISC: https://github.com/cainus/logdriver/blob/master/LICENSE

**Resolution:**
ISC

**Affected definitions**:
- [log-driver 1.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/log-driver/1.2.1/1.2.1)