### PR TITLE
Bond.Runtime.CSharp 4.3.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
@@ -51,6 +51,9 @@ revisions:
   4.2.1:
     licensed:
       declared: MIT
+  4.3.0:
+    licensed:
+      declared: MIT
   5.0.0:
     described:
       releaseDate: '2016-09-13'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bond.Runtime.CSharp 4.3.0

**Details:**
NuGet is MIT: https://github.com/Microsoft/bond/blob/4.3.0/LICENSE
GitHub is MIT

**Resolution:**
MIT

**Affected definitions**:
- [Bond.Runtime.CSharp 4.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Runtime.CSharp/4.3.0/4.3.0)