### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/fmtlib/fmt.yaml
+++ b/curations/git/github/fmtlib/fmt.yaml
@@ -30,6 +30,9 @@ revisions:
         path: LICENSE.rst
     licensed:
       declared: OTHER
+  cc09f1a6798c085c325569ef466bcdcffdc266d4:
+    licensed:
+      declared: MIT
   cd4af11efc9c622896a3e4cb599fa28668ca3d05:
     licensed:
       declared: OTHER

--- a/curations/git/github/fmtlib/fmt.yaml
+++ b/curations/git/github/fmtlib/fmt.yaml
@@ -32,7 +32,7 @@ revisions:
       declared: OTHER
   cc09f1a6798c085c325569ef466bcdcffdc266d4:
     licensed:
-      declared: MIT
+      declared: OTHER
   cd4af11efc9c622896a3e4cb599fa28668ca3d05:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License missing MIT License 
File Location 
https://github.com/fmtlib/fmt/tree/cc09f1a6798c085c325569ef466bcdcffdc266d4

In Github link they have mentioned "{fmt} is distributed under the MIT license."


**Resolution:**
https://github.com/fmtlib/fmt/tree/cc09f1a6798c085c325569ef466bcdcffdc266d4




**Affected definitions**:
- [fmt cc09f1a6798c085c325569ef466bcdcffdc266d4](https://clearlydefined.io/definitions/git/github/fmtlib/fmt/cc09f1a6798c085c325569ef466bcdcffdc266d4/cc09f1a6798c085c325569ef466bcdcffdc266d4)