### PR TITLE
@progress/kendo-angular-inputs 6.6.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-angular-inputs.yaml
+++ b/curations/npm/npmjs/@progress/kendo-angular-inputs.yaml
@@ -16,6 +16,9 @@ revisions:
   6.6.0:
     licensed:
       declared: OTHER
+  6.6.1:
+    licensed:
+      declared: OTHER
   6.7.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@progress/kendo-angular-inputs 6.6.1

**Details:**
ClearlyDefined license is OTHER (Telerik End User License Agreement for Kendo UI)
NPM states see license folder


**Resolution:**
OTHER

**Affected definitions**:
- [kendo-angular-inputs 6.6.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-angular-inputs/6.6.1/6.6.1)