### PR TITLE
commons-jelly/commons-jelly-tags-xml 1.1

### DIFF
--- a/curations/nuget/nuget/-/Jil.yaml
+++ b/curations/nuget/nuget/-/Jil.yaml
@@ -6,6 +6,9 @@ revisions:
   2.14.0:
     licensed:
       declared: MIT
+  2.14.5:
+    licensed:
+      declared: MIT
   2.15.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
commons-jelly/commons-jelly-tags-xml 1.1

**Details:**
Nuget is MIT
GitHub is MIT: https://github.com/kevin-montrose/Jil/blob/2.14.5/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Jil 2.14.5](https://clearlydefined.io/definitions/nuget/nuget/-/Jil/2.14.5/2.14.5)