### PR TITLE
com.github.stephenc.high-scale-lib/high-scale-lib 1.1.4

### DIFF
--- a/curations/maven/mavencentral/com.github.stephenc.high-scale-lib/high-scale-lib.yaml
+++ b/curations/maven/mavencentral/com.github.stephenc.high-scale-lib/high-scale-lib.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: high-scale-lib
+  namespace: com.github.stephenc.high-scale-lib
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.4:
+    licensed:
+      declared: CC-PDDC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.github.stephenc.high-scale-lib/high-scale-lib 1.1.4

**Details:**
ClearlyDefined license is CC-PDDC
Maven pom references CC Public Domain

**Resolution:**
CC-PDDC

**Affected definitions**:
- [high-scale-lib 1.1.4](https://clearlydefined.io/definitions/maven/mavencentral/com.github.stephenc.high-scale-lib/high-scale-lib/1.1.4/1.1.4)