### PR TITLE
curator-test 2.6.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.curator/curator-test.yaml
+++ b/curations/maven/mavencentral/org.apache.curator/curator-test.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: curator-test
+  namespace: org.apache.curator
+  provider: mavencentral
+  type: maven
+revisions:
+  2.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
curator-test 2.6.0

**Details:**
Maven POM is Apache-2.0: https://repo1.maven.org/maven2/org/apache/curator/curator-test/2.6.0/curator-test-2.6.0.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [curator-test 2.6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.curator/curator-test/2.6.0/2.6.0)