### PR TITLE
saucelabs1.0.1

### DIFF
--- a/curations/npm/npmjs/-/saucelabs.yaml
+++ b/curations/npm/npmjs/-/saucelabs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-2.0
   1.3.0:
     licensed:
       declared: MIT

--- a/curations/npm/npmjs/-/saucelabs.yaml
+++ b/curations/npm/npmjs/-/saucelabs.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.0.1:
     licensed:
-      declared: Apache-2.0
+      declared: MIT
   1.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
saucelabs1.0.1

**Details:**
NPM license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/saucelabs/node-saucelabs/blob/main/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [saucelabs 1.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/saucelabs/1.0.1/1.0.1)