### PR TITLE
NLog.Extensions.Logging1.5.0

### DIFF
--- a/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/NLog.Extensions.Logging.yaml
@@ -21,6 +21,9 @@ revisions:
   1.4.0:
     licensed:
       declared: BSD-2-Clause
+  1.5.0:
+    licensed:
+      declared: BSD-2-Clause
   1.5.1:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Extensions.Logging1.5.0

**Details:**
NuGet license field is BSD-2-Clause
GitHub license is BSD-2-Clause:  https://github.com/NLog/NLog.Extensions.Logging/blob/v1.5.0/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [NLog.Extensions.Logging 1.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Extensions.Logging/1.5.0/1.5.0)