### PR TITLE
Sendgrid 8.0.5

### DIFF
--- a/curations/nuget/nuget/-/Sendgrid.yaml
+++ b/curations/nuget/nuget/-/Sendgrid.yaml
@@ -12,6 +12,9 @@ revisions:
   8.0.2:
     licensed:
       declared: MIT
+  8.0.5:
+    licensed:
+      declared: MIT
   9.10.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Sendgrid 8.0.5

**Details:**
Nuspec license link is broken
Nuget license is MIT
GitHub license is MIT: https://github.com/sendgrid/sendgrid-csharp/blob/v8.0.5/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [Sendgrid 8.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Sendgrid/8.0.5/8.0.5)