### PR TITLE
Java 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Java.yaml
+++ b/curations/nuget/nuget/-/Java.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Java
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Java 1.0.0

**Details:**
ClearlyDefined no files
Nuget license field is missing
Nuget project field is missing

**Resolution:**
NONE

**Affected definitions**:
- [Java 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Java/1.0.0/1.0.0)