### PR TITLE
mysql/mysql-connector-java versions 8.0.11 or higher

### DIFF
--- a/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
+++ b/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
@@ -4,10 +4,31 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  8.0.11:
+    licensed:
+      declared: OTHER
+  8.0.12:
+    licensed:
+      declared: OTHER
+  8.0.13:
+    licensed:
+      declared: OTHER
+  8.0.14:
+    licensed:
+      declared: OTHER
+  8.0.15:
+    licensed:
+      declared: OTHER
   8.0.16:
     licensed:
       declared: OTHER
+  8.0.17:
+    licensed:
+      declared: OTHER
   8.0.19:
+    licensed:
+      declared: OTHER
+  8.0.21:
     licensed:
       declared: OTHER
   8.0.22:
@@ -16,9 +37,15 @@ revisions:
   8.0.23:
     licensed:
       declared: OTHER
+  8.0.24:
+    licensed:
+      declared: OTHER
   8.0.25:
     licensed:
       declared: OTHER
   8.0.26:
     licensed:
-      declared: GPL-2.0-only WITH Universal-FOSS-exception-1.0
+      declared: OTHER
+  8.0.27:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mysql/mysql-connector-java versions 8.0.11 or higher

**Details:**
Have a LICENSE file with 3 paragraphs of customized license language - no SPDX we can use, so OTHER

**Resolution:**
Example of custom language on LICENSE file:Without limiting your rights under the GPLv2, the authors of MySQL hereby grant
   you an additional permission to link the program and your derivative
   works with the separately licensed software that they have included
   with the program.


**Affected definitions**:
- [mysql-connector-java 8.0.27](https://clearlydefined.io/definitions/maven/mavencentral/mysql/mysql-connector-java/8.0.27)