### PR TITLE
aspectjrt 1.8.9

### DIFF
--- a/curations/maven/mavencentral/org.aspectj/aspectjrt.yaml
+++ b/curations/maven/mavencentral/org.aspectj/aspectjrt.yaml
@@ -7,6 +7,9 @@ revisions:
   1.7.0:
     licensed:
       declared: EPL-1.0
+  1.8.9:
+    licensed:
+      declared: EPL-1.0
   1.9.7.M3:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
aspectjrt 1.8.9

**Details:**
Maven license field indicates EPL-1.0: https://mvnrepository.com/artifact/org.aspectj/aspectjrt/1.8.9
Maven link links to EPL-1.0
Maven pom indicates EPL-1.0

**Resolution:**
EPL-1.0

**Affected definitions**:
- [aspectjrt 1.8.9](https://clearlydefined.io/definitions/maven/mavencentral/org.aspectj/aspectjrt/1.8.9/1.8.9)