### PR TITLE
DotNetCore.NPOI 1.2.2

### DIFF
--- a/curations/nuget/nuget/-/DotNetCore.NPOI.yaml
+++ b/curations/nuget/nuget/-/DotNetCore.NPOI.yaml
@@ -9,3 +9,6 @@ revisions:
   1.2.1:
     licensed:
       declared: Apache-2.0
+  1.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetCore.NPOI 1.2.2

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/dotnetcore/NPOI/blob/v1.2.2/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [DotNetCore.NPOI 1.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetCore.NPOI/1.2.2/1.2.2)