### PR TITLE
NuGet.Configuration 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Configuration.yaml
+++ b/curations/nuget/nuget/-/NuGet.Configuration.yaml
@@ -12,6 +12,9 @@ revisions:
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0
+  4.8.0:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Configuration 4.8.0

**Details:**
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.8.0.5158/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Configuration 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Configuration/4.8.0/4.8.0)