### PR TITLE
distlib 0.3.4

### DIFF
--- a/curations/pypi/pypi/-/distlib.yaml
+++ b/curations/pypi/pypi/-/distlib.yaml
@@ -17,3 +17,6 @@ revisions:
       releaseDate: '2021-09-22'
     licensed:
       declared: OTHER
+  0.3.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
distlib 0.3.4

**Details:**
PyPi license field indicates Python
The project page is OTHER: https://bitbucket.org/pypa/distlib/src/master/LICENSE.txt


**Resolution:**
OTHER

**Affected definitions**:
- [distlib 0.3.4](https://clearlydefined.io/definitions/pypi/pypi/-/distlib/0.3.4/0.3.4)