### PR TITLE
microsoft-web-helpers 2.0.20710

### DIFF
--- a/curations/nuget/nuget/-/microsoft-web-helpers.yaml
+++ b/curations/nuget/nuget/-/microsoft-web-helpers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: microsoft-web-helpers
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.20710:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
microsoft-web-helpers 2.0.20710

**Details:**
Nuget license links to OTHER: https://www.microsoft.com/web/webpi/eula/aspnetcomponent_rtw_enu.htm


**Resolution:**
OTHER

**Affected definitions**:
- [microsoft-web-helpers 2.0.20710](https://clearlydefined.io/definitions/nuget/nuget/-/microsoft-web-helpers/2.0.20710/2.0.20710)