### PR TITLE
jQuery.UI.Combined 1.8.13

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -27,6 +27,9 @@ revisions:
   1.8.11:
     licensed:
       declared: MIT
+  1.8.13:
+    licensed:
+      declared: MIT
   1.8.20.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery.UI.Combined 1.8.13

**Details:**
Nuget license field links to Source code under MIT: http://jquery.org/license/
Project https://jqueryui.com/ includes link to GitHub which has MIT license: https://github.com/jquery/jquery-ui/blob/1.8.13/MIT-LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [jQuery.UI.Combined 1.8.13](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.8.13/1.8.13)