### PR TITLE
com.amazonaws/amazon-kinesis-producer 0.12.8

### DIFF
--- a/curations/maven/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
+++ b/curations/maven/mavencentral/com.amazonaws/amazon-kinesis-producer.yaml
@@ -5,8 +5,11 @@ coordinates:
   type: maven
 revisions:
   0.12.11:
-    licensed:
-      declared: OTHER
     files:
       - license: OTHER
         path: META-INF/LICENSE
+    licensed:
+      declared: OTHER
+  0.12.8:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.amazonaws/amazon-kinesis-producer 0.12.8

**Details:**
ClearlyDefined license is OTHER: https://clearlydefined.io/file/5463e441fe0cfc09af3f7287dc5cbb254ce3389b3b08f75019eb23ae9944e3c2
Maven is OTHER: https://repo1.maven.org/maven2/com/amazonaws/amazon-kinesis-producer/0.14.0/amazon-kinesis-producer-0.14.0.pom
GitHub is OTHER: https://github.com/awslabs/

**Resolution:**
OTHER

**Affected definitions**:
- [amazon-kinesis-producer 0.12.8](https://clearlydefined.io/definitions/maven/mavencentral/com.amazonaws/amazon-kinesis-producer/0.12.8/0.12.8)