### PR TITLE
jmock 2.4.0

### DIFF
--- a/curations/maven/mavencentral/org.jmock/jmock.yaml
+++ b/curations/maven/mavencentral/org.jmock/jmock.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jmock
+  namespace: org.jmock
+  provider: mavencentral
+  type: maven
+revisions:
+  2.4.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jmock 2.4.0

**Details:**
Maven license field is BSD
Maven license link is: BSD-3-Clause:  http://jmock.org/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jmock 2.4.0](https://clearlydefined.io/definitions/maven/mavencentral/org.jmock/jmock/2.4.0/2.4.0)