### PR TITLE
LessJie.System.Web.Http 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/LessJie.System.Web.Http.yaml
+++ b/curations/nuget/nuget/-/LessJie.System.Web.Http.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: LessJie.System.Web.Http
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LessJie.System.Web.Http 1.0.0

**Details:**
Nuget missing license field and project link
Searched Way Back Machine and did not find

**Resolution:**
NONE

**Affected definitions**:
- [LessJie.System.Web.Http 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/LessJie.System.Web.Http/1.0.0/1.0.0)