### PR TITLE
CommunityEFProviderWrappers.EFProviderWrapperToolkit 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/CommunityEFProviderWrappers.EFProviderWrapperToolkit.yaml
+++ b/curations/nuget/nuget/-/CommunityEFProviderWrappers.EFProviderWrapperToolkit.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.0:
     licensed:
-      declared: NONE
+      declared: MS-PL

--- a/curations/nuget/nuget/-/CommunityEFProviderWrappers.EFProviderWrapperToolkit.yaml
+++ b/curations/nuget/nuget/-/CommunityEFProviderWrappers.EFProviderWrapperToolkit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CommunityEFProviderWrappers.EFProviderWrapperToolkit
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommunityEFProviderWrappers.EFProviderWrapperToolkit 1.0.0

**Details:**
Nuget license link is broken
Github link is broken

**Resolution:**
NONE

**Affected definitions**:
- [CommunityEFProviderWrappers.EFProviderWrapperToolkit 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommunityEFProviderWrappers.EFProviderWrapperToolkit/1.0.0/1.0.0)