### PR TITLE
Docker.DotNet 3.125.0

### DIFF
--- a/curations/nuget/nuget/-/Docker.DotNet.yaml
+++ b/curations/nuget/nuget/-/Docker.DotNet.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.125.0:
+    licensed:
+      declared: MIT
   3.125.2:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Docker.DotNet.yaml
+++ b/curations/nuget/nuget/-/Docker.DotNet.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.125.0:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   3.125.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Docker.DotNet 3.125.0

**Details:**
NuGet License field links to MIT: https://www.nuget.org/packages/Docker.DotNet/3.125.5/License
GitHub link broken

**Resolution:**
MIT

**Affected definitions**:
- [Docker.DotNet 3.125.0](https://clearlydefined.io/definitions/nuget/nuget/-/Docker.DotNet/3.125.0/3.125.0)