### PR TITLE
Aspose.Email20.6.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Email.yaml
+++ b/curations/nuget/nuget/-/Aspose.Email.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  20.6.0:
+    licensed:
+      declared: OTHER
   20.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Email20.6.0

**Details:**
License is Aspose EULA
NuGet license field links to Aspose EULA

**Resolution:**
OTHER

**Affected definitions**:
- [Aspose.Email 20.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Email/20.6.0/20.6.0)