### PR TITLE
StyleCop.Analyzers 1.0.0-beta008

### DIFF
--- a/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
+++ b/curations/nuget/nuget/-/StyleCop.Analyzers.yaml
@@ -8,6 +8,9 @@ revisions:
       releaseDate: '2016-01-28'
     licensed:
       declared: Apache-2.0
+  1.0.0-beta008:
+    licensed:
+      declared: Apache-2.0
   1.0.0-rc1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StyleCop.Analyzers 1.0.0-beta008

**Details:**
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/1.0.0-beta008/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [StyleCop.Analyzers 1.0.0-beta008](https://clearlydefined.io/definitions/nuget/nuget/-/StyleCop.Analyzers/1.0.0-beta008/1.0.0-beta008)