### PR TITLE
azureml-train-restclients-hyperdrive 1.35.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -180,6 +180,9 @@ revisions:
   1.34.0:
     licensed:
       declared: OTHER
+  1.35.0:
+    licensed:
+      declared: OTHER
   1.36.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-restclients-hyperdrive 1.35.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER
Azureml SDK: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.35.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.35.0/1.35.0)