### PR TITLE
gsap 1.20.3

### DIFF
--- a/curations/npm/npmjs/-/gsap.yaml
+++ b/curations/npm/npmjs/-/gsap.yaml
@@ -3,6 +3,12 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.20.3:
+    files:
+      - license: OTHER
+        path: package/package.json
+    licensed:
+      declared: OTHER
   2.1.2:
     files:
       - license: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gsap 1.20.3

**Details:**
Package.json says "MIT," but that is incorrect.  It references the standard "no charge" license on greensock.com.  See: https://clearlydefined.io/file/c0b0571bb25d737c60200a163806889b8f1c84af90ae38b0f31f8b3dd51284ea

**Resolution:**
Curating OTHER for both package.json and the declared field. 

**Affected definitions**:
- [gsap 1.20.3](https://clearlydefined.io/definitions/npm/npmjs/-/gsap/1.20.3/1.20.3)