### PR TITLE
dependabot-hex 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-hex.yaml
+++ b/curations/gem/rubygems/-/dependabot-hex.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-hex
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-hex 0.162.2

**Details:**
Ruby indicates OTHER
Ruby links to GitHub which is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.0/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-hex 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-hex/0.162.2/0.162.2)