### PR TITLE
 System.IO.Abstractions.TestingHelpers 2.0.0.124

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0.124:
+    licensed:
+      declared: MIT
   2.1.0.174:
     licensed:
       declared: MS-PL

--- a/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.TestingHelpers.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.0.0.124:
     licensed:
-      declared: MIT
+      declared: MS-PL
   2.1.0.174:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 System.IO.Abstractions.TestingHelpers 2.0.0.124

**Details:**
Nuget license field links to MIT
ClearlyDefined nuspec includes project link that has a MIT license: https://github.com/TestableIO/System.IO.Abstractions/blob/main/LICENSE
Note: Project link in GitHub goes to a project with MS-PL: https://github.com/TestableIO/System.IO.Abstractions/blob/df30d1b26b7

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions.TestingHelpers 2.0.0.124](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions.TestingHelpers/2.0.0.124/2.0.0.124)