### PR TITLE
StructureMap.WebApi2 3.0.4.125

### DIFF
--- a/curations/nuget/nuget/-/StructureMap.WebApi2.yaml
+++ b/curations/nuget/nuget/-/StructureMap.WebApi2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StructureMap.WebApi2
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.4.125:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StructureMap.WebApi2 3.0.4.125

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/webadvanced/Structuremap.WebAPI2/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [StructureMap.WebApi2 3.0.4.125](https://clearlydefined.io/definitions/nuget/nuget/-/StructureMap.WebApi2/3.0.4.125/3.0.4.125)