### PR TITLE
dependabot-composer 0.162.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-composer.yaml
+++ b/curations/gem/rubygems/-/dependabot-composer.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.162.0:
+    licensed:
+      declared: OTHER
   0.162.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-composer 0.162.0

**Details:**
RubyGems indicates Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.0/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-composer 0.162.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-composer/0.162.0/0.162.0)