### PR TITLE
 Akka.Persistence 1.3.10

### DIFF
--- a/curations/nuget/nuget/-/Akka.Persistence.yaml
+++ b/curations/nuget/nuget/-/Akka.Persistence.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Persistence
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Akka.Persistence 1.3.10

**Details:**
ClearlyDefined nuspec indicates Apache-2.0
Nuget license links indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/v1.3.10/LICENSE


**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Persistence 1.3.10](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Persistence/1.3.10/1.3.10)