### PR TITLE
Bogus 29.0.1

### DIFF
--- a/curations/nuget/nuget/-/Bogus.yaml
+++ b/curations/nuget/nuget/-/Bogus.yaml
@@ -23,7 +23,7 @@ revisions:
       declared: MIT
   29.0.1:
     licensed:
-      declared: MIT OR BSD-3-Clause
+      declared: MIT
   29.0.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Bogus.yaml
+++ b/curations/nuget/nuget/-/Bogus.yaml
@@ -21,6 +21,9 @@ revisions:
   28.0.3:
     licensed:
       declared: MIT
+  29.0.1:
+    licensed:
+      declared: MIT OR BSD-3-Clause
   29.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bogus 29.0.1

**Details:**
ClearlyDefined license is MIT OR BSD-3-Clause
Nuget license field links to same as above
GitHub license is same as above: https://github.com/bchavez/Bogus/blob/v29.0.1/LICENSE

**Resolution:**
MIT OR BSD-3-Clause

**Affected definitions**:
- [Bogus 29.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bogus/29.0.1/29.0.1)