### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/assimp/assimp.yaml
+++ b/curations/git/github/assimp/assimp.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  80799bdbf90ce626475635815ee18537718a05b1:
+    licensed:
+      declared: BSD-3-Clause AND OTHER
   b2ea762b027c6975f8a1398cdda988803326b253:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing

**Resolution:**
Filled in the declared license as per https://github.com/assimp/assimp/blob/80799bdbf90ce626475635815ee18537718a05b1/LICENSE.

**Affected definitions**:
- [assimp 80799bdbf90ce626475635815ee18537718a05b1](https://clearlydefined.io/definitions/git/github/assimp/assimp/80799bdbf90ce626475635815ee18537718a05b1/80799bdbf90ce626475635815ee18537718a05b1)