### PR TITLE
qs 0.5.1

### DIFF
--- a/curations/npm/npmjs/-/qs.yaml
+++ b/curations/npm/npmjs/-/qs.yaml
@@ -6,6 +6,9 @@ revisions:
   0.4.2:
     licensed:
       declared: MIT
+  0.5.1:
+    licensed:
+      declared: MIT
   0.5.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
qs 0.5.1

**Details:**
ClearlyDefined package.json links to this project with MIT: https://github.com/tj/node-querystring/tree/0.5.1
NPM indicates BSD-3-Clause
GitHub license is BSD-3-Clause:  https://github.com/ljharb/qs/blob/14c69e6b29661a01c but is not the same repository as noted in the ClearlyDefined package.json

**Resolution:**
MIT

**Affected definitions**:
- [qs 0.5.1](https://clearlydefined.io/definitions/npm/npmjs/-/qs/0.5.1/0.5.1)