### PR TITLE
DeviceDetector.NET 4.1.0

### DIFF
--- a/curations/nuget/nuget/-/DeviceDetector.NET.yaml
+++ b/curations/nuget/nuget/-/DeviceDetector.NET.yaml
@@ -6,6 +6,9 @@ revisions:
   3.11.4:
     licensed:
       declared: Apache-2.0
+  4.1.0:
+    licensed:
+      declared: Apache-2.0
   4.2.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DeviceDetector.NET 4.1.0

**Details:**
ClearlyDefined license is Apache-2.0
Nuget is Apache-2.0: https://www.nuget.org/packages/DeviceDetector.NET/4.1.0/License
GitHub is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [DeviceDetector.NET 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/DeviceDetector.NET/4.1.0/4.1.0)