### PR TITLE
 jinjava 2.5.6

### DIFF
--- a/curations/maven/mavencentral/com.hubspot.jinjava/jinjava.yaml
+++ b/curations/maven/mavencentral/com.hubspot.jinjava/jinjava.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jinjava
+  namespace: com.hubspot.jinjava
+  provider: mavencentral
+  type: maven
+revisions:
+  2.5.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jinjava 2.5.6

**Details:**
ClearlyDefined no files
Maven no license field or linked license: https://mvnrepository.com/artifact/com.hubspot.jinjava/jinjava/2.5.6
GitHub license is Apache-2.0: https://github.com/HubSpot/jinjava/blob/jinjava-2.5.6/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jinjava 2.5.6](https://clearlydefined.io/definitions/maven/mavencentral/com.hubspot.jinjava/jinjava/2.5.6/2.5.6)