### PR TITLE
TestStack.White 0.13.3

### DIFF
--- a/curations/nuget/nuget/-/TestStack.White.yaml
+++ b/curations/nuget/nuget/-/TestStack.White.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: TestStack.White
+  provider: nuget
+  type: nuget
+revisions:
+  0.13.3:
+    licensed:
+      declared: Apache-2.0 OR MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
TestStack.White 0.13.3

**Details:**
Nuget license is dual licensed Apache-2.0 OR MIT
GitHub is same as above: https://github.com/TestStack/White/blob/0.13.2/LICENSE.txt

**Resolution:**
Apache-2.0 OR MIT

**Affected definitions**:
- [TestStack.White 0.13.3](https://clearlydefined.io/definitions/nuget/nuget/-/TestStack.White/0.13.3/0.13.3)