### PR TITLE
jersey-test-framework-core 1.19

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-core.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-test-framework-core
+  namespace: com.sun.jersey.jersey-test-framework
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.19':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-test-framework-core 1.19

**Details:**
ClearlyDefined pom indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license link and pom indicate same as above

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-test-framework-core 1.19](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey.jersey-test-framework/jersey-test-framework-core/1.19/1.19)