### PR TITLE
 jsp-api 2.2

### DIFF
--- a/curations/maven/mavencentral/javax.servlet.jsp/jsp-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet.jsp/jsp-api.yaml
@@ -7,3 +7,6 @@ revisions:
   '2.1':
     licensed:
       declared: 'CDDL-1.0 AND Apache-1.1 AND Apache-2.0 '
+  '2.2':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only

--- a/curations/maven/mavencentral/javax.servlet.jsp/jsp-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet.jsp/jsp-api.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   '2.1':
     licensed:
-      declared: 'CDDL-1.0 AND Apache-1.1 AND Apache-2.0 '
+      declared: CDDL-1.0 AND Apache-1.1 AND Apache-2.0
   '2.2':
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only
+      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jsp-api 2.2

**Details:**
ClearlyDefined is CDDL-1.1 OR GPL-2.0-only
Maven license link states: CDDL + GPLv2 with classpath exception
Maven POM is: CDDL-1.1 OR GPL-2.0-only (note no classpath exception found): https://repo1.maven.org/maven2/javax/servlet/jsp/jsp-api/2.2/jsp-api-2.2.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only

**Affected definitions**:
- [jsp-api 2.2](https://clearlydefined.io/definitions/maven/mavencentral/javax.servlet.jsp/jsp-api/2.2/2.2)