### PR TITLE
ansi-to-react 4.0.3-alpha.0

### DIFF
--- a/curations/npm/npmjs/-/ansi-to-react.yaml
+++ b/curations/npm/npmjs/-/ansi-to-react.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ansi-to-react
+  provider: npmjs
+  type: npm
+revisions:
+  4.0.3-alpha.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ansi-to-react 4.0.3-alpha.0

**Details:**
BSD-3-Clause - see https://github.com/nteract/ansi-to-react/issues/39

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [ansi-to-react 4.0.3-alpha.0](https://clearlydefined.io/definitions/npm/npmjs/-/ansi-to-react/4.0.3-alpha.0/4.0.3-alpha.0)