### PR TITLE
set-filter 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/set-filter.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/set-filter.yaml
@@ -10,9 +10,12 @@ revisions:
   24.1.0:
     licensed:
       declared: OTHER
-  26.1.0:
+  25.0.1:
     licensed:
       declared: OTHER
-  25.0.1:
+  25.1.0:
+    licensed:
+      declared: OTHER AND MIT
+  26.1.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@ag-grid-enterprise/set-filter.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/set-filter.yaml
@@ -15,7 +15,7 @@ revisions:
       declared: OTHER
   25.1.0:
     licensed:
-      declared: OTHER AND MIT
+      declared: OTHER
   26.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
set-filter 25.1.0

**Details:**
ClearlyDefined license indicates OTHER
NPM indicates OTHER
GitHub license is MIT AND OTHER: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [set-filter 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/set-filter/25.1.0/25.1.0)