### PR TITLE
azureml-automl-core 1.36.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -174,6 +174,9 @@ revisions:
   1.34.1:
     licensed:
       declared: OTHER
+  1.36.1:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.36.1

**Details:**
ClearlyDefined no files
PyPi indicates other
Azureml SDK: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-automl-core 1.36.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.36.1/1.36.1)