### PR TITLE
snakeyaml 1.4

### DIFF
--- a/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
+++ b/curations/maven/mavencentral/org.yaml/snakeyaml.yaml
@@ -7,6 +7,9 @@ revisions:
   '1.15':
     licensed:
       declared: Apache-2.0
+  '1.4':
+    licensed:
+      declared: Apache-2.0
   '1.6':
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
snakeyaml 1.4

**Details:**
Maven license field indicates Apache-2.0
Maven POM indicates Apache-2.0: https://repo1.maven.org/maven2/org/yaml/snakeyaml/1.4/snakeyaml-1.4.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [snakeyaml 1.4](https://clearlydefined.io/definitions/maven/mavencentral/org.yaml/snakeyaml/1.4/1.4)