### PR TITLE
Bond.Compiler 5.3.1

### DIFF
--- a/curations/nuget/nuget/-/Bond.Compiler.yaml
+++ b/curations/nuget/nuget/-/Bond.Compiler.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  5.3.1:
+    licensed:
+      declared: MIT
   8.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Compiler 5.3.1

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/microsoft/bond/blob/5.3.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Bond.Compiler 5.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Compiler/5.3.1/5.3.1)