### PR TITLE
Strathweb.CacheOutput.WebApi2 0.10.0

### DIFF
--- a/curations/nuget/nuget/-/Strathweb.CacheOutput.WebApi2.yaml
+++ b/curations/nuget/nuget/-/Strathweb.CacheOutput.WebApi2.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.10.0:
+    licensed:
+      declared: Apache-2.0
   0.11.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Strathweb.CacheOutput.WebApi2 0.10.0

**Details:**
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/filipw/Strathweb.CacheOutput/blob/dev/License.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Strathweb.CacheOutput.WebApi2 0.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Strathweb.CacheOutput.WebApi2/0.10.0/0.10.0)