### PR TITLE
 Lamar 4.3.0

### DIFF
--- a/curations/nuget/nuget/-/Lamar.yaml
+++ b/curations/nuget/nuget/-/Lamar.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
-  4.4.0:
+  4.3.0:
     licensed:
       declared: MIT
   4.3.1:
+    licensed:
+      declared: MIT
+  4.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Lamar 4.3.0

**Details:**
ClearlyDefined license file links to MIT license
Nuget license field links to MIT
GitHub license is MIT: https://github.com/JasperFX/lamar/blob/v4.3/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Lamar 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Lamar/4.3.0/4.3.0)