### PR TITLE
dependabot-nuget 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-nuget.yaml
+++ b/curations/gem/rubygems/-/dependabot-nuget.yaml
@@ -6,3 +6,6 @@ revisions:
   0.162.1:
     licensed:
       declared: OTHER
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-nuget 0.162.2

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-nuget 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-nuget/0.162.2/0.162.2)