### PR TITLE
minimal-json 0.9.1

### DIFF
--- a/curations/maven/mavencentral/com.eclipsesource.minimal-json/minimal-json.yaml
+++ b/curations/maven/mavencentral/com.eclipsesource.minimal-json/minimal-json.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: minimal-json
+  namespace: com.eclipsesource.minimal-json
+  provider: mavencentral
+  type: maven
+revisions:
+  0.9.1:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
minimal-json 0.9.1

**Details:**
ClearlyDefined POM project links to GitHub with MIT that was added after the date of the Maven package: https://github.com/ralfstx/minimal-json/blob/5c3b4dac49ed5dbd6ab789e7ccc3d2caa0dd3f9d/LICENSE
Maven license field and pom indicates EPL-1.0: http://www.eclipse.org/legal/epl-v10.html


**Resolution:**
EPL-1.0

**Affected definitions**:
- [minimal-json 0.9.1](https://clearlydefined.io/definitions/maven/mavencentral/com.eclipsesource.minimal-json/minimal-json/0.9.1/0.9.1)