### PR TITLE
azureml-pipeline-steps 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-steps.yaml
@@ -183,6 +183,9 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-steps 1.36.0

**Details:**
ClearlyDefined no files
PyPi indicates OTHER: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-pipeline-steps 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-steps/1.36.0/1.36.0)