### PR TITLE
NMemory 1.1.0

### DIFF
--- a/curations/nuget/nuget/-/NMemory.yaml
+++ b/curations/nuget/nuget/-/NMemory.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.1:
     licensed:
       declared: MIT
+  1.1.0:
+    licensed:
+      declared: MIT
   1.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NMemory 1.1.0

**Details:**
ClearlyDefined nuspec license link broken
Nuget license links is MIT: 
https://github.com/zzzprojects/nmemory/blob/8cddab81a33e553b4c70f3e097bb84593a84fb5d/LICENSE
Project links NMemory homepage

**Resolution:**
MIT

**Affected definitions**:
- [NMemory 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/NMemory/1.1.0/1.1.0)