### PR TITLE
Add license to v1.1.1 go-multierror

### DIFF
--- a/curations/git/github/hashicorp/go-multierror.yaml
+++ b/curations/git/github/hashicorp/go-multierror.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: go-multierror
+  namespace: hashicorp
+  provider: github
+  type: git
+revisions:
+  9974e9ec57696378079ecc3accd3d6f29401b3a0:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Add license to v1.1.1 go-multierror

**Details:**
Updates the license for go-multierror to MPL-2.0

**Resolution:**
Updates the license for go-multierror to MPL-2.0

**Affected definitions**:
- [go-multierror 9974e9ec57696378079ecc3accd3d6f29401b3a0](https://clearlydefined.io/definitions/git/github/hashicorp/go-multierror/9974e9ec57696378079ecc3accd3d6f29401b3a0/9974e9ec57696378079ecc3accd3d6f29401b3a0)