### PR TITLE
NSwag.MSBuild 12.3.1

### DIFF
--- a/curations/nuget/nuget/-/NSwag.MSBuild.yaml
+++ b/curations/nuget/nuget/-/NSwag.MSBuild.yaml
@@ -9,6 +9,9 @@ revisions:
   12.2.5:
     licensed:
       declared: MIT
+  12.3.1:
+    licensed:
+      declared: MIT
   13.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NSwag.MSBuild 12.3.1

**Details:**
ClearlyDefined download link broken
Nuget license field links to MIT
GitHub license is MIT: https://github.com/RicoSuter/NSwag/blob/master/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [NSwag.MSBuild 12.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/NSwag.MSBuild/12.3.1/12.3.1)