### PR TITLE
streamline 0.4.11

### DIFF
--- a/curations/npm/npmjs/-/streamline.yaml
+++ b/curations/npm/npmjs/-/streamline.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: streamline
+  provider: npmjs
+  type: npm
+revisions:
+  0.4.11:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
streamline 0.4.11

**Details:**
ClearlyDefined readme indicates MIT
NPM license field is MIT
GitHub is MIT: https://github.com/Sage/streamlinejs/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [streamline 0.4.11](https://clearlydefined.io/definitions/npm/npmjs/-/streamline/0.4.11/0.4.11)