### PR TITLE
DotNetty.Common 0.4.6

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Common.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Common.yaml
@@ -6,6 +6,9 @@ revisions:
   0.4.5:
     licensed:
       declared: MIT
+  0.4.6:
+    licensed:
+      declared: MIT
   0.4.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetty.Common 0.4.6

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/Azure/DotNetty/blob/dev/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [DotNetty.Common 0.4.6](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetty.Common/0.4.6/0.4.6)