### PR TITLE
dtd-parser 1.4.1

### DIFF
--- a/curations/maven/mavencentral/com.sun.xml.dtd-parser/dtd-parser.yaml
+++ b/curations/maven/mavencentral/com.sun.xml.dtd-parser/dtd-parser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dtd-parser
+  namespace: com.sun.xml.dtd-parser
+  provider: mavencentral
+  type: maven
+revisions:
+  1.4.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dtd-parser 1.4.1

**Details:**
ClearlyDefined license is BSD-3-Clause
Maven license link is EDL-1.0: https://mvnrepository.com/artifact/com.sun.xml.dtd-parser/dtd-parser/1.4.1
Maven pom is BSD-3-Clause


**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [dtd-parser 1.4.1](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.xml.dtd-parser/dtd-parser/1.4.1/1.4.1)