### PR TITLE
 NuGet.Build.Tasks.Pack 4.3.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Build.Tasks.Pack.yaml
+++ b/curations/nuget/nuget/-/NuGet.Build.Tasks.Pack.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.3.0:
+    licensed:
+      declared: Apache-2.0
   4.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 NuGet.Build.Tasks.Pack 4.3.0

**Details:**
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.3.0.4202/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Build.Tasks.Pack 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Build.Tasks.Pack/4.3.0/4.3.0)