### PR TITLE
FluentMigrator.Extensions.SqlServer 3.2.1

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Extensions.SqlServer.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Extensions.SqlServer.yaml
@@ -6,3 +6,6 @@ revisions:
   3.1.3:
     licensed:
       declared: Apache-2.0
+  3.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Extensions.SqlServer 3.2.1

**Details:**
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.1/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Extensions.SqlServer 3.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Extensions.SqlServer/3.2.1/3.2.1)