### PR TITLE
LargeAddressAware 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/LargeAddressAware.yaml
+++ b/curations/nuget/nuget/-/LargeAddressAware.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.1:
     licensed:
       declared: MIT
+  1.0.3:
+    licensed:
+      declared: MIT
   1.0.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LargeAddressAware 1.0.3

**Details:**
ClearlyDefined nuspec license links to MIT
Nuget license field links to MIT
GitHub license is MIT: https://github.com/KirillOsenkov/LargeAddressAware/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [LargeAddressAware 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/LargeAddressAware/1.0.3/1.0.3)