### PR TITLE
Newtonsoft.Json5.0.5

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -46,6 +46,9 @@ revisions:
   5.0.4:
     licensed:
       declared: MIT
+  5.0.5:
+    licensed:
+      declared: MIT
   5.0.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json5.0.5

**Details:**
NuGet license is MIT: https://licenses.nuget.org/MIT
GitHub license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [Newtonsoft.Json 5.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/5.0.5/5.0.5)