### PR TITLE
Exchange.WebServices.Managed.Api 2.2.1.1

### DIFF
--- a/curations/nuget/nuget/-/Exchange.WebServices.Managed.Api.yaml
+++ b/curations/nuget/nuget/-/Exchange.WebServices.Managed.Api.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.2.1.1:
+    licensed:
+      declared: MIT
   2.2.1.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Exchange.WebServices.Managed.Api 2.2.1.1

**Details:**
NuGet license is MIT
GitHub license is MIT: https://github.com/marksl/ews-managed-api-publish/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Exchange.WebServices.Managed.Api 2.2.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Exchange.WebServices.Managed.Api/2.2.1.1/2.2.1.1)