### PR TITLE
org.junit.platform/junit-platform-engine 1.8.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
@@ -37,6 +37,9 @@ revisions:
   1.7.2:
     licensed:
       declared: EPL-2.0
+  1.8.1:
+    licensed:
+      declared: EPL-2.0
   1.8.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-engine 1.8.1

**Details:**
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/platform/junit-platform-suite-engine/1.8.0/junit-platform-suite-engine-1.8.0.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-engine 1.8.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-engine/1.8.1/1.8.1)