### PR TITLE
dependabot-python 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-python.yaml
+++ b/curations/gem/rubygems/-/dependabot-python.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-python
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-python 0.162.2

**Details:**
RubyGems license is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-python 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-python/0.162.2/0.162.2)