### PR TITLE
Newtonsoft.Json 5.0.4

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -43,6 +43,9 @@ revisions:
   5.0.1:
     licensed:
       declared: MIT
+  5.0.4:
+    licensed:
+      declared: MIT
   5.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json 5.0.4

**Details:**
ClearlyDefined nuspec license link broken
Nuget license is MIT
GitHub license is MIT: https://github.com/JamesNK/Newtonsoft.Json/blob/master/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Newtonsoft.Json 5.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/5.0.4/5.0.4)