### PR TITLE
pylint-celery 0.3

### DIFF
--- a/curations/pypi/pypi/-/pylint-celery.yaml
+++ b/curations/pypi/pypi/-/pylint-celery.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pylint-celery
+  provider: pypi
+  type: pypi
+revisions:
+  '0.3':
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pylint-celery 0.3

**Details:**
ClearlyDefined PKG-INFO file indicates GPLv2
PyPi license field indicates: GPLv2
GitHub license indicates GPLv2
No reference to "or-later"

**Resolution:**
GPL-2.0-only

**Affected definitions**:
- [pylint-celery 0.3](https://clearlydefined.io/definitions/pypi/pypi/-/pylint-celery/0.3/0.3)