### PR TITLE
mercator 0.1.9

### DIFF
--- a/curations/npm/npmjs/-/mercator.yaml
+++ b/curations/npm/npmjs/-/mercator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mercator
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.9:
+    licensed:
+      declared: GPL-1.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mercator 0.1.9

**Details:**
ClearllyDefined package.json indicates GPL
NPM license field indicates GPL
GitHub does not include license

**Resolution:**
GPL-1.0-or-later
Per curation guidelines: "If the only license information is “GPL,” with no COPYING license file, code the license as “GPL-1.0-or-later." 

**Affected definitions**:
- [mercator 0.1.9](https://clearlydefined.io/definitions/npm/npmjs/-/mercator/0.1.9/0.1.9)