### PR TITLE
pcf-scripts 1.3.1

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -9,6 +9,9 @@ revisions:
   1.1.6:
     licensed:
       declared: OTHER
+  1.3.1:
+    licensed:
+      declared: OTHER
   1.3.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.3.1

**Details:**
ClearlyDefined license file is MSLT: MICROSOFT POWERAPPS CLI
NPM license field indicates see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-scripts 1.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.3.1/1.3.1)