### PR TITLE
junit-platform-commons 1.3.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -7,6 +7,9 @@ revisions:
   1.2.0:
     licensed:
       declared: EPL-2.0
+  1.3.1:
+    licensed:
+      declared: EPL-2.0
   1.4.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-platform-commons 1.3.1

**Details:**
ClearlyDefined license is EPL-2.0
Maven license field and link indicates EPL-2.0:  https://mvnrepository.com/artifact/org.junit.platform/junit-platform-commons/1.3.1
POM indicates EPL-2.0

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-commons 1.3.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.3.1/1.3.1)