### PR TITLE
Declared license not recorgnized

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -79,3 +79,6 @@ revisions:
   21.2.0:
     licensed:
       declared: UPL-1.0
+  21.3.0:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license not recorgnized

**Details:**
As defined in the GitHub repository (https://github.com/oracle/graal/blob/vm-21.3.0/sdk/LICENSE.md), the declared license is UPL 1.0

**Resolution:**
Set declared license to UPL 1.0

**Affected definitions**:
- [graal-sdk 21.3.0](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.0/21.3.0)