### PR TITLE
ExtCore.Mvc.Infrastructure 5.1.0

### DIFF
--- a/curations/nuget/nuget/-/ExtCore.Mvc.Infrastructure.yaml
+++ b/curations/nuget/nuget/-/ExtCore.Mvc.Infrastructure.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ExtCore.Mvc.Infrastructure
+  provider: nuget
+  type: nuget
+revisions:
+  5.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ExtCore.Mvc.Infrastructure 5.1.0

**Details:**
Nuget has no license info
Project Home page links to Github with Apache-2.0: https://github.com/ExtCore/ExtCore/blob/5.1.0/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ExtCore.Mvc.Infrastructure 5.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/ExtCore.Mvc.Infrastructure/5.1.0/5.1.0)