### PR TITLE
innosetup 6.0.5

### DIFF
--- a/curations/npm/npmjs/-/innosetup.yaml
+++ b/curations/npm/npmjs/-/innosetup.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: innosetup
+  provider: npmjs
+  type: npm
+revisions:
+  6.0.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
innosetup 6.0.5

**Details:**
ClearlyDefined license is OTHER
NPM license is NONE
GitHub license is OTHER: https://github.com/felicienfrancois/node-innosetup-compiler/blob/master/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [innosetup 6.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/innosetup/6.0.5/6.0.5)