### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/ggg17226/kaptcha.yaml
+++ b/curations/git/github/ggg17226/kaptcha.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kaptcha
+  namespace: ggg17226
+  provider: github
+  type: git
+revisions:
+  02da219e0f5d5e57b556f8e9d89c053d5b9751a3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Apache License 2.0 License missing in declared license.
File Location:
https://github.com/ggg17226/kaptcha/blob/v2.3.3/LICENSE.txt

**Resolution:**
File Location :
https://github.com/ggg17226/kaptcha/blob/v2.3.3/LICENSE.txt

**Affected definitions**:
- [kaptcha 02da219e0f5d5e57b556f8e9d89c053d5b9751a3](https://clearlydefined.io/definitions/git/github/ggg17226/kaptcha/02da219e0f5d5e57b556f8e9d89c053d5b9751a3/02da219e0f5d5e57b556f8e9d89c053d5b9751a3)