### PR TITLE
boost_regex-vc110 1.57.0

### DIFF
--- a/curations/nuget/nuget/-/boost_regex-vc110.yaml
+++ b/curations/nuget/nuget/-/boost_regex-vc110.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.57.0:
     licensed:
-      declared: MIT
+      declared: BSL-1.0

--- a/curations/nuget/nuget/-/boost_regex-vc110.yaml
+++ b/curations/nuget/nuget/-/boost_regex-vc110.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_regex-vc110
+  provider: nuget
+  type: nuget
+revisions:
+  1.57.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_regex-vc110 1.57.0

**Details:**
Nuget license and project links are broken
Nuspec includes link to MIT license: https://github.com/x64asf/GetBoost/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [boost_regex-vc110 1.57.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_regex-vc110/1.57.0/1.57.0)