### PR TITLE
ILReader 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/ILReader.yaml
+++ b/curations/nuget/nuget/-/ILReader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ILReader
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ILReader 1.0.0

**Details:**
Nuget no license field included
Nuget no link to project
Searched Way Back Machine and no license info found

**Resolution:**
NONE

**Affected definitions**:
- [ILReader 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/ILReader/1.0.0/1.0.0)