### PR TITLE
wicg-inert 3.1.0

### DIFF
--- a/curations/npm/npmjs/-/wicg-inert.yaml
+++ b/curations/npm/npmjs/-/wicg-inert.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  3.1.0:
+    licensed:
+      declared: W3C-20150513
   3.1.1:
     licensed:
       declared: W3C-20150513


### PR DESCRIPTION

**Type:** Missing

**Summary:**
wicg-inert 3.1.0

**Details:**
package.json doesn't include license info but links to Github.
GitHub license is W3C-20150513: https://github.com/WICG/inert/blob/v3.1.0/LICENSE.md

**Resolution:**
W3C-20150513

**Affected definitions**:
- [wicg-inert 3.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/wicg-inert/3.1.0/3.1.0)