### PR TITLE
K4os.Compression.LZ4.Streams 1.2.15

### DIFF
--- a/curations/nuget/nuget/-/K4os.Compression.LZ4.Streams.yaml
+++ b/curations/nuget/nuget/-/K4os.Compression.LZ4.Streams.yaml
@@ -6,6 +6,9 @@ revisions:
   1.1.11:
     licensed:
       declared: MIT
+  1.2.15:
+    licensed:
+      declared: MIT
   1.2.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
K4os.Compression.LZ4.Streams 1.2.15

**Details:**
ClearlyDefined license is MIT
NuGet license field links to MIT
GitHub license is MIT: https://github.com/MiloszKrajewski/K4os.Compression.LZ4/blob/1.2.15/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [K4os.Compression.LZ4.Streams 1.2.15](https://clearlydefined.io/definitions/nuget/nuget/-/K4os.Compression.LZ4.Streams/1.2.15/1.2.15)