### PR TITLE
AppInsights.EnterpriseTelemetry.AspNetCore.Extension 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/AppInsights.EnterpriseTelemetry.AspNetCore.Extension.yaml
+++ b/curations/nuget/nuget/-/AppInsights.EnterpriseTelemetry.AspNetCore.Extension.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: AppInsights.EnterpriseTelemetry.AspNetCore.Extension
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AppInsights.EnterpriseTelemetry.AspNetCore.Extension 1.0.3

**Details:**
NuGet license is MIT
GitHub license is MIT: https://github.com/microsoft/AppInsights.EnterpriseTelemetry/blob/1.0.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AppInsights.EnterpriseTelemetry.AspNetCore.Extension 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/AppInsights.EnterpriseTelemetry.AspNetCore.Extension/1.0.3/1.0.3)