### PR TITLE
statsd-parser 0.0.4

### DIFF
--- a/curations/npm/npmjs/-/statsd-parser.yaml
+++ b/curations/npm/npmjs/-/statsd-parser.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: statsd-parser
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
statsd-parser 0.0.4

**Details:**
ClearlyDefined license is Apache-2.0
NPM license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/dscape/statsd-parser/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [statsd-parser 0.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/statsd-parser/0.0.4/0.0.4)