### PR TITLE
azureml-telemetry 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -204,6 +204,9 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-telemetry 1.36.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER
Azureml SDK: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-telemetry 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.36.0/1.36.0)