### PR TITLE
SpecFlow.CustomPlugin 1.9.0

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.CustomPlugin.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.CustomPlugin.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SpecFlow.CustomPlugin
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow.CustomPlugin 1.9.0

**Details:**
NuGet license link is BSD-3-Clause: https://www.nuget.org/packages/SpecFlow.CustomPlugin/3.9.40/License

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [SpecFlow.CustomPlugin 1.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow.CustomPlugin/1.9.0/1.9.0)