### PR TITLE
string-to-js0.0.1

### DIFF
--- a/curations/npm/npmjs/-/string-to-js.yaml
+++ b/curations/npm/npmjs/-/string-to-js.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: string-to-js
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
string-to-js0.0.1

**Details:**
ClearlyDefined package.json has no license info
NPM license field is NONE but there is a MIT license on the page: https://www.npmjs.com/package/string-to-js


**Resolution:**
MIT

**Affected definitions**:
- [string-to-js 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/string-to-js/0.0.1/0.0.1)