### PR TITLE
Nito.AsyncEx 5.0.0-pre-05

### DIFF
--- a/curations/nuget/nuget/-/Nito.AsyncEx.yaml
+++ b/curations/nuget/nuget/-/Nito.AsyncEx.yaml
@@ -3,12 +3,12 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
-  3.0.0:
-    licensed:
-      declared: MIT
   2.1.3:
     licensed:
       declared: MS-PL
+  3.0.0:
+    licensed:
+      declared: MIT
   3.0.1:
     licensed:
       declared: MIT
@@ -16,5 +16,8 @@ revisions:
     licensed:
       declared: MIT
   5.0.0:
+    licensed:
+      declared: MIT
+  5.0.0-pre-05:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nito.AsyncEx 5.0.0-pre-05

**Details:**
Nuget is MIT
GitHub is MIT: https://github.com/StephenCleary/AsyncEx/blob/v5.0.0-pre-05/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Nito.AsyncEx 5.0.0-pre-05](https://clearlydefined.io/definitions/nuget/nuget/-/Nito.AsyncEx/5.0.0-pre-05/5.0.0-pre-05)