### PR TITLE
com.sun.jersey/jersey-grizzly21.9

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-grizzly2.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-grizzly2.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.19':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.9':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.sun.jersey/jersey-grizzly21.9

**Details:**
Maven indicates CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0: https://mvnrepository.com/artifact/com.sun.jersey/jersey-grizzly2/1.9.1

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jersey-grizzly2 1.9](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-grizzly2/1.9/1.9)