### PR TITLE
 jodd-bean 5.0.13

### DIFF
--- a/curations/maven/mavencentral/org.jodd/jodd-bean.yaml
+++ b/curations/maven/mavencentral/org.jodd/jodd-bean.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jodd-bean
+  namespace: org.jodd
+  provider: mavencentral
+  type: maven
+revisions:
+  5.0.13:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jodd-bean 5.0.13

**Details:**
Maven POM indicates BSD-2-Clause: 
https://repo1.maven.org/maven2/org/jodd/jodd-bean/5.0.13/jodd-bean-5.0.13.pom
Maven indicates BSD-2-Clause

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [jodd-bean 5.0.13](https://clearlydefined.io/definitions/maven/mavencentral/org.jodd/jodd-bean/5.0.13/5.0.13)