### PR TITLE
Update libzmq license

### DIFF
--- a/curations/git/github/zeromq/libzmq.yaml
+++ b/curations/git/github/zeromq/libzmq.yaml
@@ -7,3 +7,6 @@ revisions:
   2cb1240db64ce1ea299e00474c646a2453a8435b:
     licensed:
       declared: OTHER
+  4097855ddaaa65ed7b5e8cb86d143842a594eebd:
+    licensed:
+      declared: LGPL-3.0

--- a/curations/git/github/zeromq/libzmq.yaml
+++ b/curations/git/github/zeromq/libzmq.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: OTHER
   4097855ddaaa65ed7b5e8cb86d143842a594eebd:
     licensed:
-      declared: LGPL-3.0
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update libzmq license

**Details:**
The component is labeled with a declared license of GPL-3.0, which appears to be inaccurate. The project declares it is licensed as LGPL.

I am not sure of the details of how the "declaration" was made from data sources - but thought this was a good starting point.

**Resolution:**
Update the declared license to be LGPL-3.0, as per:

https://github.com/zeromq/libzmq/tree/master#license

https://github.com/zeromq/libzmq/blob/master/COPYING.LESSER

**Affected definitions**:
- [libzmq 4097855ddaaa65ed7b5e8cb86d143842a594eebd](https://clearlydefined.io/definitions/git/github/zeromq/libzmq/4097855ddaaa65ed7b5e8cb86d143842a594eebd)