### PR TITLE
System.IO.Abstractions 2.1.0.230

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -15,6 +15,9 @@ revisions:
   2.1.0.178:
     licensed:
       declared: MS-PL
+  2.1.0.230:
+    licensed:
+      declared: MIT
   3.0.10:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions 2.1.0.230

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
GitHub license is MIT: https://github.com/TestableIO/System.IO.Abstractions/blob/v2.1.0.234/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions 2.1.0.230](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/2.1.0.230/2.1.0.230)