### PR TITLE
streamline 0.10.17

### DIFF
--- a/curations/npm/npmjs/-/streamline.yaml
+++ b/curations/npm/npmjs/-/streamline.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: streamline
+  provider: npmjs
+  type: npm
+revisions:
+  0.10.17:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
streamline 0.10.17

**Details:**
ClearlyDefined Readme file indicates MIT
NPM license field is MIT
GitHub readme indicates MIT license: https://github.com/Sage/streamlinejs/tree/v0.10.17

**Resolution:**
MIT

**Affected definitions**:
- [streamline 0.10.17](https://clearlydefined.io/definitions/npm/npmjs/-/streamline/0.10.17/0.10.17)