### PR TITLE
pillow 9.0.1

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -18,3 +18,6 @@ revisions:
   9.0.0:
     licensed:
       declared: HPND
+  9.0.1:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow 9.0.1

**Details:**
Correcting license

**Resolution:**
HPND

**Affected definitions**:
- [pillow 9.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/9.0.1/9.0.1)