### PR TITLE
rijs.serve 1.1.1

### DIFF
--- a/curations/npm/npmjs/-/rijs.serve.yaml
+++ b/curations/npm/npmjs/-/rijs.serve.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rijs.serve
+  provider: npmjs
+  type: npm
+revisions:
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rijs.serve 1.1.1

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM links to same as above
GitHub package.json is same as above

**Resolution:**
MIT

**Affected definitions**:
- [rijs.serve 1.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/rijs.serve/1.1.1/1.1.1)