### PR TITLE
NLog.Config 4.6.8

### DIFF
--- a/curations/nuget/nuget/-/NLog.Config.yaml
+++ b/curations/nuget/nuget/-/NLog.Config.yaml
@@ -123,6 +123,9 @@ revisions:
   4.6.6:
     licensed:
       declared: BSD-3-Clause
+  4.6.8:
+    licensed:
+      declared: BSD-3-Clause
   4.7.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NLog.Config 4.6.8

**Details:**
Nuget license is BSD-3-Clause
Github license is BSD-3-Clause: https://github.com/NLog/NLog/blob/v4.6.8/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [NLog.Config 4.6.8](https://clearlydefined.io/definitions/nuget/nuget/-/NLog.Config/4.6.8/4.6.8)