### PR TITLE
org.tukaani/xz1.9

### DIFF
--- a/curations/maven/mavencentral/org.tukaani/xz.yaml
+++ b/curations/maven/mavencentral/org.tukaani/xz.yaml
@@ -16,3 +16,6 @@ revisions:
   '1.8':
     licensed:
       declared: OTHER
+  '1.9':
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.tukaani/xz1.9

**Details:**
Maven pom indicates OTHER (public domain): https://repo1.maven.org/maven2/org/tukaani/xz/1.9/xz-1.9.pom

**Resolution:**
OTHER

**Affected definitions**:
- [xz 1.9](https://clearlydefined.io/definitions/maven/mavencentral/org.tukaani/xz/1.9/1.9)