### PR TITLE
NServiceBus6.2.1

### DIFF
--- a/curations/nuget/nuget/-/NServiceBus.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NServiceBus
+  provider: nuget
+  type: nuget
+revisions:
+  6.2.1:
+    licensed:
+      declared: RPL-1.1

--- a/curations/nuget/nuget/-/NServiceBus.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   6.2.1:
     licensed:
-      declared: RPL-1.1
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NServiceBus6.2.1

**Details:**
NuGet license field is: https://www.nuget.org/packages/NServiceBus/7.6.0/License
GitHub license is: https://github.com/Particular/NServiceBus/blob/6.2.1/LICENSE.md

**Resolution:**
RPL-1.1

**Affected definitions**:
- [NServiceBus 6.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/NServiceBus/6.2.1/6.2.1)