### PR TITLE
Octokit 0.29.0

### DIFF
--- a/curations/nuget/nuget/-/Octokit.yaml
+++ b/curations/nuget/nuget/-/Octokit.yaml
@@ -24,6 +24,9 @@ revisions:
   0.24.0:
     licensed:
       declared: MIT
+  0.29.0:
+    licensed:
+      declared: MIT
   0.32.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Octokit 0.29.0

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/octokit/octokit.net/blob/v0.29.0/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [Octokit 0.29.0](https://clearlydefined.io/definitions/nuget/nuget/-/Octokit/0.29.0/0.29.0)