### PR TITLE
NuGet.Core 2.11.1

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.11.1:
+    licensed:
+      declared: Apache-2.0
   2.12.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Core 2.11.1

**Details:**
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet2/blob/2.14/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Core 2.11.1](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Core/2.11.1/2.11.1)