### PR TITLE
org.opengis/geoapi 3.0.1

### DIFF
--- a/curations/maven/mavencentral/org.opengis/geoapi.yaml
+++ b/curations/maven/mavencentral/org.opengis/geoapi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: geoapi
+  namespace: org.opengis
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.opengis/geoapi 3.0.1

**Details:**
Maven indicates OGC-1.0 but the standard paragraph #2 has been omitted.  https://spdx.org/licenses/OGC-1.0.html
Maven: https://mvnrepository.com/artifact/org.opengis/geoapi-parent/3.0.1
License: https://raw.githubusercontent.com/opengeospatial/geoapi/master/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [geoapi 3.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.opengis/geoapi/3.0.1/3.0.1)