### PR TITLE
org.glassfish.grizzly/grizzly-http2.1.2

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.grizzly/grizzly-http.yaml
+++ b/curations/maven/mavencentral/org.glassfish.grizzly/grizzly-http.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.1.2:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.2.21:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.glassfish.grizzly/grizzly-http2.1.2

**Details:**
Maven POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
https://repo1.maven.org/maven2/org/glassfish/grizzly/grizzly-http-all/2.1.2/grizzly-http-all-2.1.2.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [grizzly-http 2.1.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.grizzly/grizzly-http/2.1.2/2.1.2)