### PR TITLE
jsonlint-mod 1.7.5

### DIFF
--- a/curations/npm/npmjs/-/jsonlint-mod.yaml
+++ b/curations/npm/npmjs/-/jsonlint-mod.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.7.5:
+    licensed:
+      declared: MIT
   1.7.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsonlint-mod 1.7.5

**Details:**
ClearlyDefined Readme states MIT
NPM license field states NONE
GitHub Readme states MIT: https://github.com/circlecell/jsonlint-mod/blob/master/README.md

**Resolution:**
MIT

**Affected definitions**:
- [jsonlint-mod 1.7.5](https://clearlydefined.io/definitions/npm/npmjs/-/jsonlint-mod/1.7.5/1.7.5)