### PR TITLE
org.apache.ant/ant 1.7.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.ant/ant.yaml
+++ b/curations/maven/mavencentral/org.apache.ant/ant.yaml
@@ -7,6 +7,9 @@ revisions:
   1.7.0:
     licensed:
       declared: Apache-2.0
+  1.7.1:
+    licensed:
+      declared: Apache-2.0
   1.8.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.ant/ant 1.7.1

**Details:**
Maven pom is Apache-2.0: https://repo1.maven.org/maven2/org/apache/ant/ant/1.7.1/ant-1.7.1.pom
Maven license field and link are Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ant 1.7.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.ant/ant/1.7.1/1.7.1)