### PR TITLE
DotNetty.Codecs 0.4.6

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Codecs.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Codecs.yaml
@@ -6,6 +6,9 @@ revisions:
   0.4.5:
     licensed:
       declared: MIT
+  0.4.6:
+    licensed:
+      declared: MIT
   0.4.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetty.Codecs 0.4.6

**Details:**
NuGet license is MIT
GitHub license is MIT: https://github.com/Azure/DotNetty/blob/v0.4.0/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [DotNetty.Codecs 0.4.6](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetty.Codecs/0.4.6/0.4.6)