### PR TITLE
AjaxControlToolkit 16.1.0

### DIFF
--- a/curations/nuget/nuget/-/AjaxControlToolkit.yaml
+++ b/curations/nuget/nuget/-/AjaxControlToolkit.yaml
@@ -6,6 +6,9 @@ revisions:
   15.1.3:
     licensed:
       declared: BSD-3-Clause
+  16.1.0:
+    licensed:
+      declared: BSD-3-Clause
   16.1.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AjaxControlToolkit 16.1.0

**Details:**
ClearlyDefined license indicates BSD-3-Clause
Nuget license is BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/DevExpress/AjaxControlToolkit/blob/16.1.0/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [AjaxControlToolkit 16.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/AjaxControlToolkit/16.1.0/16.1.0)