### PR TITLE
System.Security.AccessControl 4.6.0-preview6.19303.8

### DIFF
--- a/curations/nuget/nuget/-/System.Security.AccessControl.yaml
+++ b/curations/nuget/nuget/-/System.Security.AccessControl.yaml
@@ -15,6 +15,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview6.19303.8:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.AccessControl 4.6.0-preview6.19303.8

**Details:**
ClearlyDefined license is MIT
NuGet license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.AccessControl 4.6.0-preview6.19303.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.AccessControl/4.6.0-preview6.19303.8/4.6.0-preview6.19303.8)