### PR TITLE
jodd-core 5.0.13

### DIFF
--- a/curations/maven/mavencentral/org.jodd/jodd-core.yaml
+++ b/curations/maven/mavencentral/org.jodd/jodd-core.yaml
@@ -7,3 +7,6 @@ revisions:
   3.5.2:
     licensed:
       declared: BSD-2-Clause
+  5.0.13:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jodd-core 5.0.13

**Details:**
Maven license is BSD-2-Clause: https://mvnrepository.com/artifact/org.jodd/jodd-core/5.0.13
POM indicates BSD-2-Clause
GitHub is BSD-2-Clause: https://github.com/oblac/jodd/blob/master/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [jodd-core 5.0.13](https://clearlydefined.io/definitions/maven/mavencentral/org.jodd/jodd-core/5.0.13/5.0.13)