### PR TITLE
System.IO.Abstractions7.1.10

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -39,3 +39,6 @@ revisions:
   7.0.7:
     licensed:
       declared: MIT
+  7.1.10:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions7.1.10

**Details:**
ClearlyDefined license file indicates MIT
NuGet license field is MIT
GitHub license is MIT: https://github.com/TestableIO/System.IO.Abstractions/blob/v7.1.10/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions 7.1.10](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/7.1.10/7.1.10)