### PR TITLE
python-easyconfig0.1.7

### DIFF
--- a/curations/pypi/pypi/-/python-easyconfig.yaml
+++ b/curations/pypi/pypi/-/python-easyconfig.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: python-easyconfig
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
python-easyconfig0.1.7

**Details:**
ClearlyDefined package.json is MIT
PyPi license field indicates MIT

**Resolution:**
MIT

**Affected definitions**:
- [python-easyconfig 0.1.7](https://clearlydefined.io/definitions/pypi/pypi/-/python-easyconfig/0.1.7/0.1.7)