### PR TITLE
side-bar 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/side-bar.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/side-bar.yaml
@@ -15,7 +15,7 @@ revisions:
       declared: OTHER
   25.1.0:
     licensed:
-      declared: OTHER AND MIT
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@ag-grid-enterprise/side-bar.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/side-bar.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.1.0:
+    licensed:
+      declared: OTHER AND MIT
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
side-bar 25.1.0

**Details:**
ClearlyDefined license indicates OTHER (AG GRID ENTERPRISE EULA v13.0)
NPM license field indicates Commercial
GitHub license is MIT AND OTHER: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [side-bar 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/side-bar/25.1.0/25.1.0)