### PR TITLE
ICSharpCode.SharpZipLib.dll 0.85.4.369

### DIFF
--- a/curations/nuget/nuget/-/ICSharpCode.SharpZipLib.dll.yaml
+++ b/curations/nuget/nuget/-/ICSharpCode.SharpZipLib.dll.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ICSharpCode.SharpZipLib.dll
+  provider: nuget
+  type: nuget
+revisions:
+  0.85.4.369:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ICSharpCode.SharpZipLib.dll 0.85.4.369

**Details:**
Nuget license field is missing
Nuget does not include project link
No license info found

**Resolution:**
NONE

**Affected definitions**:
- [ICSharpCode.SharpZipLib.dll 0.85.4.369](https://clearlydefined.io/definitions/nuget/nuget/-/ICSharpCode.SharpZipLib.dll/0.85.4.369/0.85.4.369)