### PR TITLE
jaxb-xjc 2.3.2

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jaxb/jaxb-xjc.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jaxb/jaxb-xjc.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jaxb-xjc
+  namespace: org.glassfish.jaxb
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxb-xjc 2.3.2

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven license field indicates EDL 1.0: http://www.eclipse.org/org/documents/edl-v10.php
Maven POM indicates EDL 1.0

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jaxb-xjc 2.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jaxb/jaxb-xjc/2.3.2/2.3.2)