### PR TITLE
FiddlerCore 4.4.8.4

### DIFF
--- a/curations/nuget/nuget/-/FiddlerCore.yaml
+++ b/curations/nuget/nuget/-/FiddlerCore.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.4.8.4:
+    licensed:
+      declared: OTHER
   4.5.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FiddlerCore 4.4.8.4

**Details:**
NuGet license field links to OTHER (Telerik End User License Agreement for FiddlerCore Embedded Engine (Last Updated March 18, 2015)): http://fiddlerbook.com/fiddler/core/license.txt


**Resolution:**
OTHER

**Affected definitions**:
- [FiddlerCore 4.4.8.4](https://clearlydefined.io/definitions/nuget/nuget/-/FiddlerCore/4.4.8.4/4.4.8.4)