### PR TITLE
AjaxControlToolkit 15.1.2

### DIFF
--- a/curations/nuget/nuget/-/AjaxControlToolkit.yaml
+++ b/curations/nuget/nuget/-/AjaxControlToolkit.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  15.1.2:
+    licensed:
+      declared: BSD-3-Clause
   15.1.3:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AjaxControlToolkit 15.1.2

**Details:**
Nuget license link is broken
GitHub license is BSD-3-Clause: https://github.com/DevExpress/AjaxControlToolkit/blob/15.1.2/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [AjaxControlToolkit 15.1.2](https://clearlydefined.io/definitions/nuget/nuget/-/AjaxControlToolkit/15.1.2/15.1.2)