### PR TITLE
azureml-defaults 1.37.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-defaults.yaml
+++ b/curations/pypi/pypi/-/azureml-defaults.yaml
@@ -147,6 +147,9 @@ revisions:
   1.35.0:
     licensed:
       declared: OTHER
+  1.37.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-defaults 1.37.0

**Details:**
PyPi license is OTHER: Azureml SDK License: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-defaults 1.37.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-defaults/1.37.0/1.37.0)