### PR TITLE
SQLinq3 3.0.1

### DIFF
--- a/curations/nuget/nuget/-/SQLinq3.yaml
+++ b/curations/nuget/nuget/-/SQLinq3.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SQLinq3
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.1:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SQLinq3 3.0.1

**Details:**
Nuspec license links to LGPL-2.1-only
Nuget license link is LGPL-2.1-only
GitHub license is LGPL-2.1-only: https://github.com/crpietschmann/SQLinq/blob/master/LICENSE

**Resolution:**
LGPL-2.1-only

**Affected definitions**:
- [SQLinq3 3.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/SQLinq3/3.0.1/3.0.1)