### PR TITLE
Swashbuckle.Examples 3.12.0

### DIFF
--- a/curations/nuget/nuget/-/Swashbuckle.Examples.yaml
+++ b/curations/nuget/nuget/-/Swashbuckle.Examples.yaml
@@ -6,6 +6,9 @@ revisions:
   3.10.0:
     licensed:
       declared: MIT
+  3.12.0:
+    licensed:
+      declared: MIT
   3.9.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Swashbuckle.Examples 3.12.0

**Details:**
NuGet license field links to MIT
GitHub is MIT: https://github.com/mattfrear/Swashbuckle.Examples/blob/3.12.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Swashbuckle.Examples 3.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Swashbuckle.Examples/3.12.0/3.12.0)