### PR TITLE
NLog.Schema 4.6.8

### DIFF
--- a/curations/nuget/nuget/-/NLog.Schema.yaml
+++ b/curations/nuget/nuget/-/NLog.Schema.yaml
@@ -111,6 +111,9 @@ revisions:
   4.6.6:
     licensed:
       declared: BSD-3-Clause
+  4.6.8:
+    licensed:
+      declared: BSD-3-Clause
   4.7.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Schema 4.6.8

**Details:**
ClearlyDefined license is BSD-3-Clause
NuGet license field is BSD-3-Clause
GitHub BSD-3-Clause: https://github.com/NLog/NLog/blob/v4.6.8/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [NLog.Schema 4.6.8](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Schema/4.6.8/4.6.8)