### PR TITLE
pcf-start 1.3.1

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -12,6 +12,9 @@ revisions:
   1.2.6:
     licensed:
       declared: OTHER
+  1.3.1:
+    licensed:
+      declared: OTHER
   1.3.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 1.3.1

**Details:**
ClearlyDefined license is: MICROSOFT POWERAPPS CLI MSLT - OTHER
NPM license field states see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-start 1.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.3.1/1.3.1)