### PR TITLE
azureml-train-automl-client 1.37.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-automl-client.yaml
+++ b/curations/pypi/pypi/-/azureml-train-automl-client.yaml
@@ -147,6 +147,9 @@ revisions:
   1.36.0:
     licensed:
       declared: OTHER
+  1.37.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-train-automl-client 1.37.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-train-automl-client 1.37.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-automl-client/1.37.0/1.37.0)