### PR TITLE
LinqKit1.1.3.1

### DIFF
--- a/curations/nuget/nuget/-/LinqKit.yaml
+++ b/curations/nuget/nuget/-/LinqKit.yaml
@@ -6,3 +6,6 @@ revisions:
   1.1.16:
     licensed:
       declared: MIT
+  1.1.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LinqKit1.1.3.1

**Details:**
NuGet license links is MIT
GitHub license is MIT: https://github.com/scottksmith95/LINQKit/blob/1.2.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [LinqKit 1.1.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/LinqKit/1.1.3.1/1.1.3.1)