### PR TITLE
org.ow2.asm/asm 5.0.1

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.0.1:
+    licensed:
+      declared: BSD-3-Clause
   5.0.3:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.ow2.asm/asm 5.0.1

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/org/ow2/asm/asm/5.0.1/asm-5.0.1.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm 5.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm/5.0.1/5.0.1)