### PR TITLE
ecj 4.4.2

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.jdt.core.compiler/ecj.yaml
+++ b/curations/maven/mavencentral/org.eclipse.jdt.core.compiler/ecj.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  4.4.2:
+    licensed:
+      declared: EPL-1.0
   4.6.1:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ecj 4.4.2

**Details:**
ClearlyDefined no license info found
Maven license is EPL-1.0
POM indicates EPL-1.0

**Resolution:**
EPL-1.0

**Affected definitions**:
- [ecj 4.4.2](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.jdt.core.compiler/ecj/4.4.2/4.4.2)