### PR TITLE
column-tool-panel 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/column-tool-panel.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/column-tool-panel.yaml
@@ -15,7 +15,7 @@ revisions:
       declared: OTHER
   25.1.0:
     licensed:
-      declared: OTHER AND MIT
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@ag-grid-enterprise/column-tool-panel.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/column-tool-panel.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.1.0:
+    licensed:
+      declared: OTHER AND MIT
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
column-tool-panel 25.1.0

**Details:**
ClearlyDefined license is OTHER AND MIT
NPM indicates Commercial
GitHub license is OTHER AND MIT: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
OTHER AND MIT

**Affected definitions**:
- [column-tool-panel 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/column-tool-panel/25.1.0/25.1.0)