### PR TITLE
sepia 2.0.2

### DIFF
--- a/curations/npm/npmjs/-/sepia.yaml
+++ b/curations/npm/npmjs/-/sepia.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sepia
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sepia 2.0.2

**Details:**
ClearlyDefined license file is Apache-2.0
NPM license field indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/LinkedInAttic/sepia/blob/cbac689fd93ed5ed9b78d907f665bcd8983ec45e/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [sepia 2.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/sepia/2.0.2/2.0.2)