### PR TITLE
@ag-grid-enterprise/range-selection23.2.1

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/range-selection.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/range-selection.yaml
@@ -7,6 +7,9 @@ revisions:
   23.1.1:
     licensed:
       declared: OTHER
+  23.2.1:
+    licensed:
+      declared: OTHER
   24.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/range-selection23.2.1

**Details:**
ClearlyDefined license is OTHER
NPM license field indicates Commercial
GitHub license is OTHER: https://github.com/ag-grid/ag-grid/blob/v23.2.1/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [range-selection 23.2.1](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/range-selection/23.2.1/23.2.1)