### PR TITLE
boost 1.76.0

### DIFF
--- a/curations/nuget/nuget/-/boost.yaml
+++ b/curations/nuget/nuget/-/boost.yaml
@@ -104,4 +104,4 @@ revisions:
       declared: Apache-2.0
   1.76.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
boost 1.76.0

**Details:**
Updating NuGet package license based on package author's comment here: https://github.com/sergey-shandar/getboost/issues/64#issuecomment-1027229549

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost 1.76.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost/1.76.0/1.76.0)