### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/maven/mavencentral/org.jvnet/animal-sniffer-annotation.yaml
+++ b/curations/maven/mavencentral/org.jvnet/animal-sniffer-annotation.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: animal-sniffer-annotation
+  namespace: org.jvnet
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is one NOASSERTION mentioned in the Declared License. But there is CDDL 1.0 License declared in the following Repository 
https://mvnrepository.com/artifact/org.jvnet/animal-sniffer-annotation/1.0

**Resolution:**
Since there is CDDL 1.0 License found in the Source Code Repository of the FOSS Component, it is being curated as CDD-1.0 instead if NOASSERTION. 
License Details : https://mvnrepository.com/artifact/org.jvnet/animal-sniffer-annotation/1.0

**Affected definitions**:
- [animal-sniffer-annotation 1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet/animal-sniffer-annotation/1.0/1.0)