### PR TITLE
commons-digester 1.6

### DIFF
--- a/curations/maven/mavencentral/commons-digester/commons-digester.yaml
+++ b/curations/maven/mavencentral/commons-digester/commons-digester.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.6':
+    licensed:
+      declared: Apache-2.0
   '1.8':
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-digester 1.6

**Details:**
ClearlyDefined license file is Apache-2.0
Maven license field is Apache-2.0: https://mvnrepository.com/artifact/commons-digester/commons-digester/1.6

**Resolution:**
Apache-2.0

**Affected definitions**:
- [commons-digester 1.6](https://clearlydefined.io/definitions/maven/mavencentral/commons-digester/commons-digester/1.6/1.6)