### PR TITLE
jQuery 1.6.0

### DIFF
--- a/curations/nuget/nuget/-/jQuery.yaml
+++ b/curations/nuget/nuget/-/jQuery.yaml
@@ -71,6 +71,9 @@ revisions:
   1.5.2:
     licensed:
       declared: MIT
+  1.6.0:
+    licensed:
+      declared: MIT
   1.6.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery 1.6.0

**Details:**
NuGet license field is MIT: http://jquery.org/license/

**Resolution:**
MIT

**Affected definitions**:
- [jQuery 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery/1.6.0/1.6.0)