### PR TITLE
utilities 1.0.5

### DIFF
--- a/curations/npm/npmjs/-/utilities.yaml
+++ b/curations/npm/npmjs/-/utilities.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: utilities
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
utilities 1.0.5

**Details:**
package.json doesn't have license info but link to Github
Github is Apache-2.0: https://github.com/mde/utilities/blob/v1.0.5/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [utilities 1.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/utilities/1.0.5/1.0.5)