### PR TITLE
Glimpse.AspNet1.9.2

### DIFF
--- a/curations/nuget/nuget/-/Glimpse.AspNet.yaml
+++ b/curations/nuget/nuget/-/Glimpse.AspNet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Glimpse.AspNet
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Glimpse.AspNet1.9.2

**Details:**
NuGet license links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/Glimpse/Glimpse/blob/1.9.2-aspnet/license.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Glimpse.AspNet 1.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/Glimpse.AspNet/1.9.2/1.9.2)