### PR TITLE
mimepull 1.9.3

### DIFF
--- a/curations/maven/mavencentral/org.jvnet.mimepull/mimepull.yaml
+++ b/curations/maven/mavencentral/org.jvnet.mimepull/mimepull.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mimepull
+  namespace: org.jvnet.mimepull
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.3:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mimepull 1.9.3

**Details:**
Maven POM and license fields indicate indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
POM: https://repo1.maven.org/maven2/org/jvnet/mimepull/mimepull/1.9.3/mimepull-1.9.3.pom


**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [mimepull 1.9.3](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.3/1.9.3)