### PR TITLE
sass 0.5.0

### DIFF
--- a/curations/npm/npmjs/-/sass.yaml
+++ b/curations/npm/npmjs/-/sass.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sass
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
sass 0.5.0

**Details:**
ClearlyDefined package.json no license info
NPM license is MIT
GitHub license is MIT: https://github.com/sass/dart-sass/blob/cf28c7ed200691828e34aade7ba1629e2ebb4757/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [sass 0.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/sass/0.5.0/0.5.0)