### PR TITLE
FluentMigrator.Abstractions 3.2.1

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Abstractions.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Abstractions.yaml
@@ -6,3 +6,6 @@ revisions:
   3.1.3:
     licensed:
       declared: Apache-2.0
+  3.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Abstractions 3.2.1

**Details:**
Nuget license field is Apache-2.0
GitHub license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Abstractions 3.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Abstractions/3.2.1/3.2.1)