### PR TITLE
Serilog.Extensions.Autofac.DependencyInjection 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/Serilog.Extensions.Autofac.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/Serilog.Extensions.Autofac.DependencyInjection.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Serilog.Extensions.Autofac.DependencyInjection
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Serilog.Extensions.Autofac.DependencyInjection 1.3.0

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/alsami/Serilog.Extensions.Autofac.DependencyInjection/blob/1.3.0/licence.md

**Resolution:**
MIT

**Affected definitions**:
- [Serilog.Extensions.Autofac.DependencyInjection 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Serilog.Extensions.Autofac.DependencyInjection/1.3.0/1.3.0)