### PR TITLE
MarkdownDeep.NET 1.5.0

### DIFF
--- a/curations/nuget/nuget/-/MarkdownDeep.NET.yaml
+++ b/curations/nuget/nuget/-/MarkdownDeep.NET.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MarkdownDeep.NET
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MarkdownDeep.NET 1.5.0

**Details:**
Nuget license field links to Apache-2.0
Nuget project links to project with Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [MarkdownDeep.NET 1.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/MarkdownDeep.NET/1.5.0/1.5.0)