### PR TITLE
Xamarin.Android.Support.v7.MediaRouter 25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.v7.MediaRouter.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.v7.MediaRouter.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  25.4.0.2:
+    licensed:
+      declared: MIT
   27.0.2:
     licensed:
       declared: MIT
@@ -11,7 +14,7 @@ revisions:
       declared: MIT
   28.0.0.1:
     licensed:
-      declared: MIT  
+      declared: MIT
   28.0.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.v7.MediaRouter 25.4.0.2

**Details:**
Nuget is MIT
GitHub is MIT: https://github.com/xamarin/AndroidSupportComponents/blob/25.4.0.2/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Android.Support.v7.MediaRouter 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.v7.MediaRouter/25.4.0.2/25.4.0.2)