### PR TITLE
dependabot-cargo 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-cargo.yaml
+++ b/curations/gem/rubygems/-/dependabot-cargo.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-cargo
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-cargo 0.162.1

**Details:**
RubyGems license field is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-cargo 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-cargo/0.162.1/0.162.1)