### PR TITLE
javax.mail/javax.mail-api 1.6.2

### DIFF
--- a/curations/maven/mavencentral/javax.mail/javax.mail-api.yaml
+++ b/curations/maven/mavencentral/javax.mail/javax.mail-api.yaml
@@ -7,3 +7,6 @@ revisions:
   1.5.4:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  1.6.2:
+    licensed:
+      declared: MS-PL

--- a/curations/maven/mavencentral/javax.mail/javax.mail-api.yaml
+++ b/curations/maven/mavencentral/javax.mail/javax.mail-api.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.6.2:
     licensed:
-      declared: MS-PL
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.mail/javax.mail-api 1.6.2

**Details:**
Note: there is mention of other licenses but believe they are discovered not the declared
Nuget is MS-PL
GitHub is MS-PL: https://raw.githubusercontent.com/haf/DotNetZip.Semverd/master/LICENSE

**Resolution:**
MS-PL

**Affected definitions**:
- [javax.mail-api 1.6.2](https://clearlydefined.io/definitions/maven/mavencentral/javax.mail/javax.mail-api/1.6.2/1.6.2)