### PR TITLE
kendo-angular-popup 3.0.6

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-popup.yaml
@@ -16,6 +16,9 @@ revisions:
   3.0.5:
     licensed:
       declared: OTHER
+  3.0.6:
+    licensed:
+      declared: OTHER
   3.0.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-popup 3.0.6

**Details:**
ClearlyDefined license indicates OTHER
NPM indicates see license folder and indicates This package is part of Kendo UI for Angular—a commercial library. You will need to install a license key when adding the package to your project. For more information, please refer to the https://www.telerik.

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-popup 3.0.6](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-popup/3.0.6/3.0.6)