### PR TITLE
azureml-sdk 1.38.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-sdk.yaml
+++ b/curations/pypi/pypi/-/azureml-sdk.yaml
@@ -225,6 +225,9 @@ revisions:
   1.37.0:
     licensed:
       declared: OTHER
+  1.38.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-sdk 1.38.0

**Details:**
PyPi license is OTHER: Azureml SDK License: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-sdk 1.38.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-sdk/1.38.0/1.38.0)