### PR TITLE
junit-jupiter 5.6.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -13,6 +13,9 @@ revisions:
   5.5.2:
     licensed:
       declared: EPL-2.0
+  5.6.0:
+    licensed:
+      declared: EPL-2.0
   5.6.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter 5.6.0

**Details:**
ClearlyDefined license is EPL-2.0
Maven license field indicates EPL-2.0
Maven license linked is EPL-2.0: https://www.eclipse.org/legal/epl-v20.html

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter 5.6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.6.0/5.6.0)