### PR TITLE
EFxceptions0.4.5

### DIFF
--- a/curations/nuget/nuget/-/EFxceptions.yaml
+++ b/curations/nuget/nuget/-/EFxceptions.yaml
@@ -9,3 +9,6 @@ revisions:
   0.4.4:
     licensed:
       declared: MIT
+  0.4.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EFxceptions0.4.5

**Details:**
NuGet license field is MIT: https://www.nuget.org/packages/EFxceptions/0.4.5/License
ClearlyDefined license file didn't have license info
GitHub did not have a license

**Resolution:**
MIT

**Affected definitions**:
- [EFxceptions 0.4.5](https://clearlydefined.io/definitions/nuget/nuget/-/EFxceptions/0.4.5/0.4.5)