### PR TITLE
YamlDotNet 4.2.2

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.yaml
@@ -24,6 +24,9 @@ revisions:
   4.1.0:
     licensed:
       declared: MIT
+  4.2.2:
+    licensed:
+      declared: MIT
   4.3.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet 4.2.2

**Details:**
Nuget license link is broken
GitHub license is MIT: https://github.com/aaubry/YamlDotNet/wiki

**Resolution:**
MIT

**Affected definitions**:
- [YamlDotNet 4.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet/4.2.2/4.2.2)