### PR TITLE
scala-library 2.11.7

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
@@ -16,6 +16,9 @@ revisions:
   2.11.12:
     licensed:
       declared: BSD-3-Clause
+  2.11.7:
+    licensed:
+      declared: BSD-3-Clause
   2.11.8:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scala-library 2.11.7

**Details:**
Maven license field indicates BSD-3-Clause: https://mvnrepository.com/artifact/org.scala-lang/scala-library/2.11.7
POM indicates BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-library 2.11.7](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-library/2.11.7/2.11.7)