### PR TITLE
Declared license contained NOASSERTION

### DIFF
--- a/curations/git/github/hibernate/hibernate-orm.yaml
+++ b/curations/git/github/hibernate/hibernate-orm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hibernate-orm
+  namespace: hibernate
+  provider: github
+  type: git
+revisions:
+  18026e0dd5660cb1330a2fef009d99f61e78e2ff:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared license contained NOASSERTION

**Details:**
NOASSERTION needs to be omitted from Declared License section as this FOSS component version is distributed under LGPL v2.1 or later.

**Resolution:**
Updated the license as per the information found in https://github.com/hibernate/hibernate-orm/blob/18026e0dd5660cb1330a2fef009d99f61e78e2ff/lgpl.txt.

**Affected definitions**:
- [hibernate-orm 18026e0dd5660cb1330a2fef009d99f61e78e2ff](https://clearlydefined.io/definitions/git/github/hibernate/hibernate-orm/18026e0dd5660cb1330a2fef009d99f61e78e2ff/18026e0dd5660cb1330a2fef009d99f61e78e2ff)