### PR TITLE
azureml-dataset-runtime 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -87,3 +87,6 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime 1.36.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER: https://pypi.org/project/azureml-dataset-runtime/

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataset-runtime 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.36.0/1.36.0)