### PR TITLE
System.Security.Cryptography.Xml 4.4.1

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Cryptography.Xml.yaml
+++ b/curations/nuget/nuget/-/System.Security.Cryptography.Xml.yaml
@@ -6,6 +6,9 @@ revisions:
   4.4.0:
     licensed:
       declared: MIT
+  4.4.1:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Cryptography.Xml 4.4.1

**Details:**
ClearlyDefined license is MIT
NuGet license field links to MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.Cryptography.Xml 4.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Cryptography.Xml/4.4.1/4.4.1)