### PR TITLE
FluentMigrator.Extensions.Oracle 3.2.1

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Extensions.Oracle.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Extensions.Oracle.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FluentMigrator.Extensions.Oracle
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Extensions.Oracle 3.2.1

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.1/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Extensions.Oracle 3.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Extensions.Oracle/3.2.1/3.2.1)