### PR TITLE
classworlds 1.1

### DIFF
--- a/curations/maven/mavencentral/classworlds/classworlds.yaml
+++ b/curations/maven/mavencentral/classworlds/classworlds.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: Plexus
   1.1-alpha-2:
     licensed:
-      declared: OTHER
+      declared: Plexus

--- a/curations/maven/mavencentral/classworlds/classworlds.yaml
+++ b/curations/maven/mavencentral/classworlds/classworlds.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.1':
+    licensed:
+      declared: Plexus
   1.1-alpha-2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
classworlds 1.1

**Details:**
ClearlyDefined license is Plexus: https://clearlydefined.io/file/03a2b366e5616aeb5f0825c9e8943680eeacad54222b4066490d47507a3dff2a
Maven does not include any license info or in pom: https://mvnrepository.com/artifact/classworlds/classworlds/1.1

**Resolution:**
Plexus

**Affected definitions**:
- [classworlds 1.1](https://clearlydefined.io/definitions/maven/mavencentral/classworlds/classworlds/1.1/1.1)