### PR TITLE
NuGet.Frameworks4.6.2

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Frameworks.yaml
+++ b/curations/nuget/nuget/-/NuGet.Frameworks.yaml
@@ -18,6 +18,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.6.2:
+    licensed:
+      declared: Apache-2.0
   4.6.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Frameworks4.6.2

**Details:**
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.6.2.5055/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Frameworks 4.6.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Frameworks/4.6.2/4.6.2)