### PR TITLE
peppercorn 0.6

### DIFF
--- a/curations/pypi/pypi/-/peppercorn.yaml
+++ b/curations/pypi/pypi/-/peppercorn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: peppercorn
+  provider: pypi
+  type: pypi
+revisions:
+  '0.6':
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/pypi/pypi/-/peppercorn.yaml
+++ b/curations/pypi/pypi/-/peppercorn.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   '0.6':
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause-Modification


### PR DESCRIPTION

**Type:** Missing

**Summary:**
peppercorn 0.6

**Details:**
ClearlyDefined license is BSD-3-Clause
PyPi indicates BSD (modified was green changes using DIFF tool)

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [peppercorn 0.6](https://clearlydefined.io/definitions/pypi/pypi/-/peppercorn/0.6/0.6)