### PR TITLE
cryonic 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/cryonic.yaml
+++ b/curations/npm/npmjs/-/cryonic.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cryonic
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
cryonic 1.0.0

**Details:**
ClearlyDefined Package.json does not include license
NPM license field is NONE
GitHub package.json does not include license but found MIT license in: 
https://github.com/hunterloftis/cryo/blob/master/lib/cryo.js

**Resolution:**
MIT

**Affected definitions**:
- [cryonic 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/cryonic/1.0.0/1.0.0)