### PR TITLE
popper1.0.1

### DIFF
--- a/curations/npm/npmjs/-/popper.yaml
+++ b/curations/npm/npmjs/-/popper.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: popper
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
popper1.0.1

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM license field links to same as above
GitHub package.json is same as above

**Resolution:**
MIT

**Affected definitions**:
- [popper 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/popper/1.0.1/1.0.1)