### PR TITLE
Swashbuckle.Swagger 6.0.0-beta902

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.Swagger.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.Swagger.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle.Swagger
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.0-beta902:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.Swagger 6.0.0-beta902

**Details:**
ClearlyDefined nuspec license link broken
Nuget license link broken
GItHub license is BSD-3-Clause: https://github.com/domaindrivendev/Swashbuckle.WebApi/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Swashbuckle.Swagger 6.0.0-beta902](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.Swagger/6.0.0-beta902/6.0.0-beta902)