### PR TITLE
LibGit2Sharp.NativeBinaries 1.0.210

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -23,7 +23,7 @@ revisions:
       declared: GPL-2.0-only WITH GCC-exception-2.0
   1.0.210:
     licensed:
-      declared: GPL-2.0-with-GCC-exception
+      declared: GPL-2.0-only WITH GCC-exception-2.0
   1.0.217:
     licensed:
       declared: GPL-2.0-only WITH GCC-exception-2.0

--- a/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.NativeBinaries.yaml
@@ -21,6 +21,9 @@ revisions:
   1.0.185:
     licensed:
       declared: GPL-2.0-only WITH GCC-exception-2.0
+  1.0.210:
+    licensed:
+      declared: GPL-2.0-with-GCC-exception
   1.0.217:
     licensed:
       declared: GPL-2.0-only WITH GCC-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LibGit2Sharp.NativeBinaries 1.0.210

**Details:**
ClearlyDefined COPYING file is GPL-2.0-with-GCC-exception
Nuget license field links to GPL-2.0-with-GCC-exception
GitHub license is MIT: https://github.com/libgit2/libgit2sharp.nativebinaries/blob/d080f13055a1c84a155b2509711eaf686a7d2f60/LICENSE.md

**Resolution:**
GPL-2.0-with-GCC-exception

**Affected definitions**:
- [LibGit2Sharp.NativeBinaries 1.0.210](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp.NativeBinaries/1.0.210/1.0.210)