### PR TITLE
org.jvnet.hudson/embedded-rhino-debugger 1.2

### DIFF
--- a/curations/maven/mavencentral/org.jvnet.hudson/embedded-rhino-debugger.yaml
+++ b/curations/maven/mavencentral/org.jvnet.hudson/embedded-rhino-debugger.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: embedded-rhino-debugger
+  namespace: org.jvnet.hudson
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.2':
+    licensed:
+      declared: MPL-1.1

--- a/curations/maven/mavencentral/org.jvnet.hudson/embedded-rhino-debugger.yaml
+++ b/curations/maven/mavencentral/org.jvnet.hudson/embedded-rhino-debugger.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.2':
     licensed:
-      declared: MPL-1.1
+      declared: MPL-1.1 OR GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jvnet.hudson/embedded-rhino-debugger 1.2

**Details:**
No license info in maven pom: https://repo1.maven.org/maven2/org/jvnet/hudson/embedded-rhino-debugger/1.2/embedded-rhino-debugger-1.2.pom
Source files indicate MPL-1.1

**Resolution:**
MPL-1.1

**Affected definitions**:
- [embedded-rhino-debugger 1.2](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet.hudson/embedded-rhino-debugger/1.2/1.2)