### PR TITLE
Owin.HSTS 0.2.0

### DIFF
--- a/curations/nuget/nuget/-/Owin.HSTS.yaml
+++ b/curations/nuget/nuget/-/Owin.HSTS.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Owin.HSTS
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Owin.HSTS 0.2.0

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license link is broken
Nuget project link is broken

**Resolution:**
NONE

**Affected definitions**:
- [Owin.HSTS 0.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Owin.HSTS/0.2.0/0.2.0)