### PR TITLE
com.h2database/h2 1.4.190

### DIFF
--- a/curations/maven/mavencentral/com.h2database/h2.yaml
+++ b/curations/maven/mavencentral/com.h2database/h2.yaml
@@ -7,6 +7,9 @@ revisions:
   1.3.166:
     licensed:
       declared: MPL-2.0 OR EPL-1.0
+  1.4.190:
+    licensed:
+      declared: MPL-2.0 OR EPL-1.0
   1.4.192:
     licensed:
       declared: MPL-2.0 OR EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.h2database/h2 1.4.190

**Details:**
Maven license is MPL-2.0 OR EPL-1.0:  http://h2database.com/html/license.html

**Resolution:**
MPL-2.0 OR EPL-1.0

**Affected definitions**:
- [h2 1.4.190](https://clearlydefined.io/definitions/maven/mavencentral/com.h2database/h2/1.4.190/1.4.190)