### PR TITLE
kendo-angular-common 2.0.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-common.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-common.yaml
@@ -19,3 +19,6 @@ revisions:
   2.0.0:
     licensed:
       declared: OTHER
+  2.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-common 2.0.1

**Details:**
ClearlyDefined license is OTHER
NPM license field is OTHER
NPM indicates: https://www.telerik.com/purchase/license-agreement/kendo-ui

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-common 2.0.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-common/2.0.1/2.0.1)