### PR TITLE
Antlr 3.1.3.42154

### DIFF
--- a/curations/nuget/nuget/-/Antlr.yaml
+++ b/curations/nuget/nuget/-/Antlr.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.1.3.42154:
+    licensed:
+      declared: BSD-3-Clause
   3.4.1.9004:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Antlr 3.1.3.42154

**Details:**
ClearlyDefined nuspec had no license info
Nuget license field links to BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/antlr/antlrcs/blob/master/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Antlr 3.1.3.42154](https://clearlydefined.io/definitions/nuget/nuget/-/Antlr/3.1.3.42154/3.1.3.42154)