### PR TITLE
AspNet.ScriptManager.jQuery.UI.Combined 1.8.24

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.UI.Combined.yaml
@@ -9,3 +9,6 @@ revisions:
   1.8.20:
     licensed:
       declared: NONE
+  1.8.24:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AspNet.ScriptManager.jQuery.UI.Combined 1.8.24

**Details:**
NuGet no license field and no link to project.
ClearlyDefined no license info found.

**Resolution:**
NONE

**Affected definitions**:
- [AspNet.ScriptManager.jQuery.UI.Combined 1.8.24](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.jQuery.UI.Combined/1.8.24/1.8.24)