### PR TITLE
AdaptiveExpressions 4.9.1

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveExpressions.yaml
+++ b/curations/nuget/nuget/-/AdaptiveExpressions.yaml
@@ -45,6 +45,9 @@ revisions:
   4.9.0:
     licensed:
       declared: MIT
+  4.9.1:
+    licensed:
+      declared: MIT
   4.9.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AdaptiveExpressions 4.9.1

**Details:**
ClearlyDefined license indicates MIT
NuGet license links to MIT
GitHub license is MIT: https://github.com/microsoft/botbuilder-dotnet/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AdaptiveExpressions 4.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveExpressions/4.9.1/4.9.1)