### PR TITLE
scss-parser 1.0.5

### DIFF
--- a/curations/npm/npmjs/-/scss-parser.yaml
+++ b/curations/npm/npmjs/-/scss-parser.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.4:
     licensed:
       declared: BSD-3-Clause
+  1.0.5:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scss-parser 1.0.5

**Details:**
ClearlyDefined license is BSD-3-Clause
NPM states see license 
GitHub is BSD-3-Clause: https://github.com/salesforce-ux/scss-parser#readme

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scss-parser 1.0.5](https://clearlydefined.io/definitions/npm/npmjs/-/scss-parser/1.0.5/1.0.5)