### PR TITLE
com.thoughtworks.xstream/xstream 1.4.11.1

### DIFF
--- a/curations/maven/mavencentral/com.thoughtworks.xstream/xstream.yaml
+++ b/curations/maven/mavencentral/com.thoughtworks.xstream/xstream.yaml
@@ -7,3 +7,6 @@ revisions:
   1.4.11:
     licensed:
       declared: BSD-3-Clause
+  1.4.11.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.thoughtworks.xstream/xstream 1.4.11.1

**Details:**
Maven POM indicates BSD
Maven license links to BSD-3-Clause: http://x-stream.github.io/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [xstream 1.4.11.1](https://clearlydefined.io/definitions/maven/mavencentral/com.thoughtworks.xstream/xstream/1.4.11.1/1.4.11.1)