### PR TITLE
org.ow2.asm/asm-tree5.0.1

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm-tree.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm-tree.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.0.1:
+    licensed:
+      declared: BSD-3-Clause
   5.0.3:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.ow2.asm/asm-tree5.0.1

**Details:**
Maven POM is BSD-3-Clause
https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.0.1/asm-commons-5.0.1.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm-tree 5.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm-tree/5.0.1/5.0.1)