### PR TITLE
 OpenTracing.Contrib.Grpc 0.2.0

### DIFF
--- a/curations/nuget/nuget/-/OpenTracing.Contrib.Grpc.yaml
+++ b/curations/nuget/nuget/-/OpenTracing.Contrib.Grpc.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OpenTracing.Contrib.Grpc
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 OpenTracing.Contrib.Grpc 0.2.0

**Details:**
ClearlyDefined license is Apache-2.0
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/opentracing-contrib/csharp-grpc/blob/v0.2.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [OpenTracing.Contrib.Grpc 0.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/OpenTracing.Contrib.Grpc/0.2.0/0.2.0)