### PR TITLE
MathNet.Numerics 3.6.0

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.yaml
@@ -18,6 +18,9 @@ revisions:
   3.20.2:
     licensed:
       declared: MIT
+  3.6.0:
+    licensed:
+      declared: MIT
   3.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MathNet.Numerics 3.6.0

**Details:**
ClearlyDefined license is MIT
NuGet license field links to MIT
GitHub license is MIT: https://github.com/mathnet/mathnet-numerics/blob/master/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [MathNet.Numerics 3.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics/3.6.0/3.6.0)