### PR TITLE
Reactive.AzureStorage.Table 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Reactive.AzureStorage.Table.yaml
+++ b/curations/nuget/nuget/-/Reactive.AzureStorage.Table.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Reactive.AzureStorage.Table
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Reactive.AzureStorage.Table 1.0.0

**Details:**
Nuget project license's readme indicates license is "the software is open source"
Search for "license" in project did not find a license

**Resolution:**
NONE

**Affected definitions**:
- [Reactive.AzureStorage.Table 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Reactive.AzureStorage.Table/1.0.0/1.0.0)