### PR TITLE
 torchtext 0.9.1

### DIFF
--- a/curations/pypi/pypi/-/torchtext.yaml
+++ b/curations/pypi/pypi/-/torchtext.yaml
@@ -15,3 +15,6 @@ revisions:
   0.8.1:
     licensed:
       declared: BSD-3-Clause
+  0.9.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 torchtext 0.9.1

**Details:**
PyPi license field indicates BSD
GitHub license is BSD-3-Clause: https://github.com/pytorch/text/blob/v0.9.1-rc1/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [torchtext 0.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/torchtext/0.9.1/0.9.1)