### PR TITLE
pycocotools 2.0.4

### DIFF
--- a/curations/pypi/pypi/-/pycocotools.yaml
+++ b/curations/pypi/pypi/-/pycocotools.yaml
@@ -9,3 +9,6 @@ revisions:
   2.0.2:
     licensed:
       declared: BSD-2-Clause-Views
+  2.0.4:
+    licensed:
+      declared: BSD-2-Clause-Views


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pycocotools 2.0.4

**Details:**
ClearlyDefined PKG-INFO indicates FreeBSD
PyPi indicates FreeBSD
GitHub license is BSD-2-Clause-Views:  https://github.com/ppwwyyxx/cocoapi/blob/master/license.txt

**Resolution:**
BSD-2-Clause-Views

**Affected definitions**:
- [pycocotools 2.0.4](https://clearlydefined.io/definitions/pypi/pypi/-/pycocotools/2.0.4/2.0.4)