### PR TITLE
slf4j-test 1.2.0

### DIFF
--- a/curations/maven/mavencentral/uk.org.lidalia/slf4j-test.yaml
+++ b/curations/maven/mavencentral/uk.org.lidalia/slf4j-test.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: slf4j-test
+  namespace: uk.org.lidalia
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
slf4j-test 1.2.0

**Details:**
ClearlyDefined no files
Maven license field indicates MIT
Maven links to MIT: https://raw.githubusercontent.com/Mahoney/lidalia-parent/master/X11-LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [slf4j-test 1.2.0](https://clearlydefined.io/definitions/maven/mavencentral/uk.org.lidalia/slf4j-test/1.2.0/1.2.0)