### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/trentrichardson/jsonsql.yaml
+++ b/curations/git/github/trentrichardson/jsonsql.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsonsql
+  namespace: trentrichardson
+  provider: github
+  type: git
+revisions:
+  a9b954bad061fe1c22df9c631d77a89a9c7e4016:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
I have added MIT License for this component and it was previously SPDX .

https://github.com/trentrichardson/JsonSQL/blob/v0.1.0/README.md

**Resolution:**
Please verify from below link 
https://github.com/trentrichardson/JsonSQL/blob/v0.1.0/README.md

**Affected definitions**:
- [jsonsql a9b954bad061fe1c22df9c631d77a89a9c7e4016](https://clearlydefined.io/definitions/git/github/trentrichardson/jsonsql/a9b954bad061fe1c22df9c631d77a89a9c7e4016/a9b954bad061fe1c22df9c631d77a89a9c7e4016)