### PR TITLE
mborgerding/kissfft 0a70dfd0cf2cd620f993c280

### DIFF
--- a/curations/git/github/mborgerding/kissfft.yaml
+++ b/curations/git/github/mborgerding/kissfft.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kissfft
+  namespace: mborgerding
+  provider: github
+  type: git
+revisions:
+  0a70dfd0cf2cd620f993c280661372da808c941a:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mborgerding/kissfft 0a70dfd0cf2cd620f993c280

**Details:**
It appears the main declared license is in the COPYING file.  I see a LICENSES folder, too, but the "declared" appears to be BSD-3-Clause

**Resolution:**
https://github.com/mborgerding/kissfft/blob/0a70dfd0cf2cd620f993c280661372da808c941a/COPYING

**Affected definitions**:
- [kissfft 0a70dfd0cf2cd620f993c280661372da808c941a](https://clearlydefined.io/definitions/git/github/mborgerding/kissfft/0a70dfd0cf2cd620f993c280661372da808c941a/0a70dfd0cf2cd620f993c280661372da808c941a)