### PR TITLE
colorcet 2.0.2

### DIFF
--- a/curations/pypi/pypi/-/colorcet.yaml
+++ b/curations/pypi/pypi/-/colorcet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: colorcet
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.2:
+    licensed:
+      declared: CC-BY-4.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
colorcet 2.0.2

**Details:**
PyPi license field is CC-BY-4.0
GitHub license is CC-BY-4.0: https://github.com/holoviz/colorcet/blob/v2.0.2/LICENSE.txt

**Resolution:**
CC-BY-4.0

**Affected definitions**:
- [colorcet 2.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/colorcet/2.0.2/2.0.2)