### PR TITLE
 NAudio.Lame 1.0.4

### DIFF
--- a/curations/nuget/nuget/-/NAudio.Lame.yaml
+++ b/curations/nuget/nuget/-/NAudio.Lame.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.4:
+    licensed:
+      declared: MIT
   1.0.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 NAudio.Lame 1.0.4

**Details:**
ClearlyDefined nuspec links to project with MIT
Nuget license field links to MIT
GitHub license is MIT: https://github.com/Corey-M/NAudio.Lame/blob/master/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [NAudio.Lame 1.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/NAudio.Lame/1.0.4/1.0.4)