### PR TITLE
udunits 4.5.5

### DIFF
--- a/curations/maven/mavencentral/edu.ucar/udunits.yaml
+++ b/curations/maven/mavencentral/edu.ucar/udunits.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: udunits
+  namespace: edu.ucar
+  provider: mavencentral
+  type: maven
+revisions:
+  4.5.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
udunits 4.5.5

**Details:**
ClearlyDefined pom no license info
Maven pom no license info
Maven license link is BSD-3-Clause: https://www.unidata.ucar.edu/software/netcdf/copyright.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [udunits 4.5.5](https://clearlydefined.io/definitions/maven/mavencentral/edu.ucar/udunits/4.5.5/4.5.5)