### PR TITLE
CommunityEFProviderWrappers.EFTracingProvider 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/CommunityEFProviderWrappers.EFTracingProvider.yaml
+++ b/curations/nuget/nuget/-/CommunityEFProviderWrappers.EFTracingProvider.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CommunityEFProviderWrappers.EFTracingProvider
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommunityEFProviderWrappers.EFTracingProvider 1.0.0

**Details:**
Nuget license field and project link are both broken
No license info found

**Resolution:**
NONE

**Affected definitions**:
- [CommunityEFProviderWrappers.EFTracingProvider 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommunityEFProviderWrappers.EFTracingProvider/1.0.0/1.0.0)