### PR TITLE
kendo-angular-intl 3.1.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-intl.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-intl.yaml
@@ -22,3 +22,6 @@ revisions:
   3.1.0:
     licensed:
       declared: OTHER
+  3.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-intl 3.1.1

**Details:**
ClearlyDefined license is OTHER: Telerik End User License Agreement for Kendo UI
NPM license field indicates Commercial

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-intl 3.1.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-intl/3.1.1/3.1.1)