### PR TITLE
Aspose.Email 21.4.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Email.yaml
+++ b/curations/nuget/nuget/-/Aspose.Email.yaml
@@ -6,6 +6,9 @@ revisions:
   20.8.0:
     licensed:
       declared: OTHER
+  21.4.0:
+    licensed:
+      declared: OTHER
   5.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Email 21.4.0

**Details:**
NuGet package page points to a commercial license: https://www.nuget.org/packages/Aspose.Email/21.4.0/License

**Resolution:**
We curate OTHER for commercial

**Affected definitions**:
- [Aspose.Email 21.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Email/21.4.0/21.4.0)