### PR TITLE
javax.transaction/javax.transaction-api 1.3

### DIFF
--- a/curations/maven/mavencentral/javax.transaction/javax.transaction-api.yaml
+++ b/curations/maven/mavencentral/javax.transaction/javax.transaction-api.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.2':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.3':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.transaction/javax.transaction-api 1.3

**Details:**
ClearlyDefined license is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
Maven pom is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0: https://repo1.maven.org/maven2/javax/transaction/javax.transaction-api/1.3/javax.transaction-api-1.3.pom


**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.transaction-api 1.3](https://clearlydefined.io/definitions/maven/mavencentral/javax.transaction/javax.transaction-api/1.3/1.3)