### PR TITLE
icon-android 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/icon-android.yaml
+++ b/curations/npm/npmjs/-/icon-android.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: icon-android
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
icon-android 0.0.1

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM license is same as above

**Resolution:**
MIT

**Affected definitions**:
- [icon-android 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/icon-android/0.0.1/0.0.1)