### PR TITLE
org.jmock/jmock 2.6.0

### DIFF
--- a/curations/maven/mavencentral/org.jmock/jmock.yaml
+++ b/curations/maven/mavencentral/org.jmock/jmock.yaml
@@ -7,3 +7,6 @@ revisions:
   2.4.0:
     licensed:
       declared: BSD-3-Clause
+  2.6.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jmock/jmock 2.6.0

**Details:**
Maven is BSD-3-Clause: http://jmock.org/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jmock 2.6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.jmock/jmock/2.6.0/2.6.0)