### PR TITLE
RequireJS 2.1.15

### DIFF
--- a/curations/nuget/nuget/-/RequireJS.yaml
+++ b/curations/nuget/nuget/-/RequireJS.yaml
@@ -6,6 +6,9 @@ revisions:
   2.1.14:
     licensed:
       declared: BSD-3-Clause OR MIT
+  2.1.15:
+    licensed:
+      declared: MIT
   2.1.17:
     licensed:
       declared: BSD-3-Clause OR MIT

--- a/curations/nuget/nuget/-/RequireJS.yaml
+++ b/curations/nuget/nuget/-/RequireJS.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: BSD-3-Clause OR MIT
   2.1.15:
     licensed:
-      declared: MIT
+      declared: BSD-3-Clause OR MIT
   2.1.17:
     licensed:
       declared: BSD-3-Clause OR MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RequireJS 2.1.15

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/requirejs/requirejs/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [RequireJS 2.1.15](https://clearlydefined.io/definitions/nuget/nuget/-/RequireJS/2.1.15/2.1.15)