### PR TITLE
newrelic3.4.0.95

### DIFF
--- a/curations/pypi/pypi/-/newrelic.yaml
+++ b/curations/pypi/pypi/-/newrelic.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: newrelic
+  provider: pypi
+  type: pypi
+revisions:
+  3.4.0.95:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
newrelic3.4.0.95

**Details:**
ClearlyDefined PKG-INFO indicates OTHER
PyPi indicates Apache-2.0
GitHub license is OTHER: "New Relic for Python is free-to-use, proprietary software. Please see the LICENSE file in the distribution for details on the New Relic License agreement and the licenses of its dependencies."


**Resolution:**
OTHER

**Affected definitions**:
- [newrelic 3.4.0.95](https://clearlydefined.io/definitions/pypi/pypi/-/newrelic/3.4.0.95/3.4.0.95)