### PR TITLE
System.Security.Principal.Windows 4.6.0-preview6.19303.8

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Principal.Windows.yaml
+++ b/curations/nuget/nuget/-/System.Security.Principal.Windows.yaml
@@ -21,6 +21,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview6.19303.8:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Principal.Windows 4.6.0-preview6.19303.8

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.Principal.Windows 4.6.0-preview6.19303.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Principal.Windows/4.6.0-preview6.19303.8/4.6.0-preview6.19303.8)