### PR TITLE
boost_thread-vc110 1.57.0

### DIFF
--- a/curations/nuget/nuget/-/boost_thread-vc110.yaml
+++ b/curations/nuget/nuget/-/boost_thread-vc110.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_thread-vc110
+  provider: nuget
+  type: nuget
+revisions:
+  1.57.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_thread-vc110 1.57.0

**Details:**
NuGet license is BSL-1.0
GitHub is BSL-1.0: https://github.com/sergey-shandar/getboost/blob/828f4cb7cecd18610b9ce97186cf2f3aed29ef14/LICENSE

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_thread-vc110 1.57.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_thread-vc110/1.57.0/1.57.0)