### PR TITLE
 NLog.Web.AspNetCore 4.8.4

### DIFF
--- a/curations/nuget/nuget/-/NLog.Web.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/NLog.Web.AspNetCore.yaml
@@ -36,6 +36,9 @@ revisions:
   4.8.1:
     licensed:
       declared: BSD-3-Clause
+  4.8.4:
+    licensed:
+      declared: BSD-3-Clause
   4.8.5:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 NLog.Web.AspNetCore 4.8.4

**Details:**
Nuget license field links to BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/NLog/NLog.Web/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [NLog.Web.AspNetCore 4.8.4](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Web.AspNetCore/4.8.4/4.8.4)