### PR TITLE
SonarAnalyzer.CSharp 7.3.0.5690

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -35,7 +35,7 @@ revisions:
       declared: LGPL-3.0-or-later
   7.3.0.5690:
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later
   7.7.0.7192:
     licensed:
       declared: LGPL-3.0-or-later

--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -33,6 +33,9 @@ revisions:
   7.17.0.9346:
     licensed:
       declared: LGPL-3.0-or-later
+  7.3.0.5690:
+    licensed:
+      declared: LGPL-3.0-only
   7.7.0.7192:
     licensed:
       declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SonarAnalyzer.CSharp 7.3.0.5690

**Details:**
ClearlyDefined license link broken
Nuget license is LGPL-3.0-only: https://licenses.nuget.org/LGPL-3.0-only
Project links to: https://www.sonarlint.org/visualstudio

**Resolution:**
LGPL-3.0-only

**Affected definitions**:
- [SonarAnalyzer.CSharp 7.3.0.5690](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/7.3.0.5690/7.3.0.5690)