### PR TITLE
 org.jacoco.agent 0.8.2

### DIFF
--- a/curations/maven/mavencentral/org.jacoco/org.jacoco.agent.yaml
+++ b/curations/maven/mavencentral/org.jacoco/org.jacoco.agent.yaml
@@ -7,6 +7,9 @@ revisions:
   0.7.9:
     licensed:
       declared: EPL-1.0
+  0.8.2:
+    licensed:
+      declared: EPL-1.0
   0.8.3:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 org.jacoco.agent 0.8.2

**Details:**
ClearlyDefined pom indicates EPL-1.0
Maven license field is EPL-1.0: https://mvnrepository.com/artifact/org.jacoco/org.jacoco.agent/0.8.2
Maven POM is EPL-1.0

**Resolution:**
EPL-1.0

**Affected definitions**:
- [org.jacoco.agent 0.8.2](https://clearlydefined.io/definitions/maven/mavencentral/org.jacoco/org.jacoco.agent/0.8.2/0.8.2)