### PR TITLE
sp-dialog 1.11.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-dialog.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-dialog.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1.11.0:
     licensed:
-      declared: Unlicense
+      declared: OTHER
   1.13.0:
     licensed:
       declared: OTHER

--- a/curations/npm/npmjs/@microsoft/sp-dialog.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-dialog.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.11.0:
+    licensed:
+      declared: Unlicense
   1.13.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sp-dialog 1.11.0

**Details:**
ClearlyDefined package.json indicates Unlicense
NPM license field indicates Unlicense

**Resolution:**
Unlicense

**Affected definitions**:
- [sp-dialog 1.11.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-dialog/1.11.0/1.11.0)