### PR TITLE
EWS-Api-2.1 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/EWS-Api-2.1.yaml
+++ b/curations/nuget/nuget/-/EWS-Api-2.1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: EWS-Api-2.1
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EWS-Api-2.1 1.0.0

**Details:**
Nuget license link is broken
No other license info found

**Resolution:**
NONE

**Affected definitions**:
- [EWS-Api-2.1 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/EWS-Api-2.1/1.0.0/1.0.0)