### PR TITLE
ExtentReports 4.1.0

### DIFF
--- a/curations/nuget/nuget/-/ExtentReports.yaml
+++ b/curations/nuget/nuget/-/ExtentReports.yaml
@@ -6,3 +6,6 @@ revisions:
   2.41.0:
     licensed:
       declared: BSD-3-Clause
+  4.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ExtentReports 4.1.0

**Details:**
ClearlyDefined license is Apache-2.0
Nuget License field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/extent-framework/extentreports-csharp/blob/v4.1.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ExtentReports 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/ExtentReports/4.1.0/4.1.0)