### PR TITLE
dependabot-maven 0.162.1

### DIFF
--- a/curations/gem/rubygems/-/dependabot-maven.yaml
+++ b/curations/gem/rubygems/-/dependabot-maven.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
-  0.162.2:
+  0.129.5:
     licensed:
       declared: OTHER
-  0.129.5:
+  0.162.1:
+    licensed:
+      declared: OTHER
+  0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-maven 0.162.1

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.162.1/LICENSE


**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-maven 0.162.1](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-maven/0.162.1/0.162.1)