### PR TITLE
MongoDB.Bson.signed 2.10.4

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Bson.signed.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Bson.signed.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
-  2.8.0:
+  2.10.4:
     licensed:
       declared: Apache-2.0
   2.11.2:
+    licensed:
+      declared: Apache-2.0
+  2.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MongoDB.Bson.signed 2.10.4

**Details:**
ClearlyDefined license is Apache-2.0
Nuget license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [MongoDB.Bson.signed 2.10.4](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Bson.signed/2.10.4/2.10.4)