### PR TITLE
License should not include NOASSERTION 

### DIFF
--- a/curations/maven/mavencentral/org.postgresql/postgresql.yaml
+++ b/curations/maven/mavencentral/org.postgresql/postgresql.yaml
@@ -8,7 +8,7 @@ revisions:
     files:
       - attributions:
           - 'Copyright (c) 1997, PostgreSQL Global Development Group'
-        license: Apache-2.0 AND BSD-2-Clause
+        license: BSD-2-Clause
         path: META-INF/LICENSE
   9.3-1102-jdbc41:
     licensed:

--- a/curations/maven/mavencentral/org.postgresql/postgresql.yaml
+++ b/curations/maven/mavencentral/org.postgresql/postgresql.yaml
@@ -4,6 +4,12 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  42.3.2:
+    files:
+      - attributions:
+          - 'Copyright (c) 1997, PostgreSQL Global Development Group'
+        license: Apache-2.0 AND BSD-2-Clause
+        path: META-INF/LICENSE
   9.3-1102-jdbc41:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License should not include NOASSERTION 

**Details:**
The license file in the META-INF folder gives no indication of NOASSERTION. Instead, it seems to be very clear about the fact that the component is BSD-2 licensed

**Resolution:**
Remove the NOASSERTION key word from the discovered license

**Affected definitions**:
- [postgresql 42.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.postgresql/postgresql/42.3.2/42.3.2)