### PR TITLE
Resolve case of SPDX license

### DIFF
--- a/curations/git/github/go-openapi/swag.yaml
+++ b/curations/git/github/go-openapi/swag.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: swag
+  namespace: go-openapi
+  provider: github
+  type: git
+revisions:
+  cf0bdb963811675a4d7e74901cefc7411a1df939:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of SPDX license

**Details:**
the license of this component is Apache however, in the delcared license it's mentioned as SPDX. Please find the attached link as below.

https://github.com/go-openapi/swag/blob/cf0bdb963811675a4d7e74901cefc7411a1df939/LICENSE

**Resolution:**
Link below: https://github.com/go-openapi/swag/blob/cf0bdb963811675a4d7e74901cefc7411a1df939/LICENSE

**Affected definitions**:
- [swag cf0bdb963811675a4d7e74901cefc7411a1df939](https://clearlydefined.io/definitions/git/github/go-openapi/swag/cf0bdb963811675a4d7e74901cefc7411a1df939/cf0bdb963811675a4d7e74901cefc7411a1df939)