### PR TITLE
coveralls.io 1.4.2

### DIFF
--- a/curations/nuget/nuget/-/coveralls.io.yaml
+++ b/curations/nuget/nuget/-/coveralls.io.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.4.2:
     licensed:
-      declared: GPL-3.0-or-later
+      declared: GPL-3.0-only

--- a/curations/nuget/nuget/-/coveralls.io.yaml
+++ b/curations/nuget/nuget/-/coveralls.io.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: coveralls.io
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.2:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
coveralls.io 1.4.2

**Details:**
NuGet license field is: GPL-3.0-or-later
GitHub Readme license is GPL-3.0-or-later
https://github.com/coveralls-net/coveralls.net/blob/aac5494c82755ebdf63a53d460dec5aa19ea8eac/README.md

**Resolution:**
GPL-3.0-or-later

**Affected definitions**:
- [coveralls.io 1.4.2](https://clearlydefined.io/definitions/nuget/nuget/-/coveralls.io/1.4.2/1.4.2)