### PR TITLE
cdm 4.5.5

### DIFF
--- a/curations/maven/mavencentral/edu.ucar/cdm.yaml
+++ b/curations/maven/mavencentral/edu.ucar/cdm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cdm
+  namespace: edu.ucar
+  provider: mavencentral
+  type: maven
+revisions:
+  4.5.5:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/edu.ucar/cdm.yaml
+++ b/curations/maven/mavencentral/edu.ucar/cdm.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   4.5.5:
     licensed:
-      declared: BSD-3-Clause
+      declared: NetCDF


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cdm 4.5.5

**Details:**
Maven POM has no license info
Maven license field links to BSD-3-Clause: https://www.unidata.ucar.edu/software/netcdf/copyright.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [cdm 4.5.5](https://clearlydefined.io/definitions/maven/mavencentral/edu.ucar/cdm/4.5.5/4.5.5)