### PR TITLE
org.jacoco.core 0.8.4

### DIFF
--- a/curations/maven/mavencentral/org.jacoco/org.jacoco.core.yaml
+++ b/curations/maven/mavencentral/org.jacoco/org.jacoco.core.yaml
@@ -7,3 +7,6 @@ revisions:
   0.7.9:
     licensed:
       declared: EPL-1.0
+  0.8.4:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jacoco.core 0.8.4

**Details:**
ClearlyDefined About file indicates EPL-1.0
Maven license field is EPL-1.0: https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin/0.8.4
POM is EPL-1.0

**Resolution:**
EPL-1.0

**Affected definitions**:
- [org.jacoco.core 0.8.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jacoco/org.jacoco.core/0.8.4/0.8.4)