### PR TITLE
@ag-grid-enterprise/set-filter 25.3.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/set-filter.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/set-filter.yaml
@@ -16,6 +16,9 @@ revisions:
   25.1.0:
     licensed:
       declared: OTHER
+  25.3.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/set-filter 25.3.0

**Details:**
ClearlyDefined license is OTHER: AG GRID ENTERPRISE EULA v13.0
NPM indicates OTHER
GitHub is OTHER: https://github.com/ag-grid/ag-grid/blob/v25.3.0/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [set-filter 25.3.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/set-filter/25.3.0/25.3.0)