### PR TITLE
text-encoding 0.5.2

### DIFF
--- a/curations/npm/npmjs/-/text-encoding.yaml
+++ b/curations/npm/npmjs/-/text-encoding.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: text-encoding
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
text-encoding 0.5.2

**Details:**
Package.json links to GitHub but no license info
NPM is Dual licensed Unlicense and Apache-2.0
GitHub is Apache-2.0 at time of this package: https://github.com/inexorabletash/text-encoding/blob/v0.5.2/LICENSE.md

**Resolution:**
Apache-2.0

**Affected definitions**:
- [text-encoding 0.5.2](https://clearlydefined.io/definitions/npm/npmjs/-/text-encoding/0.5.2/0.5.2)