### PR TITLE
JetBrains.dotMemoryUnit 3.0.20171219.105559

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.dotMemoryUnit.yaml
+++ b/curations/nuget/nuget/-/JetBrains.dotMemoryUnit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.0.20171219.105559:
+    licensed:
+      declared: OTHER
   3.1.20200127.214830:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.dotMemoryUnit 3.0.20171219.105559

**Details:**
Nuget license field links to OTHER: https://www.jetbrains.com/legal/docs/toolbox/user/
Nuget project links to JetBrains site

**Resolution:**
OTHER

**Affected definitions**:
- [JetBrains.dotMemoryUnit 3.0.20171219.105559](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.dotMemoryUnit/3.0.20171219.105559/3.0.20171219.105559)