### PR TITLE
 Unity.AspNet.WebApi 5.10.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.AspNet.WebApi.yaml
+++ b/curations/nuget/nuget/-/Unity.AspNet.WebApi.yaml
@@ -21,6 +21,9 @@ revisions:
   5.0.9:
     licensed:
       declared: Apache-2.0
+  5.10.0:
+    licensed:
+      declared: Apache-2.0
   5.11.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Unity.AspNet.WebApi 5.10.0

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/unitycontainer/aspnet-webapi/blob/5.10.0.88/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.AspNet.WebApi 5.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.AspNet.WebApi/5.10.0/5.10.0)