### PR TITLE
Declared license contained NOASSERTION

### DIFF
--- a/curations/git/github/hibernate/hibernate-orm.yaml
+++ b/curations/git/github/hibernate/hibernate-orm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hibernate-orm
+  namespace: hibernate
+  provider: github
+  type: git
+revisions:
+  31f8d9efb65373c9f31e94cf4dd0dd73abbc6d66:
+    licensed:
+      declared: LGPL-2.1-or-later

--- a/curations/git/github/hibernate/hibernate-orm.yaml
+++ b/curations/git/github/hibernate/hibernate-orm.yaml
@@ -10,4 +10,3 @@ revisions:
   31f8d9efb65373c9f31e94cf4dd0dd73abbc6d66:
     licensed:
       declared: LGPL-2.1-or-later
- 


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license contained NOASSERTION

**Details:**
NOASSERTION needs to be omitted from Declared License section as this FOSS component version is distributed under LGPL v2.1 or later.

**Resolution:**
Updated the license as per the information found in https://github.com/hibernate/hibernate-orm/blob/31f8d9efb65373c9f31e94cf4dd0dd73abbc6d66/lgpl.txt.

**Affected definitions**:
- [hibernate-orm 31f8d9efb65373c9f31e94cf4dd0dd73abbc6d66](https://clearlydefined.io/definitions/git/github/hibernate/hibernate-orm/31f8d9efb65373c9f31e94cf4dd0dd73abbc6d66/31f8d9efb65373c9f31e94cf4dd0dd73abbc6d66)