### PR TITLE
net.java.dev.jna:jna 5.9.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -15,4 +15,4 @@ revisions:
       declared: Apache-2.0 OR LGPL-2.1-or-later
   5.9.0:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 OR LGPL-2.1-or-later

--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -13,3 +13,6 @@ revisions:
   4.1.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later
+  5.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.java.dev.jna:jna

**Details:**
Since version 4.0 it is on Apache 2.0 license

**Resolution:**
Updates license to Apache 2.0. See https://github.com/java-native-access/jna/blob/master/LICENSE

**Affected definitions**:
- [jna 5.9.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/5.9.0/5.9.0)