### PR TITLE
Selenium.WebDriver.IEDriver 3.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: Unlicense
+  3.0.0.1:
+    licensed:
+      declared: Unlicense
   3.13.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.IEDriver 3.0.0.1

**Details:**
Nuget license links to Unlicensed
GitHub license is Unlicensed: https://github.com/jsakamoto/nupkg-selenium-webdriver-iedriver/blob/v.3.0.0.1/LICENSE

**Resolution:**
Unlicensed

**Affected definitions**:
- [Selenium.WebDriver.IEDriver 3.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.IEDriver/3.0.0.1/3.0.0.1)