### PR TITLE
codemodel 2.3.2

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jaxb/codemodel.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jaxb/codemodel.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: codemodel
+  namespace: org.glassfish.jaxb
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
codemodel 2.3.2

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven POM indicates BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [codemodel 2.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jaxb/codemodel/2.3.2/2.3.2)