### PR TITLE
Ninject.Web.WebApi.OwinHost 3.2.4

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Web.WebApi.OwinHost.yaml
+++ b/curations/nuget/nuget/-/Ninject.Web.WebApi.OwinHost.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.2.4:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 OR MS-PL

--- a/curations/nuget/nuget/-/Ninject.Web.WebApi.OwinHost.yaml
+++ b/curations/nuget/nuget/-/Ninject.Web.WebApi.OwinHost.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Web.WebApi.OwinHost
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Web.WebApi.OwinHost 3.2.4

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/ninject/Ninject.Web.WebApi/blob/3.2.4/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Ninject.Web.WebApi.OwinHost 3.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Web.WebApi.OwinHost/3.2.4/3.2.4)