### PR TITLE
azureml-sdk 1.36.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-sdk.yaml
+++ b/curations/pypi/pypi/-/azureml-sdk.yaml
@@ -219,7 +219,7 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
-1.36.0:
+  1.36.0:
     licensed:
       declared: OTHER
   1.37.0:

--- a/curations/pypi/pypi/-/azureml-sdk.yaml
+++ b/curations/pypi/pypi/-/azureml-sdk.yaml
@@ -219,6 +219,9 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
+  1.36.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-sdk 1.36.0

**Details:**
PyPi license field indicates OTHER
https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-sdk 1.36.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-sdk/1.36.0/1.36.0)