### PR TITLE
dependabot-docker 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-docker.yaml
+++ b/curations/gem/rubygems/-/dependabot-docker.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.162.1:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-docker 0.162.1

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-docker 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-docker/0.162.1/0.162.1)