### PR TITLE
Selenium.Chrome.WebDriver 2.40.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.Chrome.WebDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.Chrome.WebDriver.yaml
@@ -15,6 +15,9 @@ revisions:
   2.38.0:
     licensed:
       declared: Unlicense
+  2.40.0:
+    licensed:
+      declared: Unlicense
   2.41.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.Chrome.WebDriver 2.40.0

**Details:**
ClearlyDefined nuspec license links to Unlicense
Nuget license field is Unlicense
GitHub license is Unlicense

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.Chrome.WebDriver 2.40.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.Chrome.WebDriver/2.40.0/2.40.0)