### PR TITLE
request 2.36.0

### DIFF
--- a/curations/npm/npmjs/-/request.yaml
+++ b/curations/npm/npmjs/-/request.yaml
@@ -6,3 +6,6 @@ revisions:
   2.34.0:
     licensed:
       declared: Apache-2.0
+  2.36.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
request 2.36.0

**Details:**
ClearlyDefined license is Apache-2.0
NPM license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/request/request/blob/v2.36.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [request 2.36.0](https://clearlydefined.io/definitions/npm/npmjs/-/request/2.36.0/2.36.0)