### PR TITLE
asm 5.1

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -15,6 +15,9 @@ revisions:
   5.0.4:
     licensed:
       declared: BSD-3-Clause
+  '5.1':
+    licensed:
+      declared: BSD-3-Clause
   '6.0':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
asm 5.1

**Details:**
Maven license field is BSD
https://mvnrepository.com/artifact/org.ow2.asm/asm/5.1
Maven POM is BSD-3-Clause
Maven linked license is BSD-3-Clause: https://asm.ow2.io/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm 5.1](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm/5.1/5.1)