### PR TITLE
pouchdb-collections 1.0.1

### DIFF
--- a/curations/npm/npmjs/-/pouchdb-collections.yaml
+++ b/curations/npm/npmjs/-/pouchdb-collections.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pouchdb-collections
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pouchdb-collections 1.0.1

**Details:**
ClearlyDefined package.json indicates Apache-2.0
NPM license field indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/pouchdb/pouchdb/blob/1.0.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [pouchdb-collections 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/pouchdb-collections/1.0.1/1.0.1)