### PR TITLE
Faker.Net 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/Faker.Net.yaml
+++ b/curations/nuget/nuget/-/Faker.Net.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.3:
+    licensed:
+      declared: MIT
   1.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Faker.Net 1.0.3

**Details:**
Nuget license field is missing but includes link to project
GitHub license is MIT: https://github.com/oriches/faker-cs/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Faker.Net 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/Faker.Net/1.0.3/1.0.3)