### PR TITLE
https://github.com/angular/angular.js/blob/v 1.6.8/LICENSE

### DIFF
--- a/curations/nuget/nuget/-/AngularJS.Core.yaml
+++ b/curations/nuget/nuget/-/AngularJS.Core.yaml
@@ -27,6 +27,9 @@ revisions:
   1.6.5:
     licensed:
       declared: MIT
+  1.6.8:
+    licensed:
+      declared: MIT
   1.6.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
https://github.com/angular/angular.js/blob/v 1.6.8/LICENSE

**Details:**
Nuget is MIT
GitHub is MIT: https://github.com/angular/angular.js/blob/v1.6.8/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [AngularJS.Core 1.6.8](https://clearlydefined.io/definitions/nuget/nuget/-/AngularJS.Core/1.6.8/1.6.8)