### PR TITLE
streamline-streams 0.1.5

### DIFF
--- a/curations/npm/npmjs/-/streamline-streams.yaml
+++ b/curations/npm/npmjs/-/streamline-streams.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: streamline-streams
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
streamline-streams 0.1.5

**Details:**
ClearlyDefined package.json links to project
NPM license field indicates MIT
GitHub license is MIT referenced in package.json

**Resolution:**
MIT

**Affected definitions**:
- [streamline-streams 0.1.5](https://clearlydefined.io/definitions/npm/npmjs/-/streamline-streams/0.1.5/0.1.5)