### PR TITLE
UriTemplate.Core 1.0.2

### DIFF
--- a/curations/nuget/nuget/-/UriTemplate.Core.yaml
+++ b/curations/nuget/nuget/-/UriTemplate.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: UriTemplate.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
UriTemplate.Core 1.0.2

**Details:**
Nuget license field is missing
GitHub license is Apache-2.0: https://github.com/pierewoj/dotnet-uritemplate/blob/master/license.md

**Resolution:**
Apache-2.0

**Affected definitions**:
- [UriTemplate.Core 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/UriTemplate.Core/1.0.2/1.0.2)