### PR TITLE
Ninject.MockingKernel 3.3.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MockingKernel.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.yaml
@@ -9,3 +9,6 @@ revisions:
   3.2.2:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.3.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.MockingKernel 3.3.0

**Details:**
Nuget license field links to Apache-2.0 OR MS-PL
GitHub license is Apache-2.0 OR MS-PL: https://github.com/ninject/Ninject.MockingKernel/blob/3.3.0/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.MockingKernel 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MockingKernel/3.3.0/3.3.0)