### PR TITLE
Declared license is missing

### DIFF
--- a/curations/maven/mavencentral/io.netty/netty-tcnative-classes.yaml
+++ b/curations/maven/mavencentral/io.netty/netty-tcnative-classes.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: netty-tcnative-classes
+  namespace: io.netty
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.46.Final:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is missing

**Details:**
The project's GitHub repo at https://github.com/netty/netty-tcnative/tree/netty-tcnative-parent-2.0.46.Final clearly declares the license to be Apache 2.0

**Resolution:**
Set declared license to Apache 2.0

**Affected definitions**:
- [netty-tcnative-classes 2.0.46.Final](https://clearlydefined.io/definitions/maven/mavencentral/io.netty/netty-tcnative-classes/2.0.46.Final/2.0.46.Final)