### PR TITLE
NJsonSchema 10.0.28

### DIFF
--- a/curations/nuget/nuget/-/NJsonSchema.yaml
+++ b/curations/nuget/nuget/-/NJsonSchema.yaml
@@ -15,6 +15,9 @@ revisions:
   10.0.27:
     licensed:
       declared: MIT
+  10.0.28:
+    licensed:
+      declared: MIT
   10.1.11:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NJsonSchema 10.0.28

**Details:**
ClearlyDefined license file indicates MIT
Nuget license is MIT
GitHub license is MIT: https://github.com/RicoSuter/NJsonSchema/blob/v10.3.1/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [NJsonSchema 10.0.28](https://clearlydefined.io/definitions/nuget/nuget/-/NJsonSchema/10.0.28/10.0.28)