### PR TITLE
NLog.Config 4.7.0

### DIFF
--- a/curations/nuget/nuget/-/NLog.Config.yaml
+++ b/curations/nuget/nuget/-/NLog.Config.yaml
@@ -123,6 +123,9 @@ revisions:
   4.6.6:
     licensed:
       declared: BSD-3-Clause
+  4.7.0:
+    licensed:
+      declared: BSD-3-Clause
   4.7.10:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Config 4.7.0

**Details:**
License file indicates BSD-3-Clause
Nuget is BSD-3-Clause
GitHub is BSD-3-Clause: https://github.com/NLog/NLog/blob/v4.7/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [NLog.Config 4.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Config/4.7.0/4.7.0)