### PR TITLE
EPPlus 4.0.5

### DIFF
--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -6,6 +6,9 @@ revisions:
   4.0.4:
     licensed:
       declared: LGPL-2.1-or-later
+  4.0.5:
+    licensed:
+      declared: OTHER
   4.1.0:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EPPlus 4.0.5

**Details:**
NuGet license field links to OTHER
GitHub license is OTHER: https://github.com/EPPlusSoftware/EPPlus/blob/develop/license.md

**Resolution:**
OTHER

**Affected definitions**:
- [EPPlus 4.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/EPPlus/4.0.5/4.0.5)