### PR TITLE
WebRequest.WebRequestHandler 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/WebRequest.WebRequestHandler.yaml
+++ b/curations/nuget/nuget/-/WebRequest.WebRequestHandler.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0:
     licensed:
       declared: NONE
+  1.0.3:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WebRequest.WebRequestHandler 1.0.3

**Details:**
NuGet license field is missing
Project website doesn't have license info

**Resolution:**
NONE

**Affected definitions**:
- [WebRequest.WebRequestHandler 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/WebRequest.WebRequestHandler/1.0.3/1.0.3)