### PR TITLE
System.Data.HashFunction.FNV 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.Data.HashFunction.FNV.yaml
+++ b/curations/nuget/nuget/-/System.Data.HashFunction.FNV.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Data.HashFunction.FNV
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.HashFunction.FNV 2.0.0

**Details:**
NuGet license field is MIT
GitHub license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [System.Data.HashFunction.FNV 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.HashFunction.FNV/2.0.0/2.0.0)