### PR TITLE
dependabot-git_submodules 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-git_submodules.yaml
+++ b/curations/gem/rubygems/-/dependabot-git_submodules.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-git_submodules
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-git_submodules 0.162.2

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-git_submodules 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-git_submodules/0.162.2/0.162.2)