### PR TITLE
engine.io-client-pure 1.5.9

### DIFF
--- a/curations/npm/npmjs/-/engine.io-client-pure.yaml
+++ b/curations/npm/npmjs/-/engine.io-client-pure.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: engine.io-client-pure
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
engine.io-client-pure 1.5.9

**Details:**
ClearlyDefined Readme indicates MIT
NPM license field indicates NONE
GitHub Readme indicates MIT: https://github.com/socketio/engine.io-client/tree/1.5.4

**Resolution:**
MIT

**Affected definitions**:
- [engine.io-client-pure 1.5.9](https://clearlydefined.io/definitions/npm/npmjs/-/engine.io-client-pure/1.5.9/1.5.9)