### PR TITLE
Mono.Options.Signed 0.2.3

### DIFF
--- a/curations/nuget/nuget/-/Mono.Options.Signed.yaml
+++ b/curations/nuget/nuget/-/Mono.Options.Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Mono.Options.Signed
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.3:
+    licensed:
+      declared: MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Mono.Options.Signed 0.2.3

**Details:**
Nuget license links to MIT AND OTHER (patent).  The 3rd party code mentioned I believe is discovered: https://github.com/mono/mono/blob/main/LICENSE
GitHub links to same as above

**Resolution:**
MIT AND OTHER

**Affected definitions**:
- [Mono.Options.Signed 0.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Mono.Options.Signed/0.2.3/0.2.3)