### PR TITLE
DotNetSeleniumExtras.PageObjects.Core 3.12.0

### DIFF
--- a/curations/nuget/nuget/-/DotNetSeleniumExtras.PageObjects.Core.yaml
+++ b/curations/nuget/nuget/-/DotNetSeleniumExtras.PageObjects.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetSeleniumExtras.PageObjects.Core
+  provider: nuget
+  type: nuget
+revisions:
+  3.12.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetSeleniumExtras.PageObjects.Core 3.12.0

**Details:**
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/Dreamescaper/DotNetSeleniumExtras.Core/blob/v3.12.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [DotNetSeleniumExtras.PageObjects.Core 3.12.0](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetSeleniumExtras.PageObjects.Core/3.12.0/3.12.0)