### PR TITLE
Akka.Cluster.Sharding 1.3.15-beta

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.Sharding.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.Sharding.yaml
@@ -6,3 +6,6 @@ revisions:
   1.3.10-beta:
     licensed:
       declared: Apache-2.0
+  1.3.15-beta:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster.Sharding 1.3.15-beta

**Details:**
NuGet license field links to Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/1.3.15/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Cluster.Sharding 1.3.15-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster.Sharding/1.3.15-beta/1.3.15-beta)