### PR TITLE
azureml-train-automl-client 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -141,6 +141,9 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client 1.36.0

**Details:**
ClearlyDefined no files
PyPi license field indicates OTHER: Other/Proprietary License (https://aka.ms/azureml-sdk-license)
Project links to Azure Machine Learning SDK for Python

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-train-automl-client 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.36.0/1.36.0)