### PR TITLE
deepspeed 0.3.15

### DIFF
--- a/curations/pypi/pypi/-/deepspeed.yaml
+++ b/curations/pypi/pypi/-/deepspeed.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  0.3.15:
+    licensed:
+      declared: MIT
   0.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
deepspeed 0.3.15

**Details:**
ClearlyDefined PKG-INFO indicates MIT
PyPi license field indicates MIT
GitHub license is MIT: https://github.com/microsoft/DeepSpeed/blob/v0.3.15/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [deepspeed 0.3.15](https://clearlydefined.io/definitions/pypi/pypi/-/deepspeed/0.3.15/0.3.15)