### PR TITLE
conventional-changelog 0.0.17

### DIFF
--- a/curations/npm/npmjs/-/conventional-changelog.yaml
+++ b/curations/npm/npmjs/-/conventional-changelog.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: conventional-changelog
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.17:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
conventional-changelog 0.0.17

**Details:**
ClearlyDefined package.json indicates BSD
NPM license field is MIT
GitHub Readme includes BSD: https://github.com/conventional-changelog/conventional-changelog/tree/v0.0.17

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [conventional-changelog 0.0.17](https://clearlydefined.io/definitions/npm/npmjs/-/conventional-changelog/0.0.17/0.0.17)