### PR TITLE
NuGet.CommandLine 4.9.2

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -36,6 +36,9 @@ revisions:
   4.7.1:
     licensed:
       declared: Apache-2.0
+  4.9.2:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.CommandLine 4.9.2

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.CommandLine 4.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.9.2/4.9.2)