### PR TITLE
Correcting identifiers

### DIFF
--- a/curations/git/github/test-unit/test-unit.yaml
+++ b/curations/git/github/test-unit/test-unit.yaml
@@ -9,7 +9,7 @@ revisions:
       - attributions:
           - Copyright (c) 2001-2008 Python Software Foundation
           - Copyright (c) 2008-2011 Kouhei Sutou
-        license: GPL-2.0-only OR LGPL-2.1-or-later OR Python-2.0 OR Ruby
+        license: GPL-2.0-only OR LGPL-2.1-or-later OR OTHER OR Ruby
         path: lib/test/unit/diff.rb
       - attributions:
           - Copyright (c) 2012-2015 Kouhei Sutou <kou@clear-code.com>

--- a/curations/git/github/test-unit/test-unit.yaml
+++ b/curations/git/github/test-unit/test-unit.yaml
@@ -9,11 +9,11 @@ revisions:
       - attributions:
           - Copyright (c) 2001-2008 Python Software Foundation
           - Copyright (c) 2008-2011 Kouhei Sutou
-        license: GPL-2.0 OR LGPL-2.1-or-later OR Python-2.0
+        license: GPL-2.0-only OR LGPL-2.1-or-later OR Python-2.0 OR Ruby
         path: lib/test/unit/diff.rb
       - attributions:
           - Copyright (c) 2012-2015 Kouhei Sutou <kou@clear-code.com>
-        license: GPL-2.0 OR LGPL-2.1-or-later
+        license: GPL-2.0-only OR LGPL-2.1-or-later OR Ruby
         path: lib/test-unit.rb
     licensed:
       declared: Ruby OR GPL-2.0-only


### PR DESCRIPTION
https://clearlydefined.io/definitions/git/github/test-unit/test-unit/c004319558db37f5f6426ea52668920690ceb9a8

Files:
- [lib/test/unit/diff.rb](https://github.com/test-unit/test-unit/blob/c004319558db37f5f6426ea52668920690ceb9a8/lib/test/unit/diff.rb)
- [lib/test-unit.rb](https://github.com/test-unit/test-unit/blob/c004319558db37f5f6426ea52668920690ceb9a8/lib/test-unit.rb)


Correcting GPL-2.0 to GPL-2.0-only and added missing Ruby per https://github.com/test-unit/test-unit/blob/c004319558db37f5f6426ea52668920690ceb9a8/COPYING#L64-L67

This is using the older Ruby license that is GPL 2.0 or Ruby.
https://github.com/test-unit/test-unit/blob/c004319558db37f5f6426ea52668920690ceb9a8/COPYING#L5-L6