### PR TITLE
MathNet.Numerics 3.17.0

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.yaml
@@ -9,6 +9,9 @@ revisions:
   3.11.0:
     licensed:
       declared: MIT
+  3.17.0:
+    licensed:
+      declared: MIT
   3.20.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MathNet.Numerics 3.17.0

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/mathnet/mathnet-numerics/blob/v3.17.0/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [MathNet.Numerics 3.17.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics/3.17.0/3.17.0)