### PR TITLE
Akka 1.4.17

### DIFF
--- a/curations/nuget/nuget/-/Akka.yaml
+++ b/curations/nuget/nuget/-/Akka.yaml
@@ -12,3 +12,6 @@ revisions:
   1.4.10:
     licensed:
       declared: Apache-2.0
+  1.4.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka 1.4.17

**Details:**
ClearlyDefined license file indicates Apache-2.0
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/1.4.17/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka 1.4.17](https://clearlydefined.io/definitions/nuget/nuget/-/Akka/1.4.17/1.4.17)