### PR TITLE
azureml-pipeline 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline.yaml
@@ -132,6 +132,9 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline 1.36.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-pipeline 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline/1.36.0/1.36.0)