### PR TITLE
com.jcraft/jsch0.1.51

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.yaml
@@ -10,6 +10,9 @@ revisions:
   0.1.42:
     licensed:
       declared: BSD-3-Clause
+  0.1.51:
+    licensed:
+      declared: BSD-3-Clause
   0.1.52:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.jcraft/jsch0.1.51

**Details:**
Maven POM includes link to BSD-3-Clause: http://www.jcraft.com/jsch/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jsch 0.1.51](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch/0.1.51/0.1.51)