### PR TITLE
NuGet.Configuration 4.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Configuration.yaml
+++ b/curations/nuget/nuget/-/NuGet.Configuration.yaml
@@ -12,6 +12,9 @@ revisions:
   3.5.0-beta2-1484:
     licensed:
       declared: Apache-2.0
+  4.2.0:
+    licensed:
+      declared: Apache-2.0
   4.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Configuration 4.2.0

**Details:**
Nuget links to Apache-2.0
GitHub is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.2.0-rtm-2457/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Configuration 4.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Configuration/4.2.0/4.2.0)