### PR TITLE
@ag-grid-enterprise/range-selection25.3.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/range-selection.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/range-selection.yaml
@@ -16,6 +16,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.3.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/range-selection25.3.0

**Details:**
ClearlyDefined license is OTHER (AG GRID ENTERPRISE EULA v13.0)
NPM license is Commercial
GitHub license is OTHER: https://github.com/ag-grid/ag-grid/blob/v25.3.0/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [range-selection 25.3.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/range-selection/25.3.0/25.3.0)