### PR TITLE
PnP.Core1.1.0

### DIFF
--- a/curations/nuget/nuget/-/PnP.Core.yaml
+++ b/curations/nuget/nuget/-/PnP.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PnP.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PnP.Core1.1.0

**Details:**
NuGet no license field
GitHub license is MIT: https://github.com/pnp/pnpcore/blob/1.1.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [PnP.Core 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/PnP.Core/1.1.0/1.1.0)