### PR TITLE
MathNet.Numerics.Data.Text 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.Data.Text.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.Data.Text.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MathNet.Numerics.Data.Text
+  provider: nuget
+  type: nuget
+revisions:
+  4.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MathNet.Numerics.Data.Text 4.0.0

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/mathnet/mathnet-numerics/blob/v4.0.0/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [MathNet.Numerics.Data.Text 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics.Data.Text/4.0.0/4.0.0)