### PR TITLE
Node.js 0.12.7

### DIFF
--- a/curations/nuget/nuget/-/Node.js.yaml
+++ b/curations/nuget/nuget/-/Node.js.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.12.7:
+    licensed:
+      declared: MIT
   5.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Node.js 0.12.7

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://raw.githubusercontent.com/nodejs/node/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Node.js 0.12.7](https://clearlydefined.io/definitions/nuget/nuget/-/Node.js/0.12.7/0.12.7)