### PR TITLE
Enchilada.Azure 1.1.0

### DIFF
--- a/curations/nuget/nuget/-/Enchilada.Azure.yaml
+++ b/curations/nuget/nuget/-/Enchilada.Azure.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Enchilada.Azure
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Enchilada.Azure 1.1.0

**Details:**
NuGet no license field
GitHub license is MIT: https://github.com/sparkeh9/Enchilada/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Enchilada.Azure 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Enchilada.Azure/1.1.0/1.1.0)