### PR TITLE
org.junit.jupiter/junit-jupiter 5.8.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -31,3 +31,6 @@ revisions:
   5.7.2:
     licensed:
       declared: EPL-2.0
+  5.8.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter 5.8.2

**Details:**
ClearlyDefined license is EPL-2.0
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-migrationsupport/5.8.2/junit-jupiter-migrationsupport-5.8.2.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter 5.8.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.8.2/5.8.2)