### PR TITLE
javassist/javassist 3.11.0.GA

### DIFF
--- a/curations/maven/mavencentral/javassist/javassist.yaml
+++ b/curations/maven/mavencentral/javassist/javassist.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javassist
+  namespace: javassist
+  provider: mavencentral
+  type: maven
+revisions:
+  3.11.0.GA:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavencentral/javassist/javassist.yaml
+++ b/curations/maven/mavencentral/javassist/javassist.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.11.0.GA:
     licensed:
-      declared: OTHER
+      declared: MPL-1.1 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javassist/javassist 3.11.0.GA

**Details:**
Maven POM: https://repo1.maven.org/maven2/javassist/javassist/3.11.0.GA/javassist-3.11.0.GA.pom
does not specify license but includes a link to http://www.javassist.org that includes a link to GitHub which is OTHER (Java Assist License): https://github.com/jboss-javassist/javassist/blob/rel_3_11_0_g

**Resolution:**
OTHER

**Affected definitions**:
- [javassist 3.11.0.GA](https://clearlydefined.io/definitions/maven/mavencentral/javassist/javassist/3.11.0.GA/3.11.0.GA)