### PR TITLE
 TelerikMvcExtensions 2013.2.611

### DIFF
--- a/curations/nuget/nuget/-/TelerikMvcExtensions.yaml
+++ b/curations/nuget/nuget/-/TelerikMvcExtensions.yaml
@@ -6,3 +6,6 @@ revisions:
   2013.1.219:
     licensed:
       declared: OTHER
+  2013.2.611:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 TelerikMvcExtensions 2013.2.611

**Details:**
Nuget project links to Telerik website.  This appears to be the license applicable to TelerikMVCExtensions: https://www.telerik.com/purchase/license-agreement/kendo-ui

**Resolution:**
OTHER

**Affected definitions**:
- [TelerikMvcExtensions 2013.2.611](https://clearlydefined.io/definitions/nuget/nuget/-/TelerikMvcExtensions/2013.2.611/2013.2.611)