### PR TITLE
Selenium.Firefox.WebDriver 0.23.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
@@ -12,3 +12,6 @@ revisions:
   0.22.0:
     licensed:
       declared: Unlicense
+  0.23.0:
+    licensed:
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.Firefox.WebDriver 0.23.0

**Details:**
NuGet license field is Unlicense
GitHub license is Unlicense: https://github.com/jbaranda/nupkg-selenium-webdrivers/blob/master/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.Firefox.WebDriver 0.23.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.Firefox.WebDriver/0.23.0/0.23.0)