### PR TITLE
Add missing source location and declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.logging.log4j/log4j-api.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.logging.log4j/log4j-api.yaml
@@ -21,3 +21,19 @@ revisions:
         url: 'https://github.com/apache/logging-log4j2/commit/c30a1398a6697fb832c650870c44284d0052103e'
     licensed:
       declared: Apache-2.0
+  2.17.1:
+    described:
+      facets:
+        dev:
+          - log4j-api/src/main
+        tests:
+          - log4j-api/src/test
+      sourceLocation:
+        name: logging-log4j2
+        namespace: apache
+        provider: github
+        revision: 11dafda0c43eb31cca67f3b0ed0ca9b81780db76
+        type: git
+        url: 'https://github.com/apache/logging-log4j2/commit/11dafda0c43eb31cca67f3b0ed0ca9b81780db76'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing source location and declared license

**Details:**
missing source location and declared license

**Resolution:**
Add missing source location and declared license

**Affected definitions**:
- [log4j-api 2.17.1](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.logging.log4j/log4j-api/2.17.1/2.17.1)