### PR TITLE
org.apache.zookeeper/zookeeper 3.4.8

### DIFF
--- a/curations/maven/mavencentral/org.apache.zookeeper/zookeeper.yaml
+++ b/curations/maven/mavencentral/org.apache.zookeeper/zookeeper.yaml
@@ -10,3 +10,6 @@ revisions:
   3.4.7:
     licensed:
       declared: Apache-2.0
+  3.4.8:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.zookeeper/zookeeper 3.4.8

**Details:**
Maven JAR is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [zookeeper 3.4.8](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.zookeeper/zookeeper/3.4.8/3.4.8)