### PR TITLE
org.scala-lang/scala-actors2.11.12

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-actors.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-actors.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: scala-actors
+  namespace: org.scala-lang
+  provider: mavencentral
+  type: maven
+revisions:
+  2.11.12:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scala-actors2.11.12

**Details:**
Maven POM is BSD-3-Clause: https://repo1.maven.org/maven2/org/scala-lang/scala-actors/2.11.12/scala-actors-2.11.12.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-actors 2.11.12](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-actors/2.11.12/2.11.12)