### PR TITLE
browser-icons 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/browser-icons.yaml
+++ b/curations/npm/npmjs/-/browser-icons.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: browser-icons
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
browser-icons 0.0.1

**Details:**
ClearlyDefined package.json is MIT: https://pemrouz.mit-license.org/
NPM license is same as above

**Resolution:**
MIT

**Affected definitions**:
- [browser-icons 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/browser-icons/0.0.1/0.0.1)