### PR TITLE
 asm-commons 5.1

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm-commons.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm-commons.yaml
@@ -12,6 +12,9 @@ revisions:
         path: META-INF/MANIFEST.MF
     licensed:
       declared: BSD-3-Clause
+  '5.1':
+    licensed:
+      declared: BSD-3-Clause
   '6.0':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 asm-commons 5.1

**Details:**
Maven license is BSD-3-Clause: https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.1/asm-commons-5.1.pom
Project license is BSD-3-Clause: https://asm.ow2.io/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm-commons 5.1](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm-commons/5.1/5.1)