### PR TITLE
Unity.Interception5.10.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.Interception.yaml
+++ b/curations/nuget/nuget/-/Unity.Interception.yaml
@@ -6,6 +6,9 @@ revisions:
   5.0.1:
     licensed:
       declared: Apache-2.0
+  5.10.0:
+    licensed:
+      declared: Apache-2.0
   5.11.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Interception5.10.0

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0:https://github.com/unitycontainer/unity/blob/5.10.0.755/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Interception 5.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Interception/5.10.0/5.10.0)