### PR TITLE
System.Runtime.Caching4.5.0-preview 1-25914-04

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.Caching.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.Caching.yaml
@@ -6,6 +6,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview1-25914-04:
+    licensed:
+      declared: MIT
   4.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Runtime.Caching4.5.0-preview 1-25914-04

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Runtime.Caching 4.5.0-preview1-25914-04](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.Caching/4.5.0-preview1-25914-04/4.5.0-preview1-25914-04)