### PR TITLE
AspNetCore.HealthChecks.Uris 2.2.3

### DIFF
--- a/curations/nuget/nuget/-/AspNetCore.HealthChecks.Uris.yaml
+++ b/curations/nuget/nuget/-/AspNetCore.HealthChecks.Uris.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.1:
     licensed:
       declared: Apache-2.0
+  2.2.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AspNetCore.HealthChecks.Uris 2.2.3

**Details:**
Nuget is Apache-2.0
Github is Apache-2.0: https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/blob/2.2.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [AspNetCore.HealthChecks.Uris 2.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/AspNetCore.HealthChecks.Uris/2.2.3/2.2.3)