### PR TITLE
org.junit.jupiter/junit-jupiter-engine 5.2.0-M1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -7,6 +7,9 @@ revisions:
   5.2.0:
     licensed:
       declared: EPL-2.0
+  5.2.0-M1:
+    licensed:
+      declared: EPL-2.0
   5.3.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter-engine 5.2.0-M1

**Details:**
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.2.0-M1/junit-jupiter-engine-5.2.0-M1.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter-engine 5.2.0-M1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.2.0-M1/5.2.0-M1)