### PR TITLE
System.DirectoryServices 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/System.DirectoryServices.yaml
+++ b/curations/nuget/nuget/-/System.DirectoryServices.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.0.0:
+    licensed:
+      declared: MIT
   4.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.DirectoryServices 4.0.0

**Details:**
Nuget license is MIT
Github license is MIT: https://github.com/dotnet/runtime/blob/release/5.0/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.DirectoryServices 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/System.DirectoryServices/4.0.0/4.0.0)