### PR TITLE
 SpreadsheetLight 3.4.9

### DIFF
--- a/curations/nuget/nuget/-/SpreadsheetLight.yaml
+++ b/curations/nuget/nuget/-/SpreadsheetLight.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SpreadsheetLight
+  provider: nuget
+  type: nuget
+revisions:
+  3.4.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
 SpreadsheetLight 3.4.9

**Details:**
Nuget license is MIT
https://www.nuget.org/packages/SpreadsheetLight/3.5.0/License

**Resolution:**
MIT

**Affected definitions**:
- [SpreadsheetLight 3.4.9](https://clearlydefined.io/definitions/nuget/nuget/-/SpreadsheetLight/3.4.9/3.4.9)