### PR TITLE
backports.shutil_which 3.5.2

### DIFF
--- a/curations/pypi/pypi/-/backports.shutil_which.yaml
+++ b/curations/pypi/pypi/-/backports.shutil_which.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: backports.shutil_which
+  provider: pypi
+  type: pypi
+revisions:
+  3.5.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
Type: Missing

Summary:
backports.shutil_which 3.5.2

Details:
Add MIT License

Resolution:
License Url:
https://github.com/minrk/backports.shutil_which/blob/3.5.2/LICENSE