### PR TITLE
 LibGit2Sharp 0.25.0

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.yaml
@@ -39,6 +39,9 @@ revisions:
   0.24.1:
     licensed:
       declared: MIT
+  0.25.0:
+    licensed:
+      declared: MIT
   0.25.0-preview-0033:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 LibGit2Sharp 0.25.0

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/libgit2/libgit2sharp/blob/v0.25/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [LibGit2Sharp 0.25.0](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp/0.25.0/0.25.0)