### PR TITLE
dependabot-docker0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-docker.yaml
+++ b/curations/gem/rubygems/-/dependabot-docker.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-docker
+  provider: rubygems
+  type: gem
+revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-docker0.129.5

**Details:**
RubyGems license field indicates Nonstandard
The source repository is OTHER: https://github.com/dependabot/dependabot-core/blob/main/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-docker 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-docker/0.129.5/0.129.5)