### PR TITLE
dependabot-go_modules 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-go_modules.yaml
+++ b/curations/gem/rubygems/-/dependabot-go_modules.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.162.1:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-go_modules 0.162.1

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-go_modules 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-go_modules/0.162.1/0.162.1)