### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/blacklabel/grouped_categories.yaml
+++ b/curations/git/github/blacklabel/grouped_categories.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: grouped_categories
+  namespace: blacklabel
+  provider: github
+  type: git
+revisions:
+  f93ad04c668a0d7e5443d97358dca77bd31cf8b8:
+    licensed:
+      declared: CC-BY-3.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing.

**Resolution:**
Filled in the declared license as found in https://github.com/blacklabel/grouped_categories/blob/f93ad04c668a0d7e5443d97358dca77bd31cf8b8/license.txt.

**Affected definitions**:
- [grouped_categories f93ad04c668a0d7e5443d97358dca77bd31cf8b8](https://clearlydefined.io/definitions/git/github/blacklabel/grouped_categories/f93ad04c668a0d7e5443d97358dca77bd31cf8b8/f93ad04c668a0d7e5443d97358dca77bd31cf8b8)