### PR TITLE
boost_chrono-vc141 1.64.0

### DIFF
--- a/curations/nuget/nuget/-/boost_chrono-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_chrono-vc141.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.64.0:
+    licensed:
+      declared: Apache-2.0
   1.69.0:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/boost_chrono-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_chrono-vc141.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.64.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0
   1.69.0:
     licensed:
-      declared: Apache-2.0
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_chrono-vc141 1.64.0

**Details:**
Nuget is Apache-2.0
GitHub is Apache-2.0: https://github.com/sergey-shandar/getboost/blob/1.62.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [boost_chrono-vc141 1.64.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_chrono-vc141/1.64.0/1.64.0)