### PR TITLE
log4js 0.6.12

### DIFF
--- a/curations/npm/npmjs/-/log4js.yaml
+++ b/curations/npm/npmjs/-/log4js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: log4js
+  provider: npmjs
+  type: npm
+revisions:
+  0.6.12:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
log4js 0.6.12

**Details:**
ClearlyDefined package.json links to project with Apache-2.0
NPM license field indicates Apache-2.0
GitHub is Apache-2.0: https://github.com/log4js-node/log4js-node/blob/v6.1.2/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [log4js 0.6.12](https://clearlydefined.io/definitions/npm/npmjs/-/log4js/0.6.12/0.6.12)