### PR TITLE
NuGet.Versioning 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -9,6 +9,9 @@ revisions:
   3.3.0:
     licensed:
       declared: Apache-2.0
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Versioning 3.5.0

**Details:**
Nuget license links to Apache-2.0: https://licenses.nuget.org/Apache-2.0
GitHub project license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt


**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Versioning 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/3.5.0/3.5.0)