### PR TITLE
SinonJS 1.9.1

### DIFF
--- a/curations/nuget/nuget/-/SinonJS.yaml
+++ b/curations/nuget/nuget/-/SinonJS.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SinonJS
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SinonJS 1.9.1

**Details:**
NuGet license field missing
Nuget project link goes to project based with link to GitHub with BSD-3-Clause: https://github.com/sinonjs/sinon/blob/v1.9.1/LICENSE
Note: BSD-3 Clause declared 5/3/2014 and merged but didn’t seem to hold so I submitted this PR

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [SinonJS 1.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/SinonJS/1.9.1/1.9.1)