### PR TITLE
qunitjs 1.12.0

### DIFF
--- a/curations/npm/npmjs/-/qunitjs.yaml
+++ b/curations/npm/npmjs/-/qunitjs.yaml
@@ -6,3 +6,6 @@ revisions:
   1.10.0:
     licensed:
       declared: MIT
+  1.12.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
qunitjs 1.12.0

**Details:**
ClearlyDefined license is MIT
NPM license field states MIT
GitHub license is MIT: https://github.com/qunitjs/qunit/blob/v1.12.0/MIT-LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [qunitjs 1.12.0](https://clearlydefined.io/definitions/npm/npmjs/-/qunitjs/1.12.0/1.12.0)