### PR TITLE
typed-ast 1.5.2

### DIFF
--- a/curations/pypi/pypi/-/typed-ast.yaml
+++ b/curations/pypi/pypi/-/typed-ast.yaml
@@ -42,3 +42,6 @@ revisions:
   1.5.1:
     licensed:
       declared: Apache-2.0
+  1.5.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
typed-ast 1.5.2

**Details:**
ClearlyDefined PKG-INFO indicates Apache-2.0
PyPi license field is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [typed-ast 1.5.2](https://clearlydefined.io/definitions/pypi/pypi/-/typed-ast/1.5.2/1.5.2)