### PR TITLE
JetBrains.ReSharper.CommandLineTools2021.3.3

### DIFF
--- a/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
+++ b/curations/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools.yaml
@@ -132,6 +132,9 @@ revisions:
   2021.3.2:
     licensed:
       declared: OTHER
+  2021.3.3:
+    licensed:
+      declared: OTHER
   9.1.20150408.154812:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JetBrains.ReSharper.CommandLineTools2021.3.3

**Details:**
NuGet license link goes to EULA style license: https://www.nuget.org/packages/JetBrains.ReSharper.CommandLineTools/2021.3.3/License

**Resolution:**
EULA style license = OTHER

**Affected definitions**:
- [JetBrains.ReSharper.CommandLineTools 2021.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/JetBrains.ReSharper.CommandLineTools/2021.3.3/2021.3.3)