### PR TITLE
System.Text.Json2.0.0.11

### DIFF
--- a/curations/nuget/nuget/-/System.Text.Json.yaml
+++ b/curations/nuget/nuget/-/System.Text.Json.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.0.0.11:
     licensed:
-      declared: MIT
+      declared: OTHER
   4.6.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/System.Text.Json.yaml
+++ b/curations/nuget/nuget/-/System.Text.Json.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0.11:
+    licensed:
+      declared: MIT
   4.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Text.Json2.0.0.11

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/381372f6f12884caee5bb90f52649040827e19cc/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Text.Json 2.0.0.11](https://clearlydefined.io/definitions/nuget/nuget/-/System.Text.Json/2.0.0.11/2.0.0.11)