### PR TITLE
rijs 0.9.1

### DIFF
--- a/curations/npm/npmjs/-/rijs.yaml
+++ b/curations/npm/npmjs/-/rijs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rijs
+  provider: npmjs
+  type: npm
+revisions:
+  0.9.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rijs 0.9.1

**Details:**
ClearlyDefined license is MIT: https://pemrouz.mit-license.org/
NPM links to same as above

**Resolution:**
MIT

**Affected definitions**:
- [rijs 0.9.1](https://clearlydefined.io/definitions/npm/npmjs/-/rijs/0.9.1/0.9.1)