### PR TITLE
Akka.Cluster 1.4.17

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.yaml
@@ -12,3 +12,6 @@ revisions:
   1.4.10:
     licensed:
       declared: Apache-2.0
+  1.4.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster 1.4.17

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0:https://github.com/akkadotnet/akka.net/blob/1.4.17/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Cluster 1.4.17](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster/1.4.17/1.4.17)