### PR TITLE
Ben.Demystifier 0.1.1

### DIFF
--- a/curations/nuget/nuget/-/Ben.Demystifier.yaml
+++ b/curations/nuget/nuget/-/Ben.Demystifier.yaml
@@ -6,6 +6,9 @@ revisions:
   0.1.0:
     licensed:
       declared: Apache-2.0
+  0.1.1:
+    licensed:
+      declared: Apache-2.0
   0.1.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ben.Demystifier 0.1.1

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/benaadams/Ben.Demystifier/blob/v0.0.1/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Ben.Demystifier 0.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Ben.Demystifier/0.1.1/0.1.1)