### PR TITLE
Xamarin.Google.Guava.ListenableFuture 1.0.0.4

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Google.Guava.ListenableFuture.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Google.Guava.ListenableFuture.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0.2:
     licensed:
       declared: MIT
+  1.0.0.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Google.Guava.ListenableFuture 1.0.0.4

**Details:**
ClearlyDefined license is MIT
NuGet license field links to MIT
GitHub license is MIT: https://github.com/xamarin/XamarinComponents/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Google.Guava.ListenableFuture 1.0.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Google.Guava.ListenableFuture/1.0.0.4/1.0.0.4)