### PR TITLE
asm-commons 5.2

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm-commons.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm-commons.yaml
@@ -15,6 +15,9 @@ revisions:
   '5.1':
     licensed:
       declared: BSD-3-Clause
+  '5.2':
+    licensed:
+      declared: BSD-3-Clause
   '6.0':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
asm-commons 5.2

**Details:**
ClearlyDefined no files
Maven license field is BSD
Maven license link is BSD-3-Clause: https://asm.ow2.io/license.html


**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm-commons 5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm-commons/5.2/5.2)