### PR TITLE
RestSharp 106.2.2

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -35,6 +35,9 @@ revisions:
   106.2.1:
     licensed:
       declared: Apache-2.0
+  106.2.2:
+    licensed:
+      declared: Apache-2.0
   106.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RestSharp 106.2.2

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/restsharp/RestSharp/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [RestSharp 106.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/106.2.2/106.2.2)