### PR TITLE
distlib 0.3.3 & typing-extensions 4.0.1

### DIFF
--- a/curations/pypi/pypi/-/distlib.yaml
+++ b/curations/pypi/pypi/-/distlib.yaml
@@ -13,5 +13,7 @@ revisions:
     licensed:
       declared: OTHER
   0.3.3:
+    described:
+      releaseDate: '2021-09-22'
     licensed:
       declared: OTHER

--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -33,3 +33,8 @@ revisions:
   4.0.0:
     licensed:
       declared: OTHER
+  4.0.1:
+    described:
+      releaseDate: '2021-11-30'
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
distlib 0.3.3 & typing-extensions 4.0.1

**Details:**
adding licenses for distlib 0.3.3 & typing-extensions 4.0.1

**Resolution:**
pull the previous licenses forward

**Affected definitions**:
- [distlib 0.3.3](https://clearlydefined.io/definitions/pypi/pypi/-/distlib/0.3.3),- [typing-extensions 4.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/typing-extensions/4.0.1)