### PR TITLE
System.IO.Abstractions 6.0.21

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -24,6 +24,9 @@ revisions:
   6.0.14:
     licensed:
       declared: MIT
+  6.0.21:
+    licensed:
+      declared: MIT
   7.0.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions 6.0.21

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
GitHub license is MIT: https://github.com/TestableIO/System.IO.Abstractions/blob/v6.0.21/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions 6.0.21](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/6.0.21/6.0.21)