### PR TITLE
azureml-dataprep 2.7.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -171,6 +171,9 @@ revisions:
   2.7.1:
     licensed:
       declared: OTHER
+  2.7.2:
+    licensed:
+      declared: OTHER
   2.7.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.7.2

**Details:**
PyPi indicates OTHER

SDK license is: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.7.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.7.2/2.7.2)