### PR TITLE
 HtmlAgilityPack 1.11.4

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -81,6 +81,9 @@ revisions:
   1.11.38:
     licensed:
       declared: MIT
+  1.11.4:
+    licensed:
+      declared: MIT
   1.11.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 HtmlAgilityPack 1.11.4

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
GitHub license is MIT: https://github.com/zzzprojects/html-agility-pack/blob/v1.11.39/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [HtmlAgilityPack 1.11.4](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.4/1.11.4)