### PR TITLE
dependabot-terraform0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-terraform.yaml
+++ b/curations/gem/rubygems/-/dependabot-terraform.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.162.1:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-terraform0.162.1

**Details:**
RubyGems license field is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-terraform 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-terraform/0.162.1/0.162.1)