### PR TITLE
DotNetCore.NPOI.Core1 .2.2

### DIFF
--- a/curations/nuget/nuget/-/DotNetCore.NPOI.Core.yaml
+++ b/curations/nuget/nuget/-/DotNetCore.NPOI.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetCore.NPOI.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetCore.NPOI.Core1 .2.2

**Details:**
ClearlyDefined license file indicates Apache-2.0
NuGet license field is Apache-2.0
GitHub license is Apache-2.0: https://github.com/dotnetcore/NPOI/blob/v1.2.2/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [DotNetCore.NPOI.Core 1.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetCore.NPOI.Core/1.2.2/1.2.2)