### PR TITLE
NUglify 1.16.1

### DIFF
--- a/curations/nuget/nuget/-/NUglify.yaml
+++ b/curations/nuget/nuget/-/NUglify.yaml
@@ -12,6 +12,9 @@ revisions:
   1.13.8:
     licensed:
       declared: BSD-2-Clause
+  1.16.1:
+    licensed:
+      declared: BSD-2-Clause
   1.16.4:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NUglify 1.16.1

**Details:**
Nuget doesn't include a license field
Nuget links to project.  GitHub license is BSD-2-Clause: https://github.com/trullock/NUglify/blob/master/license.txt

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [NUglify 1.16.1](https://clearlydefined.io/definitions/nuget/nuget/-/NUglify/1.16.1/1.16.1)