### PR TITLE
System.Runtime.CompilerServices.Unsafe 4.5.0-rc1

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
@@ -9,6 +9,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-rc1:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Runtime.CompilerServices.Unsafe 4.5.0-rc1

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT
GitHub license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [System.Runtime.CompilerServices.Unsafe 4.5.0-rc1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe/4.5.0-rc1/4.5.0-rc1)