### PR TITLE
 NServiceBus.DataBus.AzureBlobStorage 1.1.0

### DIFF
--- a/curations/nuget/nuget/-/NServiceBus.DataBus.AzureBlobStorage.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.DataBus.AzureBlobStorage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NServiceBus.DataBus.AzureBlobStorage
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: RPL-1.1

--- a/curations/nuget/nuget/-/NServiceBus.DataBus.AzureBlobStorage.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.DataBus.AzureBlobStorage.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.0:
     licensed:
-      declared: RPL-1.1
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 NServiceBus.DataBus.AzureBlobStorage 1.1.0

**Details:**
Nuget license field links to https://www.nuget.org/packages/NServiceBus.DataBus.AzureBlobStorage/4.0.0/License indicate RPL-1.1
GitHub license links to same: https://github.com/Particular/NServiceBus.DataBus.AzureBlobStorage/blob/1.1.0/LICENSE.md

**Resolution:**
RPL-1.1

**Affected definitions**:
- [NServiceBus.DataBus.AzureBlobStorage 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/NServiceBus.DataBus.AzureBlobStorage/1.1.0/1.1.0)