### PR TITLE
pillow9.0.0

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -15,3 +15,6 @@ revisions:
   6.2.1:
     licensed:
       declared: HPND
+  9.0.0:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow9.0.0

**Details:**
Fixing Declared license to HPND

**Resolution:**
https://github.com/python-pillow/Pillow/blob/9.0.0/LICENSE

**Affected definitions**:
- [pillow 9.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/9.0.0/9.0.0)