### PR TITLE
Add missing license to AppInsights.WindowsDesktop 2.18.1

### DIFF
--- a/curations/nuget/nuget/-/AppInsights.WindowsDesktop.yaml
+++ b/curations/nuget/nuget/-/AppInsights.WindowsDesktop.yaml
@@ -6,3 +6,6 @@ revisions:
   2.17.1:
     licensed:
       declared: MIT
+  2.18.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing license

**Details:**
The MIT license is linked in the GitHub repository, which is linked on the NuGet.org package details page.
License URL: https://github.com/novotnyllc/AppInsights.WindowsDesktop/blob/main/LICENSE

**Resolution:**
Add MIT license per GitHub repo.

**Affected definitions**:
- [AppInsights.WindowsDesktop 2.18.1](https://clearlydefined.io/definitions/nuget/nuget/-/AppInsights.WindowsDesktop/2.18.1)