### PR TITLE
 jna-platform 4.0.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  4.0.0:
+    licensed:
+      declared: LGPL-2.1-or-later OR Apache-2.0
   4.1.0:
     licensed:
       declared: Apache-2.0 AND LGPL-2.1

--- a/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: LGPL-2.1-or-later OR Apache-2.0
   4.1.0:
     licensed:
-      declared: Apache-2.0 AND LGPL-2.1
+      declared: Apache-2.0 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jna-platform 4.0.0

**Details:**
Maven license is: LGPL-2.1-or-later OR Apache-2.0:  https://mvnrepository.com/artifact/net.java.dev.jna/jna-platform/4.0.0
GitHub Readme is same as above: https://github.com/java-native-access/jna/tree/4.0

**Resolution:**
LGPL-2.1-or-later OR Apache-2.0

**Affected definitions**:
- [jna-platform 4.0.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna-platform/4.0.0/4.0.0)