### PR TITLE
express-partials0.3.0

### DIFF
--- a/curations/npm/npmjs/-/express-partials.yaml
+++ b/curations/npm/npmjs/-/express-partials.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: express-partials
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
express-partials0.3.0

**Details:**
NPM license field indicates NONE but page includes MIT

**Resolution:**
MIT

**Affected definitions**:
- [express-partials 0.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/express-partials/0.3.0/0.3.0)