### PR TITLE
dependabot-common 0.129.5

### DIFF
--- a/curations/gem/rubygems/-/dependabot-common.yaml
+++ b/curations/gem/rubygems/-/dependabot-common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-common
+  provider: rubygems
+  type: gem
+revisions:
+  0.129.5:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-common 0.129.5

**Details:**
RubyGems license is Nonstandard
GitHub license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.129.5/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-common 0.129.5](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-common/0.129.5/0.129.5)