### PR TITLE
net.sf.jtidy/jtidy r938

### DIFF
--- a/curations/maven/mavencentral/net.sf.jtidy/jtidy.yaml
+++ b/curations/maven/mavencentral/net.sf.jtidy/jtidy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jtidy
+  namespace: net.sf.jtidy
+  provider: mavencentral
+  type: maven
+revisions:
+  r938:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
net.sf.jtidy/jtidy r938

**Details:**
Maven is a HTMLTIDY but has modifications which make it OTHER:  http://jtidy.sourceforge.net/license.html

**Resolution:**
OTHER

**Affected definitions**:
- [jtidy r938](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.jtidy/jtidy/r938/r938)