### PR TITLE
ap 0.2.0

### DIFF
--- a/curations/npm/npmjs/-/ap.yaml
+++ b/curations/npm/npmjs/-/ap.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ap
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ap 0.2.0

**Details:**
NPM license field indicates: MIT/X11
Package.json indicates MIT/X11
MIT/X11 is not a SPDX and not an identical match to MIT: https://en.wikipedia.org/wiki/MIT_License#X11_License

**Resolution:**
Not sure if this should be OTHER for MIT/X11 or MIT

**Affected definitions**:
- [ap 0.2.0](https://clearlydefined.io/definitions/npm/npmjs/-/ap/0.2.0/0.2.0)