### PR TITLE
Akka.Serialization.Hyperion 1.3.10-beta

### DIFF
--- a/curations/nuget/nuget/-/Akka.Serialization.Hyperion.yaml
+++ b/curations/nuget/nuget/-/Akka.Serialization.Hyperion.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Serialization.Hyperion
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.10-beta:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Serialization.Hyperion 1.3.10-beta

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/v1.3.10/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Serialization.Hyperion 1.3.10-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Serialization.Hyperion/1.3.10-beta/1.3.10-beta)