### PR TITLE
librdkafka.redist 1.6.1

### DIFF
--- a/curations/nuget/nuget/-/librdkafka.redist.yaml
+++ b/curations/nuget/nuget/-/librdkafka.redist.yaml
@@ -42,6 +42,9 @@ revisions:
   1.5.3:
     licensed:
       declared: BSD-2-Clause
+  1.6.1:
+    licensed:
+      declared: BSD-2-Clause
   1.7.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
librdkafka.redist 1.6.1

**Details:**
NuGet license is BSD-2-Cause
GitHub license is BSD-2-Clause: https://github.com/edenhill/librdkafka/blob/v1.6.1/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [librdkafka.redist 1.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/librdkafka.redist/1.6.1/1.6.1)