### PR TITLE
JetBrains.ReSharper.CommandLineTools 2018.1.0

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2018.1.0:
+    licensed:
+      declared: OTHER
   2018.3.3:
     licensed:
       declared: OTHER
@@ -120,10 +123,10 @@ revisions:
   2021.2.2:
     licensed:
       declared: OTHER
-  2021.3.1:
+  2021.3.0:
     licensed:
       declared: OTHER
-  2021.3.0:
+  2021.3.1:
     licensed:
       declared: OTHER
   9.1.20150408.154812:

--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -129,9 +129,6 @@ revisions:
   2021.3.1:
     licensed:
       declared: OTHER
-  2021.3.1:
-    licensed:
-      declared: OTHER
   2021.3.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools 2018.1.0

**Details:**
NuGet license field is OTHER: https://www.jetbrains.com/legal/docs/resharper/resharper_clt_license/

**Resolution:**
OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2018.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2018.1.0/2018.1.0)