### PR TITLE
org.apache.shiro/shiro-crypto-hash:1.8.0

### DIFF
--- a/curations/maven/mavencentral/org.apache.shiro/shiro-crypto-hash.yaml
+++ b/curations/maven/mavencentral/org.apache.shiro/shiro-crypto-hash.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: shiro-crypto-hash
+  namespace: org.apache.shiro
+  provider: mavencentral
+  type: maven
+revisions:
+  1.8.0:
+    described:
+      releaseDate: '2021-08-23'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.apache.shiro/shiro-crypto-hash:1.8.0

**Details:**
Fixed release date

**Resolution:**
https://github.com/apache/shiro/tree/shiro-root-1.8.0

**Affected definitions**:
- [shiro-crypto-hash 1.8.0](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.shiro/shiro-crypto-hash/1.8.0)