### PR TITLE
junit-platform-runner 1.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-runner.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-runner.yaml
@@ -10,6 +10,9 @@ revisions:
   1.4.0:
     licensed:
       declared: EPL-2.0
+  1.5.2:
+    licensed:
+      declared: EPL-2.0
   1.7.0:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-platform-runner 1.5.2

**Details:**
ClearlyDefined pom indicates EPL-2.0
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-runner/1.5.2/junit-platform-runner-1.5.2.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-runner 1.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-runner/1.5.2/1.5.2)