### PR TITLE
azureml-core 1.37.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -390,6 +390,9 @@ revisions:
   1.37.0:
     licensed:
       declared: OTHER
+  1.37.0.post1:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-core 1.37.0.post1

**Details:**
PyPi license field links to OTHER  Azureml SDK LIicense: https://aka.ms/azureml-sdk-license


**Resolution:**
OTHER

**Affected definitions**:
- [azureml-core 1.37.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.37.0.post1/1.37.0.post1)