### PR TITLE
com.google.code.findbugs:jsr305 3.0.2

### DIFF
--- a/curations/sourcearchive/mavencentral/com.google.code.findbugs/jsr305.yaml
+++ b/curations/sourcearchive/mavencentral/com.google.code.findbugs/jsr305.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   3.0.2:
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause

--- a/curations/sourcearchive/mavencentral/com.google.code.findbugs/jsr305.yaml
+++ b/curations/sourcearchive/mavencentral/com.google.code.findbugs/jsr305.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsr305
+  namespace: com.google.code.findbugs
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  3.0.2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is incorrect in Maven Central

**Details:**
The correct license is here https://github.com/findbugsproject/findbugs/blob/master/findbugs/licenses/LICENSE-jsr305.txt


**Resolution:**
License is updated

**Affected definitions**:
- [jsr305 3.0.2](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.google.code.findbugs/jsr305/3.0.2/3.0.2)