### PR TITLE
galaxy 0.1.12

### DIFF
--- a/curations/npm/npmjs/-/galaxy.yaml
+++ b/curations/npm/npmjs/-/galaxy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: galaxy
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.12:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
galaxy 0.1.12

**Details:**
ClearlyDefined readme indicates license is MIT
NPM license field indicates NONE
GitHub license is on readme and is MIT:  https://github.com/bjouhier/galaxy/tree/v0.1.12

**Resolution:**
MIT

**Affected definitions**:
- [galaxy 0.1.12](https://clearlydefined.io/definitions/npm/npmjs/-/galaxy/0.1.12/0.1.12)