### PR TITLE
Rx-Core 2.1.30204

### DIFF
--- a/curations/nuget/nuget/-/Rx-Core.yaml
+++ b/curations/nuget/nuget/-/Rx-Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.30204:
+    licensed:
+      declared: Apache-2.0
   2.1.30214:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Core 2.1.30204

**Details:**
Nuget license info indicates MIT
GitHub current license is MIT.  However, Nuget package date 5/25/15 there was no license. An Apache-2.0 license was added 6/6/2016

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Rx-Core 2.1.30204](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Core/2.1.30204/2.1.30204)