### PR TITLE
azureml-automl-core 1.37.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -183,6 +183,9 @@ revisions:
   1.36.1:
     licensed:
       declared: OTHER
+  1.37.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.37.0

**Details:**
PyPi indicates OTHER
https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-automl-core 1.37.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.37.0/1.37.0)