### PR TITLE
jersey-multipart 1.19

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey.contribs/jersey-multipart.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey.contribs/jersey-multipart.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-multipart
+  namespace: com.sun.jersey.contribs
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.19':
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-multipart 1.19

**Details:**
ClearlyDefined license is GPL-2.0-only WITH Classpath-exception-2.0
Maven license is same as above: https://mvnrepository.com/artifact/com.sun.jersey.contribs/jersey-multipart/1.19

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-multipart 1.19](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey.contribs/jersey-multipart/1.19/1.19)