### PR TITLE
Fastenshtein 1.0.0.5

### DIFF
--- a/curations/nuget/nuget/-/Fastenshtein.yaml
+++ b/curations/nuget/nuget/-/Fastenshtein.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Fastenshtein
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Fastenshtein 1.0.0.5

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/DanHarltey/Fastenshtein/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Fastenshtein 1.0.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Fastenshtein/1.0.0.5/1.0.0.5)