### PR TITLE
 aether-util 0.9.0.M2

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.aether/aether-util.yaml
+++ b/curations/maven/mavencentral/org.eclipse.aether/aether-util.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.9.0.M2:
+    licensed:
+      declared: EPL-1.0
   1.0.2.v20150114:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 aether-util 0.9.0.M2

**Details:**
ClearlyDefined About file is EPL-1.0
Maven license link and POM indicate EPL-1.0: http://www.eclipse.org/legal/epl-v10.html
Maven respository: https://mvnrepository.com/artifact/org.eclipse.aether/aether-util/0.9.0.M2

**Resolution:**
EPL-1.0

**Affected definitions**:
- [aether-util 0.9.0.M2](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.aether/aether-util/0.9.0.M2/0.9.0.M2)