### PR TITLE
T4Scaffolding.Core 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/T4Scaffolding.Core.yaml
+++ b/curations/nuget/nuget/-/T4Scaffolding.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: T4Scaffolding.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
T4Scaffolding.Core 1.0.0

**Details:**
ClearlyDefined nuspec file does not include license or project link
Nuget missing license field and project link

**Resolution:**
NONE

**Affected definitions**:
- [T4Scaffolding.Core 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/T4Scaffolding.Core/1.0.0/1.0.0)