### PR TITLE
MSTest.TestFramework 2.2.4-preview-20210331-02

### DIFF
--- a/curations/nuget/nuget/-/MSTest.TestFramework.yaml
+++ b/curations/nuget/nuget/-/MSTest.TestFramework.yaml
@@ -29,3 +29,6 @@ revisions:
   2.2.4:
     licensed:
       declared: MIT
+  2.2.4-preview-20210331-02:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MSTest.TestFramework 2.2.4-preview-20210331-02

**Details:**
ClearlyDefined license file is MIT
NuGet license field is MIT
GitHub license is MIT: https://github.com/microsoft/testfx/blob/rel/2.2.4/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [MSTest.TestFramework 2.2.4-preview-20210331-02](https://clearlydefined.io/definitions/nuget/nuget/-/MSTest.TestFramework/2.2.4-preview-20210331-02/2.2.4-preview-20210331-02)