### PR TITLE
AspNet.ScriptManager.jQuery 1.7.1

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.2:
     licensed:
       declared: NONE
+  1.7.1:
+    licensed:
+      declared: NONE
   1.8.2:
     licensed:
       declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AspNet.ScriptManager.jQuery 1.7.1

**Details:**
Nuget no license field included
Nuget no project link included
Check Way Back Machine did not find it
Checked other versions and did not find any license

**Resolution:**
NONE

**Affected definitions**:
- [AspNet.ScriptManager.jQuery 1.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.jQuery/1.7.1/1.7.1)