### PR TITLE
System.IO.Abstractions 2.0.0.116

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.0.0.116:
     licensed:
-      declared: MIT
+      declared: MS-PL
   2.0.0.124:
     licensed:
       declared: MS-PL

--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0.116:
+    licensed:
+      declared: MIT
   2.0.0.124:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions 2.0.0.116

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/TestableIO/System.IO.Abstractions/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions 2.0.0.116](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/2.0.0.116/2.0.0.116)