### PR TITLE
GeoCoordinate.NetCore 1.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/GeoCoordinate.NetCore.yaml
+++ b/curations/nuget/nuget/-/GeoCoordinate.NetCore.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: GeoCoordinate.NetCore
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GeoCoordinate.NetCore 1.0.0.1

**Details:**
ClearlyDefined downloaded package an no license info found
NuGet no license field
GitHub no license info found: https://github.com/cormaltes/GPSOAuthSharp

**Resolution:**
NONE

**Affected definitions**:
- [GeoCoordinate.NetCore 1.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/GeoCoordinate.NetCore/1.0.0.1/1.0.0.1)