### PR TITLE
AdaptiveExpressions 4.12.0

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveExpressions.yaml
+++ b/curations/nuget/nuget/-/AdaptiveExpressions.yaml
@@ -18,6 +18,9 @@ revisions:
   4.11.2:
     licensed:
       declared: MIT
+  4.12.0:
+    licensed:
+      declared: MIT
   4.12.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AdaptiveExpressions 4.12.0

**Details:**
ClearlyDefined license indicates MIT
NuGet license field indicates MIT
GitHub license is MIT: https://github.com/microsoft/botbuilder-dotnet/blob/4.12/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AdaptiveExpressions 4.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveExpressions/4.12.0/4.12.0)