### PR TITLE
syntax 1.0.0

### DIFF
--- a/curations/gem/rubygems/-/syntax.yaml
+++ b/curations/gem/rubygems/-/syntax.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: syntax
+  provider: rubygems
+  type: gem
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
syntax 1.0.0

**Details:**
RubyGems license field states N/A
GitHub indicates NONE at the time of this package but later as BSD-3-Clause: https://github.com/dblock/syntax/blob/v1.2.0/LICENSE

**Resolution:**
NONE

**Affected definitions**:
- [syntax 1.0.0](https://clearlydefined.io/definitions/gem/rubygems/-/syntax/1.0.0/1.0.0)