### PR TITLE
System.CommandLine.DragonFruit 0.2.0-alpha.19174.3

### DIFF
--- a/curations/nuget/nuget/-/System.CommandLine.DragonFruit.yaml
+++ b/curations/nuget/nuget/-/System.CommandLine.DragonFruit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.CommandLine.DragonFruit
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.0-alpha.19174.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.CommandLine.DragonFruit 0.2.0-alpha.19174.3

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/dotnet/command-line-api/blob/main/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [System.CommandLine.DragonFruit 0.2.0-alpha.19174.3](https://clearlydefined.io/definitions/nuget/nuget/-/System.CommandLine.DragonFruit/0.2.0-alpha.19174.3/0.2.0-alpha.19174.3)