### PR TITLE
icon-osx 0.0.1

### DIFF
--- a/curations/npm/npmjs/-/icon-osx.yaml
+++ b/curations/npm/npmjs/-/icon-osx.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: icon-osx
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
icon-osx 0.0.1

**Details:**
package.json links to MIT: https://pemrouz.mit-license.org/
NPM license same as above

**Resolution:**
MIT

**Affected definitions**:
- [icon-osx 0.0.1](https://clearlydefined.io/definitions/npm/npmjs/-/icon-osx/0.0.1/0.0.1)