### PR TITLE
org.junit.platform/junit-platform-commons 1.6.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -19,6 +19,9 @@ revisions:
   1.5.2:
     licensed:
       declared: EPL-2.0
+  1.6.0:
+    licensed:
+      declared: EPL-2.0
   1.6.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-commons 1.6.0

**Details:**
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.6.0/junit-platform-commons-1.6.0.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-commons 1.6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.6.0/1.6.0)