### PR TITLE
Selenium.Firefox.WebDriver 0.19.1

### DIFF
--- a/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.19.1:
+    licensed:
+      declared: Unlicense
   0.22.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.Firefox.WebDriver 0.19.1

**Details:**
ClearlyDefined nuspec license links to Unlicense
Nuget license field links to Unlicense
GitHub license is Unlicense: https://github.com/jbaranda/nupkg-selenium-webdrivers/blob/master/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.Firefox.WebDriver 0.19.1](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.Firefox.WebDriver/0.19.1/0.19.1)