### PR TITLE
azureml-dataset-runtime 1.38.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
+++ b/curations/pypi/pypi/-/azureml-dataset-runtime.yaml
@@ -93,3 +93,6 @@ revisions:
   1.37.0:
     licensed:
       declared: OTHER
+  1.38.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataset-runtime 1.38.0

**Details:**
PyPi license is OTHER: Azureml SDK License: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataset-runtime 1.38.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataset-runtime/1.38.0/1.38.0)