### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/ajaxorg/ace-builds.yaml
+++ b/curations/git/github/ajaxorg/ace-builds.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ace-builds
+  namespace: ajaxorg
+  provider: github
+  type: git
+revisions:
+  8a271c3dae5267e4a124f378d940f221cc7b3dab:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The described license has one NOASSERTION with no proper license mentioned.

License found path : https://github.com/ajaxorg/ace-builds/blob/v1.4.1/LICENSE

**Resolution:**
Since there is no License specified, it is being curated as BSD-3-Clause instead of NOASSERTION.

License path : https://github.com/ajaxorg/ace-builds/blob/v1.4.1/LICENSE

**Affected definitions**:
- [ace-builds 8a271c3dae5267e4a124f378d940f221cc7b3dab](https://clearlydefined.io/definitions/git/github/ajaxorg/ace-builds/8a271c3dae5267e4a124f378d940f221cc7b3dab/8a271c3dae5267e4a124f378d940f221cc7b3dab)