### PR TITLE
org.scala-lang/scalap 2.11.8

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scalap.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scalap.yaml
@@ -13,3 +13,6 @@ revisions:
   2.11.12:
     licensed:
       declared: BSD-3-Clause
+  2.11.8:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.scala-lang/scalap.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scalap.yaml
@@ -9,10 +9,10 @@ revisions:
       declared: BSD-3-Clause
   2.11.11:
     licensed:
-      declared: Apache-2.0
+      declared: BSD-3-Clause
   2.11.12:
     licensed:
       declared: BSD-3-Clause
   2.11.8:
     licensed:
-      declared: Apache-2.0
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scalap 2.11.8

**Details:**
maven is Apache-2.0: https://search.maven.org/artifact/org.scala-lang.modules/scala-java8-compat_2.11
GitHub is Apache-2.0: https://github.com/scala/scala-java8-compat/blob/main/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [scalap 2.11.8](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scalap/2.11.8/2.11.8)