### PR TITLE
plumber 0.4.8

### DIFF
--- a/curations/npm/npmjs/-/plumber.yaml
+++ b/curations/npm/npmjs/-/plumber.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: plumber
+  provider: npmjs
+  type: npm
+revisions:
+  0.4.8:
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
plumber 0.4.8

**Details:**
ClearlyDefined license file is GPL-3.0-only
NPM license field is GPL
GitHub package.json indicates GPL

**Resolution:**
GPL-3.0-only

**Affected definitions**:
- [plumber 0.4.8](https://clearlydefined.io/definitions/npm/npmjs/-/plumber/0.4.8/0.4.8)