### PR TITLE
commander 1.3.2

### DIFF
--- a/curations/npm/npmjs/-/commander.yaml
+++ b/curations/npm/npmjs/-/commander.yaml
@@ -12,6 +12,9 @@ revisions:
   1.1.1:
     licensed:
       declared: MIT
+  1.3.2:
+    licensed:
+      declared: MIT
   2.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commander 1.3.2

**Details:**
ClearlyDefined Readme includes MIT
NPM License field is MIT
GitHub Readme includes MIT: https://github.com/tj/commander.js/blob/1.3.2/Readme.md

**Resolution:**
MIT

**Affected definitions**:
- [commander 1.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/commander/1.3.2/1.3.2)