### PR TITLE
HtmlAgilityPack 1.11.8

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -90,6 +90,9 @@ revisions:
   1.11.7:
     licensed:
       declared: MIT
+  1.11.8:
+    licensed:
+      declared: MIT
   1.11.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack 1.11.8

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/zzzprojects/html-agility-pack/blob/v1.11.8/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [HtmlAgilityPack 1.11.8](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.11.8/1.11.8)