### PR TITLE
rxtx 2.1.7

### DIFF
--- a/curations/maven/mavencentral/org.rxtx/rxtx.yaml
+++ b/curations/maven/mavencentral/org.rxtx/rxtx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: rxtx
+  namespace: org.rxtx
+  provider: mavencentral
+  type: maven
+revisions:
+  2.1.7:
+    licensed:
+      declared: LGPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rxtx 2.1.7

**Details:**
Maven indicates LGPL: https://mvnrepository.com/artifact/org.rxtx/rxtx/2.1.7
Maven license link is: LGPL-2.0-or-later
POM is: LGPL-2.0-or-later

**Resolution:**
LGPL-2.0-or-later

**Affected definitions**:
- [rxtx 2.1.7](https://clearlydefined.io/definitions/maven/mavencentral/org.rxtx/rxtx/2.1.7/2.1.7)