### PR TITLE
javax.servlet/servlet-api 2.3

### DIFF
--- a/curations/maven/mavencentral/javax.servlet/servlet-api.yaml
+++ b/curations/maven/mavencentral/javax.servlet/servlet-api.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '2.3':
+    licensed:
+      declared: Apache-1.1
   '2.4':
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.servlet/servlet-api 2.3

**Details:**
Maven pom did not have license info
Opened several java files and they all had Apache-1.1 licenses

**Resolution:**
Apache-1.1

**Affected definitions**:
- [servlet-api 2.3](https://clearlydefined.io/definitions/maven/mavencentral/javax.servlet/servlet-api/2.3/2.3)