### PR TITLE
azureml-automl-core 1.38.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -189,6 +189,9 @@ revisions:
   1.37.0:
     licensed:
       declared: OTHER
+  1.38.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.38.0

**Details:**
PyPi license is OTHER: Azureml SDK License: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-automl-core 1.38.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.38.0/1.38.0)