### PR TITLE
CassandraCSharpDriver 3.3.2

### DIFF
--- a/curations/nuget/nuget/-/CassandraCSharpDriver.yaml
+++ b/curations/nuget/nuget/-/CassandraCSharpDriver.yaml
@@ -12,3 +12,6 @@ revisions:
   3.3.0:
     licensed:
       declared: Apache-2.0
+  3.3.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CassandraCSharpDriver 3.3.2

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/datastax/csharp-driver/blob/1.0.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [CassandraCSharpDriver 3.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/CassandraCSharpDriver/3.3.2/3.3.2)