### PR TITLE
org.tallison/jmatio 1.5

### DIFF
--- a/curations/maven/mavencentral/org.tallison/jmatio.yaml
+++ b/curations/maven/mavencentral/org.tallison/jmatio.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jmatio
+  namespace: org.tallison
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.5':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.tallison/jmatio 1.5

**Details:**
maven is BSD: https://repo1.maven.org/maven2/org/tallison/jmatio/1.5/

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jmatio 1.5](https://clearlydefined.io/definitions/maven/mavencentral/org.tallison/jmatio/1.5/1.5)