### PR TITLE
 bash-color 0.0.3

### DIFF
--- a/curations/npm/npmjs/-/bash-color.yaml
+++ b/curations/npm/npmjs/-/bash-color.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: bash-color
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 bash-color 0.0.3

**Details:**
NPM license field indicates MIT
GitHub license is MIT: https://github.com/mbilokonsky/bash-color/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [bash-color 0.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/bash-color/0.0.3/0.0.3)