### PR TITLE
 System.Data.SQLite.Core 1.0.111

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
@@ -12,6 +12,9 @@ revisions:
   1.0.110:
     licensed:
       declared: OTHER
+  1.0.111:
+    licensed:
+      declared: OTHER
   1.0.112:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 System.Data.SQLite.Core 1.0.111

**Details:**
ClearlyDefined license is Public Domain
Nuget license link is Public Domain
Project links to SQLite home page

**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.Core 1.0.111](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Core/1.0.111/1.0.111)