### PR TITLE
javax.websocket-api 1.0

### DIFF
--- a/curations/maven/mavencentral/javax.websocket/javax.websocket-api.yaml
+++ b/curations/maven/mavencentral/javax.websocket/javax.websocket-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.0':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.1':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.websocket-api 1.0

**Details:**
ClearlyDefined pom indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven license field and links same as above
POM same as above

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.websocket-api 1.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.websocket/javax.websocket-api/1.0/1.0)