### PR TITLE
 Azure.ActiveDirectory 0.1.5197.40350

### DIFF
--- a/curations/nuget/nuget/-/Azure.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Azure.ActiveDirectory.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Azure.ActiveDirectory
+  provider: nuget
+  type: nuget
+revisions:
+  0.1.5197.40350:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Azure.ActiveDirectory 0.1.5197.40350

**Details:**
Nuget license field is missing
Github - No  license info found: https://github.com/grufffta/Azure.ActiveDirectory

**Resolution:**
NONE

**Affected definitions**:
- [Azure.ActiveDirectory 0.1.5197.40350](https://clearlydefined.io/definitions/nuget/nuget/-/Azure.ActiveDirectory/0.1.5197.40350/0.1.5197.40350)