### PR TITLE
python2 2.7.13

### DIFF
--- a/curations/nuget/nuget/-/python2.yaml
+++ b/curations/nuget/nuget/-/python2.yaml
@@ -5,10 +5,10 @@ coordinates:
 revisions:
   2.7.12:
     licensed:
-      declared: Python-2.0
+      declared: OTHER
   2.7.13:
     licensed:
       declared: OTHER
   2.7.17:
     licensed:
-      declared: Python-2.0
+      declared: OTHER

--- a/curations/nuget/nuget/-/python2.yaml
+++ b/curations/nuget/nuget/-/python2.yaml
@@ -6,6 +6,9 @@ revisions:
   2.7.12:
     licensed:
       declared: Python-2.0
+  2.7.13:
+    licensed:
+      declared: OTHER
   2.7.17:
     licensed:
       declared: Python-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
python2 2.7.13

**Details:**
Nuget license is OTHER: https://docs.python.org/2.7/license.html

**Resolution:**
OTHER

**Affected definitions**:
- [python2 2.7.13](https://clearlydefined.io/definitions/nuget/nuget/-/python2/2.7.13/2.7.13)