### PR TITLE
SmartFormat.NET2.2.0

### DIFF
--- a/curations/nuget/nuget/-/SmartFormat.NET.yaml
+++ b/curations/nuget/nuget/-/SmartFormat.NET.yaml
@@ -6,6 +6,9 @@ revisions:
   1.6.1:
     licensed:
       declared: MIT
+  2.2.0:
+    licensed:
+      declared: MIT
   2.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SmartFormat.NET2.2.0

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/axuno/SmartFormat/blob/v2.2.0.0/license.txt

**Resolution:**
MIT

**Affected definitions**:
- [SmartFormat.NET 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/SmartFormat.NET/2.2.0/2.2.0)