### PR TITLE
Xamarin.TestCloud.Agent 0.21.7

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.TestCloud.Agent.yaml
+++ b/curations/nuget/nuget/-/Xamarin.TestCloud.Agent.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.21.7:
+    licensed:
+      declared: EPL-1.0
   0.21.8:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.TestCloud.Agent 0.21.7

**Details:**
ClearlyDefined license is EPL-1.0
Nuget is EPL-1.0: https://github.com/calabash/calabash-ios-server/blob/0.21.7/LICENSE
Github is EPL-1.0: 

**Resolution:**
EPL-1.0

**Affected definitions**:
- [Xamarin.TestCloud.Agent 0.21.7](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.TestCloud.Agent/0.21.7/0.21.7)