### PR TITLE
sourcemap-validator 1.1.1

### DIFF
--- a/curations/npm/npmjs/-/sourcemap-validator.yaml
+++ b/curations/npm/npmjs/-/sourcemap-validator.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sourcemap-validator
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sourcemap-validator 1.1.1

**Details:**
ClearlyDefined package.json no license info
NPM license field indicates NONE
GitHub license is MIT (in readme): https://github.com/ben-ng/sourcemap-validator/tree/v1.1.1

**Resolution:**
MIT

**Affected definitions**:
- [sourcemap-validator 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/sourcemap-validator/1.1.1/1.1.1)