### PR TITLE
mail 1.4.4

### DIFF
--- a/curations/maven/mavencentral/javax.mail/mail.yaml
+++ b/curations/maven/mavencentral/javax.mail/mail.yaml
@@ -7,6 +7,9 @@ revisions:
   1.4.1:
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+  1.4.4:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.4.5:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mail 1.4.4

**Details:**
Maven pom and license field indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [mail 1.4.4](https://clearlydefined.io/definitions/maven/mavencentral/javax.mail/mail/1.4.4/1.4.4)