### PR TITLE
 junit-jupiter-api 5.3.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
@@ -10,6 +10,9 @@ revisions:
   5.3.1:
     licensed:
       declared: EPL-2.0
+  5.3.2:
+    licensed:
+      declared: EPL-2.0
   5.4.0:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 junit-jupiter-api 5.3.2

**Details:**
Maven license link and field indicate EPL-2.0: https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api/5.3.2
POM indicates EPL-2.0

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter-api 5.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.3.2/5.3.2)