### PR TITLE
rijs.core 1.2.6

### DIFF
--- a/curations/npm/npmjs/-/rijs.core.yaml
+++ b/curations/npm/npmjs/-/rijs.core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rijs.core
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rijs.core 1.2.6

**Details:**
ClearlyDefined package.json includes link: https://pemrouz.mit-license.org/ which is MIT
GitHub no license file but package.json has same link as above

**Resolution:**
MIT

**Affected definitions**:
- [rijs.core 1.2.6](https://clearlydefined.io/definitions/npm/npmjs/-/rijs.core/1.2.6/1.2.6)