### PR TITLE
doctrine 1.3.0

### DIFF
--- a/curations/npm/npmjs/-/doctrine.yaml
+++ b/curations/npm/npmjs/-/doctrine.yaml
@@ -6,6 +6,9 @@ revisions:
   0.7.2:
     licensed:
       declared: BSD-2-Clause
+  1.3.0:
+    licensed:
+      declared: BSD-2-Clause
   1.5.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
doctrine 1.3.0

**Details:**
Clearly Defined license is BSD-2-Clause
NPM Readme is BSD-2-Clause
GitHub license is BSD-2-Clause: https://github.com/eslint/doctrine/blob/v1.3.0/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [doctrine 1.3.0](https://clearlydefined.io/definitions/npm/npmjs/-/doctrine/1.3.0/1.3.0)