### PR TITLE
FluentAssertions2.0.0.1

### DIFF
--- a/curations/nuget/nuget/-/FluentAssertions.yaml
+++ b/curations/nuget/nuget/-/FluentAssertions.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.0.0.1:
     licensed:
-      declared: NONE
+      declared: Apache-2.0
   2.0.1:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/FluentAssertions.yaml
+++ b/curations/nuget/nuget/-/FluentAssertions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0.1:
+    licensed:
+      declared: NONE
   2.0.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentAssertions2.0.0.1

**Details:**
NuGet license link is broken
GitHub license link is broken
Way Back Machine has no info

**Resolution:**
NONE

**Affected definitions**:
- [FluentAssertions 2.0.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentAssertions/2.0.0.1/2.0.0.1)