### PR TITLE
hamljs 0.6.2

### DIFF
--- a/curations/npm/npmjs/-/hamljs.yaml
+++ b/curations/npm/npmjs/-/hamljs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hamljs
+  provider: npmjs
+  type: npm
+revisions:
+  0.6.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hamljs 0.6.2

**Details:**
package.json does not include license info
NPM indicates NONE
Readme includes MIT: https://github.com/tj/haml.js/tree/0.6.2

**Resolution:**
MIT

**Affected definitions**:
- [hamljs 0.6.2](https://clearlydefined.io/definitions/npm/npmjs/-/hamljs/0.6.2/0.6.2)