### PR TITLE
jsch 0.1.38

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.1.38:
+    licensed:
+      declared: BSD-3-Clause
   0.1.42:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsch 0.1.38

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/com/jcraft/jsch/0.1.38/jsch-0.1.38.pom
License link: http://www.jcraft.com/jsch/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jsch 0.1.38](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch/0.1.38/0.1.38)