### PR TITLE
ECToken 1.0.28

### DIFF
--- a/curations/nuget/nuget/-/ECToken.yaml
+++ b/curations/nuget/nuget/-/ECToken.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ECToken
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.28:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ECToken 1.0.28

**Details:**
NuGet license field is broken
GitHub license is Apache-2.0: https://github.com/EdgeCast/ectoken/blob/master/LICENSE-2.0.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ECToken 1.0.28](https://clearlydefined.io/definitions/nuget/nuget/-/ECToken/1.0.28/1.0.28)