### PR TITLE
 azureml-pipeline-core 1.37.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -189,6 +189,9 @@ revisions:
   1.36.0:
     licensed:
       declared: OTHER
+  1.37.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 azureml-pipeline-core 1.37.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.37.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.37.0/1.37.0)