### PR TITLE
dependabot-gradle 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-gradle.yaml
+++ b/curations/gem/rubygems/-/dependabot-gradle.yaml
@@ -12,3 +12,6 @@ revisions:
   0.162.1:
     licensed:
       declared: OTHER
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-gradle 0.162.2

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-gradle 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-gradle/0.162.2/0.162.2)