### PR TITLE
Rx-Interfaces 2.1.30204

### DIFF
--- a/curations/nuget/nuget/-/Rx-Interfaces.yaml
+++ b/curations/nuget/nuget/-/Rx-Interfaces.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.30204:
+    licensed:
+      declared: Apache-2.0
   2.1.30214:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Interfaces 2.1.30204

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/dotnet/reactive/blob/main/LICENSE
In 2016 an Apache-2.0 license was in the license history.  There appears to have been no license when package was created in 2015.
Checked Way Back Machine and did not find URL

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Rx-Interfaces 2.1.30204](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Interfaces/2.1.30204/2.1.30204)