### PR TITLE
org.junit.jupiter/junit-jupiter-params 5.8.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -34,6 +34,9 @@ revisions:
   5.8.0-M1:
     licensed:
       declared: EPL-2.0
+  5.8.1:
+    licensed:
+      declared: EPL-2.0
   5.8.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter-params 5.8.1

**Details:**
Maven pom is EPL-2.0: https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/5.8.1/junit-jupiter-params-5.8.1.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter-params 5.8.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.8.1/5.8.1)