### PR TITLE
Ninject.MockingKernel.Moq 3.3.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
@@ -6,3 +6,6 @@ revisions:
   3.2.2:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.3.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.MockingKernel.Moq 3.3.0

**Details:**
NuGet license indicates dual licensed
GitHub indicates dual licensed: https://github.com/ninject/Ninject.MockingKernel/blob/3.3.0/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.MockingKernel.Moq 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MockingKernel.Moq/3.3.0/3.3.0)