### PR TITLE
dependabot-github_actions 0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-github_actions.yaml
+++ b/curations/gem/rubygems/-/dependabot-github_actions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-github_actions
+  provider: rubygems
+  type: gem
+revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-github_actions 0.129.5

**Details:**
RubyGems license field indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/main/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-github_actions 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-github_actions/0.129.5/0.129.5)