### PR TITLE
FluentValidation 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/FluentValidation.yaml
+++ b/curations/nuget/nuget/-/FluentValidation.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: Apache-2.0
   6.2.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentValidation 2.0.0

**Details:**
NuGet license field is broken
NuGet project link is broken
Nuspec license link is Apache-2.0: https://github.com/FluentValidation/FluentValidation/blob/main/License.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentValidation 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/FluentValidation/2.0.0/2.0.0)