### PR TITLE
DocumentFormat.OpenXml 2.7.1

### DIFF
--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -9,6 +9,9 @@ revisions:
   2.5.0:
     licensed:
       declared: Apache-2.0
+  2.7.1:
+    licensed:
+      declared: Apache-2.0
   2.7.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DocumentFormat.OpenXml 2.7.1

**Details:**
NuGet license link broken for this version
GitHub license is Apache-2.0: https://github.com/OfficeDev/Open-XML-SDK/blob/v2.7.1/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [DocumentFormat.OpenXml 2.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/DocumentFormat.OpenXml/2.7.1/2.7.1)