### PR TITLE
CommandLineArgumentsParser 2.6.0.5

### DIFF
--- a/curations/nuget/nuget/-/CommandLineArgumentsParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineArgumentsParser.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.6.0.5:
+    licensed:
+      declared: MIT
   3.0.13:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommandLineArgumentsParser 2.6.0.5

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license field links to MIT
GitHub license is MIT: https://github.com/j-maly/CommandLineParser/blob/master/LICENCE.md


**Resolution:**
MIT

**Affected definitions**:
- [CommandLineArgumentsParser 2.6.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineArgumentsParser/2.6.0.5/2.6.0.5)