### PR TITLE
book 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/book.yaml
+++ b/curations/npm/npmjs/-/book.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: book
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
book 1.0.0

**Details:**
ClearlyDefined package.json links to GitHub but no license link
NPM indicates NONE
GitHub no license found

**Resolution:**
NONE

**Affected definitions**:
- [book 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/book/1.0.0/1.0.0)