### PR TITLE
icon-safari0.0.1

### DIFF
--- a/curations/npm/npmjs/-/icon-safari.yaml
+++ b/curations/npm/npmjs/-/icon-safari.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: icon-safari
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
icon-safari0.0.1

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM license field is MIT

**Resolution:**
MIT

**Affected definitions**:
- [icon-safari 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/icon-safari/0.0.1/0.0.1)