### PR TITLE
jekyll-oembed 0.0.1

### DIFF
--- a/curations/gem/rubygems/-/jekyll-oembed.yaml
+++ b/curations/gem/rubygems/-/jekyll-oembed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: jekyll-oembed
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jekyll-oembed 0.0.1

**Details:**
RubyGems states NONE
GitHub has no license: https://github.com/stereobooster/jekyll_oembed

**Resolution:**
NONE

**Affected definitions**:
- [jekyll-oembed 0.0.1](https://clearlydefined.io/definitions/gem/rubygems/-/jekyll-oembed/0.0.1/0.0.1)