### PR TITLE
 System.Reactive.Core 4.1.2

### DIFF
--- a/curations/nuget/nuget/-/System.Reactive.Core.yaml
+++ b/curations/nuget/nuget/-/System.Reactive.Core.yaml
@@ -21,3 +21,6 @@ revisions:
   4.0.0:
     licensed:
       declared: Apache-2.0
+  4.1.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 System.Reactive.Core 4.1.2

**Details:**
Nuget license links to MIT
GitHub license is Apache-2.0: https://github.com/dotnet/reactive/blob/rxnet-v4.1.2/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [System.Reactive.Core 4.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/System.Reactive.Core/4.1.2/4.1.2)