### PR TITLE
NServiceBus.Log4Net 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/NServiceBus.Log4Net.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.Log4Net.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.0.0:
     licensed:
-      declared: RPL-1.5
+      declared: OTHER

--- a/curations/nuget/nuget/-/NServiceBus.Log4Net.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.Log4Net.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NServiceBus.Log4Net
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: RPL-1.5


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NServiceBus.Log4Net 2.0.0

**Details:**
NuGet license field links to: RPL-1.5
GitHub license is RPL-1.5: https://github.com/Particular/NServiceBus.Log4Net/blob/master/LICENSE.md

**Resolution:**
RPL-1.5

**Affected definitions**:
- [NServiceBus.Log4Net 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/NServiceBus.Log4Net/2.0.0/2.0.0)