### PR TITLE
Adds missing info for dotnet scanner

### DIFF
--- a/curations/nuget/nuget/-/dotnet-sonarscanner.yaml
+++ b/curations/nuget/nuget/-/dotnet-sonarscanner.yaml
@@ -13,4 +13,4 @@ revisions:
         type: git
         url: 'https://github.com/sonarsource/sonar-scanner-msbuild/commit/c2cc39130ade25de918e43552e7e94e6839baf59'
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later

--- a/curations/nuget/nuget/-/dotnet-sonarscanner.yaml
+++ b/curations/nuget/nuget/-/dotnet-sonarscanner.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: dotnet-sonarscanner
+  provider: nuget
+  type: nuget
+revisions:
+  5.4.0:
+    described:
+      sourceLocation:
+        name: sonar-scanner-msbuild
+        namespace: sonarsource
+        provider: github
+        revision: c2cc39130ade25de918e43552e7e94e6839baf59
+        type: git
+        url: 'https://github.com/sonarsource/sonar-scanner-msbuild/commit/c2cc39130ade25de918e43552e7e94e6839baf59'
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adds missing info for dotnet scanner

**Details:**
Missing license and repo location

**Resolution:**
ClearlyDefined didn't have license information for this component

**Affected definitions**:
- [dotnet-sonarscanner 5.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/dotnet-sonarscanner/5.4.0)