### PR TITLE
System.Security.AccessControl 4.6.0-preview7.19362.9

### DIFF
--- a/curations/nuget/nuget/-/System.Security.AccessControl.yaml
+++ b/curations/nuget/nuget/-/System.Security.AccessControl.yaml
@@ -15,6 +15,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview7.19362.9:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.AccessControl 4.6.0-preview7.19362.9

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/ed3d384706c03937e4eac3c377779f0048fa4c3e/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.AccessControl 4.6.0-preview7.19362.9](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.AccessControl/4.6.0-preview7.19362.9/4.6.0-preview7.19362.9)