### PR TITLE
 Mindbox.Expressions 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Mindbox.Expressions.yaml
+++ b/curations/nuget/nuget/-/Mindbox.Expressions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Mindbox.Expressions
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: NONE

--- a/curations/nuget/nuget/-/Mindbox.Expressions.yaml
+++ b/curations/nuget/nuget/-/Mindbox.Expressions.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.2.0:
     licensed:
-      declared: NONE
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 Mindbox.Expressions 3.2.0

**Details:**
NuGet license field is missing
NuGet project link is missing
ClearlyDefined downloaded package and no license info found

**Resolution:**
NONE

**Affected definitions**:
- [Mindbox.Expressions 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Mindbox.Expressions/3.2.0/3.2.0)