### PR TITLE
License should not include NOASSERTION

### DIFF
--- a/curations/maven/mavencentral/org.postgresql/postgresql.yaml
+++ b/curations/maven/mavencentral/org.postgresql/postgresql.yaml
@@ -10,6 +10,12 @@ revisions:
           - 'Copyright (c) 1997, PostgreSQL Global Development Group'
         license: BSD-2-Clause
         path: META-INF/LICENSE
+  42.3.3:
+    files:
+      - attributions:
+          - 'Copyright (c) 1997, PostgreSQL Global Development Group'
+        license: BSD-2-Clause
+        path: META-INF/LICENSE
   9.3-1102-jdbc41:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License should not include NOASSERTION

**Details:**
The license file in the META-INF folder gives no indication of NOASSERTION. Instead, it seems to be very clear about the fact that the component is BSD-2 licensed

**Resolution:**
Remove the NOASSERTION and APACHE-2.0 key words from the discovered license

Also see https://github.com/clearlydefined/curated-data/pull/17865

**Affected definitions**:
- [postgresql 42.3.3](https://clearlydefined.io/definitions/maven/mavencentral/org.postgresql/postgresql/42.3.3/42.3.3)