### PR TITLE
dependabot-bundler 0.162.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-bundler.yaml
+++ b/curations/gem/rubygems/-/dependabot-bundler.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.162.0:
+    licensed:
+      declared: OTHER
   0.162.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-bundler 0.162.0

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-bundler 0.162.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-bundler/0.162.0/0.162.0)