### PR TITLE
elmah 1.1.0

### DIFF
--- a/curations/nuget/nuget/-/elmah.yaml
+++ b/curations/nuget/nuget/-/elmah.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: elmah
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
elmah 1.1.0

**Details:**
Nuget license links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/elmah/Elmah/blob/master/COPYING.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [elmah 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/elmah/1.1.0/1.1.0)