### PR TITLE
core 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.1.0:
+    licensed:
+      declared: MIT AND OTHER
   26.0.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
@@ -15,7 +15,7 @@ revisions:
       declared: OTHER
   25.1.0:
     licensed:
-      declared: MIT AND OTHER
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
core 25.1.0

**Details:**
ClearlyDefined license is OTHER: AG GRID ENTERPRISE EULA v13.0
NPM indicates Commercial
GitHub indicates: OTHER AND MIT: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
OTHER AND MIT

**Affected definitions**:
- [core 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/core/25.1.0/25.1.0)