### PR TITLE
HtmlAgilityPack 1.11.9

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -90,6 +90,9 @@ revisions:
   1.11.7:
     licensed:
       declared: MIT
+  1.11.9:
+    licensed:
+      declared: MIT
   1.4.6:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack 1.11.9

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/zzzprojects/html-agility-pack/blob/v1.11.19/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [HtmlAgilityPack 1.11.9](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.9/1.11.9)