### PR TITLE
https://mvnrepository.com/artifact/org.kohsuke.jinterop/j-interop/ 2.0.8-kohsuke-1

### DIFF
--- a/curations/maven/mavencentral/org.kohsuke.jinterop/j-interop.yaml
+++ b/curations/maven/mavencentral/org.kohsuke.jinterop/j-interop.yaml
@@ -6,4 +6,7 @@ coordinates:
 revisions:
   2.0.6-kohsuke-1:
     licensed:
-      declared: MIT
+      declared: LGPL-3.0-or-later
+  2.0.8-kohsuke-1:
+    licensed:
+      declared: LGPL-3.0-or-later

--- a/curations/maven/mavencentral/org.kohsuke.jinterop/j-interop.yaml
+++ b/curations/maven/mavencentral/org.kohsuke.jinterop/j-interop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: j-interop
+  namespace: org.kohsuke.jinterop
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.6-kohsuke-1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
https://mvnrepository.com/artifact/org.kohsuke.jinterop/j-interop/ 2.0.8-kohsuke-1

**Details:**
Maven is MIT: https://mvnrepository.com/artifact/org.kohsuke.jinterop/j-interop/2.0.8-kohsuke-1

**Resolution:**
MIT

**Affected definitions**:
- [j-interop 2.0.6-kohsuke-1](https://clearlydefined.io/definitions/maven/mavencentral/org.kohsuke.jinterop/j-interop/2.0.6-kohsuke-1/2.0.6-kohsuke-1)