### PR TITLE
dependabot-hex 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-hex.yaml
+++ b/curations/gem/rubygems/-/dependabot-hex.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.162.1:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-hex 0.162.1

**Details:**
RubyGems license field indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-hex 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-hex/0.162.1/0.162.1)