### PR TITLE
Pcap.Net.x64 1.0.4.1

### DIFF
--- a/curations/nuget/nuget/-/Pcap.Net.x64.yaml
+++ b/curations/nuget/nuget/-/Pcap.Net.x64.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.3:
     licensed:
       declared: BSD-3-Clause
+  1.0.4.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Pcap.Net.x64 1.0.4.1

**Details:**
Nuget license is BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/PcapDotNet/Pcap.Net/blob/v1.0.4/license.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Pcap.Net.x64 1.0.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Pcap.Net.x64/1.0.4.1/1.0.4.1)