### PR TITLE
discovery/commons-discovery 0.4

### DIFF
--- a/curations/maven/mavencentral/commons-discovery/commons-discovery.yaml
+++ b/curations/maven/mavencentral/commons-discovery/commons-discovery.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-discovery
+  namespace: commons-discovery
+  provider: mavencentral
+  type: maven
+revisions:
+  '0.4':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
discovery/commons-discovery 0.4

**Details:**
ClearlyDefined license is Apache-2.0
Maven pom is Apache-2.0: https://repo1.maven.org/maven2/commons-discovery/commons-discovery/0.4/commons-discovery-0.4.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [commons-discovery 0.4](https://clearlydefined.io/definitions/maven/mavencentral/commons-discovery/commons-discovery/0.4/0.4)