### PR TITLE
Aspose.Cells17.12.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Cells.yaml
+++ b/curations/nuget/nuget/-/Aspose.Cells.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  17.12.0:
+    licensed:
+      declared: OTHER
   21.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Cells17.12.0

**Details:**
ClearlyDefined license is OTHER - Apose EULA
NuGet license link to same

**Resolution:**
OTHER

**Affected definitions**:
- [Aspose.Cells 17.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Cells/17.12.0/17.12.0)