### PR TITLE
org.junit.vintage/junit-vintage-engine 5.6.3

### DIFF
--- a/curations/maven/mavencentral/org.junit.vintage/junit-vintage-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.vintage/junit-vintage-engine.yaml
@@ -16,6 +16,9 @@ revisions:
   5.6.2:
     licensed:
       declared: EPL-2.0
+  5.6.3:
+    licensed:
+      declared: EPL-2.0
   5.7.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.vintage/junit-vintage-engine 5.6.3

**Details:**
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/vintage/junit-vintage-engine/5.6.3/junit-vintage-engine-5.6.3.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-vintage-engine 5.6.3](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.vintage/junit-vintage-engine/5.6.3/5.6.3)