### PR TITLE
mapbox-gl 1.13.0

### DIFF
--- a/curations/npm/npmjs/-/mapbox-gl.yaml
+++ b/curations/npm/npmjs/-/mapbox-gl.yaml
@@ -18,6 +18,9 @@ revisions:
   1.12.0:
     licensed:
       declared: BSD-3-Clause
+  1.13.0:
+    licensed:
+      declared: BSD-3-Clause
   1.13.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mapbox-gl 1.13.0

**Details:**
ClearlyDefined license is MIT
NPM license indicates see license in license directory
GitHub license is MIT: https://github.com/mapbox/mapbox-gl-js/blob/v1.13.0/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [mapbox-gl 1.13.0](https://clearlydefined.io/definitions/npm/npmjs/-/mapbox-gl/1.13.0/1.13.0)