### PR TITLE
VSSDK.IDE.10 10.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.IDE.10.yaml
+++ b/curations/nuget/nuget/-/VSSDK.IDE.10.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.IDE.10
+  provider: nuget
+  type: nuget
+revisions:
+  10.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VSSDK.IDE.10 10.0.4

**Details:**
ClearlyDefined nuspec or files had no license info
Nuget did not have a license field or project field

**Resolution:**
NONE

**Affected definitions**:
- [VSSDK.IDE.10 10.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.IDE.10/10.0.4/10.0.4)