### PR TITLE
 PackageA 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/PackageA.yaml
+++ b/curations/nuget/nuget/-/PackageA.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PackageA
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 PackageA 1.0.0

**Details:**
Nuget no license field or project link
No license information in nuspec

**Resolution:**
NONE

**Affected definitions**:
- [PackageA 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/PackageA/1.0.0/1.0.0)