### PR TITLE
javax.measure/jsr- 2750.9.3

### DIFF
--- a/curations/maven/mavencentral/javax.measure/jsr-275.yaml
+++ b/curations/maven/mavencentral/javax.measure/jsr-275.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.9.3:
+    licensed:
+      declared: OTHER
   1.0.0:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.measure/jsr- 2750.9.3

**Details:**
POM state "Specification License": https://repo1.maven.org/maven2/javax/measure/jsr-275/0.9.3/jsr-275-0.9.3.pom

**Resolution:**
OTHER

**Affected definitions**:
- [jsr-275 0.9.3](https://clearlydefined.io/definitions/maven/mavencentral/javax.measure/jsr-275/0.9.3/0.9.3)