### PR TITLE
excel-export 25.3.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/excel-export.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/excel-export.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.3.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
excel-export 25.3.0

**Details:**
ClearlyDefined license file is OTHER
NPM indicates Commercial
GitHub license is OTHER: https://github.com/ag-grid/ag-grid/blob/v25.3.0/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [excel-export 25.3.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/excel-export/25.3.0/25.3.0)