### PR TITLE
kendo-angular-grid 3.14.4

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-grid.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-grid.yaml
@@ -7,6 +7,9 @@ revisions:
   3.13.0:
     licensed:
       declared: OTHER
+  3.14.4:
+    licensed:
+      declared: OTHER
   4.7.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-grid 3.14.4

**Details:**
ClearlyDefined license is OTHER: Telerik End User License Agreement for Kendo UI**](http://www.telerik.com/purchase/license-agreement/kendo-ui)
NPM license field indicates OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-grid 3.14.4](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-grid/3.14.4/3.14.4)