### PR TITLE
snakeyaml 1.6

### DIFF
--- a/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
+++ b/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.15':
     licensed:
       declared: Apache-2.0
+  '1.6':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
snakeyaml 1.6

**Details:**
Maven license field indicates Apache-2.0: https://mvnrepository.com/artifact/org.yaml/snakeyaml/1.6
Pom indicates Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [snakeyaml 1.6](https://clearlydefined.io/definitions/maven/mavencentral/org.yaml/snakeyaml/1.6/1.6)