### PR TITLE
testrunner 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/testrunner.yaml
+++ b/curations/npm/npmjs/-/testrunner.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: testrunner
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
testrunner 1.0.0

**Details:**
ClearlyDefined package.json has no license info
NPM license field indicates NONE
GitHub license is MIT: https://github.com/aikar/wormhole/blob/1.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [testrunner 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/testrunner/1.0.0/1.0.0)