### PR TITLE
System.Security.Principal.Windows 4.6.0-preview7.19362.9

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Principal.Windows.yaml
+++ b/curations/nuget/nuget/-/System.Security.Principal.Windows.yaml
@@ -24,6 +24,9 @@ revisions:
   4.6.0-preview6.19303.8:
     licensed:
       declared: MIT
+  4.6.0-preview7.19362.9:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Principal.Windows 4.6.0-preview7.19362.9

**Details:**
ClearlyDefined license is MIT
NuGet license is MIT
GitHub license is MIT: https://github.com/dotnet/runtime

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.Principal.Windows 4.6.0-preview7.19362.9](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Principal.Windows/4.6.0-preview7.19362.9/4.6.0-preview7.19362.9)