### PR TITLE
com.hubspot.jackson/jackson-datatype-protobuf0.9.9-jackson2.9-proto2

### DIFF
--- a/curations/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf.yaml
+++ b/curations/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf.yaml
@@ -7,3 +7,6 @@ revisions:
   0.9.10-jackson2.9-proto2:
     licensed:
       declared: Apache-2.0
+  0.9.9-jackson2.9-proto2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.hubspot.jackson/jackson-datatype-protobuf0.9.9-jackson2.9-proto2

**Details:**
GitHub license is Apache-2.0: https://github.com/HubSpot/jackson-datatype-protobuf/blob/master/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jackson-datatype-protobuf 0.9.9-jackson2.9-proto2](https://clearlydefined.io/definitions/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf/0.9.9-jackson2.9-proto2/0.9.9-jackson2.9-proto2)