### PR TITLE
rijs.components3.1.16

### DIFF
--- a/curations/npm/npmjs/-/rijs.components.yaml
+++ b/curations/npm/npmjs/-/rijs.components.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rijs.components
+  provider: npmjs
+  type: npm
+revisions:
+  3.1.16:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rijs.components3.1.16

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM license field links to same as above
GitHub package.json includes same license link as above

**Resolution:**
MIT

**Affected definitions**:
- [rijs.components 3.1.16](https://clearlydefined.io/definitions/npm/npmjs/-/rijs.components/3.1.16/3.1.16)