### PR TITLE
LightningDB 0.13.0

### DIFF
--- a/curations/nuget/nuget/-/LightningDB.yaml
+++ b/curations/nuget/nuget/-/LightningDB.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: LightningDB
+  provider: nuget
+  type: nuget
+revisions:
+  0.13.0:
+    licensed:
+      declared: OLDAP-2.8


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LightningDB 0.13.0

**Details:**
NuGet license field links to OLDAP-2.8
GitHub license is OLDAP-2.8: https://github.com/CoreyKaylor/Lightning.NET/blob/v0.13.0/LICENSE

**Resolution:**
OLDAP-2.8

**Affected definitions**:
- [LightningDB 0.13.0](https://clearlydefined.io/definitions/nuget/nuget/-/LightningDB/0.13.0/0.13.0)