### PR TITLE
jbcrypt 0.3m

### DIFF
--- a/curations/maven/mavencentral/org.mindrot/jbcrypt.yaml
+++ b/curations/maven/mavencentral/org.mindrot/jbcrypt.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jbcrypt
+  namespace: org.mindrot
+  provider: mavencentral
+  type: maven
+revisions:
+  0.3m:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/org.mindrot/jbcrypt.yaml
+++ b/curations/maven/mavencentral/org.mindrot/jbcrypt.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   0.3m:
     licensed:
-      declared: BSD-3-Clause
+      declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jbcrypt 0.3m

**Details:**
ClearlyDefined pom indicates BSD
Maven license field and link indicates BSD
Maven pom indicates BSD
Per curation guidelines curate as BSD-3-Clause 

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jbcrypt 0.3m](https://clearlydefined.io/definitions/maven/mavencentral/org.mindrot/jbcrypt/0.3m/0.3m)