### PR TITLE
Swashbuckle 6.0.0-beta902

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Swashbuckle
+  provider: nuget
+  type: nuget
+revisions:
+  6.0.0-beta902:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle 6.0.0-beta902

**Details:**
Nuget license field links to BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/domaindrivendev/Swashbuckle.WebApi/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Swashbuckle 6.0.0-beta902](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle/6.0.0-beta902/6.0.0-beta902)