### PR TITLE
PnP.Framework 1.4.0

### DIFF
--- a/curations/nuget/nuget/-/PnP.Framework.yaml
+++ b/curations/nuget/nuget/-/PnP.Framework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PnP.Framework
+  provider: nuget
+  type: nuget
+revisions:
+  1.4.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PnP.Framework 1.4.0

**Details:**
Nuget links to GitHub project
GitHub is MIT: https://github.com/pnp/pnpframework/blob/1.4.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [PnP.Framework 1.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/PnP.Framework/1.4.0/1.4.0)