### PR TITLE
pcf-scripts 1.2.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -9,6 +9,9 @@ revisions:
   1.1.6:
     licensed:
       declared: OTHER
+  1.2.6:
+    licensed:
+      declared: OTHER
   1.3.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.2.6

**Details:**
NPM license indicates see license folder
ClearlyDefined license is OTHER: MICROSOFT POWERAPPS CLI MSLT

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-scripts 1.2.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.2.6/1.2.6)