### PR TITLE
NuGet.Packaging 4.7.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.yaml
@@ -15,6 +15,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.7.0:
+    licensed:
+      declared: Apache-2.0
   4.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging 4.7.0

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Packaging 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging/4.7.0/4.7.0)