### PR TITLE
NuGet.Protocol 4.7.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Protocol.yaml
+++ b/curations/nuget/nuget/-/NuGet.Protocol.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.7.0:
+    licensed:
+      declared: Apache-2.0
   4.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Protocol 4.7.0

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Protocol 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Protocol/4.7.0/4.7.0)