### PR TITLE
zrender 4.0.4

### DIFF
--- a/curations/npm/npmjs/-/zrender.yaml
+++ b/curations/npm/npmjs/-/zrender.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  4.0.4:
+    licensed:
+      declared: BSD-3-Clause
   4.0.7:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
zrender 4.0.4

**Details:**
ClearlyDefined license is BSD-3-Clause
NPM is BSD-3-Clause
GitHub is BSD-3-Clause: https://github.com/ecomfe/zrender/blob/4.0.4/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [zrender 4.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/zrender/4.0.4/4.0.4)