### PR TITLE
scala-library 2.10.4

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
@@ -7,6 +7,9 @@ revisions:
   2.10.3:
     licensed:
       declared: BSD-3-Clause
+  2.10.4:
+    licensed:
+      declared: BSD-3-Clause
   2.11.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scala-library 2.10.4

**Details:**
Maven indicates BSD
Maven license links to: https://www.scala-lang.org/license/ which states: Scala is licensed under the Apache License, Version 2.0 Versions of Scala distributed prior to December 2018 were licensed under the BSD 3-Clause License.

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-library 2.10.4](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-library/2.10.4/2.10.4)