### PR TITLE
pleeease-filters 3.0.0

### DIFF
--- a/curations/npm/npmjs/-/pleeease-filters.yaml
+++ b/curations/npm/npmjs/-/pleeease-filters.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  3.0.0:
+    licensed:
+      declared: MIT
   3.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pleeease-filters 3.0.0

**Details:**
NPM license field indicates MIT
GitHub license in Readme is MIT: https://github.com/iamvdo/pleeease-filters

**Resolution:**
MIT

**Affected definitions**:
- [pleeease-filters 3.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/pleeease-filters/3.0.0/3.0.0)