### PR TITLE
 swagger-ui-bundle 0.0.8

### DIFF
--- a/curations/pypi/pypi/-/swagger-ui-bundle.yaml
+++ b/curations/pypi/pypi/-/swagger-ui-bundle.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: swagger-ui-bundle
+  provider: pypi
+  type: pypi
+revisions:
+  0.0.8:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 swagger-ui-bundle 0.0.8

**Details:**
ClearlyDefined PKG-INFO indicates Apache-2.0
PyPi license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/dtkav/swagger_ui_bundle/blob/v0.0.8/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [swagger-ui-bundle 0.0.8](https://clearlydefined.io/definitions/pypi/pypi/-/swagger-ui-bundle/0.0.8/0.0.8)