### PR TITLE
Optional.Collections1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Optional.Collections.yaml
+++ b/curations/nuget/nuget/-/Optional.Collections.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Optional.Collections
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Optional.Collections1.1.0

**Details:**
NuGet license field is missing
GitHub license is MIT: https://github.com/nlkl/Optional/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Optional.Collections 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Optional.Collections/1.1.0/1.1.0)