### PR TITLE
org.mvel/mvel2 2.0.14

### DIFF
--- a/curations/maven/mavencentral/org.mvel/mvel2.yaml
+++ b/curations/maven/mavencentral/org.mvel/mvel2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mvel2
+  namespace: org.mvel
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.14:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.mvel/mvel2 2.0.14

**Details:**
POM does not include license but an earlier version noted Apache-2.0: https://repo1.maven.org/maven2/org/codehaus/mvel/1.2.22-java1.6/mvel-1.2.22-java1.6.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [mvel2 2.0.14](https://clearlydefined.io/definitions/maven/mavencentral/org.mvel/mvel2/2.0.14/2.0.14)