### PR TITLE
AppForSharePointOnlineWebToolkit 3.1.5

### DIFF
--- a/curations/nuget/nuget/-/AppForSharePointOnlineWebToolkit.yaml
+++ b/curations/nuget/nuget/-/AppForSharePointOnlineWebToolkit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AppForSharePointOnlineWebToolkit
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.5:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AppForSharePointOnlineWebToolkit 3.1.5

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license link is broken
Nuget project link is broken

**Resolution:**
NONE

**Affected definitions**:
- [AppForSharePointOnlineWebToolkit 3.1.5](https://clearlydefined.io/definitions/nuget/nuget/-/AppForSharePointOnlineWebToolkit/3.1.5/3.1.5)