### PR TITLE
hibernate-jpa-2.0-api 1.0.1.Final

### DIFF
--- a/curations/maven/mavencentral/org.hibernate.javax.persistence/hibernate-jpa-2.0-api.yaml
+++ b/curations/maven/mavencentral/org.hibernate.javax.persistence/hibernate-jpa-2.0-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hibernate-jpa-2.0-api
+  namespace: org.hibernate.javax.persistence
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.1.Final:
+    licensed:
+      declared: EPL-1.0

--- a/curations/maven/mavencentral/org.hibernate.javax.persistence/hibernate-jpa-2.0-api.yaml
+++ b/curations/maven/mavencentral/org.hibernate.javax.persistence/hibernate-jpa-2.0-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.0.1.Final:
     licensed:
-      declared: EPL-1.0
+      declared: EPL-1.0 OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hibernate-jpa-2.0-api 1.0.1.Final

**Details:**
ClearlyDefined license is EPL-1.0
Maven POM is EPL-1.0: https://repo1.maven.org/maven2/org/hibernate/javax/persistence/hibernate-jpa-2.0-api/1.0.1.Final/hibernate-jpa-2.0-api-1.0.1.Final.pom

**Resolution:**
EPL-1.0

**Affected definitions**:
- [hibernate-jpa-2.0-api 1.0.1.Final](https://clearlydefined.io/definitions/maven/mavencentral/org.hibernate.javax.persistence/hibernate-jpa-2.0-api/1.0.1.Final/1.0.1.Final)