### PR TITLE
ReportGenerator 1.9.1

### DIFF
--- a/curations/nuget/nuget/-/ReportGenerator.yaml
+++ b/curations/nuget/nuget/-/ReportGenerator.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.9.1:
+    licensed:
+      declared: Apache-2.0
   2.1.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ReportGenerator 1.9.1

**Details:**
ClearlyDefined license is Apache-2.0
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/danielpalme/ReportGenerator/blob/main/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ReportGenerator 1.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/ReportGenerator/1.9.1/1.9.1)