### PR TITLE
scala-reflect 2.11.2

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -16,6 +16,9 @@ revisions:
   2.11.12:
     licensed:
       declared: BSD-3-Clause
+  2.11.2:
+    licensed:
+      declared: BSD-3-Clause
   2.11.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scala-reflect 2.11.2

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.11.1/scala-reflect-2.11.1.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-reflect 2.11.2](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.11.2/2.11.2)