### PR TITLE
Prism 5.0.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.yaml
+++ b/curations/nuget/nuget/-/Prism.yaml
@@ -6,3 +6,6 @@ revisions:
   4.1.0:
     licensed:
       declared: MS-PL
+  5.0.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Prism.yaml
+++ b/curations/nuget/nuget/-/Prism.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   4.1.0:
     licensed:
-      declared: MS-PL
+      declared: OTHER
   5.0.0:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism 5.0.0

**Details:**
Nuspec includes license link and project link which includes MIT
GitHub license is MIT: https://github.com/PrismLibrary/Prism/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Prism 5.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism/5.0.0/5.0.0)