### PR TITLE
Ninject.MockingKernel 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MockingKernel.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL
   3.2.2:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.MockingKernel 3.2.0

**Details:**
ClearlyDefined nuspec states Apache-2.0 OR MS-PL
Nuget license field links to same as above
GitHub license is same as above: https://github.com/ninject/Ninject/blob/3.2.0-final/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.MockingKernel 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MockingKernel/3.2.0/3.2.0)