### PR TITLE
WebRequest.WebRequestHandler 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/WebRequest.WebRequestHandler.yaml
+++ b/curations/nuget/nuget/-/WebRequest.WebRequestHandler.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WebRequest.WebRequestHandler
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WebRequest.WebRequestHandler 1.0.0

**Details:**
ClearlyDefined - nuspec file did not have license info
Nuget did not have license field
Project link had no license info: https://docs.microsoft.com/en-us/dotnet/api/system.net.http.webrequesthandler?redirectedfrom=MSDN&view=netframework-4.8

**Resolution:**
NONE

**Affected definitions**:
- [WebRequest.WebRequestHandler 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/WebRequest.WebRequestHandler/1.0.0/1.0.0)