### PR TITLE
ibrik 2.0.0

### DIFF
--- a/curations/npm/npmjs/-/ibrik.yaml
+++ b/curations/npm/npmjs/-/ibrik.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.1:
     licensed:
       declared: BSD-2-Clause
+  2.0.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ibrik 2.0.0

**Details:**
NPM license states NONE
GitHub license is BSD-2-Clause: https://github.com/Constellation/ibrik/blob/2.0.0/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [ibrik 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/ibrik/2.0.0/2.0.0)