### PR TITLE
koa2-ratelimit 0.9.0

### DIFF
--- a/curations/npm/npmjs/-/koa2-ratelimit.yaml
+++ b/curations/npm/npmjs/-/koa2-ratelimit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: koa2-ratelimit
+  provider: npmjs
+  type: npm
+revisions:
+  0.9.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
koa2-ratelimit 0.9.0

**Details:**
ClearlyDefined Readme indicates MIT
NPM states NONE
GitHub readme is MIT: https://github.com/ysocorp/koa2-ratelimit/blob/v0.9.0/README.md

**Resolution:**
MIT

**Affected definitions**:
- [koa2-ratelimit 0.9.0](https://clearlydefined.io/definitions/npm/npmjs/-/koa2-ratelimit/0.9.0/0.9.0)