### PR TITLE
azureml-dataprep 2.6.6

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -183,6 +183,9 @@ revisions:
   2.6.4:
     licensed:
       declared: OTHER
+  2.6.6:
+    licensed:
+      declared: OTHER
   2.7.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep 2.6.6

**Details:**
PyPi license is OTHER: Azureml SDK License: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 2.6.6](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/2.6.6/2.6.6)