### PR TITLE
loggly 0.3.11

### DIFF
--- a/curations/npm/npmjs/-/loggly.yaml
+++ b/curations/npm/npmjs/-/loggly.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: loggly
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.11:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
loggly 0.3.11

**Details:**
ClearlyDefined links to project with MIT
NPM license field indicates MIT
GitHub license is MIT: https://github.com/winstonjs/node-loggly/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [loggly 0.3.11](https://clearlydefined.io/definitions/npm/npmjs/-/loggly/0.3.11/0.3.11)