### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/npm/npmjs/-/unorm.yaml
+++ b/curations/npm/npmjs/-/unorm.yaml
@@ -7,16 +7,16 @@ revisions:
     files:
       - attributions:
           - 'Copyright (c) 2008-2013 Matsuza <matsuza@gmail.com> , Bjarke Walling <bwp@bwp.dk>'
-        license: MIT OR GPL-2.0-only
+        license: MIT OR GPL-2.0-or-later
         path: package/README.md
-      - license: MIT OR GPL-2.0-only
+      - license: MIT OR GPL-2.0-or-later
         path: package/package.json
       - attributions:
           - 'Copyright (c) 2008-2013 Matsuza <matsuza@gmail.com> , Bjarke Walling <bwp@bwp.dk>'
-        license: MIT OR GPL-2.0-only
+        license: MIT OR GPL-2.0-or-later
         path: package/LICENSE.md
     licensed:
-      declared: MIT OR GPL-2.0-only
+      declared: MIT OR GPL-2.0-or-later
   1.5.0:
     licensed:
       declared: MIT OR GPL-2.0-or-later

--- a/curations/npm/npmjs/-/unorm.yaml
+++ b/curations/npm/npmjs/-/unorm.yaml
@@ -17,6 +17,9 @@ revisions:
         path: package/LICENSE.md
     licensed:
       declared: MIT OR GPL-2.0-only
+  1.5.0:
+    licensed:
+      declared: MIT OR GPL-2.0-or-later
   1.6.0:
     licensed:
       declared: MIT OR GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The Declared License has NOASSERTION and the Source URL shows the Component is dual Licensed under MIT & GPL 2.0 or Later

License File Path : https://github.com/walling/unorm/blob/v1.5.0/LICENSE.md

**Resolution:**
Since the Source is located with the Dual License information, it is being curated as MIT OR GPL 2.0 License instead of NOASSERTION

Dual License File Path :https://github.com/walling/unorm/blob/v1.5.0/LICENSE.md

**Affected definitions**:
- [unorm 1.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/unorm/1.5.0/1.5.0)