### PR TITLE
txw2 20110809

### DIFF
--- a/curations/maven/mavencentral/com.sun.xml.txw2/txw2.yaml
+++ b/curations/maven/mavencentral/com.sun.xml.txw2/txw2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: txw2
+  namespace: com.sun.xml.txw2
+  provider: mavencentral
+  type: maven
+revisions:
+  '20110809':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
txw2 20110809

**Details:**
ClearlyDefined pom indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven pom indicates same as above
https://mvnrepository.com/artifact/com.sun.xml.txw2/txw2/20110809

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [txw2 20110809](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.xml.txw2/txw2/20110809/20110809)