### PR TITLE
pyzmq 19.0.2

### DIFF
--- a/curations/pypi/pypi/-/pyzmq.yaml
+++ b/curations/pypi/pypi/-/pyzmq.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  19.0.2:
+    licensed:
+      declared: BSD-3-Clause
   22.0.2:
     licensed:
       declared: BSD-3-Clause AND LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pyzmq 19.0.2

**Details:**
In package there's a COPYING.BSD file, which is BSD-3-Clause.  That is the top "declared" license.  

**Resolution:**
There's also a COPYING.LESSER LGPL-3.0 file that is a "discovered" license, I think, as applies to just part of the package (cpython bindings).

**Affected definitions**:
- [pyzmq 19.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/pyzmq/19.0.2/19.0.2)