### PR TITLE
dependabot-composer 0.162.2

### DIFF
--- a/curations/gem/rubygems/-/dependabot-composer.yaml
+++ b/curations/gem/rubygems/-/dependabot-composer.yaml
@@ -9,3 +9,6 @@ revisions:
   0.162.1:
     licensed:
       declared: OTHER
+  0.162.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-composer 0.162.2

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-composer 0.162.2](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-composer/0.162.2/0.162.2)