### PR TITLE
xunit.extensibility.core 2.2.0-beta5-build3474

### DIFF
--- a/curations/nuget/nuget/-/xunit.extensibility.core.yaml
+++ b/curations/nuget/nuget/-/xunit.extensibility.core.yaml
@@ -24,6 +24,9 @@ revisions:
   2.2.0-beta2-build3300:
     licensed:
       declared: Apache-2.0
+  2.2.0-beta5-build3474:
+    licensed:
+      declared: Apache-2.0
   2.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.extensibility.core 2.2.0-beta5-build3474

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/xunit/xunit/blob/2.3-beta5/license.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [xunit.extensibility.core 2.2.0-beta5-build3474](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.extensibility.core/2.2.0-beta5-build3474/2.2.0-beta5-build3474)