### PR TITLE
CLAP 4.3.0

### DIFF
--- a/curations/nuget/nuget/-/CLAP.yaml
+++ b/curations/nuget/nuget/-/CLAP.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.3.0:
+    licensed:
+      declared: MIT
   4.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CLAP 4.3.0

**Details:**
NuGet license field link is broken
GitHub license is MIT: https://github.com/adrianaisemberg/CLAP/blob/master/license.txt

**Resolution:**
MIT

**Affected definitions**:
- [CLAP 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/CLAP/4.3.0/4.3.0)