### PR TITLE
 Swashbuckle.AspNetCore 5.6.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.AspNetCore.yaml
@@ -75,6 +75,9 @@ revisions:
   5.5.1:
     licensed:
       declared: MIT
+  5.6.0:
+    licensed:
+      declared: MIT
   5.6.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Swashbuckle.AspNetCore 5.6.0

**Details:**
ClearlyDefined license is MIT
Nuget license field indicates MIT
GitHub license is MIT: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/blob/v5.6.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Swashbuckle.AspNetCore 5.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.AspNetCore/5.6.0/5.6.0)