### PR TITLE
NuGet.SolutionRestoreManager.Interop 4.3.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.SolutionRestoreManager.Interop.yaml
+++ b/curations/nuget/nuget/-/NuGet.SolutionRestoreManager.Interop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.SolutionRestoreManager.Interop
+  provider: nuget
+  type: nuget
+revisions:
+  4.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.SolutionRestoreManager.Interop 4.3.0

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.3.0.4202/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.SolutionRestoreManager.Interop 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.SolutionRestoreManager.Interop/4.3.0/4.3.0)