### PR TITLE
YamlDotNet 4.0.0

### DIFF
--- a/curations/nuget/nuget/-/YamlDotNet.yaml
+++ b/curations/nuget/nuget/-/YamlDotNet.yaml
@@ -21,6 +21,9 @@ revisions:
   3.8.0:
     licensed:
       declared: MIT
+  4.0.0:
+    licensed:
+      declared: MIT
   4.1.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
YamlDotNet 4.0.0

**Details:**
Nuget license is MIT: https://aaubry.net/pages/license.html
Project license states MIT

**Resolution:**
MIT

**Affected definitions**:
- [YamlDotNet 4.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/YamlDotNet/4.0.0/4.0.0)