### PR TITLE
com.arthenica/ffmpeg-kit-min 4.5.1.LTS

### DIFF
--- a/curations/maven/mavencentral/com.arthenica/ffmpeg-kit-min.yaml
+++ b/curations/maven/mavencentral/com.arthenica/ffmpeg-kit-min.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ffmpeg-kit-min
+  namespace: com.arthenica
+  provider: mavencentral
+  type: maven
+revisions:
+  4.5.1.LTS:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.arthenica/ffmpeg-kit-min 4.5.1.LTS

**Details:**
Pom says LGPL-3.0 and file headers say LGPL-3.0-or-later

**Resolution:**
LGPL-3.0-or-later

**Affected definitions**:
- [ffmpeg-kit-min 4.5.1.LTS](https://clearlydefined.io/definitions/maven/mavencentral/com.arthenica/ffmpeg-kit-min/4.5.1.LTS/4.5.1.LTS)