### PR TITLE
antlr4-python3-runtime 4.9.3

### DIFF
--- a/curations/pypi/pypi/-/antlr4-python3-runtime.yaml
+++ b/curations/pypi/pypi/-/antlr4-python3-runtime.yaml
@@ -41,3 +41,6 @@ revisions:
   4.9.2:
     licensed:
       declared: BSD-3-Clause
+  4.9.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
antlr4-python3-runtime 4.9.3

**Details:**
ClearlyDefined PKG-INFO indicates BSD
PyPi license field indicates BSD
GitHub license is BSD-3-Clause: https://github.com/antlr/antlr4/blob/master/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [antlr4-python3-runtime 4.9.3](https://clearlydefined.io/definitions/pypi/pypi/-/antlr4-python3-runtime/4.9.3/4.9.3)