### PR TITLE
icon-opera 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/icon-opera.yaml
+++ b/curations/npm/npmjs/-/icon-opera.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: icon-opera
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
icon-opera 0.0.1

**Details:**
package.json links to MIT: https://pemrouz.mit-license.org/
NPM is same as above


**Resolution:**
MIT

**Affected definitions**:
- [icon-opera 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/icon-opera/0.0.1/0.0.1)