### PR TITLE
org.junit.jupiter/junit-jupiter5.6.3

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -19,6 +19,9 @@ revisions:
   5.6.2:
     licensed:
       declared: EPL-2.0
+  5.6.3:
+    licensed:
+      declared: EPL-2.0
   5.7.0:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter5.6.3

**Details:**
ClearlyDefined license is EPL-2.0
Maven POM is EPL-2.0: https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter/5.6.3/junit-jupiter-5.6.3.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter 5.6.3](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.6.3/5.6.3)