### PR TITLE
org.jvnet.hudson/jtidy 4aug2000r7-dev-hudson-1

### DIFF
--- a/curations/maven/mavencentral/org.jvnet.hudson/jtidy.yaml
+++ b/curations/maven/mavencentral/org.jvnet.hudson/jtidy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jtidy
+  namespace: org.jvnet.hudson
+  provider: mavencentral
+  type: maven
+revisions:
+  4aug2000r7-dev-hudson-1:
+    licensed:
+      declared: HTMLTIDY


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jvnet.hudson/jtidy 4aug2000r7-dev-hudson-1

**Details:**
POM References HTMLTIDY license:
https://repo1.maven.org/maven2/jtidy/jtidy/4aug2000r7-dev/jtidy-4aug2000r7-dev.pom

**Resolution:**
HTMLTIDY

**Affected definitions**:
- [jtidy 4aug2000r7-dev-hudson-1](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet.hudson/jtidy/4aug2000r7-dev-hudson-1/4aug2000r7-dev-hudson-1)