### PR TITLE
FluentMigrator.Runner.SqlServer 3.2.17

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Runner.SqlServer.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Runner.SqlServer.yaml
@@ -9,3 +9,6 @@ revisions:
   3.2.1:
     licensed:
       declared: Apache-2.0
+  3.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Runner.SqlServer 3.2.17

**Details:**
license file indicates Apache-2.0
Nuget links to Apache-2.0
Github is Apache-2.0: https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.17/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Runner.SqlServer 3.2.17](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner.SqlServer/3.2.17/3.2.17)