### PR TITLE
FluentMigrator.Runner.Hana 3.2.1

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Runner.Hana.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Runner.Hana.yaml
@@ -6,3 +6,6 @@ revisions:
   3.1.3:
     licensed:
       declared: Apache-2.0
+  3.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Runner.Hana 3.2.1

**Details:**
Nuget license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.1/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Runner.Hana 3.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner.Hana/3.2.1/3.2.1)