### PR TITLE
jQuery.UI.Combined 1.8.16

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -33,6 +33,9 @@ revisions:
   1.8.13:
     licensed:
       declared: MIT
+  1.8.16:
+    licensed:
+      declared: MIT
   1.8.20.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jQuery.UI.Combined 1.8.16

**Details:**
NuGet is MIT: http://jquery.org/license/
GitHub is MIT: https://github.com/jquery/jquery-ui/blob/1.8.16/MIT-LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [jQuery.UI.Combined 1.8.16](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.8.16/1.8.16)