### PR TITLE
estraverse 1.5.0

### DIFF
--- a/curations/npm/npmjs/-/estraverse.yaml
+++ b/curations/npm/npmjs/-/estraverse.yaml
@@ -12,6 +12,9 @@ revisions:
   1.3.2:
     licensed:
       declared: BSD-2-Clause
+  1.5.0:
+    licensed:
+      declared: BSD-2-Clause
   1.5.1:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
estraverse 1.5.0

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field states BSD-2-Clause
GitHub license is BSD-2-Clause: https://github.com/estools/estraverse/blob/1.5.0/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [estraverse 1.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/estraverse/1.5.0/1.5.0)