### PR TITLE
gmbal-api-only 3.0.0-b023

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.gmbal/gmbal-api-only.yaml
+++ b/curations/maven/mavencentral/org.glassfish.gmbal/gmbal-api-only.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: gmbal-api-only
+  namespace: org.glassfish.gmbal
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.0-b023:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gmbal-api-only 3.0.0-b023

**Details:**
Maven indicates CDDL and GPL: https://mvnrepository.com/artifact/org.glassfish.gmbal/gmbal-api-only/3.0.0-b023
POM indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [gmbal-api-only 3.0.0-b023](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.gmbal/gmbal-api-only/3.0.0-b023/3.0.0-b023)