### PR TITLE
json2php 0.0.4

### DIFF
--- a/curations/npm/npmjs/-/json2php.yaml
+++ b/curations/npm/npmjs/-/json2php.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: json2php
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
json2php 0.0.4

**Details:**
ClearlyDefined package.json states BSD
NPM license field states BSD
GitHub package.json states BSD

**Resolution:**
Per curation guidelines BSD-3-Clause

**Affected definitions**:
- [json2php 0.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/json2php/0.0.4/0.0.4)