### PR TITLE
dependabot-maven 0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-maven.yaml
+++ b/curations/gem/rubygems/-/dependabot-maven.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-maven
+  provider: rubygems
+  type: gem
+revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-maven 0.129.5

**Details:**
RubyGems license field indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.129.5/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-maven 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-maven/0.129.5/0.129.5)