### PR TITLE
NuGet.Packaging 4.9.2

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.yaml
@@ -24,6 +24,9 @@ revisions:
   4.8.0:
     licensed:
       declared: Apache-2.0
+  4.9.2:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging 4.9.2

**Details:**
Nuget is Apache-2.0: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt
GitHub is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Packaging 4.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging/4.9.2/4.9.2)