### PR TITLE
BingMapAppSDK 1.0.1011.1716

### DIFF
--- a/curations/nuget/nuget/-/BingMapAppSDK.yaml
+++ b/curations/nuget/nuget/-/BingMapAppSDK.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: BingMapAppSDK
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1011.1716:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BingMapAppSDK 1.0.1011.1716

**Details:**
Nuget no license field
Project link has no license info: https://docs.microsoft.com/en-us/collaborate/connect-redirect

**Resolution:**
NONE

**Affected definitions**:
- [BingMapAppSDK 1.0.1011.1716](https://clearlydefined.io/definitions/nuget/nuget/-/BingMapAppSDK/1.0.1011.1716/1.0.1011.1716)