### PR TITLE
inflector_extension 0.0.8

### DIFF
--- a/curations/nuget/nuget/-/inflector_extension.yaml
+++ b/curations/nuget/nuget/-/inflector_extension.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: inflector_extension
+  provider: nuget
+  type: nuget
+revisions:
+  0.0.8:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
inflector_extension 0.0.8

**Details:**
NuGet license field links to BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/little-sharps/inflector_extension/tree/0.0.8

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [inflector_extension 0.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/inflector_extension/0.0.8/0.0.8)