### PR TITLE
glob 3.2.8

### DIFF
--- a/curations/npm/npmjs/-/glob.yaml
+++ b/curations/npm/npmjs/-/glob.yaml
@@ -18,6 +18,9 @@ revisions:
   3.2.3:
     licensed:
       declared: BSD-2-Clause
+  3.2.8:
+    licensed:
+      declared: BSD-2-Clause
   4.0.4:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
glob 3.2.8

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM License field states ISC
GitHub license is BSD-2-Clause: https://github.com/isaacs/node-glob/blob/v3.2.8/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [glob 3.2.8](https://clearlydefined.io/definitions/npm/npmjs/-/glob/3.2.8/3.2.8)