### PR TITLE
Akka.DistributedData 1.3.10-beta

### DIFF
--- a/curations/nuget/nuget/-/Akka.DistributedData.yaml
+++ b/curations/nuget/nuget/-/Akka.DistributedData.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.DistributedData
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10-beta:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.DistributedData 1.3.10-beta

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/dev/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.DistributedData 1.3.10-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.DistributedData/1.3.10-beta/1.3.10-beta)