### PR TITLE
paramiko 2.9.1

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -15,6 +15,9 @@ revisions:
   2.8.0:
     licensed:
       declared: LGPL-2.1-or-later
+  2.9.1:
+    licensed:
+      declared: LGPL-2.1-or-later
   2.9.2:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko 2.9.1

**Details:**
The metadata says LGPL, the license file is LGPL-2.1, and the header of the files say "or later"

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [paramiko 2.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.9.1/2.9.1)