### PR TITLE
Marvin.JsonPatch 2.1.0

### DIFF
--- a/curations/nuget/nuget/-/Marvin.JsonPatch.yaml
+++ b/curations/nuget/nuget/-/Marvin.JsonPatch.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.0:
     licensed:
       declared: MIT
+  2.1.0:
+    licensed:
+      declared: MIT
   2.1.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Marvin.JsonPatch 2.1.0

**Details:**
Nuget missing license field
GitHub is MIT: https://github.com/KevinDockx/JsonPatch/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Marvin.JsonPatch 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Marvin.JsonPatch/2.1.0/2.1.0)