### PR TITLE
VowpalWabbit 8.2.0.38

### DIFF
--- a/curations/nuget/nuget/-/VowpalWabbit.yaml
+++ b/curations/nuget/nuget/-/VowpalWabbit.yaml
@@ -6,6 +6,9 @@ revisions:
   8.11.0:
     licensed:
       declared: BSD-3-Clause
+  8.2.0.38:
+    licensed:
+      declared: BSD-3-Clause
   8.3.0.9:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VowpalWabbit 8.2.0.38

**Details:**
NuGet license field is BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/VowpalWabbit/vowpal_wabbit/blob/8.2.0/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [VowpalWabbit 8.2.0.38](https://clearlydefined.io/definitions/nuget/nuget/-/VowpalWabbit/8.2.0.38/8.2.0.38)