### PR TITLE
Enchilada1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Enchilada.yaml
+++ b/curations/nuget/nuget/-/Enchilada.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Enchilada
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Enchilada1.1.0

**Details:**
NuGet license field is missing
GitHub license is MIT: https://github.com/sparkeh9/Enchilada/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Enchilada 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Enchilada/1.1.0/1.1.0)