### PR TITLE
 LINQPad 5.40.0

### DIFF
--- a/curations/nuget/nuget/-/LINQPad.yaml
+++ b/curations/nuget/nuget/-/LINQPad.yaml
@@ -9,3 +9,6 @@ revisions:
   5.36.3.1:
     licensed:
       declared: OTHER
+  5.40.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 LINQPad 5.40.0

**Details:**
Nuget license field links to OTHER: http://www.linqpad.net/eula.txt
Nuget project links to LINQPad site: https://www.linqpad.net/

**Resolution:**
OTHER

**Affected definitions**:
- [LINQPad 5.40.0](https://clearlydefined.io/definitions/nuget/nuget/-/LINQPad/5.40.0/5.40.0)