### PR TITLE
pcf-scripts 1.5.4

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -27,6 +27,9 @@ revisions:
   1.5.3:
     licensed:
       declared: OTHER
+  1.5.4:
+    licensed:
+      declared: OTHER
   1.5.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.5.4

**Details:**
ClearlyDefined license is OTHER (MSLT MICROSOFT POWERAPPS CLI)
NPM states see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-scripts 1.5.4](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.5.4/1.5.4)