### PR TITLE
paramiko 2.9.2

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -15,3 +15,6 @@ revisions:
   2.8.0:
     licensed:
       declared: LGPL-2.1-or-later
+  2.9.2:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko 2.9.2

**Details:**
LICENSE file in package is LGPL-2.1 and source header files say "or later."

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [paramiko 2.9.2](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.9.2/2.9.2)