### PR TITLE
kendo-licensing 1.2.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-licensing.yaml
+++ b/curations/npm/npmjs/@progress/kendo-licensing.yaml
@@ -16,3 +16,6 @@ revisions:
   1.2.0:
     licensed:
       declared: OTHER
+  1.2.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-licensing 1.2.1

**Details:**
ClearlyDefined license is OTHER: Telerik End User License Agreement for Kendo UI Complete**](http://www.telerik.com/purchase/license-agreement/kendo-ui-complete)
NPM indicates OTHER
GitHub project link broken

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-licensing 1.2.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-licensing/1.2.1/1.2.1)