### PR TITLE
aspectjweaver 1.8.10

### DIFF
--- a/curations/maven/mavencentral/org.aspectj/aspectjweaver.yaml
+++ b/curations/maven/mavencentral/org.aspectj/aspectjweaver.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.8.10:
+    licensed:
+      declared: EPL-1.0
   1.8.6:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
aspectjweaver 1.8.10

**Details:**
Maven POM is EPL-1.0: https://repo1.maven.org/maven2/org/aspectj/aspectjweaver/1.8.10/aspectjweaver-1.8.10.pom

**Resolution:**
EPL-1.0

**Affected definitions**:
- [aspectjweaver 1.8.10](https://clearlydefined.io/definitions/maven/mavencentral/org.aspectj/aspectjweaver/1.8.10/1.8.10)