### PR TITLE
Akka.Cluster.Tools 1.3.10

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.Tools.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.Tools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Cluster.Tools
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster.Tools 1.3.10

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/akkadotnet/akka.net/blob/v1.3.10/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Akka.Cluster.Tools 1.3.10](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster.Tools/1.3.10/1.3.10)