### PR TITLE
NuGet.Packaging.Core 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
@@ -6,6 +6,9 @@ revisions:
   3.2.0:
     licensed:
       declared: Apache-2.0
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging.Core 3.5.0

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/3.5.0-rtm/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Packaging.Core 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core/3.5.0/3.5.0)