### PR TITLE
Bond.Grpc.CSharp 7.0.1

### DIFF
--- a/curations/nuget/nuget/-/Bond.Grpc.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Grpc.CSharp.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  7.0.1:
+    licensed:
+      declared: MIT
   8.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Grpc.CSharp 7.0.1

**Details:**
NuGet license is MIT
GitHub license is MIThttps://github.com/microsoft/bond/blob/7.0.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Bond.Grpc.CSharp 7.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Grpc.CSharp/7.0.1/7.0.1)