### PR TITLE
Declared license is missing

### DIFF
--- a/curations/sourcearchive/mavencentral/org.postgresql/postgresql.yaml
+++ b/curations/sourcearchive/mavencentral/org.postgresql/postgresql.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: postgresql
+  namespace: org.postgresql
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  42.3.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is missing

**Details:**
As can be seen in the project's source repository, the component is BSD-2 licensed: https://github.com/pgjdbc/pgjdbc/blob/REL42.3.2/LICENSE

**Resolution:**
Set declared license to BSD-2

**Affected definitions**:
- [postgresql 42.3.2](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.postgresql/postgresql/42.3.2/42.3.2)