### PR TITLE
torchvision 0.11.3

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -27,6 +27,9 @@ revisions:
   0.11.2:
     licensed:
       declared: BSD-3-Clause
+  0.11.3:
+    licensed:
+      declared: BSD-3-Clause
   0.2.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision 0.11.3

**Details:**
Metadata on Pypi.org is "BSD." The License file in the package is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [torchvision 0.11.3](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.11.3/0.11.3)