### PR TITLE
utilise 2.3.8

### DIFF
--- a/curations/npm/npmjs/-/utilise.yaml
+++ b/curations/npm/npmjs/-/utilise.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: utilise
+  provider: npmjs
+  type: npm
+revisions:
+  2.3.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
utilise 2.3.8

**Details:**
NPM license field links to MIT
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/

**Resolution:**
MIT

**Affected definitions**:
- [utilise 2.3.8](https://clearlydefined.io/definitions/npm/npmjs/-/utilise/2.3.8/2.3.8)