### PR TITLE
modernhttpclient 2.4.2

### DIFF
--- a/curations/nuget/nuget/-/modernhttpclient.yaml
+++ b/curations/nuget/nuget/-/modernhttpclient.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: modernhttpclient
+  provider: nuget
+  type: nuget
+revisions:
+  2.4.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
modernhttpclient 2.4.2

**Details:**
Nuget is MIT: https://github.com/anaisbetts/ModernHttpClient/blob/master/COPYING
GitHub is MIT

**Resolution:**
MIT

**Affected definitions**:
- [modernhttpclient 2.4.2](https://clearlydefined.io/definitions/nuget/nuget/-/modernhttpclient/2.4.2/2.4.2)