### PR TITLE
Optional 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Optional.yaml
+++ b/curations/nuget/nuget/-/Optional.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: MIT
   4.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Optional 3.2.0

**Details:**
ClearlyDefined nuspec project link broken and no license link
Nuget no license field
GitHub license is MIT: https://github.com/nlkl/Optional/blob/3.2.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Optional 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Optional/3.2.0/3.2.0)