### PR TITLE
xunit.runner.visualstudio 2.2.0-beta5-build1225

### DIFF
--- a/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
+++ b/curations/nuget/nuget/-/xunit.runner.visualstudio.yaml
@@ -30,6 +30,9 @@ revisions:
   2.2.0-beta1-build1144:
     licensed:
       declared: Apache-2.0
+  2.2.0-beta5-build1225:
+    licensed:
+      declared: Apache-2.0
   2.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.runner.visualstudio 2.2.0-beta5-build1225

**Details:**
NuGet license links to MIT
GitHub license is Apache-2.0: https://github.com/xunit/visualstudio.xunit/blob/2.2-beta5/License.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [xunit.runner.visualstudio 2.2.0-beta5-build1225](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.runner.visualstudio/2.2.0-beta5-build1225/2.2.0-beta5-build1225)