### PR TITLE
com.force.api/force-partner-api 29.0.0

### DIFF
--- a/curations/maven/mavencentral/com.force.api/force-partner-api.yaml
+++ b/curations/maven/mavencentral/com.force.api/force-partner-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: force-partner-api
+  namespace: com.force.api
+  provider: mavencentral
+  type: maven
+revisions:
+  29.0.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.force.api/force-partner-api 29.0.0

**Details:**
Maven pom is BSD: https://repo1.maven.org/maven2/com/force/api/force-wsc/29.0.0/force-wsc-29.0.0.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [force-partner-api 29.0.0](https://clearlydefined.io/definitions/maven/mavencentral/com.force.api/force-partner-api/29.0.0/29.0.0)