### PR TITLE
NuGet.RuntimeModel 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.RuntimeModel.yaml
+++ b/curations/nuget/nuget/-/NuGet.RuntimeModel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.RuntimeModel 3.5.0

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/3.5.0-rtm/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.RuntimeModel 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.RuntimeModel/3.5.0/3.5.0)