### PR TITLE
DotNetCore.NPOI.OpenXmlFormats 1.2.2

### DIFF
--- a/curations/nuget/nuget/-/DotNetCore.NPOI.OpenXmlFormats.yaml
+++ b/curations/nuget/nuget/-/DotNetCore.NPOI.OpenXmlFormats.yaml
@@ -6,3 +6,6 @@ revisions:
   1.2.1:
     licensed:
       declared: Apache-2.0
+  1.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetCore.NPOI.OpenXmlFormats 1.2.2

**Details:**
ClearlyDefined license file indicates Apache-2.0
Nuget license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/dotnetcore/NPOI/blob/v1.2.2/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [DotNetCore.NPOI.OpenXmlFormats 1.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetCore.NPOI.OpenXmlFormats/1.2.2/1.2.2)