### PR TITLE
tlslite 0.4.9

### DIFF
--- a/curations/pypi/pypi/-/tlslite.yaml
+++ b/curations/pypi/pypi/-/tlslite.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: tlslite
+  provider: pypi
+  type: pypi
+revisions:
+  0.4.9:
+    licensed:
+      declared: NOASSERTION AND BSD-3-Clause

--- a/curations/pypi/pypi/-/tlslite.yaml
+++ b/curations/pypi/pypi/-/tlslite.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.4.9:
     licensed:
-      declared: NOASSERTION AND BSD-3-Clause
+      declared: BSD-3-Clause OR Unlicense

--- a/curations/pypi/pypi/-/tlslite.yaml
+++ b/curations/pypi/pypi/-/tlslite.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.4.9:
     licensed:
-      declared: BSD-3-Clause OR Unlicense
+      declared: BSD-3-Clause AND Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tlslite 0.4.9

**Details:**
ClearlyDefined license is OTHER AND BSD-3-Clause
PyPi license field indicates OTHER AND BSD

**Resolution:**
OTHER AND BSD-3-Clause

**Affected definitions**:
- [tlslite 0.4.9](https://clearlydefined.io/definitions/pypi/pypi/-/tlslite/0.4.9/0.4.9)