### PR TITLE
node-html-encoder 0.0.2

### DIFF
--- a/curations/npm/npmjs/-/node-html-encoder.yaml
+++ b/curations/npm/npmjs/-/node-html-encoder.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: node-html-encoder
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.2:
+    licensed:
+      declared: NONE

--- a/curations/npm/npmjs/-/node-html-encoder.yaml
+++ b/curations/npm/npmjs/-/node-html-encoder.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.0.2:
     licensed:
-      declared: NONE
+      declared: GPL-1.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
node-html-encoder 0.0.2

**Details:**
ClearlyDefined package.json has no license info
NPM license field indicates NONE
GitHub has no license: https://github.com/minchenkov/node-html-encoder

**Resolution:**
NONE

**Affected definitions**:
- [node-html-encoder 0.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/node-html-encoder/0.0.2/0.0.2)