### PR TITLE
npmlog 1.2.0

### DIFF
--- a/curations/npm/npmjs/-/npmlog.yaml
+++ b/curations/npm/npmjs/-/npmlog.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: npmlog
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npmlog 1.2.0

**Details:**
ClearlyDefined license file is BSD-2-Clause
NPM license field states ISC
GitHub license is BSD-2-Clause: https://github.com/npm/npmlog/blob/v1.2.0/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [npmlog 1.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/npmlog/1.2.0/1.2.0)