### PR TITLE
mockito-core 2.4.0

### DIFF
--- a/curations/maven/mavencentral/org.mockito/mockito-core.yaml
+++ b/curations/maven/mavencentral/org.mockito/mockito-core.yaml
@@ -22,10 +22,10 @@ revisions:
   2.19.0:
     licensed:
       declared: MIT
-  2.23.0:
+  2.21.0:
     licensed:
       declared: MIT
-  2.21.0:
+  2.23.0:
     licensed:
       declared: MIT
   2.23.4:
@@ -35,6 +35,9 @@ revisions:
     licensed:
       declared: MIT
   2.27.0:
+    licensed:
+      declared: MIT
+  2.4.0:
     licensed:
       declared: MIT
   2.7.21:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mockito-core 2.4.0

**Details:**
ClearlyDefined license is MIT
Maven license field and link is MIT: https://mvnrepository.com/artifact/org.mockito/mockito-core/2.4.0
POM indicates MIT

**Resolution:**
MIT

**Affected definitions**:
- [mockito-core 2.4.0](https://clearlydefined.io/definitions/maven/mavencentral/org.mockito/mockito-core/2.4.0/2.4.0)