### PR TITLE
org.awaitility/awaitility3.1.3

### DIFF
--- a/curations/maven/mavencentral/org.awaitility/awaitility.yaml
+++ b/curations/maven/mavencentral/org.awaitility/awaitility.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.1.3:
+    licensed:
+      declared: Apache-2.0
   4.0.0-rc1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.awaitility/awaitility3.1.3

**Details:**
Maven POM is Apache-2.0: https://repo1.maven.org/maven2/org/awaitility/awaitility/3.1.3/awaitility-3.1.3.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [awaitility 3.1.3](https://clearlydefined.io/definitions/maven/mavencentral/org.awaitility/awaitility/3.1.3/3.1.3)