### PR TITLE
com.google.errorprone/javac 9+181-r4173-1

### DIFF
--- a/curations/maven/mavencentral/com.google.errorprone/javac.yaml
+++ b/curations/maven/mavencentral/com.google.errorprone/javac.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javac
+  namespace: com.google.errorprone
+  provider: mavencentral
+  type: maven
+revisions:
+  9+181-r4173-1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.google.errorprone/javac 9+181-r4173-1

**Details:**
Maven POM is GPL-2.0-only WITH Classpath-exception-2.0: https://repo1.maven.org/maven2/com/google/errorprone/javac/9+181-r4173-1/javac-9+181-r4173-1.pom
GitHub is GPL-2.0-only WITH Classpath-exception-2.0
https://github.com/google/error-prone-javac

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javac 9+181-r4173-1](https://clearlydefined.io/definitions/maven/mavencentral/com.google.errorprone/javac/9+181-r4173-1/9+181-r4173-1)