### PR TITLE
wct-browser-legacy 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/wct-browser-legacy.yaml
+++ b/curations/npm/npmjs/-/wct-browser-legacy.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-3-Clause
   1.0.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
wct-browser-legacy 1.0.0

**Details:**
ClearlyDefined package.json license link is MIT: http://polymer.github.io/LICENSE.txt
NPM license field links to same as above
GitHub license is MIT: https://github.com/Polymer/web-component-tester/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [wct-browser-legacy 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/wct-browser-legacy/1.0.0/1.0.0)