### PR TITLE
Akamai.EdgeGrid.Auth 0.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/Akamai.EdgeGrid.Auth.yaml
+++ b/curations/nuget/nuget/-/Akamai.EdgeGrid.Auth.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akamai.EdgeGrid.Auth
+  provider: nuget
+  type: nuget
+revisions:
+  0.0.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akamai.EdgeGrid.Auth 0.0.0.1

**Details:**
NuGet license field missing
Project is Apache-2.0: https://github.com/akamai/AkamaiOPEN-edgegrid-C-Sharp/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akamai.EdgeGrid.Auth 0.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Akamai.EdgeGrid.Auth/0.0.0.1/0.0.0.1)