### PR TITLE
LamarCompiler 2.0.1

### DIFF
--- a/curations/nuget/nuget/-/LamarCompiler.yaml
+++ b/curations/nuget/nuget/-/LamarCompiler.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.1:
+    licensed:
+      declared: MIT
   3.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LamarCompiler 2.0.1

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/JasperFx/lamar/blob/2.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [LamarCompiler 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/LamarCompiler/2.0.1/2.0.1)