### PR TITLE
kendo-angular-popup 4.0.

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
@@ -22,3 +22,6 @@ revisions:
   4.0.0:
     licensed:
       declared: OTHER
+  4.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-popup 4.0.

**Details:**
ClearlyDefined license is OTHER: Telerik End User License Agreement for Kendo UI
NPM indicates OTHER
GitHub link broken

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-popup 4.0.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-popup/4.0.1/4.0.1)