### PR TITLE
enqueue 1.0.2

### DIFF
--- a/curations/npm/npmjs/-/enqueue.yaml
+++ b/curations/npm/npmjs/-/enqueue.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: enqueue
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
enqueue 1.0.2

**Details:**
ClearlyDefined package.json has no license info
NPM license field indicates NONE
GitHub readme includes MIT: https://github.com/MatthewMueller/enqueue


**Resolution:**
MIT

**Affected definitions**:
- [enqueue 1.0.2](https://clearlydefined.io/definitions/npm/npmjs/-/enqueue/1.0.2/1.0.2)