### PR TITLE
imblearn 0.0

### DIFF
--- a/curations/pypi/pypi/-/imblearn.yaml
+++ b/curations/pypi/pypi/-/imblearn.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: imblearn
+  provider: pypi
+  type: pypi
+revisions:
+  '0.0':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
imblearn 0.0

**Details:**
ClearlyDefined PKG-INFO indicates Unknown
PyPi license field indicates MIT
GitHub license is MIT: https://github.com/scikit-learn-contrib/imbalanced-learn/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [imblearn 0.0](https://clearlydefined.io/definitions/pypi/pypi/-/imblearn/0.0/0.0)