### PR TITLE
@ag-grid-enterprise/column-tool-panel 25.3.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/column-tool-panel.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/column-tool-panel.yaml
@@ -16,6 +16,9 @@ revisions:
   25.1.0:
     licensed:
       declared: OTHER
+  25.3.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/column-tool-panel 25.3.0

**Details:**
ClearlyDefined license is OTHER (AG GRID ENTERPRISE EULA v13.0)
NPM license is Commercial
GitHub license is OTHER: https://github.com/ag-grid/ag-grid/blob/vDocs-25.3.0-20210527/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [column-tool-panel 25.3.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/column-tool-panel/25.3.0/25.3.0)