### PR TITLE
NuGet.Versioning 4.7.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Versioning.yaml
+++ b/curations/nuget/nuget/-/NuGet.Versioning.yaml
@@ -33,6 +33,9 @@ revisions:
   4.5.0:
     licensed:
       declared: Apache-2.0
+  4.7.0:
+    licensed:
+      declared: Apache-2.0
   4.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Versioning 4.7.0

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Versioning 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Versioning/4.7.0/4.7.0)