### PR TITLE
@compone/class1.1.1

### DIFF
--- a/curations/npm/npmjs/@compone/class.yaml
+++ b/curations/npm/npmjs/@compone/class.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: class
+  namespace: '@compone'
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@compone/class1.1.1

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM license field links to same as above

**Resolution:**
MIT

**Affected definitions**:
- [class 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/@compone/class/1.1.1/1.1.1)