### PR TITLE
hadoop-core 1.2.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.hadoop/hadoop-core.yaml
+++ b/curations/maven/mavencentral/org.apache.hadoop/hadoop-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hadoop-core
+  namespace: org.apache.hadoop
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hadoop-core 1.2.1

**Details:**
Maven license field is Apache-2.0
POM is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [hadoop-core 1.2.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.hadoop/hadoop-core/1.2.1/1.2.1)