### PR TITLE
row-grouping 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/row-grouping.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/row-grouping.yaml
@@ -15,7 +15,7 @@ revisions:
       declared: OTHER
   25.1.0:
     licensed:
-      declared: OTHER AND MIT
+      declared: OTHER 
   26.0.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@ag-grid-enterprise/row-grouping.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/row-grouping.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.1.0:
+    licensed:
+      declared: OTHER AND MIT
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
row-grouping 25.1.0

**Details:**
ClearlyDefined license file states OTHER: AG GRID ENTERPRISE EULA v13.0
NPM license field indicates OTHER
GitHub license indicates MIT AND OTHER: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [row-grouping 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/row-grouping/25.1.0/25.1.0)