### PR TITLE
EntityFramework.MappingAPI 6.0.0.7

### DIFF
--- a/curations/nuget/nuget/-/EntityFramework.MappingAPI.yaml
+++ b/curations/nuget/nuget/-/EntityFramework.MappingAPI.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   6.0.0.7:
     licensed:
-      declared: NONE
+      declared: BSD-2-Clause
   6.1.0.9:
     licensed:
       declared: BSD-2-Clause

--- a/curations/nuget/nuget/-/EntityFramework.MappingAPI.yaml
+++ b/curations/nuget/nuget/-/EntityFramework.MappingAPI.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  6.0.0.7:
+    licensed:
+      declared: NONE
   6.1.0.9:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EntityFramework.MappingAPI 6.0.0.7

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license link is broken
Nuget Project link goes to: https://entityframework-extensions.net/

**Resolution:**
NONE

**Affected definitions**:
- [EntityFramework.MappingAPI 6.0.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/EntityFramework.MappingAPI/6.0.0.7/6.0.0.7)