### PR TITLE
Declared License was missing for this FOSS component version.

### DIFF
--- a/curations/git/github/d3/d3.yaml
+++ b/curations/git/github/d3/d3.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  39347b4c53e8b3610db5afe4672d368535937c15:
+    licensed:
+      declared: BSD-3-Clause
   696c6d8461847b16335b47db4d68cb3d26447f90:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was missing for this FOSS component version.

**Details:**
1. Declared license was missing.

**Resolution:**
1. Filled-in the Declared License as "BSD-3clause" by referring to https://github.com/d3/d3/blob/39347b4c53e8b3610db5afe4672d368535937c15/LICENSE.

**Affected definitions**:
- [d3 39347b4c53e8b3610db5afe4672d368535937c15](https://clearlydefined.io/definitions/git/github/d3/d3/39347b4c53e8b3610db5afe4672d368535937c15/39347b4c53e8b3610db5afe4672d368535937c15)