### PR TITLE
AngularJS.Core 1.5.8

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Core.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Core.yaml
@@ -15,6 +15,9 @@ revisions:
   1.5.7:
     licensed:
       declared: MIT
+  1.5.8:
+    licensed:
+      declared: MIT
   1.5.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AngularJS.Core 1.5.8

**Details:**
Nuget license field missing
GitHub license is MIT: https://github.com/angular/angular.js/blob/v1.5.8/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AngularJS.Core 1.5.8](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Core/1.5.8/1.5.8)