### PR TITLE
Xamarin.Android.VerticalViewPager 1.0.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.VerticalViewPager.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.VerticalViewPager.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.VerticalViewPager
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.VerticalViewPager 1.0.1

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/alexrainman/VerticalViewPager/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Xamarin.Android.VerticalViewPager 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.VerticalViewPager/1.0.1/1.0.1)