### PR TITLE
Modernizr 2.7.1

### DIFF
--- a/curations/nuget/nuget/-/Modernizr.yaml
+++ b/curations/nuget/nuget/-/Modernizr.yaml
@@ -15,6 +15,9 @@ revisions:
   2.6.2:
     licensed:
       declared: MIT OR BSD-3-Clause
+  2.7.1:
+    licensed:
+      declared: MIT
   2.7.2:
     licensed:
       declared: MIT OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Modernizr 2.7.1

**Details:**
NuGet license field is MIT
Modernizr Licenes is MIT: https://modernizr.com/license/

**Resolution:**
MIT

**Affected definitions**:
- [Modernizr 2.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/Modernizr/2.7.1/2.7.1)