### PR TITLE
jquery.datatables 1.10.12

### DIFF
--- a/curations/nuget/nuget/-/jquery.datatables.yaml
+++ b/curations/nuget/nuget/-/jquery.datatables.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.10:
     licensed:
       declared: MIT
+  1.10.12:
+    licensed:
+      declared: MIT
   1.10.15:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jquery.datatables 1.10.12

**Details:**
NuGet license is MIT: https://www.datatables.net/license/mit

**Resolution:**
MIT

**Affected definitions**:
- [jquery.datatables 1.10.12](https://clearlydefined.io/definitions/nuget/nuget/-/jquery.datatables/1.10.12/1.10.12)