### PR TITLE
JetBrains.ReSharper.CommandLineTools 2021.3.2

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -120,10 +120,13 @@ revisions:
   2021.2.2:
     licensed:
       declared: OTHER
+  2021.3.0:
+    licensed:
+      declared: OTHER
   2021.3.1:
     licensed:
       declared: OTHER
-  2021.3.0:
+  2021.3.2:
     licensed:
       declared: OTHER
   9.1.20150408.154812:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2021.3.2

**Details:**
NuGet license field is OTHER: License Agreement for ReSharper Command Line Tools
Project link is OTHER: https://sales.jetbrains.com/hc/en-gb


**Resolution:**
OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.3.2/2021.3.2)