### PR TITLE
Akka.DistributedData 1.3.15-beta

### DIFF
--- a/curations/nuget/nuget/-/Akka.DistributedData.yaml
+++ b/curations/nuget/nuget/-/Akka.DistributedData.yaml
@@ -6,3 +6,6 @@ revisions:
   1.3.10-beta:
     licensed:
       declared: Apache-2.0
+  1.3.15-beta:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.DistributedData 1.3.15-beta

**Details:**
ClearlyDefined license is Apache-2.0
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/v.1.3.12/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.DistributedData 1.3.15-beta](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.DistributedData/1.3.15-beta/1.3.15-beta)