### PR TITLE
System.Management.Automation 6.2.1

### DIFF
--- a/curations/nuget/nuget/-/System.Management.Automation.yaml
+++ b/curations/nuget/nuget/-/System.Management.Automation.yaml
@@ -12,6 +12,9 @@ revisions:
   6.2.0:
     licensed:
       declared: MIT
+  6.2.1:
+    licensed:
+      declared: MIT
   6.2.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Management.Automation 6.2.1

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
GitHub license is MIT: https://github.com/PowerShell/PowerShell/blob/v6.2.1/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [System.Management.Automation 6.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Management.Automation/6.2.1/6.2.1)