### PR TITLE
NLog.Extensions.AzureTableStorage 1.1.4

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.AzureTableStorage.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.AzureTableStorage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NLog.Extensions.AzureTableStorage
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.4:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/NLog.Extensions.AzureTableStorage.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.AzureTableStorage.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.4:
     licensed:
-      declared: MIT
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Extensions.AzureTableStorage 1.1.4

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/abkonsta/NLog.Extensions.AzureStorage/blob/master/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [NLog.Extensions.AzureTableStorage 1.1.4](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.AzureTableStorage/1.1.4/1.1.4)