### PR TITLE
Alba 3.1.2

### DIFF
--- a/curations/nuget/nuget/-/Alba.yaml
+++ b/curations/nuget/nuget/-/Alba.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Alba
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Alba 3.1.2

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/JasperFx/alba/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Alba 3.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Alba/3.1.2/3.1.2)