### PR TITLE
WindowsAzure.StorageExtensions 0.7.7

### DIFF
--- a/curations/nuget/nuget/-/WindowsAzure.StorageExtensions.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.StorageExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WindowsAzure.StorageExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  0.7.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
WindowsAzure.StorageExtensions 0.7.7

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/dtretyakov/WindowsAzure/blob/0.7.7/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [WindowsAzure.StorageExtensions 0.7.7](https://clearlydefined.io/definitions/nuget/nuget/-/WindowsAzure.StorageExtensions/0.7.7/0.7.7)