### PR TITLE
https://repo1.maven.org/maven2/org/aspectj/aspectjrt/1.9.5/aspectjrt- 1.9.5.pom

### DIFF
--- a/curations/maven/mavencentral/org.aspectj/aspectjrt.yaml
+++ b/curations/maven/mavencentral/org.aspectj/aspectjrt.yaml
@@ -13,6 +13,9 @@ revisions:
   1.9.1:
     licensed:
       declared: EPL-1.0
+  1.9.5:
+    licensed:
+      declared: EPL-1.0
   1.9.7.M3:
     licensed:
       declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
https://repo1.maven.org/maven2/org/aspectj/aspectjrt/1.9.5/aspectjrt- 1.9.5.pom

**Details:**
Maven pom is EPL-1.0: https://repo1.maven.org/maven2/org/aspectj/aspectjrt/1.9.5/aspectjrt-1.9.5.pom

**Resolution:**
EPL-1.0

**Affected definitions**:
- [aspectjrt 1.9.5](https://clearlydefined.io/definitions/maven/mavencentral/org.aspectj/aspectjrt/1.9.5/1.9.5)