### PR TITLE
kuduscript 1.0.16

### DIFF
--- a/curations/npm/npmjs/-/kuduscript.yaml
+++ b/curations/npm/npmjs/-/kuduscript.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: kuduscript
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.16:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kuduscript 1.0.16

**Details:**
ClearlyDefined package.json indicates Apache-2.0
NPM license field indicates NONE
GitHub project doesn't have license but package.json indicates Apache-2.0: https://github.com/projectkudu/KuduScript/blob/v1.0.16/package.json

**Resolution:**
Apache-2.0

**Affected definitions**:
- [kuduscript 1.0.16](https://clearlydefined.io/definitions/npm/npmjs/-/kuduscript/1.0.16/1.0.16)