### PR TITLE
rijs.sessions1.1.2

### DIFF
--- a/curations/npm/npmjs/-/rijs.sessions.yaml
+++ b/curations/npm/npmjs/-/rijs.sessions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rijs.sessions
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rijs.sessions1.1.2

**Details:**
ClearlyDefined package.json includes link to MIT: https://pemrouz.mit-license.org/
NPM same link as above

**Resolution:**
MIT

**Affected definitions**:
- [rijs.sessions 1.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/rijs.sessions/1.1.2/1.1.2)