### PR TITLE
System.Net.WebSockets.WebSocketProtocol 4.6.0

### DIFF
--- a/curations/nuget/nuget/-/System.Net.WebSockets.WebSocketProtocol.yaml
+++ b/curations/nuget/nuget/-/System.Net.WebSockets.WebSocketProtocol.yaml
@@ -9,3 +9,6 @@ revisions:
   4.5.3:
     licensed:
       declared: MIT
+  4.6.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Net.WebSockets.WebSocketProtocol 4.6.0

**Details:**
ClearlyDefined license is MIT
NuGet license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Net.WebSockets.WebSocketProtocol 4.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Net.WebSockets.WebSocketProtocol/4.6.0/4.6.0)