### PR TITLE
Update license types

### DIFF
--- a/curations/pypi/pypi/-/distlib.yaml
+++ b/curations/pypi/pypi/-/distlib.yaml
@@ -13,5 +13,7 @@ revisions:
     licensed:
       declared: OTHER
   0.3.3:
+    described:
+      releaseDate: '2021-09-21'
     licensed:
-      declared: OTHER
+      declared: CNRI-Python

--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -33,3 +33,6 @@ revisions:
   4.0.0:
     licensed:
       declared: OTHER
+  4.0.1:
+    licensed:
+      declared: CNRI-Python


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update license types

**Details:**
Both libraries had a missing license type

**Resolution:**
Added the license type. Both are "Python Software Foundation License"

**Affected definitions**:
- [distlib 0.3.3](https://clearlydefined.io/definitions/pypi/pypi/-/distlib/0.3.3),- [typing-extensions 4.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/4.0.1)