### PR TITLE
Declared License was missing for this FOSS component version.

### DIFF
--- a/curations/git/github/r-dbi/dbi.yaml
+++ b/curations/git/github/r-dbi/dbi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dbi
+  namespace: r-dbi
+  provider: github
+  type: git
+revisions:
+  add9daaa98f8b6bd41eec51a92b20aff94c725b0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was missing for this FOSS component version.

**Details:**
1. Declared license was missing.

**Resolution:**
1. Filled-in the Declared License as "LGPL-2.1-or-later" by referring to https://dbi.r-dbi.org/.

**Affected definitions**:
- [dbi add9daaa98f8b6bd41eec51a92b20aff94c725b0](https://clearlydefined.io/definitions/git/github/r-dbi/dbi/add9daaa98f8b6bd41eec51a92b20aff94c725b0/add9daaa98f8b6bd41eec51a92b20aff94c725b0)