### PR TITLE
Ninject.Extensions.NamedScope 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.NamedScope.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.NamedScope.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Extensions.NamedScope
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Extensions.NamedScope 3.2.0

**Details:**
Nuget license field links to MS-PL OR Apache-2.0
GitHub license is MS-PL OR Apache-2.0: https://github.com/ninject/Ninject.Extensions.NamedScope/blob/3.2.0-final/LICENSE.txt

**Resolution:**
MS-PL OR Apache-2.0

**Affected definitions**:
- [Ninject.Extensions.NamedScope 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.NamedScope/3.2.0/3.2.0)