### PR TITLE
colorcet 2.0.6

### DIFF
--- a/curations/pypi/pypi/-/colorcet.yaml
+++ b/curations/pypi/pypi/-/colorcet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: colorcet
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.6:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
colorcet 2.0.6

**Details:**
ClearlyDefined license is: Creative Commons Attribution 4.0 International Public License (CC-BY) but the text does not appear to match: https://spdx.org/licenses/CC-BY-4.0.html
PyPi license field states OSI Approved (CC-BY License)

**Resolution:**
OTHER

**Affected definitions**:
- [colorcet 2.0.6](https://clearlydefined.io/definitions/pypi/pypi/-/colorcet/2.0.6/2.0.6)