### PR TITLE
gitbook-plugin-insert-logo 0.1.5

### DIFF
--- a/curations/npm/npmjs/-/gitbook-plugin-insert-logo.yaml
+++ b/curations/npm/npmjs/-/gitbook-plugin-insert-logo.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: gitbook-plugin-insert-logo
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.5:
+    licensed:
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gitbook-plugin-insert-logo 0.1.5

**Details:**
ClearlyDefined license file is Unlicense
NPM license field states NONE
GitHub license is Unlicense: https://github.com/matusnovak/gitbook-plugin-insert-logo/blob/master/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [gitbook-plugin-insert-logo 0.1.5](https://clearlydefined.io/definitions/npm/npmjs/-/gitbook-plugin-insert-logo/0.1.5/0.1.5)