### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.3.0

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -117,9 +117,12 @@ revisions:
   2021.2.1:
     licensed:
       declared: OTHER
-  9.1.20150408.154812:
+  2021.2.2:
     licensed:
       declared: OTHER
-  2021.2.2:
+  2021.3.0:
+    licensed:
+      declared: OTHER
+  9.1.20150408.154812:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.3.0

**Details:**
Nuget license links to License Agreement for ReSharper Command Line Tools: https://www.nuget.org/packages/JetBrains.ReSharper.CommandLineTools/2021.3.1/License 


**Resolution:**
OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.3.0/2021.3.0)