### PR TITLE
Innofactor.EfCoreJsonValueConverter.Attributes2.0.1

### DIFF
--- a/curations/nuget/nuget/-/Innofactor.EfCoreJsonValueConverter.Attributes.yaml
+++ b/curations/nuget/nuget/-/Innofactor.EfCoreJsonValueConverter.Attributes.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Innofactor.EfCoreJsonValueConverter.Attributes
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.1:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Innofactor.EfCoreJsonValueConverter.Attributes2.0.1

**Details:**
NuGet license indicates LGPL-3.0-only: https://www.nuget.org/packages/Innofactor.EfCoreJsonValueConverter.Attributes/2.0.1
No indication of "or-other" so "only"

**Resolution:**
LGPL-3.0-only

**Affected definitions**:
- [Innofactor.EfCoreJsonValueConverter.Attributes 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Innofactor.EfCoreJsonValueConverter.Attributes/2.0.1/2.0.1)