### PR TITLE
Rx-Linq 2.1.30204

### DIFF
--- a/curations/nuget/nuget/-/Rx-Linq.yaml
+++ b/curations/nuget/nuget/-/Rx-Linq.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.30204:
+    licensed:
+      declared: MIT
   2.1.30214:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Rx-Linq.yaml
+++ b/curations/nuget/nuget/-/Rx-Linq.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.1.30204:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.1.30214:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Linq 2.1.30204

**Details:**
NuGet license field links to MIT
GitHub license is MIT: https://github.com/dotnet/reactive/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Rx-Linq 2.1.30204](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Linq/2.1.30204/2.1.30204)