### PR TITLE
jsonsir0.0.2

### DIFF
--- a/curations/pypi/pypi/-/jsonsir.yaml
+++ b/curations/pypi/pypi/-/jsonsir.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jsonsir
+  provider: pypi
+  type: pypi
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsonsir0.0.2

**Details:**
ClearlyDefined PKG-INFO indicates MIT license
PyPi license field is MIT

**Resolution:**
MIT

**Affected definitions**:
- [jsonsir 0.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/jsonsir/0.0.2/0.0.2)