### PR TITLE
excel-export 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/excel-export.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/excel-export.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.1.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
excel-export 25.1.0

**Details:**
ClearlyDefined license is OTHER: AG GRID ENTERPRISE EULA v13.0
NPM license field indicates see license folder
GitHub license indicates OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [excel-export 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/excel-export/25.1.0/25.1.0)