### PR TITLE
Google.Protobuf 3.15.0-rc1

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -51,6 +51,9 @@ revisions:
   3.15.0:
     licensed:
       declared: BSD-3-Clause
+  3.15.0-rc1:
+    licensed:
+      declared: BSD-3-Clause
   3.15.5:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf 3.15.0-rc1

**Details:**
Nuget license field links to BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/protocolbuffers/protobuf/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Google.Protobuf 3.15.0-rc1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.15.0-rc1/3.15.0-rc1)