### PR TITLE
ReleaseNotesPackage 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/ReleaseNotesPackage.yaml
+++ b/curations/nuget/nuget/-/ReleaseNotesPackage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ReleaseNotesPackage
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ReleaseNotesPackage 2.0.0

**Details:**
Nuget no license field or project field included
Downloaded release notes package and no license indicated: https://nuget.info/packages/ReleaseNotesPackage/2.0
Checked Way Back Machine and URL not found

**Resolution:**
NONE

**Affected definitions**:
- [ReleaseNotesPackage 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/ReleaseNotesPackage/2.0.0/2.0.0)