### PR TITLE
org.glassfish.grizzly/grizzly-http-server2.1.

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.grizzly/grizzly-http-server.yaml
+++ b/curations/maven/mavencentral/org.glassfish.grizzly/grizzly-http-server.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.1.2:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.2.16:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.glassfish.grizzly/grizzly-http-server2.1.

**Details:**
Maven POM is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0 


**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0 

**Affected definitions**:
- [grizzly-http-server 2.1.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.grizzly/grizzly-http-server/2.1.2/2.1.2)