### PR TITLE
Jot 1.2.7

### DIFF
--- a/curations/nuget/nuget/-/Jot.yaml
+++ b/curations/nuget/nuget/-/Jot.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Jot
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Jot 1.2.7

**Details:**
Nuget license field links to MIT
GitHub license is MIT: https://github.com/anakic/Jot/blob/master/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [Jot 1.2.7](https://clearlydefined.io/definitions/nuget/nuget/-/Jot/1.2.7/1.2.7)