### PR TITLE
jsbn-rsa 1.0.3

### DIFF
--- a/curations/npm/npmjs/-/jsbn-rsa.yaml
+++ b/curations/npm/npmjs/-/jsbn-rsa.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jsbn-rsa
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jsbn-rsa 1.0.3

**Details:**
NPM is OTHER
GitHub is OTHER: https://github.com/nicomazz/jsbn-rsa/blob/master/LICENSE

It is a modified Xnet license

**Resolution:**
OTHER

**Affected definitions**:
- [jsbn-rsa 1.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/jsbn-rsa/1.0.3/1.0.3)