### PR TITLE
DotNetty.Handlers 0.4.6

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Handlers.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Handlers.yaml
@@ -6,6 +6,9 @@ revisions:
   0.4.5:
     licensed:
       declared: MIT
+  0.4.6:
+    licensed:
+      declared: MIT
   0.4.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetty.Handlers 0.4.6

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/Azure/DotNetty/blob/dev/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [DotNetty.Handlers 0.4.6](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetty.Handlers/0.4.6/0.4.6)