### PR TITLE
com.h2database/h 21.4.192

### DIFF
--- a/curations/maven/mavencentral/com.h2database/h2.yaml
+++ b/curations/maven/mavencentral/com.h2database/h2.yaml
@@ -7,6 +7,9 @@ revisions:
   1.3.166:
     licensed:
       declared: MPL-2.0 OR EPL-1.0
+  1.4.192:
+    licensed:
+      declared: MPL-1.0 OR EPL-1.0
   1.4.193:
     licensed:
       declared: MPL-2.0 OR EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.h2database/h 21.4.192

**Details:**
Maven POM is MPL-1.0 OR EPL-1.0: https://repo1.maven.org/maven2/com/h2database/h2/1.4.192/h2-1.4.192.pom

**Resolution:**
MPL-1.0 OR EPL-1.0

**Affected definitions**:
- [h2 1.4.192](https://clearlydefined.io/definitions/maven/mavencentral/com.h2database/h2/1.4.192/1.4.192)