### PR TITLE
snakeyaml 1.11

### DIFF
--- a/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
+++ b/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.11':
+    licensed:
+      declared: Apache-2.0
   '1.15':
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
snakeyaml 1.11

**Details:**
ClearlyDefined and Maven POM indicates Apache-2.0: https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.11/snakeyaml-1.11.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [snakeyaml 1.11](https://clearlydefined.io/definitions/maven/mavencentral/org.yaml/snakeyaml/1.11/1.11)