### PR TITLE
NJsonSchema 10.1.2

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -30,6 +30,9 @@ revisions:
   10.1.18:
     licensed:
       declared: MIT
+  10.1.2:
+    licensed:
+      declared: MIT
   10.1.23:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NJsonSchema 10.1.2

**Details:**
ClearlyDefined license file includes link to MIT
Nuget license field is MIT
GitHub license is MIT: https://github.com/RicoSuter/NJsonSchema/blob/master/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [NJsonSchema 10.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/NJsonSchema/10.1.2/10.1.2)