### PR TITLE
RestSharp 105.0.0

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -6,6 +6,9 @@ revisions:
   103.4.0:
     licensed:
       declared: Apache-2.0
+  105.0.0:
+    licensed:
+      declared: Apache-2.0
   105.0.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RestSharp 105.0.0

**Details:**
Nuget links to Apache-2.0
Github is Apache-2.0: https://github.com/restsharp/RestSharp/blob/105.0/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [RestSharp 105.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/105.0.0/105.0.0)