### PR TITLE
plantuml 1.2021.10

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.plantuml/plantuml.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.plantuml/plantuml.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: plantuml
+  namespace: net.sourceforge.plantuml
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2021.10:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
plantuml 1.2021.10

**Details:**
Maven pom indicates GPL-3.0-or-later: https://repo1.maven.org/maven2/net/sourceforge/plantuml/plantuml/1.2021.10/plantuml-1.2021.10.pom

**Resolution:**
GPL-3.0-or-later

**Affected definitions**:
- [plantuml 1.2021.10](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.plantuml/plantuml/1.2021.10/1.2021.10)