### PR TITLE
System.IO.FileSystem.AccessControl 4.4.0

### DIFF
--- a/curations/nuget/nuget/-/System.IO.FileSystem.AccessControl.yaml
+++ b/curations/nuget/nuget/-/System.IO.FileSystem.AccessControl.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.0:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.FileSystem.AccessControl 4.4.0

**Details:**
ClearlyDefined license is MIT
Nuget license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.FileSystem.AccessControl 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.FileSystem.AccessControl/4.4.0/4.4.0)