### PR TITLE
Add React.Core 3.4.1 license

### DIFF
--- a/curations/nuget/nuget/-/React.Core.yaml
+++ b/curations/nuget/nuget/-/React.Core.yaml
@@ -6,6 +6,9 @@ revisions:
   3.2.0:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  3.4.1:
+    licensed:
+      declared: BSD-3-Clause AND OTHER
   4.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add React.Core 3.4.1 license

**Details:**
Add missing license

**Resolution:**
This license was curated in https://github.com/clearlydefined/curated-data/pull/4879/files but due to a casing error  (see https://github.com/clearlydefined/curated-data/issues/7837), was not applied to this component.

**Affected definitions**:
- [React.Core 3.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/React.Core/3.4.1/3.4.1)