### PR TITLE
Humanizer 1.28.0

### DIFF
--- a/curations/nuget/nuget/-/Humanizer.yaml
+++ b/curations/nuget/nuget/-/Humanizer.yaml
@@ -6,6 +6,9 @@ revisions:
   1.26.1:
     licensed:
       declared: MIT
+  1.28.0:
+    licensed:
+      declared: MIT
   2.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Humanizer 1.28.0

**Details:**
NuGet license is MIT
GitHub license is MIT: https://github.com/Humanizr/Humanizer/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Humanizer 1.28.0](https://clearlydefined.io/definitions/nuget/nuget/-/Humanizer/1.28.0/1.28.0)