### PR TITLE
scala-reflect 2.12.4

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -25,3 +25,6 @@ revisions:
   2.12.3:
     licensed:
       declared: BSD-3-Clause
+  2.12.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scala-reflect 2.12.4

**Details:**
Maven license field and link indicates BSD-3-Clause
POM indicates BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-reflect 2.12.4](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.12.4/2.12.4)