### PR TITLE
tar 2.1.0

### DIFF
--- a/curations/npm/npmjs/-/tar.yaml
+++ b/curations/npm/npmjs/-/tar.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.3:
     licensed:
       declared: BSD-2-Clause
+  2.1.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tar 2.1.0

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM license field indicates ISC
GitHub license is BSD-2-Clause

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [tar 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/tar/2.1.0/2.1.0)