### PR TITLE
AspNet.ScriptManager.bootstrap 3.3.7

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.bootstrap.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.bootstrap.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: OTHER
+  3.3.7:
+    licensed:
+      declared: OTHER
   3.4.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AspNet.ScriptManager.bootstrap 3.3.7

**Details:**
ClearlyDefined nuspec had no license info
Nuget license field links to OTHER: https://webpifeed.blob.core.windows.net/webpifeed/eula/net_library_eula_enu.htm

**Resolution:**
OTHER

**Affected definitions**:
- [AspNet.ScriptManager.bootstrap 3.3.7](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.bootstrap/3.3.7/3.3.7)