### PR TITLE
onnxruntime 1.1.1

### DIFF
--- a/curations/pypi/pypi/-/onnxruntime.yaml
+++ b/curations/pypi/pypi/-/onnxruntime.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.0:
     licensed:
       declared: MIT
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
onnxruntime 1.1.1

**Details:**
PyPi license field indicates MIT
GitHub is MIT: https://github.com/microsoft/onnxruntime/blob/v1.1.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [onnxruntime 1.1.1](https://clearlydefined.io/definitions/pypi/pypi/-/onnxruntime/1.1.1/1.1.1)