### PR TITLE
EmguCV 3.1.0.1

### DIFF
--- a/curations/nuget/nuget/-/EmguCV.yaml
+++ b/curations/nuget/nuget/-/EmguCV.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: EmguCV
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.0.1:
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EmguCV 3.1.0.1

**Details:**
NuGet license field indicates GPL
GitHub license indicates GPL: https://github.com/emgucv/emgutf/blob/master/LICENSE

No specific "or-later" info found

**Resolution:**
GPL-3.0-only

**Affected definitions**:
- [EmguCV 3.1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/EmguCV/3.1.0.1/3.1.0.1)