### PR TITLE
javax.mail/mail 1.5.0-b01

### DIFF
--- a/curations/maven/mavencentral/javax.mail/mail.yaml
+++ b/curations/maven/mavencentral/javax.mail/mail.yaml
@@ -16,3 +16,6 @@ revisions:
   1.4.7:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  1.5.0-b01:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.mail/mail 1.5.0-b01

**Details:**
Maven pom is CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0: https://repo1.maven.org/maven2/javax/mail/mail/1.5.0-b01/mail-1.5.0-b01.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [mail 1.5.0-b01](https://clearlydefined.io/definitions/maven/mavencentral/javax.mail/mail/1.5.0-b01/1.5.0-b01)