### PR TITLE
coveralls 2.6.1

### DIFF
--- a/curations/npm/npmjs/-/coveralls.yaml
+++ b/curations/npm/npmjs/-/coveralls.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: coveralls
+  provider: npmjs
+  type: npm
+revisions:
+  2.6.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
coveralls 2.6.1

**Details:**
ClearlyDefined package.json states BSD
NPM license field states BSD-2-Clause
GItHub license is BSD-2-Clause: https://github.com/nickmerwin/node-coveralls/blob/master/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [coveralls 2.6.1](https://clearlydefined.io/definitions/npm/npmjs/-/coveralls/2.6.1/2.6.1)