### PR TITLE
dependabot-github_actions 0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-github_actions.yaml
+++ b/curations/gem/rubygems/-/dependabot-github_actions.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.162.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-github_actions 0.145.4

**Details:**
RubyGems is Nonstandard
Github license is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-github_actions 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-github_actions/0.145.4/0.145.4)