### PR TITLE
Prism.Mvvm 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.Mvvm.yaml
+++ b/curations/nuget/nuget/-/Prism.Mvvm.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.0:
+    licensed:
+      declared: NONE
   1.1.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.Mvvm 1.0.0

**Details:**
NuGet license link is broken
NuGet project link is broken
Way Back Machine - not  included

**Resolution:**
NONE

**Affected definitions**:
- [Prism.Mvvm 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.Mvvm/1.0.0/1.0.0)