### PR TITLE
azureml-inference-server-http 0.4.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-inference-server-http.yaml
+++ b/curations/pypi/pypi/-/azureml-inference-server-http.yaml
@@ -9,3 +9,6 @@ revisions:
   0.4.1:
     licensed:
       declared: OTHER
+  0.4.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-inference-server-http 0.4.2

**Details:**
yPi license field indicates OTHER
Azureml SDK license: https://aka.ms/azureml-sdk-license"

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-inference-server-http 0.4.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-inference-server-http/0.4.2/0.4.2)