### PR TITLE
NuGet.Protocol.Core.Types 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Protocol.Core.Types.yaml
+++ b/curations/nuget/nuget/-/NuGet.Protocol.Core.Types.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Protocol.Core.Types 3.5.0

**Details:**
Nuget is Apache-2.0: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt
GitHub is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Protocol.Core.Types 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Protocol.Core.Types/3.5.0/3.5.0)