### PR TITLE
@compone/define1.2.4

### DIFF
--- a/curations/npm/npmjs/@compone/define.yaml
+++ b/curations/npm/npmjs/@compone/define.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: define
+  namespace: '@compone'
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@compone/define1.2.4

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM license link is same as above

**Resolution:**
MIT

**Affected definitions**:
- [define 1.2.4](https://clearlydefined.io/definitions/npm/npmjs/@compone/define/1.2.4/1.2.4)