### PR TITLE
Resolve case of No assertion

### DIFF
--- a/curations/git/github/appium/appium-desktop.yaml
+++ b/curations/git/github/appium/appium-desktop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: appium-desktop
+  namespace: appium
+  provider: github
+  type: git
+revisions:
+  5cac2f51c60445b17ecc82a014d182af9d3fcdcd:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve case of No assertion

**Details:**
the declared license has one no assertion where the component has apache 2.0 license declared.
Link to license file: https://github.com/appium/appium-desktop/blob/v1.5.0/LICENSE

**Resolution:**
Since there is no ASSERTION and no license declared, it is being curated as Apache 2.0 instead of no ASSERTION.
Link to license file: https://github.com/appium/appium-desktop/blob/v1.5.0/LICENSE

**Affected definitions**:
- [appium-desktop 5cac2f51c60445b17ecc82a014d182af9d3fcdcd](https://clearlydefined.io/definitions/git/github/appium/appium-desktop/5cac2f51c60445b17ecc82a014d182af9d3fcdcd/5cac2f51c60445b17ecc82a014d182af9d3fcdcd)