### PR TITLE
azureml-dataprep 2.25.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -141,6 +141,9 @@ revisions:
   2.25.0:
     licensed:
       declared: OTHER
+  2.25.2:
+    licensed:
+      declared: OTHER
   2.3.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.25.2

**Details:**
PyPi license field links to OTHER
Azureml SDK LIicense: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.25.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.25.2/2.25.2)