### PR TITLE
validation-api 1.0.0.GA

### DIFF
--- a/curations/maven/mavencentral/javax.validation/validation-api.yaml
+++ b/curations/maven/mavencentral/javax.validation/validation-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: validation-api
+  namespace: javax.validation
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.0.GA:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
validation-api 1.0.0.GA

**Details:**
Maven license field and link indicates Apache-2.0: https://mvnrepository.com/artifact/javax.validation/validation-api/1.0.0.GA
POM indicates Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [validation-api 1.0.0.GA](https://clearlydefined.io/definitions/maven/mavencentral/javax.validation/validation-api/1.0.0.GA/1.0.0.GA)