### PR TITLE
xunit.core 2.2.0-beta5-build3474

### DIFF
--- a/curations/nuget/nuget/-/xunit.core.yaml
+++ b/curations/nuget/nuget/-/xunit.core.yaml
@@ -12,6 +12,9 @@ revisions:
   2.2.0:
     licensed:
       declared: Apache-2.0
+  2.2.0-beta5-build3474:
+    licensed:
+      declared: Apache-2.0
   2.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.core 2.2.0-beta5-build3474

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/xunit/xunit/blob/2.2-beta5/license.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [xunit.core 2.2.0-beta5-build3474](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.core/2.2.0-beta5-build3474/2.2.0-beta5-build3474)