### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/tjvantoll/nativescript-iqkeyboardmanager.yaml
+++ b/curations/git/github/tjvantoll/nativescript-iqkeyboardmanager.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: nativescript-iqkeyboardmanager
+  namespace: tjvantoll
+  provider: github
+  type: git
+revisions:
+  b705493e6cc5ab99515758179a5479ed32cb50e7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The Declared License has one NOASSERTION where the Component has MIT License declared.

link to the license file : https://github.com/tjvantoll/nativescript-IQKeyboardManager/blob/1.5.1/LICENSE

**Resolution:**
Since there is NOASSERTION and no License declared, it is being curated as MIT instead of NOASSERTION

link to the license file : https://github.com/tjvantoll/nativescript-IQKeyboardManager/blob/1.5.1/LICENSE

**Affected definitions**:
- [nativescript-iqkeyboardmanager b705493e6cc5ab99515758179a5479ed32cb50e7](https://clearlydefined.io/definitions/git/github/tjvantoll/nativescript-iqkeyboardmanager/b705493e6cc5ab99515758179a5479ed32cb50e7/b705493e6cc5ab99515758179a5479ed32cb50e7)