### PR TITLE
Updated Declared license

### DIFF
--- a/curations/git/github/sqlcipher/android-database-sqlcipher.yaml
+++ b/curations/git/github/sqlcipher/android-database-sqlcipher.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: android-database-sqlcipher
+  namespace: sqlcipher
+  provider: github
+  type: git
+revisions:
+  972d1aa0bf132608fecb7f4c8a9c695dec46a8c2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Updated Declared license

**Details:**
The declared license is marked as 'NO ASSERTION' whereas the declared license from the repository indicates it is released under BSD 3 Clause. Here is the license file-
https://github.com/sqlcipher/android-database-sqlcipher/blob/972d1aa0bf132608fecb7f4c8a9c695dec46a8c2/SQLCIPHER_LICENSE

**Resolution:**
The license information has been updated. Here is the license file which has been used as the source of information- 
https://github.com/sqlcipher/android-database-sqlcipher/blob/972d1aa0bf132608fecb7f4c8a9c695dec46a8c2/SQLCIPHER_LICENSE

**Affected definitions**:
- [android-database-sqlcipher 972d1aa0bf132608fecb7f4c8a9c695dec46a8c2](https://clearlydefined.io/definitions/git/github/sqlcipher/android-database-sqlcipher/972d1aa0bf132608fecb7f4c8a9c695dec46a8c2/972d1aa0bf132608fecb7f4c8a9c695dec46a8c2)