### PR TITLE
dependabot-elm 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-elm.yaml
+++ b/curations/gem/rubygems/-/dependabot-elm.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-elm
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-elm 0.162.2

**Details:**
RubyGems license field indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.0/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-elm 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-elm/0.162.2/0.162.2)