### PR TITLE
sjcl 1.0.7

### DIFF
--- a/curations/npm/npmjs/-/sjcl.yaml
+++ b/curations/npm/npmjs/-/sjcl.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sjcl
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.7:
+    licensed:
+      declared: BSD-2-Clause OR GPL-3.0-or-later

--- a/curations/npm/npmjs/-/sjcl.yaml
+++ b/curations/npm/npmjs/-/sjcl.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.7:
     licensed:
-      declared: BSD-2-Clause OR GPL-3.0-or-later
+      declared: BSD-2-Clause OR GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sjcl 1.0.7

**Details:**
ClearlyDefined license is BSD-2-Clause OR GPL-3.0-or-later
NPM License indicates BSD-2-Clause OR GPL-3.0-or-later
GitHub is SD-2-Clause OR GPL-3.0-or-later: https://github.com/bitwiseshiftleft/sjcl/blob/1.0.7/LICENSE.txt

**Resolution:**
BSD-2-Clause OR GPL-3.0-or-later

**Affected definitions**:
- [sjcl 1.0.7](https://clearlydefined.io/definitions/npm/npmjs/-/sjcl/1.0.7/1.0.7)