### PR TITLE
junit-jupiter-engine 5.8.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -40,6 +40,9 @@ revisions:
   5.8.0-M1:
     licensed:
       declared: EPL-2.0
+  5.8.1:
+    licensed:
+      declared: EPL-2.0
   5.8.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-jupiter-engine 5.8.1

**Details:**
ClearlyDefined license is EPL-2.0
Maven license field and link are EPL-2.0
POM indicates EPL-2.0


**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter-engine 5.8.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.8.1/5.8.1)