### PR TITLE
org.apache.tomcat/tomcat-servlet-api 9.0.33

### DIFF
--- a/curations/maven/mavencentral/org.apache.tomcat/tomcat-servlet-api.yaml
+++ b/curations/maven/mavencentral/org.apache.tomcat/tomcat-servlet-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tomcat-servlet-api
+  namespace: org.apache.tomcat
+  provider: mavencentral
+  type: maven
+revisions:
+  9.0.33:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.tomcat/tomcat-servlet-api 9.0.33

**Details:**
Maven pom is Apache-2.0: https://repo1.maven.org/maven2/org/apache/tomcat/tomcat-servlet-api/9.0.33/tomcat-servlet-api-9.0.33.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [tomcat-servlet-api 9.0.33](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.tomcat/tomcat-servlet-api/9.0.33/9.0.33)