### PR TITLE
Unity.Container 5.5.8

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -36,6 +36,9 @@ revisions:
   5.3.2:
     licensed:
       declared: Apache-2.0
+  5.5.8:
+    licensed:
+      declared: Apache-2.0
   5.7.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Container 5.5.8

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/unitycontainer/unity/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Container 5.5.8](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.5.8/5.5.8)