### PR TITLE
Selenium.WebDriver.IEDriver 3.141.5

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -24,6 +24,9 @@ revisions:
   3.141.0:
     licensed:
       declared: Unlicense
+  3.141.5:
+    licensed:
+      declared: OTHER
   3.141.59:
     licensed:
       declared: Unlicense

--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -26,7 +26,7 @@ revisions:
       declared: Unlicense
   3.141.5:
     licensed:
-      declared: OTHER
+      declared: Unlicense
   3.141.59:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.IEDriver 3.141.5

**Details:**
Nuget links to Unlicense
GitHublicense is Unlicense: https://github.com/jsakamoto/nupkg-selenium-webdriver-iedriver/blob/v.3.141.5.0/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.WebDriver.IEDriver 3.141.5](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.IEDriver/3.141.5/3.141.5)