### PR TITLE
package-license 0.1.2

### DIFF
--- a/curations/npm/npmjs/-/package-license.yaml
+++ b/curations/npm/npmjs/-/package-license.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: package-license
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
package-license 0.1.2

**Details:**
ClearlyDefined license is Apache-2.0
NPM license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/AceMetrix/package-license/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [package-license 0.1.2](https://clearlydefined.io/definitions/npm/npmjs/-/package-license/0.1.2/0.1.2)