### PR TITLE
broadbean 0.9.1

### DIFF
--- a/curations/pypi/pypi/-/broadbean.yaml
+++ b/curations/pypi/pypi/-/broadbean.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: broadbean
+  provider: pypi
+  type: pypi
+revisions:
+  0.9.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
broadbean 0.9.1

**Details:**
ClearlyDefined PKG-INFO indicates MIT
PyPi license field is MIT
GitHub license is MIT: https://github.com/QCoDeS/broadbean/blob/v0.9.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [broadbean 0.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/broadbean/0.9.1/0.9.1)