### PR TITLE
StackExchange.Redis.StrongName 1.0.330

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.312:
     licensed:
       declared: MIT
+  1.0.330:
+    licensed:
+      declared: MIT
   1.0.333:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis.StrongName 1.0.330

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/StackExchange/StackExchange.Redis/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.0.330](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.0.330/1.0.330)