### PR TITLE
 azureml-train-core 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-core.yaml
+++ b/curations/pypi/pypi/-/azureml-train-core.yaml
@@ -195,6 +195,9 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 azureml-train-core 1.36.0

**Details:**
ClearlyDefined no files
PyPi license field indicates OTHER
Azureml SDK: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-train-core 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-core/1.36.0/1.36.0)