### PR TITLE
Glimpse.Mvc5 1.5.3

### DIFF
--- a/curations/nuget/nuget/-/Glimpse.Mvc5.yaml
+++ b/curations/nuget/nuget/-/Glimpse.Mvc5.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Glimpse.Mvc5
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Glimpse.Mvc5 1.5.3

**Details:**
ClearlyDefined nuspec license links to Apache-2.0
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/Glimpse/Glimpse/blob/master/license.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Glimpse.Mvc5 1.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/Glimpse.Mvc5/1.5.3/1.5.3)