### PR TITLE
Twilio 5.6.3

### DIFF
--- a/curations/nuget/nuget/-/Twilio.yaml
+++ b/curations/nuget/nuget/-/Twilio.yaml
@@ -12,6 +12,9 @@ revisions:
   5.53.0:
     licensed:
       declared: MIT
+  5.6.3:
+    licensed:
+      declared: MIT
   5.68.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Twilio 5.6.3

**Details:**
Nuget is MIT
GitHub is MIT: https://github.com/twilio/twilio-csharp/blob/5.6.3/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Twilio 5.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/Twilio/5.6.3/5.6.3)