### PR TITLE
css-color-names 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/css-color-names.yaml
+++ b/curations/npm/npmjs/-/css-color-names.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: css-color-names
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
css-color-names 0.0.1

**Details:**
ClearlyDefined Readme indicates MIT
NPM license field indicates MIT
GitHub Readme indicates MIT: https://github.com/bahamas10/css-color-names/tree/v0.0.1

**Resolution:**
MIT

**Affected definitions**:
- [css-color-names 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/css-color-names/0.0.1/0.0.1)