### PR TITLE
System.Runtime.CompilerServices.Unsafe 4.6.0-preview3.19128.7

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
@@ -18,6 +18,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview3.19128.7:
+    licensed:
+      declared: MIT
   4.6.0-preview6.19303.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Runtime.CompilerServices.Unsafe 4.6.0-preview3.19128.7

**Details:**
ClearlyDefined license is MIT
NuGet license field is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/main/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Runtime.CompilerServices.Unsafe 4.6.0-preview3.19128.7](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe/4.6.0-preview3.19128.7/4.6.0-preview3.19128.7)