### PR TITLE
Portable.BouncyCastle 1.8.1.4

### DIFF
--- a/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
+++ b/curations/nuget/nuget/-/Portable.BouncyCastle.yaml
@@ -9,6 +9,9 @@ revisions:
   1.8.1.3:
     licensed:
       declared: MIT
+  1.8.1.4:
+    licensed:
+      declared: MIT
   1.8.10:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Portable.BouncyCastle 1.8.1.4

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/novotnyllc/bc-csharp/blob/netstandard/License.html

**Resolution:**
MIT

**Affected definitions**:
- [Portable.BouncyCastle 1.8.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/Portable.BouncyCastle/1.8.1.4/1.8.1.4)