### PR TITLE
kendo-angular-pdf-export 3.0.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-pdf-export.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-pdf-export.yaml
@@ -19,3 +19,6 @@ revisions:
   3.0.0:
     licensed:
       declared: OTHER
+  3.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
kendo-angular-pdf-export 3.0.1

**Details:**
ClearlyDefined license indicates OTHER
NPM license field indicates see license folder
OTHER: Telerik EULA

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-pdf-export 3.0.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-pdf-export/3.0.1/3.0.1)