### PR TITLE
Akka.Persistence 1.3.15

### DIFF
--- a/curations/nuget/nuget/-/Akka.Persistence.yaml
+++ b/curations/nuget/nuget/-/Akka.Persistence.yaml
@@ -6,3 +6,6 @@ revisions:
   1.3.10:
     licensed:
       declared: Apache-2.0
+  1.3.15:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Persistence 1.3.15

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/1.3.15/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Persistence 1.3.15](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Persistence/1.3.15/1.3.15)