### PR TITLE
junit-jupiter 5.7.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -22,6 +22,9 @@ revisions:
   5.7.0:
     licensed:
       declared: EPL-2.0
+  5.7.1:
+    licensed:
+      declared: EPL-2.0
   5.7.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter 5.7.1

**Details:**
ClearlyDefined license is EPL-2.0
Maven license field is EPL-2.0: https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter/5.7.1
Maven license link is EPL-2.0: https://www.eclipse.org/legal/epl-v20.html

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter 5.7.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.7.1/5.7.1)