### PR TITLE
K4os.Compression.LZ4 1.2.15

### DIFF
--- a/curations/nuget/nuget/-/K4os.Compression.LZ4.yaml
+++ b/curations/nuget/nuget/-/K4os.Compression.LZ4.yaml
@@ -48,6 +48,9 @@ revisions:
   1.2.13:
     licensed:
       declared: MIT
+  1.2.15:
+    licensed:
+      declared: MIT
   1.2.2-beta:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
K4os.Compression.LZ4 1.2.15

**Details:**
Nuget license field is MIT
GitHub license is MIT: https://github.com/MiloszKrajewski/K4os.Compression.LZ4/blob/1.2.15/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [K4os.Compression.LZ4 1.2.15](https://clearlydefined.io/definitions/nuget/nuget/-/K4os.Compression.LZ4/1.2.15/1.2.15)