### PR TITLE
declared license is not discvered correctly

### DIFF
--- a/curations/maven/mavencentral/com.mchange/c3p0.yaml
+++ b/curations/maven/mavencentral/com.mchange/c3p0.yaml
@@ -7,3 +7,6 @@ revisions:
   0.9.5.4:
     licensed:
       declared: LGPL-2.1-only OR EPL-1.0
+  0.9.5.5:
+    licensed:
+      declared: LGPL-2.1-only OR EPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
declared license is not discvered correctly

**Details:**
The component's declared license is LGPL-2.1-only OR EPL-1.0 as can be seen in the project's GitHub repository: https://github.com/swaldman/c3p0/blob/v0.9.5.5/LICENSE

**Resolution:**
Set declared license to LGPL-2.1-only OR EPL-1.0

**Affected definitions**:
- [c3p0 0.9.5.5](https://clearlydefined.io/definitions/maven/mavencentral/com.mchange/c3p0/0.9.5.5/0.9.5.5)