### PR TITLE
gym 0.21.0

### DIFF
--- a/curations/pypi/pypi/-/gym.yaml
+++ b/curations/pypi/pypi/-/gym.yaml
@@ -27,3 +27,6 @@ revisions:
   0.19.0:
     licensed:
       declared: MIT
+  0.21.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gym 0.21.0

**Details:**
ClearlyDefined PKG-INFO indicates license unknown
PyPi license field missing
GitHub is MIT: https://github.com/openai/gym/blob/v0.21.0/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [gym 0.21.0](https://clearlydefined.io/definitions/pypi/pypi/-/gym/0.21.0/0.21.0)