### PR TITLE
visdom 0.1.8.9

### DIFF
--- a/curations/pypi/pypi/-/visdom.yaml
+++ b/curations/pypi/pypi/-/visdom.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: visdom
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.8.9:
+    licensed:
+      declared: CC-BY-NC-4.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
visdom 0.1.8.9

**Details:**
ClearlyDefined PKG-INFO is CC-BY-NC-4.0
PyPi license is CC-BY-NC-4.0
GitHub license is CC-BY-NC-4.0: https://github.com/fossasia/visdom/blob/v0.1.8.9/LICENSE

**Resolution:**
CC-BY-NC-4.0

**Affected definitions**:
- [visdom 0.1.8.9](https://clearlydefined.io/definitions/pypi/pypi/-/visdom/0.1.8.9/0.1.8.9)