### PR TITLE
azureml-defaults 1.34.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-defaults.yaml
+++ b/curations/pypi/pypi/-/azureml-defaults.yaml
@@ -141,6 +141,9 @@ revisions:
   1.32.0:
     licensed:
       declared: OTHER
+  1.34.0:
+    licensed:
+      declared: OTHER
   1.35.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-defaults 1.34.0

**Details:**
PyPi license field indicates OTHER
Azureml SDK license: https://aka.ms/azureml-sdk-license"

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-defaults 1.34.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-defaults/1.34.0/1.34.0)