### PR TITLE
 System.Spatial 5.8.5

### DIFF
--- a/curations/nuget/nuget/-/System.Spatial.yaml
+++ b/curations/nuget/nuget/-/System.Spatial.yaml
@@ -21,3 +21,6 @@ revisions:
   5.8.4:
     licensed:
       declared: MIT
+  5.8.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 System.Spatial 5.8.5

**Details:**
ClearlyDefined license is MIT
Nuget License field links to MIT


**Resolution:**
MIT

**Affected definitions**:
- [System.Spatial 5.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/System.Spatial/5.8.5/5.8.5)