### PR TITLE
org.junit.platform/junit-platform-suite-api1.5.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-suite-api.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-suite-api.yaml
@@ -7,3 +7,6 @@ revisions:
   1.2.0:
     licensed:
       declared: EPL-2.0
+  1.5.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-suite-api1.5.2

**Details:**
ClearlyDefined license is EPL-2.0
Maven POM is EPL-2.0: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-api/1.5.2/junit-platform-suite-api-1.5.2.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-suite-api 1.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-suite-api/1.5.2/1.5.2)