### PR TITLE
System.Diagnostics.DiagnosticSource 4.5.0-preview2-26406-04

### DIFF
--- a/curations/nuget/nuget/-/System.Diagnostics.DiagnosticSource.yaml
+++ b/curations/nuget/nuget/-/System.Diagnostics.DiagnosticSource.yaml
@@ -12,6 +12,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview2-26406-04:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Diagnostics.DiagnosticSource 4.5.0-preview2-26406-04

**Details:**
ClearlyDefined license is MIT
NuGet license is MIT
GitHub license is MIT: https://github.com/dotnet/runtime/blob/ed3d384706c03937e4eac3c377779f0048fa4c3e/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Diagnostics.DiagnosticSource 4.5.0-preview2-26406-04](https://clearlydefined.io/definitions/nuget/nuget/-/System.Diagnostics.DiagnosticSource/4.5.0-preview2-26406-04/4.5.0-preview2-26406-04)