### PR TITLE
javax.ws.rs-api 2.0

### DIFF
--- a/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.0':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.0-m10:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception

--- a/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
@@ -9,10 +9,10 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.0-m10:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.0.1:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '2.1':
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.ws.rs-api 2.0

**Details:**
ClearlyDefined pom indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven: https://mvnrepository.com/artifact/javax.ws.rs/javax.ws.rs-api/2.0 indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.ws.rs-api 2.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.0/2.0)