### PR TITLE
dependabot-terraform 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-terraform.yaml
+++ b/curations/gem/rubygems/-/dependabot-terraform.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-terraform
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-terraform 0.162.2

**Details:**
RubyGems license field indicates Nonstandard
GitHub license indicates The Prosperity Public License 2.0.0: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-terraform 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-terraform/0.162.2/0.162.2)