### PR TITLE
scala-library 2.11.5

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-library.yaml
@@ -19,6 +19,9 @@ revisions:
   2.11.12:
     licensed:
       declared: BSD-3-Clause
+  2.11.5:
+    licensed:
+      declared: BSD-3-Clause
   2.11.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scala-library 2.11.5

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/org/scala-lang/scala-library/2.11.5/scala-library-2.11.5.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-library 2.11.5](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-library/2.11.5/2.11.5)