### PR TITLE
ChameleonForms1.2.0.16

### DIFF
--- a/curations/nuget/nuget/-/ChameleonForms.yaml
+++ b/curations/nuget/nuget/-/ChameleonForms.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ChameleonForms
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0.16:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ChameleonForms1.2.0.16

**Details:**
NuGet license is MIT
GitHub license is MIT: https://github.com/MRCollective/ChameleonForms/blob/1.2.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [ChameleonForms 1.2.0.16](https://clearlydefined.io/definitions/nuget/nuget/-/ChameleonForms/1.2.0.16/1.2.0.16)