### PR TITLE
fast-extend 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/fast-extend.yaml
+++ b/curations/npm/npmjs/-/fast-extend.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fast-extend
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: NONE

--- a/curations/npm/npmjs/-/fast-extend.yaml
+++ b/curations/npm/npmjs/-/fast-extend.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.0.2:
     licensed:
-      declared: NONE
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
fast-extend 0.0.2

**Details:**
ClearlyDefined package.json has no license info
NPM license field indicates NONE
The NPM page includes a license field that indicates Unlicense but the link is broken

**Resolution:**
NONE

**Affected definitions**:
- [fast-extend 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/fast-extend/0.0.2/0.0.2)