### PR TITLE
pem 1.9.7

### DIFF
--- a/curations/npm/npmjs/-/pem.yaml
+++ b/curations/npm/npmjs/-/pem.yaml
@@ -6,3 +6,6 @@ revisions:
   1.11.2:
     licensed:
       declared: MIT-0
+  1.9.7:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/pem.yaml
+++ b/curations/npm/npmjs/-/pem.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: MIT-0
   1.9.7:
     licensed:
-      declared: MIT
+      declared: MIT-0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pem 1.9.7

**Details:**
NPM license field indicates MIT
GitHub license is MIT: https://github.com/Dexus/pem/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [pem 1.9.7](https://clearlydefined.io/definitions/npm/npmjs/-/pem/1.9.7/1.9.7)