### PR TITLE
pylint 2.3.1

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -28,6 +28,9 @@ revisions:
         path: pylint-2.3.0/setup.py
     licensed:
       declared: GPL-2.0-only
+  2.3.1:
+    licensed:
+      declared: GPL-2.0-only
   2.4.4:
     licensed:
       declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint 2.3.1

**Details:**
Not GPL-3.0.  COPYING file is GPL-2.0.  Looked in the header of some files and it seems to be GPL-2.0-only

**Resolution:**
GPL-2.0-only

**Affected definitions**:
- [pylint 2.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.3.1/2.3.1)