### PR TITLE
NSubstitute 3.0.0

### DIFF
--- a/curations/nuget/nuget/-/NSubstitute.yaml
+++ b/curations/nuget/nuget/-/NSubstitute.yaml
@@ -33,6 +33,9 @@ revisions:
         path: LICENSE.txt
     licensed:
       declared: BSD-3-Clause
+  3.0.0:
+    licensed:
+      declared: BSD-3-Clause
   3.0.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NSubstitute 3.0.0

**Details:**
Nuget license field links to BSD-3-Clause
GitHub license is BSD-3-Clause: https://raw.githubusercontent.com/nsubstitute/NSubstitute/master/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [NSubstitute 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/NSubstitute/3.0.0/3.0.0)