### PR TITLE
NuGet.Protocol.Core.Types 4.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Protocol.Core.Types.yaml
+++ b/curations/nuget/nuget/-/NuGet.Protocol.Core.Types.yaml
@@ -9,3 +9,6 @@ revisions:
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Protocol.Core.Types 4.2.0

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Protocol.Core.Types 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Protocol.Core.Types/4.2.0/4.2.0)