### PR TITLE
native-lib-loader 2.3.4

### DIFF
--- a/curations/maven/mavencentral/org.scijava/native-lib-loader.yaml
+++ b/curations/maven/mavencentral/org.scijava/native-lib-loader.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: native-lib-loader
+  namespace: org.scijava
+  provider: mavencentral
+  type: maven
+revisions:
+  2.3.4:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
native-lib-loader 2.3.4

**Details:**

Maven POM indicates Simplified BSD license: https://repo1.maven.org/maven2/org/scijava/native-lib-loader/2.3.4/native-lib-loader-2.3.4.pom
Maven license field indicates Simplified BSD license which I believe is BSD-2-Clause

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [native-lib-loader 2.3.4](https://clearlydefined.io/definitions/maven/mavencentral/org.scijava/native-lib-loader/2.3.4/2.3.4)