### PR TITLE
desktop 2.2.3

### DIFF
--- a/curations/maven/mavencentral/com.github.axet/desktop.yaml
+++ b/curations/maven/mavencentral/com.github.axet/desktop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: desktop
+  namespace: com.github.axet
+  provider: mavencentral
+  type: maven
+revisions:
+  2.2.3:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
desktop 2.2.3

**Details:**
ClearlyDefined pom links to: http://www.gnu.org/copyleft/lesser.html
I read the curation guidelines but could not determine "only" or "later" but DIFF tool indicates "only"


**Resolution:**
LGPL-3.0-only

**Affected definitions**:
- [desktop 2.2.3](https://clearlydefined.io/definitions/maven/mavencentral/com.github.axet/desktop/2.2.3/2.2.3)