### PR TITLE
 azureml-core 1.37.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -387,6 +387,9 @@ revisions:
   1.36.0.post2:
     licensed:
       declared: OTHER
+  1.37.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 azureml-core 1.37.0

**Details:**
PyPi license field indicates OTHER
Azureml SDK license: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-core 1.37.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.37.0/1.37.0)