### PR TITLE
NoGit 0.1.0

### DIFF
--- a/curations/nuget/nuget/-/NoGit.yaml
+++ b/curations/nuget/nuget/-/NoGit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NoGit
+  provider: nuget
+  type: nuget
+revisions:
+  0.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NoGit 0.1.0

**Details:**
NuGet has no license field
GitHub license is MIT: https://github.com/whyleee/nogit/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [NoGit 0.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/NoGit/0.1.0/0.1.0)