### PR TITLE
tail-file 2.1.0

### DIFF
--- a/curations/npm/npmjs/@logdna/tail-file.yaml
+++ b/curations/npm/npmjs/@logdna/tail-file.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tail-file
+  namespace: '@logdna'
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tail-file 2.1.0

**Details:**
ClearlyDefined license is MIT
NPM license field indicates se license folder
GitHub license is MIT: https://github.com/logdna/tail-file-node/blob/v2.1.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [tail-file 2.1.0](https://clearlydefined.io/definitions/npm/npmjs/@logdna/tail-file/2.1.0/2.1.0)