### PR TITLE
 netcdf4 1.5.4

### DIFF
--- a/curations/pypi/pypi/-/netcdf4.yaml
+++ b/curations/pypi/pypi/-/netcdf4.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: netcdf4
+  provider: pypi
+  type: pypi
+revisions:
+  1.5.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 netcdf4 1.5.4

**Details:**
ClearlyDefined COPYING file is a modified MIT
PyPi license field indicates MIT
GitHub license is a modified MIT: https://github.com/Unidata/netcdf4-python/blob/v1.5.4rel/COPYING

**Resolution:**
OTHER

**Affected definitions**:
- [netcdf4 1.5.4](https://clearlydefined.io/definitions/pypi/pypi/-/netcdf4/1.5.4/1.5.4)