### PR TITLE
FluentValidation 7.2.1

### DIFF
--- a/curations/nuget/nuget/-/FluentValidation.yaml
+++ b/curations/nuget/nuget/-/FluentValidation.yaml
@@ -18,6 +18,9 @@ revisions:
   7.1.1:
     licensed:
       declared: Apache-2.0
+  7.2.1:
+    licensed:
+      declared: Apache-2.0
   7.3.3:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentValidation 7.2.1

**Details:**
ClearlyDefined nuspec links to project with Apache-2.0
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/FluentValidation/FluentValidation/blob/7.2.1/License.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentValidation 7.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentValidation/7.2.1/7.2.1)