### PR TITLE
dependabot-bundler 0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-bundler.yaml
+++ b/curations/gem/rubygems/-/dependabot-bundler.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.162.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-bundler 0.145.4

**Details:**
RubyGems is Nonstandard
GitHub is OTHER: https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-bundler 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-bundler/0.145.4/0.145.4)