### PR TITLE
CsvHelper 12.1.0

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  12.1.0:
+    licensed:
+      declared: MS-PL OR Apache-2.0
   12.1.1:
     licensed:
       declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CsvHelper 12.1.0

**Details:**
Nuget license field indicates MS-PL OR Apache-2.0
GitHub is MS-PL OR Apache-2.0: https://github.com/JoshClose/CsvHelper/blob/12.1.0/LICENSE.txt

**Resolution:**
MS-PL OR Apache-2.0

**Affected definitions**:
- [CsvHelper 12.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/12.1.0/12.1.0)