### PR TITLE
tf2onnx 1.9.2

### DIFF
--- a/curations/pypi/pypi/-/tf2onnx.yaml
+++ b/curations/pypi/pypi/-/tf2onnx.yaml
@@ -12,3 +12,6 @@ revisions:
   1.6.3:
     licensed:
       declared: MIT
+  1.9.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tf2onnx 1.9.2

**Details:**
PyPi license field indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/onnx/tensorflow-onnx/blob/v1.9.2/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [tf2onnx 1.9.2](https://clearlydefined.io/definitions/pypi/pypi/-/tf2onnx/1.9.2/1.9.2)