### PR TITLE
Selenium.Firefox.WebDriver 0.20.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
@@ -6,6 +6,9 @@ revisions:
   0.19.1:
     licensed:
       declared: Unlicense
+  0.20.0:
+    licensed:
+      declared: Unlicense
   0.22.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.Firefox.WebDriver 0.20.0

**Details:**
Nuget license field indicates Unlicense
GitHub license is Unlicense: https://github.com/jbaranda/nupkg-selenium-webdrivers/blob/master/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.Firefox.WebDriver 0.20.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.Firefox.WebDriver/0.20.0/0.20.0)