### PR TITLE
com.nimbusds/oauth 2-oidc-sdk9.9.1

### DIFF
--- a/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
+++ b/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
@@ -700,3 +700,6 @@ revisions:
   '9.7':
     licensed:
       declared: Apache-2.0
+  9.9.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.nimbusds/oauth 2-oidc-sdk9.9.1

**Details:**
Maven pom is Apache-2.0: https://repo1.maven.org/maven2/com/nimbusds/oauth2-oidc-sdk/9.9.1/oauth2-oidc-sdk-9.9.1.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [oauth2-oidc-sdk 9.9.1](https://clearlydefined.io/definitions/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/9.9.1/9.9.1)