### PR TITLE
Bogus 28.4.4

### DIFF
--- a/curations/nuget/nuget/-/Bogus.yaml
+++ b/curations/nuget/nuget/-/Bogus.yaml
@@ -21,6 +21,9 @@ revisions:
   28.0.3:
     licensed:
       declared: MIT
+  28.4.4:
+    licensed:
+      declared: MIT
   29.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bogus 28.4.4

**Details:**
ClearlyDefined license is MIT
Nuget license link is MIT
GitHub license is MIT: https://github.com/bchavez/Bogus/blob/v28.4.4/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Bogus 28.4.4](https://clearlydefined.io/definitions/nuget/nuget/-/Bogus/28.4.4/28.4.4)