### PR TITLE
org.abego.treelayout.core 1.0.1

### DIFF
--- a/curations/maven/mavencentral/org.abego.treelayout/org.abego.treelayout.core.yaml
+++ b/curations/maven/mavencentral/org.abego.treelayout/org.abego.treelayout.core.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.0.1:
+    licensed:
+      declared: BSD-3-Clause
   1.0.3:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.abego.treelayout.core 1.0.1

**Details:**
Maven POM is BSD-3-Clause: https://repo1.maven.org/maven2/org/abego/treelayout/org.abego.treelayout.core/1.0.1/org.abego.treelayout.core-1.0.1.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [org.abego.treelayout.core 1.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.abego.treelayout/org.abego.treelayout.core/1.0.1/1.0.1)