### PR TITLE
 javax.mail-api 1.5.4

### DIFF
--- a/curations/maven/mavencentral/javax.mail/javax.mail-api.yaml
+++ b/curations/maven/mavencentral/javax.mail/javax.mail-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.mail-api
+  namespace: javax.mail
+  provider: mavencentral
+  type: maven
+revisions:
+  1.5.4:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 javax.mail-api 1.5.4

**Details:**
ClearlyDefined license is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license link is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0:  https://mvnrepository.com/artifact/javax.mail/javax.mail-api/1.5.4
Maven pom is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.mail-api 1.5.4](https://clearlydefined.io/definitions/maven/mavencentral/javax.mail/javax.mail-api/1.5.4/1.5.4)