### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/maven/mavencentral/javax/javaee-web-api.yaml
+++ b/curations/maven/mavencentral/javax/javaee-web-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javaee-web-api
+  namespace: javax
+  provider: mavencentral
+  type: maven
+revisions:
+  8.0.1:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception

--- a/curations/maven/mavencentral/javax/javaee-web-api.yaml
+++ b/curations/maven/mavencentral/javax/javaee-web-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   8.0.1:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is one NOASSERTION mentioned in the Declared License where as the Maven Repository shows the Component is Dual Licensed under CDDL 1.1  or GPL 2.0 with Classpath Exception
License Details Path : https://repo1.maven.org/maven2/javax/javaee-web-api/8.0.1/javaee-web-api-8.0.1.pom


**Resolution:**
Since there is Dual License information found in the Source Code Repository, the Declared License is being Curated as CDDL 1.1 OR GPL-2.0-With Classpath-exception
License Details : https://javaee.github.io/glassfish/LICENSE

**Affected definitions**:
- [javaee-web-api 8.0.1](https://clearlydefined.io/definitions/maven/mavencentral/javax/javaee-web-api/8.0.1/8.0.1)