### PR TITLE
management-api 3.0.0-b012

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.external/management-api.yaml
+++ b/curations/maven/mavencentral/org.glassfish.external/management-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: management-api
+  namespace: org.glassfish.external
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.0-b012:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
management-api 3.0.0-b012

**Details:**
Maven pom indicates: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0:  https://repo1.maven.org/maven2/org/glassfish/external/management-api/3.0.0-b012/management-api-3.0.0-b012.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [management-api 3.0.0-b012](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.external/management-api/3.0.0-b012/3.0.0-b012)