### PR TITLE
Prism.Composition 5.0.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.Composition.yaml
+++ b/curations/nuget/nuget/-/Prism.Composition.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Prism.Composition
+  provider: nuget
+  type: nuget
+revisions:
+  5.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Composition 5.0.0

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license link is broken
Nuget project link is broken

**Resolution:**
NONE

**Affected definitions**:
- [Prism.Composition 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Composition/5.0.0/5.0.0)