### PR TITLE
mysql/mysql-connector-java 5.1.49

### DIFF
--- a/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
+++ b/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   5.1.49:
     licensed:
-      declared: GPL-2.0-only
+      declared: GPL-2.0-only WITH Universal-FOSS-exception-1.0
   8.0.11:
     licensed:
       declared: OTHER

--- a/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
+++ b/curations/maven/mavencentral/mysql/mysql-connector-java.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.1.49:
+    licensed:
+      declared: GPL-2.0-only
   8.0.11:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mysql/mysql-connector-java 5.1.49

**Details:**
Should be GPL-2.0-only WITH Universal-FOSS-exception-1.0.  Having trouble adding the WITH and will update the yaml

**Resolution:**
The pom references the exception and so do the file headers.  As of 2018, the exception is the Universal-FOSS-exception-1.0, as stated here: https://www.mysql.com/about/legal/licensing/foss-exception/

**Affected definitions**:
- [mysql-connector-java 5.1.49](https://clearlydefined.io/definitions/maven/mavencentral/mysql/mysql-connector-java/5.1.49/5.1.49)