### PR TITLE
Google.Protobuf 3.15.3

### DIFF
--- a/curations/nuget/nuget/-/Google.Protobuf.yaml
+++ b/curations/nuget/nuget/-/Google.Protobuf.yaml
@@ -54,6 +54,9 @@ revisions:
   3.15.0-rc1:
     licensed:
       declared: BSD-3-Clause
+  3.15.3:
+    licensed:
+      declared: BSD-3-Clause
   3.15.5:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Protobuf 3.15.3

**Details:**
Nuget license is BSD-3-Clause
Github license is BSD-3.0: https://github.com/protocolbuffers/protobuf/blob/v3.15.3/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Google.Protobuf 3.15.3](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Protobuf/3.15.3/3.15.3)