### PR TITLE
VSSDK.IDE.9 9.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.IDE.9.yaml
+++ b/curations/nuget/nuget/-/VSSDK.IDE.9.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.IDE.9
+  provider: nuget
+  type: nuget
+revisions:
+  9.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VSSDK.IDE.9 9.0.4

**Details:**
NuGet license field is missing
NuGet project link is missing
ClearlyDefined downloaded package and no license info found

**Resolution:**
NONE

**Affected definitions**:
- [VSSDK.IDE.9 9.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.IDE.9/9.0.4/9.0.4)