### PR TITLE
dependabot-common 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-common.yaml
+++ b/curations/gem/rubygems/-/dependabot-common.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-common
+  provider: rubygems
+  type: gem
+revisions:
+  0.162.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-common 0.162.1

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-common 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-common/0.162.1/0.162.1)