### PR TITLE
AngularJS.Route 1.6.5

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Route.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Route.yaml
@@ -12,6 +12,9 @@ revisions:
   1.5.9:
     licensed:
       declared: MIT
+  1.6.5:
+    licensed:
+      declared: MIT
   1.7.8:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngularJS.Route 1.6.5

**Details:**
Nuget project links to Angular that has GitHub link
GitHub license is MIT: https://github.com/angular/angular.js/blob/v1.6.5/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AngularJS.Route 1.6.5](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Route/1.6.5/1.6.5)