### PR TITLE
System.Data.SQLite.Linq 1.0.113

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Linq.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Linq.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.108:
     licensed:
       declared: OTHER
+  1.0.113:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.Linq 1.0.113

**Details:**
ClearlyDefined license indicates OTHER (SQLite Is Public Domain)
NuGet license field links to OTHER: https://www.sqlite.org/copyright.html

**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.Linq 1.0.113](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Linq/1.0.113/1.0.113)