### PR TITLE
NuGet.Common 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Common.yaml
+++ b/curations/nuget/nuget/-/NuGet.Common.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Common 3.5.0

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Common 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Common/3.5.0/3.5.0)