### PR TITLE
jersey-core 1.13

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-core.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-core.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.13':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.19':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jersey-core 1.13

**Details:**
Maven pom CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0: https://repo1.maven.org/maven2/com/sun/jersey/jersey-core/1.13/jersey-core-1.13.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-core 1.13](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-core/1.13/1.13)