### PR TITLE
cookie 0.0.4

### DIFF
--- a/curations/npm/npmjs/-/cookie.yaml
+++ b/curations/npm/npmjs/-/cookie.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.4:
+    licensed:
+      declared: MIT
   0.0.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cookie 0.0.4

**Details:**
ClearlyDefined nuspec project link is MIT
NPM license field indicates MIT
GitHub license is MIT: https://github.com/jshttp/cookie/commits/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [cookie 0.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/cookie/0.0.4/0.0.4)