### PR TITLE
icon-firefox 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/icon-firefox.yaml
+++ b/curations/npm/npmjs/-/icon-firefox.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: icon-firefox
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
icon-firefox 0.0.1

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM same as above

**Resolution:**
MIT

**Affected definitions**:
- [icon-firefox 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/icon-firefox/0.0.1/0.0.1)