### PR TITLE
 AppInsights.EnterpriseTelemetry 1.0.2

### DIFF
--- a/curations/nuget/nuget/-/AppInsights.EnterpriseTelemetry.yaml
+++ b/curations/nuget/nuget/-/AppInsights.EnterpriseTelemetry.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AppInsights.EnterpriseTelemetry
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 AppInsights.EnterpriseTelemetry 1.0.2

**Details:**
NuGet license field is missing
GitHub license is MIT: https://github.com/microsoft/AppInsights.EnterpriseTelemetry/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AppInsights.EnterpriseTelemetry 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/AppInsights.EnterpriseTelemetry/1.0.2/1.0.2)