### PR TITLE
boost_system-vc110 1.57.0

### DIFF
--- a/curations/nuget/nuget/-/boost_system-vc110.yaml
+++ b/curations/nuget/nuget/-/boost_system-vc110.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_system-vc110
+  provider: nuget
+  type: nuget
+revisions:
+  1.57.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_system-vc110 1.57.0

**Details:**
Nuget license is BSL-1.0
GitHub license is BSL-1.0: https://github.com/sergey-shandar/getboost/blob/master/LICENSE

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_system-vc110 1.57.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_system-vc110/1.57.0/1.57.0)