### PR TITLE
System.IO.Abstractions7.0.4

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -33,6 +33,9 @@ revisions:
   6.0.21:
     licensed:
       declared: MIT
+  7.0.4:
+    licensed:
+      declared: MIT
   7.0.7:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions7.0.4

**Details:**
NuGet license links to MIT
GitHub license is MIT: https://github.com/TestableIO/System.IO.Abstractions/blob/v7.0.4/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions 7.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/7.0.4/7.0.4)