### PR TITLE
commons-validator 1.2.0

### DIFF
--- a/curations/maven/mavencentral/commons-validator/commons-validator.yaml
+++ b/curations/maven/mavencentral/commons-validator/commons-validator.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-validator
+  namespace: commons-validator
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-validator 1.2.0

**Details:**
Maven license field and link indicates Apache-2.0: https://mvnrepository.com/artifact/commons-validator/commons-validator/1.2.0
Pom indicates Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [commons-validator 1.2.0](https://clearlydefined.io/definitions/maven/mavencentral/commons-validator/commons-validator/1.2.0/1.2.0)