### PR TITLE
net.java.dev.jna:jna-platform 5.9.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
@@ -6,10 +6,10 @@ coordinates:
 revisions:
   4.0.0:
     licensed:
-      declared: LGPL-2.1-or-later OR Apache-2.0
+      declared: Apache-2.0 OR LGPL-2.1-or-later
   4.1.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later
   5.9.0:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 OR LGPL-2.1-or-later

--- a/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna-platform.yaml
@@ -10,3 +10,6 @@ revisions:
   4.1.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later
+  5.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.java.dev.jna:jna-platform:5.9.0

**Details:**
Since version 4.0 it is on Apache 2.0 license

**Resolution:**
Updates license to Apache 2.0. See https://github.com/java-native-access/jna/blob/master/LICENSE

**Affected definitions**:
- [jna-platform 5.9.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna-platform/5.9.0/5.9.0)