### PR TITLE
com.force.api/force-metadata-api 29.0.0

### DIFF
--- a/curations/maven/mavencentral/com.force.api/force-metadata-api.yaml
+++ b/curations/maven/mavencentral/com.force.api/force-metadata-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: force-metadata-api
+  namespace: com.force.api
+  provider: mavencentral
+  type: maven
+revisions:
+  29.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.force.api/force-metadata-api 29.0.0

**Details:**
Maven POM indicates BSD: https://repo1.maven.org/maven2/com/force/api/force-wsc/29.0.0/force-wsc-29.0.0.pom
POM links to GitHub that has BSD-3-Clause: https://github.com/forcedotcom/wsc/blob/29.0.0/LICENSE.md


**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [force-metadata-api 29.0.0](https://clearlydefined.io/definitions/maven/mavencentral/com.force.api/force-metadata-api/29.0.0/29.0.0)