### PR TITLE
parsimmon 0.5.1

### DIFF
--- a/curations/npm/npmjs/-/parsimmon.yaml
+++ b/curations/npm/npmjs/-/parsimmon.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: parsimmon
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
parsimmon 0.5.1

**Details:**
ClearlyDefined package.json link to project with MIT
NPM license field is MIT
GitHub is MIT: https://github.com/jneen/parsimmon/blob/v0.5.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [parsimmon 0.5.1](https://clearlydefined.io/definitions/npm/npmjs/-/parsimmon/0.5.1/0.5.1)