### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/fchollet/keras.yaml
+++ b/curations/git/github/fchollet/keras.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: keras
+  namespace: fchollet
+  provider: github
+  type: git
+revisions:
+  018e55be7c77f168abaea898233ccec035bb39d0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing

**Resolution:**
Filled in the correct license as found at https://faroit.com/keras-docs/0.1.3/#:~:text=Keras%20is%20licensed%20under%20the%20MIT%20license. and https://github.com/keras-team/keras/blob/018e55be7c77f168abaea898233ccec035bb39d0/LICENSE.

**Affected definitions**:
- [keras 018e55be7c77f168abaea898233ccec035bb39d0](https://clearlydefined.io/definitions/git/github/fchollet/keras/018e55be7c77f168abaea898233ccec035bb39d0/018e55be7c77f168abaea898233ccec035bb39d0)