### PR TITLE
sp-css-loader 1.12.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-css-loader.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-css-loader.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sp-css-loader
+  namespace: '@microsoft'
+  provider: npmjs
+  type: npm
+revisions:
+  1.12.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-css-loader 1.12.1

**Details:**
ClearlyDefined package.json had no license info
NPM license field indicates NONE
NPM no project link

**Resolution:**
NONE

**Affected definitions**:
- [sp-css-loader 1.12.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-css-loader/1.12.1/1.12.1)