### PR TITLE
 javax.ws.rs-api 2.1.1

### DIFF
--- a/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
@@ -13,3 +13,6 @@ revisions:
   '2.1':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+  2.1.1:
+    licensed:
+      declared: EPL-2.0

--- a/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
@@ -15,4 +15,4 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.1.1:
     licensed:
-      declared: EPL-2.0
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
+++ b/curations/maven/mavencentral/javax.ws.rs/javax.ws.rs-api.yaml
@@ -6,13 +6,13 @@ coordinates:
 revisions:
   2.0-m10:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.0.1:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '2.1':
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.1.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 javax.ws.rs-api 2.1.1

**Details:**
Maven license field and links indicate EPL-2.0
POM indicates EPL-2.0

**Resolution:**
EPL-2.0

**Affected definitions**:
- [javax.ws.rs-api 2.1.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.ws.rs/javax.ws.rs-api/2.1.1/2.1.1)