### PR TITLE
azureml-dataprep 2.24.4

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -132,6 +132,9 @@ revisions:
   2.24.0:
     licensed:
       declared: OTHER
+  2.24.4:
+    licensed:
+      declared: OTHER
   2.3.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.24.4

**Details:**
ClearlyDefined no files
PyPi indicates OTHER
Azureml SDK: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.24.4](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.24.4/2.24.4)