### PR TITLE
org.jboss.logging/jboss-logging 3.1.0.CR2

### DIFF
--- a/curations/maven/mavencentral/org.jboss.logging/jboss-logging.yaml
+++ b/curations/maven/mavencentral/org.jboss.logging/jboss-logging.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jboss-logging
+  namespace: org.jboss.logging
+  provider: mavencentral
+  type: maven
+revisions:
+  3.1.0.CR2:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jboss.logging/jboss-logging 3.1.0.CR2

**Details:**
Maven pom indicates LGPL-2.1-or-later (noting either version): https://repo1.maven.org/maven2/org/jboss/logging/jboss-logging/3.1.0.CR2/jboss-logging-3.1.0.CR2.pom

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [jboss-logging 3.1.0.CR2](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.logging/jboss-logging/3.1.0.CR2/3.1.0.CR2)