### PR TITLE
Ninject.Extensions.ContextPreservation 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.ContextPreservation.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.ContextPreservation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Ninject.Extensions.ContextPreservation
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Extensions.ContextPreservation 3.2.0

**Details:**
NuGet license is Apache-2.0 OR MS-PL
GitHub license is Apache-2.0 OR MS-PL: https://github.com/ninject/Ninject.Extensions.ContextPreservation/blob/3.2.0-final/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.Extensions.ContextPreservation 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.ContextPreservation/3.2.0/3.2.0)