### PR TITLE
plexus-i18n 1.0-beta-7

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.plexus/plexus-i18n.yaml
+++ b/curations/maven/mavencentral/org.codehaus.plexus/plexus-i18n.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: plexus-i18n
+  namespace: org.codehaus.plexus
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0-beta-7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
plexus-i18n 1.0-beta-7

**Details:**
ClearlyDefined no license info found in pom
Plexus components license is Apache-2.0: https://codehaus-plexus.github.io/plexus-components/licenses.html

**Resolution:**
Apache-2.0

**Affected definitions**:
- [plexus-i18n 1.0-beta-7](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.plexus/plexus-i18n/1.0-beta-7/1.0-beta-7)