### PR TITLE
Declared license contained NOASSERTION

### DIFF
--- a/curations/git/github/hibernate/hibernate-orm.yaml
+++ b/curations/git/github/hibernate/hibernate-orm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hibernate-orm
+  namespace: hibernate
+  provider: github
+  type: git
+revisions:
+  05792d951052a72a183e58896abea9f8de515d51:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license contained NOASSERTION

**Details:**
NOASSERTION needs to be omitted from Declared License section as this FOSS component version is distributed under LGPL v2.1 or later.

**Resolution:**
Updated the license as per the information found in https://github.com/hibernate/hibernate-orm/blob/05792d951052a72a183e58896abea9f8de515d51/lgpl.txt.

**Affected definitions**:
- [hibernate-orm 05792d951052a72a183e58896abea9f8de515d51](https://clearlydefined.io/definitions/git/github/hibernate/hibernate-orm/05792d951052a72a183e58896abea9f8de515d51/05792d951052a72a183e58896abea9f8de515d51)