### PR TITLE
RESTFulSense2.0.

### DIFF
--- a/curations/nuget/nuget/-/RESTFulSense.yaml
+++ b/curations/nuget/nuget/-/RESTFulSense.yaml
@@ -15,3 +15,6 @@ revisions:
   1.9.0:
     licensed:
       declared: MIT AND CC-BY-3.0
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RESTFulSense2.0.

**Details:**
NuGet license is MIT: https://www.nuget.org/packages/RESTFulSense/2.0.0/License


**Resolution:**
MIT

**Affected definitions**:
- [RESTFulSense 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/RESTFulSense/2.0.0/2.0.0)