### PR TITLE
Xamarin.UITest 2.2.7

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.UITest.yaml
+++ b/curations/nuget/nuget/-/Xamarin.UITest.yaml
@@ -9,6 +9,9 @@ revisions:
   2.2.6:
     licensed:
       declared: OTHER
+  2.2.7:
+    licensed:
+      declared: OTHER
   3.0.0-dev24:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.UITest 2.2.7

**Details:**
Nuget is OTHER (Xamarin.UITest End User License Agreement (EULA))
Project license is OTHER: https://docs.microsoft.com/en-us/appcenter/test-cloud/frameworks/uitest/license

**Resolution:**
OTHER

**Affected definitions**:
- [Xamarin.UITest 2.2.7](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.UITest/2.2.7/2.2.7)