### PR TITLE
Xamarin.Android.CirclePageIndicator 1.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.CirclePageIndicator.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.CirclePageIndicator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Android.CirclePageIndicator
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.CirclePageIndicator 1.0.2

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/alexrainman/CirclePageIndicator/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Android.CirclePageIndicator 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.CirclePageIndicator/1.0.2/1.0.2)