### PR TITLE
coverlet.msbuild 2.5.0

### DIFF
--- a/curations/nuget/nuget/-/coverlet.msbuild.yaml
+++ b/curations/nuget/nuget/-/coverlet.msbuild.yaml
@@ -9,6 +9,9 @@ revisions:
   2.4.0:
     licensed:
       declared: MIT
+  2.5.0:
+    licensed:
+      declared: MIT
   2.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
coverlet.msbuild 2.5.0

**Details:**
Nuget is MIT
GitHub is MIT: https://github.com/coverlet-coverage/coverlet/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [coverlet.msbuild 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/coverlet.msbuild/2.5.0/2.5.0)