### PR TITLE
dependabot-git_submodules 0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-git_submodules.yaml
+++ b/curations/gem/rubygems/-/dependabot-git_submodules.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-git_submodules
+  provider: rubygems
+  type: gem
+revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-git_submodules 0.129.5

**Details:**
RubyGems license is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.129.5/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-git_submodules 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-git_submodules/0.129.5/0.129.5)