### PR TITLE
 jsch 0.1.53

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.yaml
@@ -10,6 +10,9 @@ revisions:
   0.1.52:
     licensed:
       declared: BSD-3-Clause
+  0.1.53:
+    licensed:
+      declared: BSD-3-Clause
   0.1.54:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jsch 0.1.53

**Details:**
ClearlyDefined pom indicates BSD
Maven license is BSD: https://mvnrepository.com/artifact/com.jcraft/jsch/0.1.53
Maven license link is BSD-3-Clause: http://www.jcraft.com/jsch/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jsch 0.1.53](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch/0.1.53/0.1.53)