### PR TITLE
 System.Data.SQLite.Core 1.0.108

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Core.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.102:
     licensed:
       declared: OTHER
+  1.0.108:
+    licensed:
+      declared: OTHER
   1.0.109.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 System.Data.SQLite.Core 1.0.108

**Details:**
ClearlyDefined nuspec license links to Public Domain
Nuget license field links to Public Domain
Project links to SQLLite home page

**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.Core 1.0.108](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Core/1.0.108/1.0.108)