### PR TITLE
Baseline 1.5.0

### DIFF
--- a/curations/nuget/nuget/-/Baseline.yaml
+++ b/curations/nuget/nuget/-/Baseline.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.5.0:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Baseline 1.5.0

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/JasperFx/baseline/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Baseline 1.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Baseline/1.5.0/1.5.0)