### PR TITLE
tst 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/tst.yaml
+++ b/curations/npm/npmjs/-/tst.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: tst
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/-/tst.yaml
+++ b/curations/npm/npmjs/-/tst.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.0:
     licensed:
-      declared: MIT
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tst 1.0.0

**Details:**
NPM license is MIT
GitHub package.json is MIT
GitHub license is ?: https://github.com/dy/tst/blob/v1.0.0/LICENSE
This appears to be a MIT like but not exact.

**Resolution:**
MIT

**Affected definitions**:
- [tst 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/tst/1.0.0/1.0.0)