### PR TITLE
kendo-angular-l10n 2.0.2

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-l10n.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-l10n.yaml
@@ -16,6 +16,9 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.0.2:
+    licensed:
+      declared: OTHER
   2.0.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-l10n 2.0.2

**Details:**
ClearlyDefined license is OTHER:  Telerik End User License Agreement for Kendo UI
NPM license field indicates see license folder
GitHub license is OTHER: https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-l10n 2.0.2](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-l10n/2.0.2/2.0.2)