### PR TITLE
dependabot-go_modules 0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-go_modules.yaml
+++ b/curations/gem/rubygems/-/dependabot-go_modules.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-go_modules 0.129.5

**Details:**
RubyGems license is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.129.5/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-go_modules 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-go_modules/0.129.5/0.129.5)