### PR TITLE
esmangle 0.0.17

### DIFF
--- a/curations/npm/npmjs/-/esmangle.yaml
+++ b/curations/npm/npmjs/-/esmangle.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: esmangle
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.17:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
esmangle 0.0.17

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field states NONE
GitHub license is BSD-2-Clause: https://github.com/estools/esmangle/blob/0.0.17/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [esmangle 0.0.17](https://clearlydefined.io/definitions/npm/npmjs/-/esmangle/0.0.17/0.0.17)