### PR TITLE
jdom 1.0

### DIFF
--- a/curations/maven/mavencentral/jdom/jdom.yaml
+++ b/curations/maven/mavencentral/jdom/jdom.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jdom
+  namespace: jdom
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/jdom/jdom.yaml
+++ b/curations/maven/mavencentral/jdom/jdom.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.0':
     licensed:
-      declared: BSD-3-Clause
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jdom 1.0

**Details:**
ClearlyDefined license file is BSD-3-Clause
Maven indicates Apache but does not include a link and no info found in POM

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jdom 1.0](https://clearlydefined.io/definitions/maven/mavencentral/jdom/jdom/1.0/1.0)