### PR TITLE
diff 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/diff.yaml
+++ b/curations/npm/npmjs/-/diff.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-3-Clause
   1.0.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
diff 1.0.0

**Details:**
ClearlyDefined license is BSD-3-Clause
NPM license is BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/kpdecker/jsdiff/blob/v1.0.1/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [diff 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/diff/1.0.0/1.0.0)