### PR TITLE
Paramiko 2.5.0 - 2.9.1

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -3,9 +3,21 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  2.4.3:
+    licensed:
+      declared: LGPL-2.1-or-later
+  2.5.0:
+    licensed:
+      declared: LGPL-2.1-or-later
+  2.5.1:
+    licensed:
+      declared: LGPL-2.1-or-later
   2.6.0:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-or-later
+  2.7.0:
+    licensed:
+      declared: LGPL-2.1-or-later
   2.7.1:
     licensed:
       declared: LGPL-2.1-or-later
@@ -13,6 +25,15 @@ revisions:
     licensed:
       declared: LGPL-2.1-or-later
   2.8.0:
+    licensed:
+      declared: LGPL-2.1-or-later
+  2.8.1:
+    licensed:
+      declared: LGPL-2.1-or-later
+  2.9.0:
+    licensed:
+      declared: LGPL-2.1-or-later
+  2.9.1:
     licensed:
       declared: LGPL-2.1-or-later
   2.9.2:


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Paramiko 2.5.0 - 2.9.1

**Details:**
Correcting to LGPL-2.1-or-later

**Resolution:**
Per package metadata, license file, and py file headers that indicate "or later."

**Affected definitions**:
- [paramiko 2.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.9.1)