### PR TITLE
filter-tool-panel 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/filter-tool-panel.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/filter-tool-panel.yaml
@@ -10,9 +10,12 @@ revisions:
   24.1.0:
     licensed:
       declared: OTHER
-  26.1.0:
+  25.0.1:
     licensed:
       declared: OTHER
-  25.0.1:
+  25.1.0:
+    licensed:
+      declared: MIT AND OTHER
+  26.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
filter-tool-panel 25.1.0

**Details:**
ClearlyDefined license is MIT
NPM license field is OTHER
GitHub is MIT AND OTHER: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [filter-tool-panel 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/filter-tool-panel/25.1.0/25.1.0)