### PR TITLE
ttf2woff 1.3.0

### DIFF
--- a/curations/npm/npmjs/-/ttf2woff.yaml
+++ b/curations/npm/npmjs/-/ttf2woff.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ttf2woff
+  provider: npmjs
+  type: npm
+revisions:
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ttf2woff 1.3.0

**Details:**
ClearlyDefined license is MIT
NPM license field is MIT
GitHub license is MIT: https://github.com/fontello/ttf2woff/blob/1.3.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [ttf2woff 1.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/ttf2woff/1.3.0/1.3.0)