### PR TITLE
mysql/mysql-connector-java 8.0.26

### DIFF
--- a/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
+++ b/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
@@ -21,4 +21,4 @@ revisions:
       declared: OTHER
   8.0.26:
     licensed:
-      declared: GPL-2.0-only WITH Universal-FOSS-exception-1.0
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mysql/mysql-connector-java 8.0.26

**Details:**
Due to the customized license clauses on the package LICENSE file, we had decided to just do OTHER for this.

**Resolution:**
We discontinued using WITH OTHER and decided this should just be OTHER.

**Affected definitions**:
- [mysql-connector-java 8.0.26](https://clearlydefined.io/definitions/maven/mavencentral/mysql/mysql-connector-java/8.0.26/8.0.26)