### PR TITLE
CarouselView.FormsPlugin 5.2.0

### DIFF
--- a/curations/nuget/nuget/-/CarouselView.FormsPlugin.yaml
+++ b/curations/nuget/nuget/-/CarouselView.FormsPlugin.yaml
@@ -6,3 +6,6 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  5.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CarouselView.FormsPlugin 5.2.0

**Details:**
Nuget license field links to Readme indicating MIT
GitHub license is MIT: https://github.com/alexrainman/CarouselView/blob/master/license.md

**Resolution:**
MIT

**Affected definitions**:
- [CarouselView.FormsPlugin 5.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/CarouselView.FormsPlugin/5.2.0/5.2.0)