### PR TITLE
Mars 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Mars.yaml
+++ b/curations/nuget/nuget/-/Mars.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Mars
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Mars 1.0.0

**Details:**
Nuget license field missing
Nuget does not include project link
Searched Way Back Machine and found no license info

**Resolution:**
NONE

**Affected definitions**:
- [Mars 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Mars/1.0.0/1.0.0)