### PR TITLE
ansi-to-react 3.3.4

### DIFF
--- a/curations/npm/npmjs/-/ansi-to-react.yaml
+++ b/curations/npm/npmjs/-/ansi-to-react.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ansi-to-react
+  provider: npmjs
+  type: npm
+revisions:
+  3.3.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ansi-to-react 3.3.4

**Details:**
BSD-3-Clause - see https://github.com/nteract/ansi-to-react/issues/39

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [ansi-to-react 3.3.4](https://clearlydefined.io/definitions/npm/npmjs/-/ansi-to-react/3.3.4/3.3.4)