### PR TITLE
xpath0.0.9

### DIFF
--- a/curations/npm/npmjs/-/xpath.yaml
+++ b/curations/npm/npmjs/-/xpath.yaml
@@ -15,3 +15,6 @@ revisions:
   0.0.23:
     licensed:
       declared: CC-BY-SA-2.0
+  0.0.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xpath0.0.9

**Details:**
ClearlyDefined package.json indicates MIT
NPM license field is MIT
GitHub license is MIT: https://github.com/goto100/xpath/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [xpath 0.0.9](https://clearlydefined.io/definitions/npm/npmjs/-/xpath/0.0.9/0.0.9)