### PR TITLE
Dependency 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Dependency.yaml
+++ b/curations/nuget/nuget/-/Dependency.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Dependency
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Dependency 1.0.0

**Details:**
Nuget does not have a license field or project link
Downloaded package and no license info indicated: https://nuget.info/packages/Dependency/2.0.0
Checked Way Back Machine and URL not included

**Resolution:**
NONE

**Affected definitions**:
- [Dependency 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Dependency/1.0.0/1.0.0)