### PR TITLE
System.Security.Cryptography.OpenSsl 4.5.0

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Cryptography.OpenSsl.yaml
+++ b/curations/nuget/nuget/-/System.Security.Cryptography.OpenSsl.yaml
@@ -6,6 +6,9 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.5.0:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Cryptography.OpenSsl 4.5.0

**Details:**
ClearlyDefined license is MIT
Nuget license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.Cryptography.OpenSsl 4.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Cryptography.OpenSsl/4.5.0/4.5.0)