### PR TITLE
CsvHelper 6.1.0

### DIFF
--- a/curations/nuget/nuget/-/CsvHelper.yaml
+++ b/curations/nuget/nuget/-/CsvHelper.yaml
@@ -60,6 +60,9 @@ revisions:
   6.0.0:
     licensed:
       declared: MS-PL OR Apache-2.0
+  6.1.0:
+    licensed:
+      declared: MS-PL OR Apache-2.0
   6.1.1:
     licensed:
       declared: MS-PL OR Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CsvHelper 6.1.0

**Details:**
Nuget license is MS-PL OR Apache-2.0
GitHub license is MS-PL OR Apache-2.0: https://github.com/JoshClose/CsvHelper/blob/6.1.0/LICENSE.txt

**Resolution:**
MS-PL OR Apache-2.0

**Affected definitions**:
- [CsvHelper 6.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/CsvHelper/6.1.0/6.1.0)