### PR TITLE
ant-launcher 1.7.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.ant/ant-launcher.yaml
+++ b/curations/maven/mavencentral/org.apache.ant/ant-launcher.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.7.0:
+    licensed:
+      declared: Apache-2.0
   1.8.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ant-launcher 1.7.0

**Details:**
Maven pom is Apache-2.0: https://repo1.maven.org/maven2/org/apache/ant/ant/1.7.0/ant-1.7.0.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ant-launcher 1.7.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.ant/ant-launcher/1.7.0/1.7.0)