### PR TITLE
esshorten 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/esshorten.yaml
+++ b/curations/npm/npmjs/-/esshorten.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: esshorten
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
esshorten 0.0.2

**Details:**
ClearlyDefined package.json states BSD
NPM states NONE
GitHub Readme states BSD-2-Clause: https://github.com/estools/esshorten/tree/0.0.2

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [esshorten 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/esshorten/0.0.2/0.0.2)