### PR TITLE
azureml-pipeline-steps 1.35.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
@@ -180,6 +180,9 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.35.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-steps 1.35.0

**Details:**
ClearlyDefined no files
PyPi license field indicates OTHER: https://aka.ms/azureml-sdk-license
Project page links to Azure Machine Learning SDK for Python

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-pipeline-steps 1.35.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-steps/1.35.0/1.35.0)