### PR TITLE
AjaxControlToolkit 4.1.51116

### DIFF
--- a/curations/nuget/nuget/-/AjaxControlToolkit.yaml
+++ b/curations/nuget/nuget/-/AjaxControlToolkit.yaml
@@ -21,3 +21,6 @@ revisions:
   20.1.0:
     licensed:
       declared: BSD-3-Clause
+  4.1.51116:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AjaxControlToolkit 4.1.51116

**Details:**
Nuget is BSD-3-Clause
GitHub is BSD-3-Clause: https://github.com/DevExpress/AjaxControlToolkit/blob/master/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [AjaxControlToolkit 4.1.51116](https://clearlydefined.io/definitions/nuget/nuget/-/AjaxControlToolkit/4.1.51116/4.1.51116)