### PR TITLE
relaxng-datatype 2.3.2

### DIFF
--- a/curations/maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype.yaml
+++ b/curations/maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: relaxng-datatype
+  namespace: com.sun.xml.bind.external
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
relaxng-datatype 2.3.2

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven indicates EPL-2.0: https://mvnrepository.com/artifact/com.sun.xml.bind.external/relaxng-datatype/2.3.2
pom indicates BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [relaxng-datatype 2.3.2](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype/2.3.2/2.3.2)