### PR TITLE
rijs.css 1.2.4

### DIFF
--- a/curations/npm/npmjs/-/rijs.css.yaml
+++ b/curations/npm/npmjs/-/rijs.css.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: rijs.css
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rijs.css 1.2.4

**Details:**
ClearlyDefined package.json links to MIT: https://pemrouz.mit-license.org/
NPM is same as above
GitHub is same as above

**Resolution:**
MIT

**Affected definitions**:
- [rijs.css 1.2.4](https://clearlydefined.io/definitions/npm/npmjs/-/rijs.css/1.2.4/1.2.4)