### PR TITLE
mocha 1.18.2

### DIFF
--- a/curations/npm/npmjs/-/mocha.yaml
+++ b/curations/npm/npmjs/-/mocha.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mocha
+  provider: npmjs
+  type: npm
+revisions:
+  1.18.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mocha 1.18.2

**Details:**
ClearlyDefined package.json project link is MIT
NPM license field is MIT
GitHub license is MIT: https://github.com/mochajs/mocha/blob/1.18.2/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [mocha 1.18.2](https://clearlydefined.io/definitions/npm/npmjs/-/mocha/1.18.2/1.18.2)