### PR TITLE
DependencyPackage 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/DependencyPackage.yaml
+++ b/curations/nuget/nuget/-/DependencyPackage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DependencyPackage
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DependencyPackage 1.0.0

**Details:**
Nuget license field links to nothing: http://blah/
Nuget did not include project link

**Resolution:**
NONE

**Affected definitions**:
- [DependencyPackage 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/DependencyPackage/1.0.0/1.0.0)