### PR TITLE
javax.annotation-api 1.3

### DIFF
--- a/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/maven/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -7,6 +7,9 @@ revisions:
   '1.2':
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.3':
+    licensed:
+      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.3.1:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.annotation-api 1.3

**Details:**
ClearlyDefined license is CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven pom is same as above
Maven repository: https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api/1.3

**Resolution:**
CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.annotation-api 1.3](https://clearlydefined.io/definitions/maven/mavencentral/javax.annotation/javax.annotation-api/1.3/1.3)