### PR TITLE
nanosocket1.1.0

### DIFF
--- a/curations/npm/npmjs/-/nanosocket.yaml
+++ b/curations/npm/npmjs/-/nanosocket.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: nanosocket
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nanosocket1.1.0

**Details:**
ClearlyDefined package.json is MIT
NPM license field links to MIT: https://pemrouz.mit-license.org/

**Resolution:**
MIT

**Affected definitions**:
- [nanosocket 1.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/nanosocket/1.1.0/1.1.0)