### PR TITLE
StackExchange.Redis 1.0.394

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.394:
+    licensed:
+      declared: MIT
   1.0.414:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis 1.0.394

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/StackExchange/StackExchange.Redis/blob/40a156d701183c85c368d45c01885f09170901aa/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [StackExchange.Redis 1.0.394](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis/1.0.394/1.0.394)