### PR TITLE
azureml-dataprep 2.25.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -135,6 +135,9 @@ revisions:
   2.24.4:
     licensed:
       declared: OTHER
+  2.25.0:
+    licensed:
+      declared: OTHER
   2.3.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.25.0

**Details:**
PyPi license field indicates OTHER
Azureml SDK license: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.25.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.25.0/2.25.0)