### PR TITLE
azureml-dataprep 2.6.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -162,6 +162,9 @@ revisions:
   2.6.1:
     licensed:
       declared: OTHER
+  2.6.2:
+    licensed:
+      declared: OTHER
   2.6.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.6.2

**Details:**
PyPi license field indicates OTHER
Azureml SDK license: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.6.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.6.2/2.6.2)