### PR TITLE
Rx-PlatformServices 2.2.3

### DIFF
--- a/curations/nuget/nuget/-/Rx-PlatformServices.yaml
+++ b/curations/nuget/nuget/-/Rx-PlatformServices.yaml
@@ -9,6 +9,9 @@ revisions:
   2.2.2:
     licensed:
       declared: Apache-2.0
+  2.2.3:
+    licensed:
+      declared: Apache-2.0
   2.2.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-PlatformServices 2.2.3

**Details:**
Nuget links to MIT
GitHub current license is MIT but the previous license was Apache-2.0.  It appears a the time of this package there wasn't a license and closest license was Apache-2.0 which matches other versions curated as Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Rx-PlatformServices 2.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-PlatformServices/2.2.3/2.2.3)