### PR TITLE
Nerdbank.GitVersioning 1.1.47-rc-g58708fcf8c

### DIFF
--- a/curations/nuget/nuget/-/Nerdbank.GitVersioning.yaml
+++ b/curations/nuget/nuget/-/Nerdbank.GitVersioning.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.47-rc-g58708fcf8c:
+    licensed:
+      declared: MIT
   1.4.19:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nerdbank.GitVersioning 1.1.47-rc-g58708fcf8c

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/dotnet/Nerdbank.GitVersioning/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Nerdbank.GitVersioning 1.1.47-rc-g58708fcf8c](https://clearlydefined.io/definitions/nuget/nuget/-/Nerdbank.GitVersioning/1.1.47-rc-g58708fcf8c/1.1.47-rc-g58708fcf8c)