### PR TITLE
dependabot-nuget 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-nuget.yaml
+++ b/curations/gem/rubygems/-/dependabot-nuget.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-nuget
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-nuget 0.162.1

**Details:**
RubyGems indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-nuget 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-nuget/0.162.1/0.162.1)