### PR TITLE
slowhandcuke0.0.3

### DIFF
--- a/curations/gem/rubygems/-/slowhandcuke.yaml
+++ b/curations/gem/rubygems/-/slowhandcuke.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: slowhandcuke
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
slowhandcuke0.0.3

**Details:**
RubyGems indicate license is NONE which was correct at the time of the package 11/8/2010.  Apache-2.0 license was added to GitHub on 5/1/2014: https://github.com/moredip/SlowHandCuke/blob/master/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [slowhandcuke 0.0.3](https://clearlydefined.io/definitions/gem/rubygems/-/slowhandcuke/0.0.3/0.0.3)