### PR TITLE
core 23.2.1

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
@@ -7,6 +7,9 @@ revisions:
   23.1.1:
     licensed:
       declared: OTHER
+  23.2.1:
+    licensed:
+      declared: MIT AND OTHER
   24.1.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/core.yaml
@@ -9,7 +9,7 @@ revisions:
       declared: OTHER
   23.2.1:
     licensed:
-      declared: MIT AND OTHER
+      declared: OTHER
   24.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
core 23.2.1

**Details:**
ClearlyDefined license is Commercial
NPM license field indicates Commercial
GitHub license is MIT AND OTHER: https://github.com/ag-grid/ag-grid/blob/v23.2.1/LICENSE.txt

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [core 23.2.1](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/core/23.2.1/23.2.1)