### PR TITLE
org.clapper/grizzled-slf4j_2.12 1.3.2

### DIFF
--- a/curations/maven/mavencentral/org.clapper/grizzled-slf4j_2.12.yaml
+++ b/curations/maven/mavencentral/org.clapper/grizzled-slf4j_2.12.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: grizzled-slf4j_2.12
+  namespace: org.clapper
+  provider: mavencentral
+  type: maven
+revisions:
+  1.3.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.clapper/grizzled-slf4j_2.12 1.3.2

**Details:**
Maven pom is BSD curated as BSD-3-Clause: https://repo1.maven.org/maven2/org/clapper/grizzled-slf4j_2.12/1.3.2/grizzled-slf4j_2.12-1.3.2.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [grizzled-slf4j_2.12 1.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.clapper/grizzled-slf4j_2.12/1.3.2/1.3.2)