### PR TITLE
setsimilaritysearch 0.1.7

### DIFF
--- a/curations/pypi/pypi/-/setsimilaritysearch.yaml
+++ b/curations/pypi/pypi/-/setsimilaritysearch.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: setsimilaritysearch
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
setsimilaritysearch 0.1.7

**Details:**
PKG-INFO indicates license as Unknown
PyPi license field is missing
GitHub license is Apache-2.0: https://github.com/ekzhu/SetSimilaritySearch/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [setsimilaritysearch 0.1.7](https://clearlydefined.io/definitions/pypi/pypi/-/setsimilaritysearch/0.1.7/0.1.7)