### PR TITLE
jaxen 1.1.4

### DIFF
--- a/curations/maven/mavencentral/jaxen/jaxen.yaml
+++ b/curations/maven/mavencentral/jaxen/jaxen.yaml
@@ -7,6 +7,9 @@ revisions:
   1.1.1:
     licensed:
       declared: BSD-3-Clause
+  1.1.4:
+    licensed:
+      declared: BSD-3-Clause
   1.1.6:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jaxen 1.1.4

**Details:**
Maven POM includes license link to BSD-3-Clause: https://github.com/codehaus/jaxen/blob/master/jaxen/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jaxen 1.1.4](https://clearlydefined.io/definitions/maven/mavencentral/jaxen/jaxen/1.1.4/1.1.4)