### PR TITLE
System.Security.Permissions4.6.0-preview 6.19303.8

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Permissions.yaml
+++ b/curations/nuget/nuget/-/System.Security.Permissions.yaml
@@ -15,6 +15,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview6.19303.8:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Permissions4.6.0-preview 6.19303.8

**Details:**
ClearlyDefined license file is MIT
Nuget license link is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.Permissions 4.6.0-preview6.19303.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Permissions/4.6.0-preview6.19303.8/4.6.0-preview6.19303.8)