### PR TITLE
SimpleOAuth.Net 1.0.1

### DIFF
--- a/curations/nuget/nuget/-/SimpleOAuth.Net.yaml
+++ b/curations/nuget/nuget/-/SimpleOAuth.Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SimpleOAuth.Net
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SimpleOAuth.Net 1.0.1

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/cbenard/SimpleOAuth.Net/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [SimpleOAuth.Net 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/SimpleOAuth.Net/1.0.1/1.0.1)