### PR TITLE
org.jacoco.report 0.8.4

### DIFF
--- a/curations/maven/mavencentral/org.jacoco/org.jacoco.report.yaml
+++ b/curations/maven/mavencentral/org.jacoco/org.jacoco.report.yaml
@@ -10,6 +10,9 @@ revisions:
   0.8.3:
     licensed:
       declared: EPL-1.0
+  0.8.4:
+    licensed:
+      declared: EPL-1.0
   0.8.5:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jacoco.report 0.8.4

**Details:**
ClearlyDefined pom is EPL-1.0
Maven indicates EPL-1.0
Maven POM is EPL-1.0
Maven license link is EPL-1.0: https://www.eclipse.org/legal/epl-v10.html

**Resolution:**
EPL-1.0

**Affected definitions**:
- [org.jacoco.report 0.8.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jacoco/org.jacoco.report/0.8.4/0.8.4)