### PR TITLE
org.antlr/stringtemplate 3.2

### DIFF
--- a/curations/maven/mavencentral/org.antlr/stringtemplate.yaml
+++ b/curations/maven/mavencentral/org.antlr/stringtemplate.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '3.2':
+    licensed:
+      declared: BSD-3-Clause
   3.2.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.antlr/stringtemplate 3.2

**Details:**
Maven files not found: https://mvnrepository.com/artifact/maven2.org.antlr/stringtemplate/3.2
Maven license link to BSD-3-Clause: https://www.antlr.org/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [stringtemplate 3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/stringtemplate/3.2/3.2)