### PR TITLE
dependabot-dep0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-dep.yaml
+++ b/curations/gem/rubygems/-/dependabot-dep.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.129.5:
     licensed:
-      declared: AGPL-3.0-or-later
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-dep0.129.5

**Details:**
RubyGems license field is Nonstandard
GitHub license is : AGPL-3.0-or-later
https://github.com/dependabot/dependabot-core/blob/v0.29.1/LICENSE.txt

**Resolution:**
AGPL-3.0-or-later

**Affected definitions**:
- [dependabot-dep 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-dep/0.129.5/0.129.5)