### PR TITLE
jdbc-mysql 5.1.46

### DIFF
--- a/curations/gem/rubygems/-/jdbc-mysql.yaml
+++ b/curations/gem/rubygems/-/jdbc-mysql.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jdbc-mysql
+  provider: rubygems
+  type: gem
+revisions:
+  5.1.46:
+    licensed:
+      declared: GPL-2.0-or-later

--- a/curations/gem/rubygems/-/jdbc-mysql.yaml
+++ b/curations/gem/rubygems/-/jdbc-mysql.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   5.1.46:
     licensed:
-      declared: GPL-2.0-or-later
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jdbc-mysql 5.1.46

**Details:**
ClearlyDefined license and Readme indicates GPL-2
RubyGems indicates GPL-2
GitHub indicates GPL-2: https://github.com/jruby/activerecord-jdbc-adapter/blob/jdbc-mysql-5.1.46/jdbc-mysql/LICENSE.txt


**Resolution:**
GPL-2.0-or-later

Curation Guidance: If the only license information is “GPL,” with no COPYING license file, code the license as “GPL-1.0-or-later.

**Affected definitions**:
- [jdbc-mysql 5.1.46](https://clearlydefined.io/definitions/gem/rubygems/-/jdbc-mysql/5.1.46/5.1.46)