### PR TITLE
AppForSharePointOnlineWebToolkit 3.1.4

### DIFF
--- a/curations/nuget/nuget/-/AppForSharePointOnlineWebToolkit.yaml
+++ b/curations/nuget/nuget/-/AppForSharePointOnlineWebToolkit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.1.4:
+    licensed:
+      declared: NONE
   3.1.5:
     licensed:
       declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AppForSharePointOnlineWebToolkit 3.1.4

**Details:**
NuGet license and project links are broken
Not included on Way Back Machine

**Resolution:**
NONE

**Affected definitions**:
- [AppForSharePointOnlineWebToolkit 3.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/AppForSharePointOnlineWebToolkit/3.1.4/3.1.4)