### PR TITLE
Add MIT license declaration to Dynamics365.UIAutomation.Api package versions

### DIFF
--- a/curations/nuget/nuget/-/Dynamics365.UIAutomation.Api.yaml
+++ b/curations/nuget/nuget/-/Dynamics365.UIAutomation.Api.yaml
@@ -7,137 +7,41 @@ revisions:
     licensed:
       declared: MIT
   9.0.0:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.0.0.1:
     licensed:
       declared: MIT
   9.0.2.7:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.1.0.12013:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.1.0.17139:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.1.0.23435:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.1.0.27021:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21014.138:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21062.131:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21074.117:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21084.148:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21102.117-rw2-preview:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21111.116-rw2-preview:
-    described:
-      sourceLocation:
-        name: easyrepro
-        namespace: microsoft
-        provider: github
-        revision: 4ac39d349d762303b570efd022540320ab5329c5
-        type: git
-        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Dynamics365.UIAutomation.Api.yaml
+++ b/curations/nuget/nuget/-/Dynamics365.UIAutomation.Api.yaml
@@ -6,12 +6,138 @@ revisions:
   8.2.0.2:
     licensed:
       declared: MIT
+  9.0.0:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
   9.0.0.1:
     licensed:
       declared: MIT
+  9.0.2.7:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.1.0.12013:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.1.0.17139:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.1.0.23435:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
   9.1.0.27021:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT
   9.2.21014.138:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.2.21062.131:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.2.21074.117:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.2.21084.148:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.2.21102.117-rw2-preview:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
+    licensed:
+      declared: MIT
+  9.2.21111.116-rw2-preview:
+    described:
+      sourceLocation:
+        name: easyrepro
+        namespace: microsoft
+        provider: github
+        revision: 4ac39d349d762303b570efd022540320ab5329c5
+        type: git
+        url: 'https://github.com/microsoft/easyrepro/commit/4ac39d349d762303b570efd022540320ab5329c5'
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT license declaration to Dynamics365.UIAutomation.Api package versions

**Details:**
Declar MIT license for Dynamics365.UIAutomation.Api package versions based on source GitHub repo (EasyRepro) license file

**Resolution:**
License is defined in the source project repo for these package versions in the following file: https://github.com/microsoft/EasyRepro/blob/develop/LICENSE

**Affected definitions**:
- [Dynamics365.UIAutomation.Api 9.2.21111.116-rw2-preview](https://clearlydefined.io/definitions/nuget/nuget/-/Dynamics365.UIAutomation.Api/9.2.21111.116-rw2-preview)