### PR TITLE
Selenium.Firefox.WebDriver 0.21.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.Firefox.WebDriver.yaml
@@ -9,6 +9,9 @@ revisions:
   0.20.0:
     licensed:
       declared: Unlicense
+  0.21.0:
+    licensed:
+      declared: Unlicense
   0.22.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.Firefox.WebDriver 0.21.0

**Details:**
NuGet license is Unlicense
GitHub license is Unlicense: https://github.com/jbaranda/nupkg-selenium-webdrivers/blob/master/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.Firefox.WebDriver 0.21.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.Firefox.WebDriver/0.21.0/0.21.0)