### PR TITLE
ui 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/ui.yaml
+++ b/curations/npm/npmjs/-/ui.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ui
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ui 0.1.0

**Details:**
NPM license field indicates NONE
GitHub has no license: https://github.com/marcuswestin/ui.js
However, there is mention of what I believe are discovered licenses here: https://github.com/marcuswestin/ui.js/blob/e34a2724a173bedfd0d066365e68275b8e89613b/dom/getOffset.js

**Resolution:**
NONE

**Affected definitions**:
- [ui 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/ui/0.1.0/0.1.0)