### PR TITLE
SonarAnalyzer.CSharp 7.1.0.5212

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -12,6 +12,9 @@ revisions:
   6.6.0.3969:
     licensed:
       declared: LGPL-3.0-or-later
+  7.1.0.5212:
+    licensed:
+      declared: GPL-3.0-only
   7.11.0.8083:
     licensed:
       declared: LGPL-3.0-or-later

--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -14,7 +14,7 @@ revisions:
       declared: LGPL-3.0-or-later
   7.1.0.5212:
     licensed:
-      declared: GPL-3.0-only
+      declared: LGPL-3.0-or-later
   7.11.0.8083:
     licensed:
       declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SonarAnalyzer.CSharp 7.1.0.5212

**Details:**
Nuget license field indicates: GPL-3.0-only and links to: https://licenses.nuget.org/LGPL-3.0-only
Nuget project links to: https://www.sonarlint.org/visualstudio which includes a link to GitHub GPL-3.0-only license: https://github.com/SonarSource/sonarlint-core/blob/master/LICENSE.txt 

**Resolution:**
GPL-3.0-only

**Affected definitions**:
- [SonarAnalyzer.CSharp 7.1.0.5212](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/7.1.0.5212/7.1.0.5212)