### PR TITLE
ru.vyarus/generics-resolver 3.0.2

### DIFF
--- a/curations/maven/mavencentral/ru.vyarus/generics-resolver.yaml
+++ b/curations/maven/mavencentral/ru.vyarus/generics-resolver.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: generics-resolver
+  namespace: ru.vyarus
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ru.vyarus/generics-resolver 3.0.2

**Details:**
Maven pom is MIT: https://repo1.maven.org/maven2/ru/vyarus/generics-resolver/3.0.2/generics-resolver-3.0.2.pom

**Resolution:**
MIT

**Affected definitions**:
- [generics-resolver 3.0.2](https://clearlydefined.io/definitions/maven/mavencentral/ru.vyarus/generics-resolver/3.0.2/3.0.2)