### PR TITLE
dependabot-omnibus 0.162.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-omnibus.yaml
+++ b/curations/gem/rubygems/-/dependabot-omnibus.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-omnibus
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-omnibus 0.162.0

**Details:**
RubyGems is Nonstandard
dependabot-core/LICENSE at v0.162.0 · dependabot/dependabot-core (github.com)


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-omnibus 0.162.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-omnibus/0.162.0/0.162.0)