### PR TITLE
Fix source url and release date

### DIFF
--- a/curations/maven/mavencentral/org.apache.logging.log4j/log4j-core.yaml
+++ b/curations/maven/mavencentral/org.apache.logging.log4j/log4j-core.yaml
@@ -1,0 +1,21 @@
+coordinates:
+  name: log4j-core
+  namespace: org.apache.logging.log4j
+  provider: mavencentral
+  type: maven
+revisions:
+  2.17.1:
+    described:
+      facets:
+        dev:
+          - log4j-core/src/main
+        tests:
+          - log4j-core/src/test
+      releaseDate: '2021-12-28'
+      sourceLocation:
+        name: logging-log4j2
+        namespace: apache
+        provider: github
+        revision: 11dafda0c43eb31cca67f3b0ed0ca9b81780db76
+        type: git
+        url: 'https://github.com/apache/logging-log4j2/commit/11dafda0c43eb31cca67f3b0ed0ca9b81780db76'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fix source url and release date

**Details:**
- url to maven source jar instead of git repo
- wrong release date

**Resolution:**
Fix source url and release date

**Affected definitions**:
- [log4j-core 2.17.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.logging.log4j/log4j-core/2.17.1/2.17.1)