### PR TITLE
Updating boost nuget license

### DIFF
--- a/curations/nuget/nuget/-/boost.yaml
+++ b/curations/nuget/nuget/-/boost.yaml
@@ -5,103 +5,103 @@ coordinates:
 revisions:
   1.54.0.157:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.55.0.10:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.55.0.16:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.56.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.56.0-b1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.56.0-rc1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.56.0-rc2:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.56.0-rc3:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.57.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.57.0-b10:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.57.0-b1rc1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.57.0-b1y:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.57.0-b1z:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.57.0-rc1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.58.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.58.0-b1rc1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.58.0-b1rc2:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.58.0-rc2:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.59.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.59.0-b1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.60.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.61.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.63.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.64.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.65.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.65.1:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.66.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.67.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.68.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.69.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.70.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.71.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.72.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.76.0:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION
Author stated that the Apache license was a mistake and that previous versions can be used under BSL-1.0.
https://github.com/sergey-shandar/getboost/issues/64#issuecomment-1027229549