### PR TITLE
MvvmLightLibs 5.2.0

### DIFF
--- a/curations/nuget/nuget/-/MvvmLightLibs.yaml
+++ b/curations/nuget/nuget/-/MvvmLightLibs.yaml
@@ -6,6 +6,9 @@ revisions:
   4.4.32.1:
     licensed:
       declared: MIT
+  5.2.0:
+    licensed:
+      declared: MIT
   5.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MvvmLightLibs 5.2.0

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/lbugnion/mvvmlight/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [MvvmLightLibs 5.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/MvvmLightLibs/5.2.0/5.2.0)