### PR TITLE
AutoItX.Dotnet 3.3.14.2

### DIFF
--- a/curations/nuget/nuget/-/AutoItX.Dotnet.yaml
+++ b/curations/nuget/nuget/-/AutoItX.Dotnet.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.3.14.2:
     licensed:
-      declared: MIT
+      declared: OTHER
   3.3.14.5:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/AutoItX.Dotnet.yaml
+++ b/curations/nuget/nuget/-/AutoItX.Dotnet.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.3.14.2:
+    licensed:
+      declared: MIT
   3.3.14.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AutoItX.Dotnet 3.3.14.2

**Details:**
NMP license field indicates MIT
GitHub license is MIT: https://github.com/mochajs/mocha/blob/v3.3.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AutoItX.Dotnet 3.3.14.2](https://clearlydefined.io/definitions/nuget/nuget/-/AutoItX.Dotnet/3.3.14.2/3.3.14.2)