### PR TITLE
AngularJS.Core1.6.0

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Core.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Core.yaml
@@ -18,6 +18,9 @@ revisions:
   1.5.9:
     licensed:
       declared: MIT
+  1.6.0:
+    licensed:
+      declared: MIT
   1.6.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngularJS.Core1.6.0

**Details:**
GitHub license is MIT: https://github.com/angular/angular.js/blob/v1.6.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AngularJS.Core 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Core/1.6.0/1.6.0)