### PR TITLE
Aspose.Words15.10.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Words.yaml
+++ b/curations/nuget/nuget/-/Aspose.Words.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  15.10.0:
+    licensed:
+      declared: OTHER
   17.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Aspose.Words15.10.0

**Details:**
Nuspec links to Aspose EULA
NuGet license field link to same

**Resolution:**
OTHER

**Affected definitions**:
- [Aspose.Words 15.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Words/15.10.0/15.10.0)