### PR TITLE
Selenium.WebDriver.IEDriver 2.53.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.53.0:
+    licensed:
+      declared: Unlicense
   3.0.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.IEDriver 2.53.0

**Details:**
NuGet license field is Unlicense
GitHub license is Unlicense: https://github.com/jsakamoto/nupkg-selenium-webdriver-iedriver/blob/v.2.53.0.0/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.WebDriver.IEDriver 2.53.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.IEDriver/2.53.0/2.53.0)