### PR TITLE
Serilog.Sinks.AzureApp2.1.2

### DIFF
--- a/curations/nuget/nuget/-/Serilog.Sinks.AzureApp.yaml
+++ b/curations/nuget/nuget/-/Serilog.Sinks.AzureApp.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.2:
+    licensed:
+      declared: CC0-1.0
   3.1.0:
     licensed:
       declared: CC0-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Serilog.Sinks.AzureApp2.1.2

**Details:**
NuGet license field is CC0-1.0
GItHub license is CC0-1.0: https://github.com/cnelsonakgov/serilog-sinks-azureapp/blob/v2.1.2/LICENSE

**Resolution:**
CC0-1.0

**Affected definitions**:
- [Serilog.Sinks.AzureApp 2.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/Serilog.Sinks.AzureApp/2.1.2/2.1.2)