### PR TITLE
azureml-dataprep 2.24.3

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -132,6 +132,9 @@ revisions:
   2.24.0:
     licensed:
       declared: OTHER
+  2.24.3:
+    licensed:
+      declared: OTHER
   2.24.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.24.3

**Details:**
PyPi license field indicates OTHER
No license info found on project home page
Azure Machine Learning Data Prep SDK for Python license: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.24.3](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.24.3/2.24.3)