### PR TITLE
jakarta.ws.rs-api 2.1.5

### DIFF
--- a/curations/maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.1.5:
+    licensed:
+      declared: EPL-2.0 WITH Classpath-exception-2.0
   2.1.6:
     licensed:
       declared: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   2.1.5:
     licensed:
-      declared: EPL-2.0 WITH Classpath-exception-2.0
+      declared: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
   2.1.6:
     licensed:
       declared: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jakarta.ws.rs-api 2.1.5

**Details:**
ClearlyDefined license is EPL-2.0 WITH Classpath-exception-2.0
Maven indicates EPL-2.0: https://mvnrepository.com/artifact/jakarta.ws.rs/jakarta.ws.rs-api/2.1.5

**Resolution:**
EPL-2.0 WITH Classpath-exception-2.0

**Affected definitions**:
- [jakarta.ws.rs-api 2.1.5](https://clearlydefined.io/definitions/maven/mavencentral/jakarta.ws.rs/jakarta.ws.rs-api/2.1.5/2.1.5)