### PR TITLE
System.Linq.Dynamic.Core 1.0.8.16

### DIFF
--- a/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
+++ b/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
@@ -23,3 +23,6 @@ revisions:
   1.0.20:
     licensed:
       declared: Apache-2.0
+  1.0.8.16:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Linq.Dynamic.Core 1.0.8.16

**Details:**
ClearlyDefined nuspec license link is broken
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/zzzprojects/System.Linq.Dynamic.Core/blob/1.0.8.16/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [System.Linq.Dynamic.Core 1.0.8.16](https://clearlydefined.io/definitions/nuget/nuget/-/System.Linq.Dynamic.Core/1.0.8.16/1.0.8.16)