### PR TITLE
dependabot-github_actions 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-github_actions.yaml
+++ b/curations/gem/rubygems/-/dependabot-github_actions.yaml
@@ -6,3 +6,6 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-github_actions 0.162.2

**Details:**
RubyGems license field indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-github_actions 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-github_actions/0.162.2/0.162.2)