### PR TITLE
 StyleCop.Analyzers.Error 1.0.2

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.Analyzers.Error.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.Error.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StyleCop.Analyzers.Error
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 StyleCop.Analyzers.Error 1.0.2

**Details:**
NuGet license field missing
NuGet project link missing
ClearlyDefined downloaded package an no license info found

**Resolution:**
NONE

**Affected definitions**:
- [StyleCop.Analyzers.Error 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.Analyzers.Error/1.0.2/1.0.2)