### PR TITLE
javax.annotation-api 1.3.1

### DIFF
--- a/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -9,7 +9,7 @@ revisions:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.3.1:
     licensed:
-      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.3.2:
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -7,6 +7,9 @@ revisions:
   '1.2':
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
-  '1.3.2':
+  1.3.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0
+  1.3.2:
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -9,7 +9,7 @@ revisions:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.3.1:
     licensed:
-      declared: GPL-2.0-only WITH Classpath-exception-2.0
+      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.3.2:
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.annotation-api 1.3.1

**Details:**
ClearlyDefined license file is: GPL-2.0-only WITH Classpath-exception-2.0
Maven license is: GPL-2.0-only WITH Classpath-exception-2.0
https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api/1.3.1

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.annotation-api 1.3.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.annotation/javax.annotation-api/1.3.1/1.3.1)