### PR TITLE
dom-compare-temp 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/dom-compare-temp.yaml
+++ b/curations/npm/npmjs/-/dom-compare-temp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dom-compare-temp
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dom-compare-temp 0.1.0

**Details:**
ClearlyDefined package.json links to GitHub with MIT that was published 5 years ago
NPM license field indicates NONE when published 7 years ago
GitHub license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [dom-compare-temp 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/dom-compare-temp/0.1.0/0.1.0)