### PR TITLE
Ninject.Web.Common.OwinHost 3.2.3

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Web.Common.OwinHost.yaml
+++ b/curations/nuget/nuget/-/Ninject.Web.Common.OwinHost.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Web.Common.OwinHost
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.3:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Web.Common.OwinHost 3.2.3

**Details:**
NuGet license field links to Apache-2.0 OR MS-PL
GitHub license is Apache-2.0 OR MS-PL: https://github.com/ninject/Ninject.Web.Common/blob/master/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.Web.Common.OwinHost 3.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Web.Common.OwinHost/3.2.3/3.2.3)