### PR TITLE
org.apache.shiro/shiro-crypto-hash:1.8.0

### DIFF
--- a/curations/sourcearchive/mavencentral/org.apache.shiro/shiro-crypto-hash.yaml
+++ b/curations/sourcearchive/mavencentral/org.apache.shiro/shiro-crypto-hash.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: shiro-crypto-hash
+  namespace: org.apache.shiro
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.8.0:
+    described:
+      sourceLocation:
+        name: shiro
+        namespace: apache
+        provider: github
+        revision: a86c51a11c1b6df6b097e312f5709924479edccc
+        type: git
+        url: 'https://github.com/apache/shiro/commit/a86c51a11c1b6df6b097e312f5709924479edccc'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.shiro/shiro-crypto-hash:1.8.0

**Details:**
Added source and declared dependency info

**Resolution:**
https://shiro.apache.org/
https://github.com/apache/shiro/tree/shiro-root-1.8.0

**Affected definitions**:
- [shiro-crypto-hash 1.8.0](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.apache.shiro/shiro-crypto-hash/1.8.0)