### PR TITLE
MSTestExtensions4.0.0

### DIFF
--- a/curations/nuget/nuget/-/MSTestExtensions.yaml
+++ b/curations/nuget/nuget/-/MSTestExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MSTestExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSTestExtensions4.0.0

**Details:**
NuGet missing license field
GitHub license is on the Readme and is MIT

**Resolution:**
MIT

**Affected definitions**:
- [MSTestExtensions 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MSTestExtensions/4.0.0/4.0.0)