### PR TITLE
scala-maven-plugin licensed under Unlicense

### DIFF
--- a/curations/maven/mavencentral/net.alchim31.maven/scala-maven-plugin.yaml
+++ b/curations/maven/mavencentral/net.alchim31.maven/scala-maven-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: scala-maven-plugin
+  namespace: net.alchim31.maven
+  provider: mavencentral
+  type: maven
+revisions:
+  4.5.4:
+    licensed:
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Other

**Summary:**
scala-maven-plugin licensed under Unlicense

**Details:**
Is licensed under the "Unlicense": https://github.com/davidB/scala-maven-plugin/blob/4.5.4/UNLICENSE

**Resolution:**
Selecting the "Unlicense"

**Affected definitions**:
- [scala-maven-plugin 4.5.4](https://clearlydefined.io/definitions/maven/mavencentral/net.alchim31.maven/scala-maven-plugin/4.5.4/4.5.4)