### PR TITLE
MongoDB.Driver.Core.signed 2.10.4

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Driver.Core.signed.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Driver.Core.signed.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.10.4:
+    licensed:
+      declared: Apache-2.0
   2.11.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MongoDB.Driver.Core.signed 2.10.4

**Details:**
ClearlyDefined license is Apache-2.0
Nuget license links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/mongodb/mongo-csharp-driver/blob/v2.10.4/License.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [MongoDB.Driver.Core.signed 2.10.4](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Driver.Core.signed/2.10.4/2.10.4)