### PR TITLE
Azure.Batch 2.0.2

### DIFF
--- a/curations/nuget/nuget/-/Azure.Batch.yaml
+++ b/curations/nuget/nuget/-/Azure.Batch.yaml
@@ -6,6 +6,9 @@ revisions:
   1.3.0:
     licensed:
       declared: OTHER
+  2.0.2:
+    licensed:
+      declared: Apache-2.0
   5.1.1:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Azure.Batch.yaml
+++ b/curations/nuget/nuget/-/Azure.Batch.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: OTHER
   2.0.2:
     licensed:
-      declared: Apache-2.0
+      declared: OTHER
   5.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Azure.Batch 2.0.2

**Details:**
NuGet license field is MIT
GitHub license for this version is Apache-2.0: https://github.com/Azure/azure-sdk-for-net/blob/v2.1.0.2-Oct2013/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Azure.Batch 2.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Azure.Batch/2.0.2/2.0.2)