### PR TITLE
 json-schema-validator 0.1.23

### DIFF
--- a/curations/maven/mavencentral/com.networknt/json-schema-validator.yaml
+++ b/curations/maven/mavencentral/com.networknt/json-schema-validator.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.1.23:
+    licensed:
+      declared: Apache-2.0
   1.0.57:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 json-schema-validator 0.1.23

**Details:**
ClearlyDefined POM is Apache-2.0
Maven POM for a later version is Apache-2.0
GitHub license is Apache-2.0: https://github.com/everit-org/json-schema/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [json-schema-validator 0.1.23](https://clearlydefined.io/definitions/maven/mavencentral/com.networknt/json-schema-validator/0.1.23/0.1.23)