### PR TITLE
protobuf-net 2.2.1

### DIFF
--- a/curations/nuget/nuget/-/protobuf-net.yaml
+++ b/curations/nuget/nuget/-/protobuf-net.yaml
@@ -75,6 +75,9 @@ revisions:
   2.1.0-alpha-5:
     licensed:
       declared: BSD-3-Clause
+  2.2.1:
+    licensed:
+      declared: Apache-2.0
   2.3.17:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/protobuf-net.yaml
+++ b/curations/nuget/nuget/-/protobuf-net.yaml
@@ -65,16 +65,16 @@ revisions:
       declared: Apache-2.0
   2.1.0-alpha-1:
     licensed:
-      declared: BSD-3-Clause
+      declared: Apache-2.0
   2.1.0-alpha-3:
     licensed:
-      declared: BSD-3-Clause
+      declared: Apache-2.0
   2.1.0-alpha-4:
     licensed:
-      declared: BSD-3-Clause
+      declared: Apache-2.0
   2.1.0-alpha-5:
     licensed:
-      declared: BSD-3-Clause
+      declared: Apache-2.0
   2.2.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
protobuf-net 2.2.1

**Details:**
NuGet license field indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/protobuf-net/protobuf-net/blob/2.2.1/Licence.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [protobuf-net 2.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/protobuf-net/2.2.1/2.2.1)