### PR TITLE
SharePointPnPCoreOnline 3.28.2012

### DIFF
--- a/curations/nuget/nuget/-/SharePointPnPCoreOnline.yaml
+++ b/curations/nuget/nuget/-/SharePointPnPCoreOnline.yaml
@@ -30,6 +30,9 @@ revisions:
   3.27.2011:
     licensed:
       declared: MIT
+  3.28.2012:
+    licensed:
+      declared: MIT
   3.8.1904:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SharePointPnPCoreOnline 3.28.2012

**Details:**
Nuget license field links to MIT:https://github.com/pnp/PnP-Sites-Core/blob/master/LICENSE
Nuget project links to: https://pnp.github.io/ with no license info found

**Resolution:**
MIT

**Affected definitions**:
- [SharePointPnPCoreOnline 3.28.2012](https://clearlydefined.io/definitions/nuget/nuget/-/SharePointPnPCoreOnline/3.28.2012/3.28.2012)