### PR TITLE
ExcelDataReader.DataSet 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/ExcelDataReader.DataSet.yaml
+++ b/curations/nuget/nuget/-/ExcelDataReader.DataSet.yaml
@@ -9,3 +9,6 @@ revisions:
   3.4.0:
     licensed:
       declared: MIT
+  3.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ExcelDataReader.DataSet 3.5.0

**Details:**
Nuget license links to MIT
GitHub license is MIT: https://github.com/ExcelDataReader/ExcelDataReader/blob/v3.5.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [ExcelDataReader.DataSet 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/ExcelDataReader.DataSet/3.5.0/3.5.0)