### PR TITLE
Newtonsoft.Json 6.0.7

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -70,6 +70,9 @@ revisions:
   6.0.6:
     licensed:
       declared: MIT
+  6.0.7:
+    licensed:
+      declared: MIT
   6.0.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json 6.0.7

**Details:**
ClearlyDefined nuspec license link is MIT
Nuget license field is MIT
GitHub license is MIT: https://github.com/JamesNK/Newtonsoft.Json/blob/6.0.7/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Newtonsoft.Json 6.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/6.0.7/6.0.7)