### PR TITLE
jsonform 0.0.2

### DIFF
--- a/curations/pypi/pypi/-/jsonform.yaml
+++ b/curations/pypi/pypi/-/jsonform.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jsonform
+  provider: pypi
+  type: pypi
+revisions:
+  0.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsonform 0.0.2

**Details:**
ClearlyDefined PKG-INFO is MIT
PyPi license is MIT 


**Resolution:**
MIT

**Affected definitions**:
- [jsonform 0.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/jsonform/0.0.2/0.0.2)