### PR TITLE
@progress/kendo-angular-label 3.0.3

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-label.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-label.yaml
@@ -7,3 +7,6 @@ revisions:
   3.0.2:
     licensed:
       declared: OTHER
+  3.0.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@progress/kendo-angular-label 3.0.3

**Details:**
ClearlyDefined license is OTHER (Telerik End User License Agreement for Kendo UI)
NPM license is OTHER (See license...)
GitHub license is OTHER: https://github.com/telerik/kendo-angular/blob/master/LICENSE.md

**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-label 3.0.3](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-label/3.0.3/3.0.3)