### PR TITLE
netcdf4 4.5.5

### DIFF
--- a/curations/maven/mavencentral/edu.ucar/netcdf4.yaml
+++ b/curations/maven/mavencentral/edu.ucar/netcdf4.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: netcdf4
+  namespace: edu.ucar
+  provider: mavencentral
+  type: maven
+revisions:
+  4.5.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
netcdf4 4.5.5

**Details:**
Maven links to BSD-3-Clause: http://www.unidata.ucar.edu/software/netcdf/copyright.html
POM has no license info

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [netcdf4 4.5.5](https://clearlydefined.io/definitions/maven/mavencentral/edu.ucar/netcdf4/4.5.5/4.5.5)