### PR TITLE
torchvision 0.11.1

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -21,6 +21,9 @@ revisions:
   0.10.1:
     licensed:
       declared: BSD-3-Clause
+  0.11.1:
+    licensed:
+      declared: BSD-3-Clause
   0.2.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision 0.11.1

**Details:**
ClearlyDefined no files
PyPi license field states BSD
GitHub license is BSD-3-Clause: https://github.com/pytorch/vision/blob/v0.11.1/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [torchvision 0.11.1](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.11.1/0.11.1)