### PR TITLE
kendo-ooxml 1.6.3

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-ooxml.yaml
+++ b/curations/npm/npmjs/@progress/kendo-ooxml.yaml
@@ -25,3 +25,6 @@ revisions:
   1.6.2:
     licensed:
       declared: OTHER
+  1.6.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-ooxml 1.6.3

**Details:**
ClearlyDefined license is OTHER
NPM license field indicates OTHER
Telerik End User License Agreement: https://www.telerik.com/purchase/license-agreement/kendo-ui

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-ooxml 1.6.3](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-ooxml/1.6.3/1.6.3)