### PR TITLE
ejs0.8.8

### DIFF
--- a/curations/npm/npmjs/-/ejs.yaml
+++ b/curations/npm/npmjs/-/ejs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ejs
+  provider: npmjs
+  type: npm
+revisions:
+  0.8.8:
+    licensed:
+      declared: Apache-2.0

--- a/curations/npm/npmjs/-/ejs.yaml
+++ b/curations/npm/npmjs/-/ejs.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.8.8:
     licensed:
-      declared: Apache-2.0
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ejs0.8.8

**Details:**
NPM license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/mde/ejs/blob/main/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ejs 0.8.8](https://clearlydefined.io/definitions/npm/npmjs/-/ejs/0.8.8/0.8.8)