### PR TITLE
zrender 4.0.7

### DIFF
--- a/curations/npm/npmjs/-/zrender.yaml
+++ b/curations/npm/npmjs/-/zrender.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: zrender
+  provider: npmjs
+  type: npm
+revisions:
+  4.0.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
zrender 4.0.7

**Details:**
ClearlyDefined license is BSD-3-Clause
NPM license field indicates BSD-3-Clause
GitHub license is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [zrender 4.0.7](https://clearlydefined.io/definitions/npm/npmjs/-/zrender/4.0.7/4.0.7)