### PR TITLE
NServiceBus.Azure.Transports.WindowsAzureServiceBus 7.2.1

### DIFF
--- a/curations/nuget/nuget/-/NServiceBus.Azure.Transports.WindowsAzureServiceBus.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.Azure.Transports.WindowsAzureServiceBus.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   7.2.1:
     licensed:
-      declared: RPL-1.5
+      declared: OTHER

--- a/curations/nuget/nuget/-/NServiceBus.Azure.Transports.WindowsAzureServiceBus.yaml
+++ b/curations/nuget/nuget/-/NServiceBus.Azure.Transports.WindowsAzureServiceBus.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NServiceBus.Azure.Transports.WindowsAzureServiceBus
+  provider: nuget
+  type: nuget
+revisions:
+  7.2.1:
+    licensed:
+      declared: RPL-1.5


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NServiceBus.Azure.Transports.WindowsAzureServiceBus 7.2.1

**Details:**
Nuget is RPL-1.5
GitHub is RPL-1.5: https://github.com/Particular/NServiceBus.AzureServiceBus/blob/7.2.1/LICENSE.md

**Resolution:**
RPL-1.5

**Affected definitions**:
- [NServiceBus.Azure.Transports.WindowsAzureServiceBus 7.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/NServiceBus.Azure.Transports.WindowsAzureServiceBus/7.2.1/7.2.1)