### PR TITLE
commons-jelly/commons-jelly-tags-fmt 1.0

### DIFF
--- a/curations/maven/mavencentral/commons-jelly/commons-jelly-tags-fmt.yaml
+++ b/curations/maven/mavencentral/commons-jelly/commons-jelly-tags-fmt.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-jelly-tags-fmt
+  namespace: commons-jelly
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-jelly/commons-jelly-tags-fmt 1.0

**Details:**
ClearlyDefined license is Apache-2.0
Maven is Apache-2.0: https://mvnrepository.com/artifact/commons-jelly/commons-jelly-tags-fmt/1.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [commons-jelly-tags-fmt 1.0](https://clearlydefined.io/definitions/maven/mavencentral/commons-jelly/commons-jelly-tags-fmt/1.0/1.0)