### PR TITLE
org.postgresql/postgresql 9.4.1207.jre7

### DIFF
--- a/curations/maven/mavencentral/org.postgresql/postgresql.yaml
+++ b/curations/maven/mavencentral/org.postgresql/postgresql.yaml
@@ -7,3 +7,6 @@ revisions:
   9.3-1102-jdbc41:
     licensed:
       declared: BSD-2-Clause
+  9.4.1207.jre7:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/org.postgresql/postgresql.yaml
+++ b/curations/maven/mavencentral/org.postgresql/postgresql.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   9.3-1102-jdbc41:
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause
   9.4.1207.jre7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.postgresql/postgresql 9.4.1207.jre7

**Details:**
Maven POM has no license info but includes link to GitHub: https://repo1.maven.org/maven2/org/postgresql/postgresql/9.4.1207.jre7/postgresql-9.4.1207.jre7.pom
GItHub license is BSD-3-Clause: https://github.com/pgjdbc/pgjdbc-jre7/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [postgresql 9.4.1207.jre7](https://clearlydefined.io/definitions/maven/mavencentral/org.postgresql/postgresql/9.4.1207.jre7/9.4.1207.jre7)