### PR TITLE
jacoco-maven-plugin

### DIFF
--- a/curations/maven/mavencentral/org.jacoco/jacoco-maven-plugin.yaml
+++ b/curations/maven/mavencentral/org.jacoco/jacoco-maven-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jacoco-maven-plugin
+  namespace: org.jacoco
+  provider: mavencentral
+  type: maven
+revisions:
+  0.8.4:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jacoco-maven-plugin

**Details:**
Maven license field and link indicate EPL-1.0: https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin/0.8.4
POM indicates EPL-1.0

**Resolution:**
EPL-1.0

**Affected definitions**:
- [jacoco-maven-plugin 0.8.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jacoco/jacoco-maven-plugin/0.8.4/0.8.4)