### PR TITLE
VSSDK.Shell.Interop 7.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.Shell.Interop.yaml
+++ b/curations/nuget/nuget/-/VSSDK.Shell.Interop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.Shell.Interop
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VSSDK.Shell.Interop 7.0.4

**Details:**
No license info found in files
Nuget no license info found and no link to project

**Resolution:**
NONE

**Affected definitions**:
- [VSSDK.Shell.Interop 7.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.Shell.Interop/7.0.4/7.0.4)