### PR TITLE
azureml-automl-core 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -177,6 +177,9 @@ revisions:
   1.35.1:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.36.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.36.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-automl-core 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.36.0/1.36.0)