### PR TITLE
junit-platform-engine 1.4.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
@@ -10,6 +10,9 @@ revisions:
   1.3.1:
     licensed:
       declared: EPL-2.0
+  1.4.0:
+    licensed:
+      declared: EPL-2.0
   1.4.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-platform-engine 1.4.0

**Details:**
ClearlyDefined license is EPL-2.0
Maven license field is EPL-2.0
POM is EPL-2.0: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-engine/1.4.0/junit-platform-engine-1.4.0.pom


**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-engine 1.4.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-engine/1.4.0/1.4.0)