### PR TITLE
Bond.Core.CSharp4.3.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Core.CSharp.yaml
@@ -15,6 +15,9 @@ revisions:
   4.2.1:
     licensed:
       declared: MIT
+  4.3.0:
+    licensed:
+      declared: MIT
   5.0.0:
     described:
       releaseDate: '2016-09-13'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Core.CSharp4.3.0

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/microsoft/bond/blob/4.3.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Bond.Core.CSharp 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Core.CSharp/4.3.0/4.3.0)