### PR TITLE
Akka.Cluster.Sharding 1.3.10-beta

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.Sharding.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.Sharding.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Cluster.Sharding
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10-beta:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster.Sharding 1.3.10-beta

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/dev/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Cluster.Sharding 1.3.10-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster.Sharding/1.3.10-beta/1.3.10-beta)