### PR TITLE
pydeck 0.6.2

### DIFF
--- a/curations/pypi/pypi/-/pydeck.yaml
+++ b/curations/pypi/pypi/-/pydeck.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pydeck
+  provider: pypi
+  type: pypi
+revisions:
+  0.6.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pydeck 0.6.2

**Details:**
ClearlyDefined license is Apache-2.0
PyPi license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/visgl/deck.gl/blob/master/bindings/pydeck/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [pydeck 0.6.2](https://clearlydefined.io/definitions/pypi/pypi/-/pydeck/0.6.2/0.6.2)