### PR TITLE
org.codelibs/jhighlight 1.0.3

### DIFF
--- a/curations/maven/mavencentral/org.codelibs/jhighlight.yaml
+++ b/curations/maven/mavencentral/org.codelibs/jhighlight.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jhighlight
+  namespace: org.codelibs
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.3:
+    licensed:
+      declared: CDDL-1.0 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.codelibs/jhighlight 1.0.3

**Details:**
Maven pom is CDDL-1.0 OR LGPL-2.1-or-later: https://repo1.maven.org/maven2/org/codelibs/jhighlight/1.0.3/jhighlight-1.0.3.pom
GitHub is same as above:
https://github.com/codelibs/jhighlight/blob/master/LICENSE_LGPL.txt
https://github.com/codelibs/jhighlight/blob/master/LICENSE_CDDL.txt

**Resolution:**
CDDL-1.0 OR LGPL-2.1-or-later

**Affected definitions**:
- [jhighlight 1.0.3](https://clearlydefined.io/definitions/maven/mavencentral/org.codelibs/jhighlight/1.0.3/1.0.3)