### PR TITLE
Confluent.Kafka 1.4.3

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -68,6 +68,9 @@ revisions:
   1.4.0:
     licensed:
       declared: Apache-2.0
+  1.4.3:
+    licensed:
+      declared: Apache-2.0
   1.5.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Confluent.Kafka 1.4.3

**Details:**
ClearlyDefined license indicates Apache-2.0
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.4.3/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Confluent.Kafka 1.4.3](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.4.3/1.4.3)