### PR TITLE
Grpc.Core 1.16.0

### DIFF
--- a/curations/nuget/nuget/-/Grpc.Core.yaml
+++ b/curations/nuget/nuget/-/Grpc.Core.yaml
@@ -9,6 +9,9 @@ revisions:
   1.13.1:
     licensed:
       declared: Apache-2.0
+  1.16.0:
+    licensed:
+      declared: Apache-2.0
   1.17.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Grpc.Core 1.16.0

**Details:**
ClearlyDefined nuspec license links to Apache-2.0 (which includes discovered licenses following)
Nuget license is Apache-2.0
GitHub license is Apache-2.0 (which includes discovered licenses following): https://github.com/grpc/grpc/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Grpc.Core 1.16.0](https://clearlydefined.io/definitions/nuget/nuget/-/Grpc.Core/1.16.0/1.16.0)