### PR TITLE
wct-browser-legacy 1.0.2

### DIFF
--- a/curations/npm/npmjs/-/wct-browser-legacy.yaml
+++ b/curations/npm/npmjs/-/wct-browser-legacy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wct-browser-legacy
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
wct-browser-legacy 1.0.2

**Details:**
NPM license field indicates see URL
GitHub license is BSD-3-Clause: https://github.com/Polymer/web-component-tester/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [wct-browser-legacy 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/wct-browser-legacy/1.0.2/1.0.2)