### PR TITLE
MassTransit.MessageData.Enchilada 2.0.0

### DIFF
--- a/curations/nuget/nuget/-/MassTransit.MessageData.Enchilada.yaml
+++ b/curations/nuget/nuget/-/MassTransit.MessageData.Enchilada.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MassTransit.MessageData.Enchilada
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MassTransit.MessageData.Enchilada 2.0.0

**Details:**
NuGet no license info
GitHub license is MIT: https://github.com/kevbite/MassTransit.MessageData.Enchilada/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [MassTransit.MessageData.Enchilada 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MassTransit.MessageData.Enchilada/2.0.0/2.0.0)