### PR TITLE
ColorCode 1.0.1

### DIFF
--- a/curations/nuget/nuget/-/ColorCode.yaml
+++ b/curations/nuget/nuget/-/ColorCode.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.1:
     licensed:
-      declared: NONE
+      declared: MS-PL

--- a/curations/nuget/nuget/-/ColorCode.yaml
+++ b/curations/nuget/nuget/-/ColorCode.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ColorCode
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ColorCode 1.0.1

**Details:**
Nuget link is broken
GitHub link is broken
Nuspec license link is broken

**Resolution:**
NONE

**Affected definitions**:
- [ColorCode 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/ColorCode/1.0.1/1.0.1)