### PR TITLE
ldap3 2.4

### DIFF
--- a/curations/pypi/pypi/-/ldap3.yaml
+++ b/curations/pypi/pypi/-/ldap3.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  '2.4':
+    licensed:
+      declared: LGPL-3.0-or-later
   '2.9':
     licensed:
       declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ldap3 2.4

**Details:**
LICENSE.txt in package and at the source commit are LGPL-3.0-or-later.

**Resolution:**
There's also a GPL license, but I think that would be "discovered."

**Affected definitions**:
- [ldap3 2.4](https://clearlydefined.io/definitions/pypi/pypi/-/ldap3/2.4/2.4)