### PR TITLE
dependabot-composer 0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-composer.yaml
+++ b/curations/gem/rubygems/-/dependabot-composer.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER
   0.162.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-composer 0.129.5

**Details:**
RubyGems license is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.129.5/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-composer 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-composer/0.129.5/0.129.5)