### PR TITLE
Unity.Container 5.8.5

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -48,6 +48,9 @@ revisions:
   5.8.11:
     licensed:
       declared: Apache-2.0
+  5.8.5:
+    licensed:
+      declared: Apache-2.0
   5.8.6:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Container 5.8.5

**Details:**
NuGet license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/unitycontainer/unity/blob/5.8.5.506/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Container 5.8.5](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.8.5/5.8.5)