### PR TITLE
TestPackage.AuthorSigned 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/TestPackage.AuthorSigned.yaml
+++ b/curations/nuget/nuget/-/TestPackage.AuthorSigned.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TestPackage.AuthorSigned
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TestPackage.AuthorSigned 1.0.0

**Details:**
GitHub no license field or project link.  No license info found

**Resolution:**
NONE

**Affected definitions**:
- [TestPackage.AuthorSigned 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/TestPackage.AuthorSigned/1.0.0/1.0.0)