### PR TITLE
Declared license is missing

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -82,3 +82,6 @@ revisions:
   21.3.0:
     licensed:
       declared: UPL-1.0
+  21.3.1:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is missing

**Details:**
As can be seen in the source repository at https://github.com/oracle/graal/blob/vm-21.3.1/sdk/LICENSE.md the component is UPL-1.0 licensed

**Resolution:**
Set declared license to UPL-1.0

**Affected definitions**:
- [graal-sdk 21.3.1](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/21.3.1/21.3.1)