### PR TITLE
Akka.Coordination1.4.17

### DIFF
--- a/curations/nuget/nuget/-/Akka.Coordination.yaml
+++ b/curations/nuget/nuget/-/Akka.Coordination.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Akka.Coordination
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Coordination1.4.17

**Details:**
ClearlyDefined license file is Apache-2.0
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/1.4.17/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Coordination 1.4.17](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Coordination/1.4.17/1.4.17)