### PR TITLE
Declared License was missing for this FOSS component version.

### DIFF
--- a/curations/git/github/couchbase/couchbase-net-client.yaml
+++ b/curations/git/github/couchbase/couchbase-net-client.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: couchbase-net-client
+  namespace: couchbase
+  provider: github
+  type: git
+revisions:
+  617b1a05f7491b0006c0c9df222828641aa5b5fb:
+    files:
+      - license: NONE
+        path: Src/Couchbase/IO/Operations/SubDocument/SubCounter.cs
+      - license: NONE
+        path: README.md
+      - license: NONE
+        path: Src/Couchbase/Authentication/SASL/PBKDF2.cs
+    licensed:
+      declared: Apache-2.0

--- a/curations/git/github/couchbase/couchbase-net-client.yaml
+++ b/curations/git/github/couchbase/couchbase-net-client.yaml
@@ -10,7 +10,7 @@ revisions:
         path: Src/Couchbase/IO/Operations/SubDocument/SubCounter.cs
       - license: NONE
         path: README.md
-      - license: NONE
+      - license: OTHER
         path: Src/Couchbase/Authentication/SASL/PBKDF2.cs
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was missing for this FOSS component version.

**Details:**
1. Declared license was missing.
2. Discovered Licenses were reported as NOASSERTION for 3 files but there were no license information found in those files.

**Resolution:**
1. Filled-in the Declared License as "Apache-2.0" by referring to https://docs.couchbase.com/dotnet-sdk/2.7/sdk-licenses.html. In github, The license text is found in the footer of each file in the Couchbase project and in a LICENSE file in the root of the repository.

**Affected definitions**:
- [couchbase-net-client 617b1a05f7491b0006c0c9df222828641aa5b5fb](https://clearlydefined.io/definitions/git/github/couchbase/couchbase-net-client/617b1a05f7491b0006c0c9df222828641aa5b5fb/617b1a05f7491b0006c0c9df222828641aa5b5fb)