### PR TITLE
Antlr4.StringTemplate4.0.6.9004

### DIFF
--- a/curations/nuget/nuget/-/Antlr4.StringTemplate.yaml
+++ b/curations/nuget/nuget/-/Antlr4.StringTemplate.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Antlr4.StringTemplate
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.6.9004:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Antlr4.StringTemplate4.0.6.9004

**Details:**
NuGet project links to StringTemplate site which links to GitHub with BSD-3-Clause: https://github.com/antlr/stringtemplate4/blob/25de865ef5e35791764018c3e3ce83ee4179832b/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Antlr4.StringTemplate 4.0.6.9004](https://clearlydefined.io/definitions/nuget/nuget/-/Antlr4.StringTemplate/4.0.6.9004/4.0.6.9004)