### PR TITLE
lcov-parse 0.0.4

### DIFF
--- a/curations/npm/npmjs/-/lcov-parse.yaml
+++ b/curations/npm/npmjs/-/lcov-parse.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: lcov-parse
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
lcov-parse 0.0.4

**Details:**
ClearlyDefined license is BSD-3-Clause
NPM license field indicates BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/davglass/lcov-parse/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [lcov-parse 0.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/lcov-parse/0.0.4/0.0.4)