### PR TITLE
 ADotNet 1.2.0

### DIFF
--- a/curations/nuget/nuget/-/ADotNet.yaml
+++ b/curations/nuget/nuget/-/ADotNet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ADotNet
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 ADotNet 1.2.0

**Details:**
Nuget license field links to MIT: https://www.nuget.org/packages/ADotNet/2.0.3/License
GitHub no license file found but licenses in various files is MIT

**Resolution:**
MIT

**Affected definitions**:
- [ADotNet 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/ADotNet/1.2.0/1.2.0)