### PR TITLE
commons-jelly/commons-jelly-tags-xml 1.1

### DIFF
--- a/curations/maven/mavencentral/commons-jelly/commons-jelly-tags-xml.yaml
+++ b/curations/maven/mavencentral/commons-jelly/commons-jelly-tags-xml.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: commons-jelly-tags-xml
+  namespace: commons-jelly
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-jelly/commons-jelly-tags-xml 1.1

**Details:**
ClearlyDefined license is Apache-2.0: https://clearlydefined.io/file/c71d239df91726fc519c6eb72d318ec65820627232b2f796219e87dcf35d0ab4
Maven license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [commons-jelly-tags-xml 1.1](https://clearlydefined.io/definitions/maven/mavencentral/commons-jelly/commons-jelly-tags-xml/1.1/1.1)