### PR TITLE
WordPressPCL 1.5.1

### DIFF
--- a/curations/nuget/nuget/-/WordPressPCL.yaml
+++ b/curations/nuget/nuget/-/WordPressPCL.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WordPressPCL
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WordPressPCL 1.5.1

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/wp-net/WordPressPCL/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [WordPressPCL 1.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/WordPressPCL/1.5.1/1.5.1)