### PR TITLE
ipaddress 1.0.19

### DIFF
--- a/curations/pypi/pypi/-/ipaddress.yaml
+++ b/curations/pypi/pypi/-/ipaddress.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.17:
     licensed:
       declared: PSF-2.0
+  1.0.19:
+    licensed:
+      declared: PSF-2.0
   1.0.22:
     licensed:
       declared: PSF-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ipaddress 1.0.19

**Details:**
ClearlyDefined licensee is PSF-2.0
PyPi license field indicates Python
GitHub license is PSF-2.0: https://github.com/phihag/ipaddress/blob/master/LICENSE

**Resolution:**
PSF-2.0

**Affected definitions**:
- [ipaddress 1.0.19](https://clearlydefined.io/definitions/pypi/pypi/-/ipaddress/1.0.19/1.0.19)