### PR TITLE
Innofactor.EfCoreJsonValueConverter 2.0.2

### DIFF
--- a/curations/nuget/nuget/-/Innofactor.EfCoreJsonValueConverter.yaml
+++ b/curations/nuget/nuget/-/Innofactor.EfCoreJsonValueConverter.yaml
@@ -1,0 +1,13 @@
+coordinates:
+  name: Innofactor.EfCoreJsonValueConverter
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.2:
+    files:
+      - attributions:
+          - 'Copyright (c) 2007 Free Software Foundation, Inc. <http://fsf.org/>'
+        license: LGPL-3.0-only
+        path: clearlydefined/downloaded/LICENSE
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Innofactor.EfCoreJsonValueConverter 2.0.2

**Details:**
Tooling incorrectly identifying LICENSE as GPL, when it is LGPL.  NuGet license link and repo license LGPL-3.0.  See no references to "or-later," so curating as LGPL-3.0-only.

**Resolution:**
See above

**Affected definitions**:
- [Innofactor.EfCoreJsonValueConverter 2.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Innofactor.EfCoreJsonValueConverter/2.0.2/2.0.2)