### PR TITLE
javax.websocket/javax.websocket-client-api 1.0

### DIFF
--- a/curations/maven/mavencentral/javax.websocket/javax.websocket-client-api.yaml
+++ b/curations/maven/mavencentral/javax.websocket/javax.websocket-client-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javax.websocket-client-api
+  namespace: javax.websocket
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.websocket/javax.websocket-client-api 1.0

**Details:**
Maven POM is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0:  https://repo1.maven.org/maven2/javax/websocket/javax.websocket-client-api/1.0/javax.websocket-client-api-1.0.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.websocket-client-api 1.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.websocket/javax.websocket-client-api/1.0/1.0)