### PR TITLE
serverengine 2.0.7

### DIFF
--- a/curations/gem/rubygems/-/serverengine.yaml
+++ b/curations/gem/rubygems/-/serverengine.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: serverengine
+  provider: rubygems
+  type: gem
+revisions:
+  2.0.7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
serverengine 2.0.7

**Details:**
ClearlyDefined license is Apache-2.0
RubyGems license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/treasure-data/serverengine/blob/v2.0.7/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [serverengine 2.0.7](https://clearlydefined.io/definitions/gem/rubygems/-/serverengine/2.0.7/2.0.7)