### PR TITLE
geoip-api 1.3.1

### DIFF
--- a/curations/maven/mavencentral/com.maxmind.geoip/geoip-api.yaml
+++ b/curations/maven/mavencentral/com.maxmind.geoip/geoip-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: geoip-api
+  namespace: com.maxmind.geoip
+  provider: mavencentral
+  type: maven
+revisions:
+  1.3.1:
+    licensed:
+      declared: LGPL-2.1-only

--- a/curations/maven/mavencentral/com.maxmind.geoip/geoip-api.yaml
+++ b/curations/maven/mavencentral/com.maxmind.geoip/geoip-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.3.1:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
geoip-api 1.3.1

**Details:**
Maven license and link is LGPL-2.1-only: https://mvnrepository.com/artifact/com.maxmind.geoip/geoip-api/1.3.1
GitHub is LGPL-2.1-only: https://github.com/maxmind/geoip-api-java/blob/v1.3.1/LICENSE

**Resolution:**
LGPL-2.1-only

**Affected definitions**:
- [geoip-api 1.3.1](https://clearlydefined.io/definitions/maven/mavencentral/com.maxmind.geoip/geoip-api/1.3.1/1.3.1)