### PR TITLE
skeyMicrosoftTeamFoundationWorkItemTrackingClient 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/skeyMicrosoftTeamFoundationWorkItemTrackingClient.yaml
+++ b/curations/nuget/nuget/-/skeyMicrosoftTeamFoundationWorkItemTrackingClient.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: skeyMicrosoftTeamFoundationWorkItemTrackingClient
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
skeyMicrosoftTeamFoundationWorkItemTrackingClient 1.0.0

**Details:**
NuGet has no license info and no project linked
No license info found

**Resolution:**
NONE

**Affected definitions**:
- [skeyMicrosoftTeamFoundationWorkItemTrackingClient 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/skeyMicrosoftTeamFoundationWorkItemTrackingClient/1.0.0/1.0.0)