### PR TITLE
 System.Drawing.Common 4.6.1

### DIFF
--- a/curations/nuget/nuget/-/System.Drawing.Common.yaml
+++ b/curations/nuget/nuget/-/System.Drawing.Common.yaml
@@ -24,3 +24,6 @@ revisions:
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT
+  4.6.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 System.Drawing.Common 4.6.1

**Details:**
ClearlyDefined license is MIT
NuGet license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Drawing.Common 4.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Drawing.Common/4.6.1/4.6.1)