### PR TITLE
pcf-scripts 1.3.3

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -18,6 +18,9 @@ revisions:
   1.3.1:
     licensed:
       declared: OTHER
+  1.3.3:
+    licensed:
+      declared: OTHER
   1.3.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.3.3

**Details:**
ClearlyDefined license is OTHER: Microsoft MSLT: MICROSOFT POWERAPPS CLI
NPM states license folder


**Resolution:**
OTHER

**Affected definitions**:
- [pcf-scripts 1.3.3](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.3.3/1.3.3)