### PR TITLE
Hangfire.Core 1.7.3

### DIFF
--- a/curations/nuget/nuget/-/Hangfire.Core.yaml
+++ b/curations/nuget/nuget/-/Hangfire.Core.yaml
@@ -21,6 +21,9 @@ revisions:
   1.7.22:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER
+  1.7.3:
+    licensed:
+      declared: OTHER OR LGPL-3.0-or-later
   1.7.9:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Hangfire.Core 1.7.3

**Details:**
ClearlyDefined license file indicates OTHER OR LGPL-3.0-or-later: https://clearlydefined.io/file/49574ff385f7d134b92a3afb6ab1cf9591127ea48a4c53b16fff5d47b729133b
NuGet license OTHER OR LGPL-3.0-or-later
GitHub license is OTHER OR LGPL-3.: https://github.com/HangfireIO/Hangfire/blob/v1.7.3/LICENSE.md

**Resolution:**
OTHER OR LGPL-3.0-or-later

**Affected definitions**:
- [Hangfire.Core 1.7.3](https://clearlydefined.io/definitions/nuget/nuget/-/Hangfire.Core/1.7.3/1.7.3)