### PR TITLE
less 2.6.0

### DIFF
--- a/curations/gem/rubygems/-/less.yaml
+++ b/curations/gem/rubygems/-/less.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: less
+  provider: rubygems
+  type: gem
+revisions:
+  2.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
less 2.6.0

**Details:**
RubyGems license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/less/less.js/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [less 2.6.0](https://clearlydefined.io/definitions/gem/rubygems/-/less/2.6.0/2.6.0)