### PR TITLE
icon-windows0.0.1

### DIFF
--- a/curations/npm/npmjs/-/icon-windows.yaml
+++ b/curations/npm/npmjs/-/icon-windows.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: icon-windows
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
icon-windows0.0.1

**Details:**
ClearlyDefined package.json includes license link to MIT: https://pemrouz.mit-license.org/
NPM license field is same as above

**Resolution:**
MIT

**Affected definitions**:
- [icon-windows 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/icon-windows/0.0.1/0.0.1)