### PR TITLE
JsonValue 0.6.0

### DIFF
--- a/curations/nuget/nuget/-/JsonValue.yaml
+++ b/curations/nuget/nuget/-/JsonValue.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: JsonValue
+  provider: nuget
+  type: nuget
+revisions:
+  0.6.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JsonValue 0.6.0

**Details:**
NuGet license field link is broken
NuGet source project link is broken
Way Back Machine indicates OTHER: https://web.archive.org/web/20170416172616/http://wcf.codeplex.com/license

**Resolution:**
OTHER

**Affected definitions**:
- [JsonValue 0.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/JsonValue/0.6.0/0.6.0)