### PR TITLE
LinqToExcel 1.10.1

### DIFF
--- a/curations/nuget/nuget/-/LinqToExcel.yaml
+++ b/curations/nuget/nuget/-/LinqToExcel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.10.1:
+    licensed:
+      declared: MIT
   1.11.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LinqToExcel 1.10.1

**Details:**
Nuget license field link to MIT
GitHub license is MIT: https://github.com/paulyoder/LinqToExcel/blob/v1.10.1/License.txt

**Resolution:**
MIT

**Affected definitions**:
- [LinqToExcel 1.10.1](https://clearlydefined.io/definitions/nuget/nuget/-/LinqToExcel/1.10.1/1.10.1)