### PR TITLE
xsom 2.3.2

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jaxb/xsom.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jaxb/xsom.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xsom
+  namespace: org.glassfish.jaxb
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xsom 2.3.2

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven license field is EDL-1.0
Maven pom is EDL-1.0: https://repo1.maven.org/maven2/org/glassfish/jaxb/xsom/2.3.2/xsom-2.3.2.pom
Maven license field is EPL-2.0

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [xsom 2.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jaxb/xsom/2.3.2/2.3.2)