### PR TITLE
torchvision 0.11.2

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -24,6 +24,9 @@ revisions:
   0.11.1:
     licensed:
       declared: BSD-3-Clause
+  0.11.2:
+    licensed:
+      declared: BSD-3-Clause
   0.2.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision 0.11.2

**Details:**
PyPi license indicates BSD
GitHub license is BSD-3-Clause: https://github.com/pytorch/vision/blob/v0.11.2/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [torchvision 0.11.2](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.11.2/0.11.2)