### PR TITLE
fake 0.2.2

### DIFF
--- a/curations/npm/npmjs/-/fake.yaml
+++ b/curations/npm/npmjs/-/fake.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fake
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
fake 0.2.2

**Details:**
NPM license field indicates NONE
GitHub license is MIT: https://github.com/felixge/node-fake/blob/master/License

**Resolution:**
MIT

**Affected definitions**:
- [fake 0.2.2](https://clearlydefined.io/definitions/npm/npmjs/-/fake/0.2.2/0.2.2)