### PR TITLE
System.Data.SQLite.EF6 1.0.112

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.EF6.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.102:
     licensed:
       declared: OTHER
+  1.0.112:
+    licensed:
+      declared: OTHER
   1.0.113:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.EF6 1.0.112

**Details:**
ClearlyDefined license is Public Domain - OTHER
Nuget license field links to: https://www.sqlite.org/copyright.html - OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.EF6 1.0.112](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.EF6/1.0.112/1.0.112)