### PR TITLE
plexus-velocity 1.1.7

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.plexus/plexus-velocity.yaml
+++ b/curations/maven/mavencentral/org.codehaus.plexus/plexus-velocity.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: plexus-velocity
+  namespace: org.codehaus.plexus
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
plexus-velocity 1.1.7

**Details:**
ClearlyDefined pom indciates Apache-2.0
Maven license field is Apache: https://mvnrepository.com/artifact/org.codehaus.plexus/plexus-velocity/1.1.7
Maven pom is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [plexus-velocity 1.1.7](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.plexus/plexus-velocity/1.1.7/1.1.7)