### PR TITLE
dependabot-docker 0.162.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-docker.yaml
+++ b/curations/gem/rubygems/-/dependabot-docker.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.162.0:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-docker 0.162.0

**Details:**
RubyGems is Nonstandard
dependabot-core/LICENSE at v0.162.0 · dependabot/dependabot-core (github.com)


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-docker 0.162.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-docker/0.162.0/0.162.0)