### PR TITLE
junit-platform-commons

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -31,3 +31,6 @@ revisions:
   1.7.2:
     licensed:
       declared: EPL-2.0
+  1.8.1:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-platform-commons

**Details:**
ClearlyDefined license indicates EPL-2.0
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.8.1/junit-platform-commons-1.8.1.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-commons 1.8.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.8.1/1.8.1)