### PR TITLE
AngularJS.Core 1.5.5

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Core.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Core.yaml
@@ -9,6 +9,9 @@ revisions:
   1.4.7:
     licensed:
       declared: MIT
+  1.5.5:
+    licensed:
+      declared: MIT
   1.5.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngularJS.Core 1.5.5

**Details:**
NuGet license is MIT
GitHub license is MIT: https://github.com/angular/angular.js/blob/v1.5.5/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AngularJS.Core 1.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Core/1.5.5/1.5.5)