### PR TITLE
System.Data.SQLite.EF6 1.0.108

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.102:
     licensed:
       declared: OTHER
+  1.0.108:
+    licensed:
+      declared: OTHER
   1.0.113:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.EF6 1.0.108

**Details:**
Nuget license field links to Public Domain - OTHER
Nuget project field links to SQLite home page - public domain 

**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.EF6 1.0.108](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.EF6/1.0.108/1.0.108)