### PR TITLE
MyFirstPackage 1.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/MyFirstPackage.yaml
+++ b/curations/nuget/nuget/-/MyFirstPackage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MyFirstPackage
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MyFirstPackage 1.0.0.1

**Details:**
Nuget missing license field and project link doesn't work
Downloaded package and no license info: https://nuget.info/packages/MyFirstPackage/1.0.0.1
Searched Way Back Machine and URL not found

**Resolution:**
NONE

**Affected definitions**:
- [MyFirstPackage 1.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/MyFirstPackage/1.0.0.1/1.0.0.1)