### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/gsliepen/tinc.yaml
+++ b/curations/git/github/gsliepen/tinc.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tinc
+  namespace: gsliepen
+  provider: github
+  type: git
+revisions:
+  0edef996a6d944e9143f87dd3c72390979c33630:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing.

**Resolution:**
Filled in the appropriate declared license as per https://github.com/gsliepen/tinc/blob/0edef996a6d944e9143f87dd3c72390979c33630/COPYING and http://tinc-vpn.org/.

**Affected definitions**:
- [tinc 0edef996a6d944e9143f87dd3c72390979c33630](https://clearlydefined.io/definitions/git/github/gsliepen/tinc/0edef996a6d944e9143f87dd3c72390979c33630/0edef996a6d944e9143f87dd3c72390979c33630)