### PR TITLE
MSTest.TestAdapter2.2.4-preview-20210331-02

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestAdapter.yaml
@@ -18,3 +18,6 @@ revisions:
   2.1.2:
     licensed:
       declared: MIT
+  2.2.4-preview-20210331-02:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSTest.TestAdapter2.2.4-preview-20210331-02

**Details:**
NuGet license field is MIT
GitHub license is MIT: https://github.com/microsoft/testfx/blob/v2.2.4-preview-20210331-02/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [MSTest.TestAdapter 2.2.4-preview-20210331-02](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestAdapter/2.2.4-preview-20210331-02/2.2.4-preview-20210331-02)