### PR TITLE
xunit 2.2.0-beta5-build3474

### DIFF
--- a/curations/nuget/nuget/-/xunit.yaml
+++ b/curations/nuget/nuget/-/xunit.yaml
@@ -42,6 +42,9 @@ revisions:
   2.2.0-beta4-build3444:
     licensed:
       declared: Apache-2.0
+  2.2.0-beta5-build3474:
+    licensed:
+      declared: Apache-2.0
   2.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit 2.2.0-beta5-build3474

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/xunit/xunit/blob/2.2-beta5/license.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [xunit 2.2.0-beta5-build3474](https://clearlydefined.io/definitions/nuget/nuget/-/xunit/2.2.0-beta5-build3474/2.2.0-beta5-build3474)