### PR TITLE
 plexus-interactivity-api 1.0-alpha-4

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.plexus/plexus-interactivity-api.yaml
+++ b/curations/maven/mavencentral/org.codehaus.plexus/plexus-interactivity-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.0-alpha-4:
     licensed:
-      declared: Apache-2.0
+      declared: MIT

--- a/curations/maven/mavencentral/org.codehaus.plexus/plexus-interactivity-api.yaml
+++ b/curations/maven/mavencentral/org.codehaus.plexus/plexus-interactivity-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: plexus-interactivity-api
+  namespace: org.codehaus.plexus
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0-alpha-4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 plexus-interactivity-api 1.0-alpha-4

**Details:**
ClearlyDefined pom no license info found
Maven license field is Apache-2.0: https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-interactivity-api/1.0-alpha-4
Maven pom does not have license info

**Resolution:**
Apache-2.0

**Affected definitions**:
- [plexus-interactivity-api 1.0-alpha-4](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.plexus/plexus-interactivity-api/1.0-alpha-4/1.0-alpha-4)