### PR TITLE
httpservices 4.5.5

### DIFF
--- a/curations/maven/mavencentral/edu.ucar/httpservices.yaml
+++ b/curations/maven/mavencentral/edu.ucar/httpservices.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: httpservices
+  namespace: edu.ucar
+  provider: mavencentral
+  type: maven
+revisions:
+  4.5.5:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/edu.ucar/httpservices.yaml
+++ b/curations/maven/mavencentral/edu.ucar/httpservices.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   4.5.5:
     licensed:
-      declared: Apache-2.0
+      declared: NetCDF


### PR DESCRIPTION

**Type:** Missing

**Summary:**
httpservices 4.5.5

**Details:**
Maven indicates Apache-2.0
POM indicates Apache-2.0: https://repo1.maven.org/maven2/org/apache/httpcomponents/httpclient/4.5.5/httpclient-4.5.5.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [httpservices 4.5.5](https://clearlydefined.io/definitions/maven/mavencentral/edu.ucar/httpservices/4.5.5/4.5.5)