### PR TITLE
dependabot-go_modules 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-go_modules.yaml
+++ b/curations/gem/rubygems/-/dependabot-go_modules.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-go_modules
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-go_modules 0.162.2

**Details:**
RubyGems license field indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/main/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-go_modules 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-go_modules/0.162.2/0.162.2)