### PR TITLE
azureml-mlflow 1.37.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-mlflow.yaml
+++ b/curations/pypi/pypi/-/azureml-mlflow.yaml
@@ -114,6 +114,9 @@ revisions:
   1.36.0:
     licensed:
       declared: OTHER
+  1.37.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-mlflow 1.37.0

**Details:**
PyPi license field indicates OTHER
Azureml SDK license: https://aka.ms/azureml-sdk-license"

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-mlflow 1.37.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-mlflow/1.37.0/1.37.0)