### PR TITLE
swagger2-to-postmanv2 2.0.1

### DIFF
--- a/curations/npm/npmjs/-/swagger2-to-postmanv2.yaml
+++ b/curations/npm/npmjs/-/swagger2-to-postmanv2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: swagger2-to-postmanv2
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
swagger2-to-postmanv2 2.0.1

**Details:**
NPM license field indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/postmanlabs/swagger2-postman2/blob/develop/LICENSE.md

**Resolution:**
Apache-2.0

**Affected definitions**:
- [swagger2-to-postmanv2 2.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/swagger2-to-postmanv2/2.0.1/2.0.1)