### PR TITLE
org.threadly/threadly 4.9.0

### DIFF
--- a/curations/maven/mavencentral/org.threadly/threadly.yaml
+++ b/curations/maven/mavencentral/org.threadly/threadly.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: threadly
+  namespace: org.threadly
+  provider: mavencentral
+  type: maven
+revisions:
+  4.9.0:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.threadly/threadly 4.9.0

**Details:**
Maven pom is MPL-2.0: https://repo1.maven.org/maven2/org/threadly/threadly/4.9.0/threadly-4.9.0.pom

**Resolution:**
MPL-2.0

**Affected definitions**:
- [threadly 4.9.0](https://clearlydefined.io/definitions/maven/mavencentral/org.threadly/threadly/4.9.0/4.9.0)