### PR TITLE
 antlr 2.7.6

### DIFF
--- a/curations/maven/mavencentral/antlr/antlr.yaml
+++ b/curations/maven/mavencentral/antlr/antlr.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.7.6:
+    licensed:
+      declared: BSD-3-Clause
   2.7.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 antlr 2.7.6

**Details:**
Maven does not include license info but links to https://www.antlr.org/  That page includes link to GitHub for source code which has a BSD-3-Clause license: https://github.com/antlr/antlr4/blob/master/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [antlr 2.7.6](https://clearlydefined.io/definitions/maven/mavencentral/antlr/antlr/2.7.6/2.7.6)