### PR TITLE
domready 1.0.9

### DIFF
--- a/curations/npm/npmjs/@mikaelkristiansson/domready.yaml
+++ b/curations/npm/npmjs/@mikaelkristiansson/domready.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: domready
+  namespace: '@mikaelkristiansson'
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
domready 1.0.9

**Details:**
ClearlyDefined license is MIT
NPM indicates MIT
GitHub license is MIT: https://github.com/mikaelkristiansson/domready/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [domready 1.0.9](https://clearlydefined.io/definitions/npm/npmjs/@mikaelkristiansson/domready/1.0.9/1.0.9)