### PR TITLE
expect4j 1.6

### DIFF
--- a/curations/maven/mavencentral/com.github.cverges.expect4j/expect4j.yaml
+++ b/curations/maven/mavencentral/com.github.cverges.expect4j/expect4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: expect4j
+  namespace: com.github.cverges.expect4j
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.6':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
expect4j 1.6

**Details:**
Maven POM is Apache-2.0: https://repo1.maven.org/maven2/com/github/cverges/expect4j/expect4j/1.6/expect4j-1.6.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [expect4j 1.6](https://clearlydefined.io/definitions/maven/mavencentral/com.github.cverges.expect4j/expect4j/1.6/1.6)