### PR TITLE
 jdbc-sqlite3 3.20.1

### DIFF
--- a/curations/gem/rubygems/-/jdbc-sqlite3.yaml
+++ b/curations/gem/rubygems/-/jdbc-sqlite3.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jdbc-sqlite3
+  provider: rubygems
+  type: gem
+revisions:
+  3.20.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 jdbc-sqlite3 3.20.1

**Details:**
ClearlyDefined license is Apache-2.0
RubyGems license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/jruby/activerecord-jdbc-adapter/blob/master/jdbc-sqlite3/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jdbc-sqlite3 3.20.1](https://clearlydefined.io/definitions/gem/rubygems/-/jdbc-sqlite3/3.20.1/3.20.1)