### PR TITLE
umd-compat-loader 2.0.1

### DIFF
--- a/curations/npm/npmjs/-/umd-compat-loader.yaml
+++ b/curations/npm/npmjs/-/umd-compat-loader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: umd-compat-loader
+  provider: npmjs
+  type: npm
+revisions:
+  2.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
umd-compat-loader 2.0.1

**Details:**
ClearlyDefined license is Apache-2.0
NPM license is BSD
GitHub license is Apache-2.0: https://github.com/matt-gadd/umd-compat-loader/blob/v2.0.1/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [umd-compat-loader 2.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/umd-compat-loader/2.0.1/2.0.1)