### PR TITLE
opencv 3.2.0-1

### DIFF
--- a/curations/maven/mavencentral/org.openpnp/opencv.yaml
+++ b/curations/maven/mavencentral/org.openpnp/opencv.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: opencv
+  namespace: org.openpnp
+  provider: mavencentral
+  type: maven
+revisions:
+  3.2.0-1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
opencv 3.2.0-1

**Details:**
ClearlyDefined pom indicates BSD and links to project that links to GitHub project: which includes BSD-3-Clause: https://github.com/opencv/opencv/blob/3.2.0/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [opencv 3.2.0-1](https://clearlydefined.io/definitions/maven/mavencentral/org.openpnp/opencv/3.2.0-1/3.2.0-1)