### PR TITLE
Selenium.Chrome.WebDriver 2.45.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.Chrome.WebDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.Chrome.WebDriver.yaml
@@ -21,3 +21,6 @@ revisions:
   2.41.0:
     licensed:
       declared: Unlicense
+  2.45.0:
+    licensed:
+      declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.Chrome.WebDriver 2.45.0

**Details:**
NuGet is Unlicense
GitHub is Unlicense: https://github.com/jbaranda/nupkg-selenium-webdrivers/blob/master/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.Chrome.WebDriver 2.45.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.Chrome.WebDriver/2.45.0/2.45.0)