### PR TITLE
SharePointPnP.IdentityModel.Extensions 1.2.3

### DIFF
--- a/curations/nuget/nuget/-/SharePointPnP.IdentityModel.Extensions.yaml
+++ b/curations/nuget/nuget/-/SharePointPnP.IdentityModel.Extensions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.2.3:
+    licensed:
+      declared: MIT
   1.2.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SharePointPnP.IdentityModel.Extensions 1.2.3

**Details:**
NuGet license field links to MIT: https://github.com/pnp/PnP-IdentityModel/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [SharePointPnP.IdentityModel.Extensions 1.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/SharePointPnP.IdentityModel.Extensions/1.2.3/1.2.3)