### PR TITLE
dependabot-go_modules 0.162.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-go_modules.yaml
+++ b/curations/gem/rubygems/-/dependabot-go_modules.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.162.0:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-go_modules 0.162.0

**Details:**
RubyGems is Nonstandard
dependabot-core/LICENSE at v0.162.0 · dependabot/dependabot-core (github.com)


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-go_modules 0.162.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-go_modules/0.162.0/0.162.0)