### PR TITLE
dependabot-npm_and_yarn

### DIFF
--- a/curations/gem/rubygems/-/dependabot-npm_and_yarn.yaml
+++ b/curations/gem/rubygems/-/dependabot-npm_and_yarn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-npm_and_yarn
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-npm_and_yarn

**Details:**
ClearlyDefined package.json has no license info
RubyGems license field states Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-npm_and_yarn 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-npm_and_yarn/0.162.2/0.162.2)