### PR TITLE
Swashbuckle.SwaggerGen 6.0.0-beta902

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.SwaggerGen.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.SwaggerGen.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle.SwaggerGen
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.0-beta902:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.SwaggerGen 6.0.0-beta902

**Details:**
ClearlyDefined license links is broken. 
 Project links to GitHub with BSD-3-Clause
Nuget license link is broken.
GitHub license is BSD-3-Clause: https://github.com/domaindrivendev/Swashbuckle.WebApi/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Swashbuckle.SwaggerGen 6.0.0-beta902](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.SwaggerGen/6.0.0-beta902/6.0.0-beta902)