### PR TITLE
wct-browser-legacy 0.0.1-pre.11

### DIFF
--- a/curations/npm/npmjs/-/wct-browser-legacy.yaml
+++ b/curations/npm/npmjs/-/wct-browser-legacy.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.1-pre.11:
+    licensed:
+      declared: BSD-3-Clause
   1.0.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
wct-browser-legacy 0.0.1-pre.11

**Details:**
ClearlyDefined package.json links to BSD-3-Clause: http://polymer.github.io/LICENSE.txt
NPM license field links to same as above
GitHub license is BSD-3-Clause: https://github.com/Polymer/web-component-tester/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [wct-browser-legacy 0.0.1-pre.11](https://clearlydefined.io/definitions/npm/npmjs/-/wct-browser-legacy/0.0.1-pre.11/0.0.1-pre.11)