### PR TITLE
System.Management.Automation 6.1.6

### DIFF
--- a/curations/nuget/nuget/-/System.Management.Automation.yaml
+++ b/curations/nuget/nuget/-/System.Management.Automation.yaml
@@ -12,6 +12,9 @@ revisions:
   6.1.2:
     licensed:
       declared: MIT
+  6.1.6:
+    licensed:
+      declared: MIT
   6.1.7601.17515:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Management.Automation 6.1.6

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/PowerShell/PowerShell/blob/v6.1.6/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [System.Management.Automation 6.1.6](https://clearlydefined.io/definitions/nuget/nuget/-/System.Management.Automation/6.1.6/6.1.6)