### PR TITLE
Selenium.WebDriver.IEDriver 3.11.1

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -9,6 +9,9 @@ revisions:
   3.0.0.1:
     licensed:
       declared: Unlicense
+  3.11.1:
+    licensed:
+      declared: Unlicense
   3.13.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.IEDriver 3.11.1

**Details:**
Nuget license field indicate Unlicense
GitHub license is Unlicense:https://github.com/jsakamoto/nupkg-selenium-webdriver-iedriver/blob/v.3.11.1.0/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.WebDriver.IEDriver 3.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.IEDriver/3.11.1/3.11.1)