### PR TITLE
spfx-heft-plugins 1.12.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/spfx-heft-plugins.yaml
+++ b/curations/npm/npmjs/@microsoft/spfx-heft-plugins.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: spfx-heft-plugins
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.12.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
spfx-heft-plugins 1.12.1

**Details:**
ClearlyDefined package.json no license info
NPM license field indicates NONE


**Resolution:**
NONE

**Affected definitions**:
- [spfx-heft-plugins 1.12.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/spfx-heft-plugins/1.12.1/1.12.1)