### PR TITLE
org.scala-lang/scala-reflect 2.12.1

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -25,6 +25,9 @@ revisions:
   2.11.8:
     licensed:
       declared: BSD-3-Clause
+  2.12.1:
+    licensed:
+      declared: BSD-3-Clause
   2.12.3:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scala-reflect 2.12.1

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/org/scala-lang/scala-reflect/2.12.1/scala-reflect-2.12.1.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-reflect 2.12.1](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.12.1/2.12.1)