### PR TITLE
Declared license is incorrectly discovered

### DIFF
--- a/curations/maven/mavencentral/com.mchange/mchange-commons-java.yaml
+++ b/curations/maven/mavencentral/com.mchange/mchange-commons-java.yaml
@@ -7,3 +7,6 @@ revisions:
   0.2.15:
     licensed:
       declared: LGPL-2.1-only OR EPL-1.0
+  0.2.19:
+    licensed:
+      declared: LGPL-2.1-only OR EPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license is incorrectly discovered

**Details:**
The component's declared license is LGPL-2.1-only OR EPL-1.0 as can be seen in the project's GitHub repository: https://github.com/swaldman/mchange-commons-java/blob/v0.2.19/LICENSE

**Resolution:**
Set declared license to LGPL-2.1-only OR EPL-1.0

**Affected definitions**:
- [mchange-commons-java 0.2.19](https://clearlydefined.io/definitions/maven/mavencentral/com.mchange/mchange-commons-java/0.2.19/0.2.19)