### PR TITLE
AdaptiveExpressions 4.11.0

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveExpressions.yaml
+++ b/curations/nuget/nuget/-/AdaptiveExpressions.yaml
@@ -12,6 +12,9 @@ revisions:
   4.10.3:
     licensed:
       declared: MIT
+  4.11.0:
+    licensed:
+      declared: MIT
   4.11.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AdaptiveExpressions 4.11.0

**Details:**
ClearlyDefined license indicates MIT
NuGet license is MIT
GitHub license is MIT: https://github.com/microsoft/botbuilder-dotnet/blob/524867e7c3b1bbcb7c2eae70eb4ac334f5354f8b/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AdaptiveExpressions 4.11.0](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveExpressions/4.11.0/4.11.0)