### PR TITLE
Ninject.MockingKernel.Moq 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: MS-PL OR Apache-2.0
   3.2.2:
     licensed:
       declared: Apache-2.0 OR MS-PL

--- a/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
+++ b/curations/nuget/nuget/-/Ninject.MockingKernel.Moq.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.2.0:
     licensed:
-      declared: MS-PL OR Apache-2.0
+      declared: Apache-2.0 OR MS-PL
   3.2.2:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.MockingKernel.Moq 3.2.0

**Details:**
NuGet license is MS-PL OR Apache-2.0
GitHub license is same as above: https://github.com/ninject/Ninject/blob/3.2.0-final/LICENSE.txt

**Resolution:**
MS-PL OR Apache-2.0

**Affected definitions**:
- [Ninject.MockingKernel.Moq 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MockingKernel.Moq/3.2.0/3.2.0)