### PR TITLE
npmconf 2.1.1

### DIFF
--- a/curations/npm/npmjs/-/npmconf.yaml
+++ b/curations/npm/npmjs/-/npmconf.yaml
@@ -6,3 +6,6 @@ revisions:
   0.0.24:
     licensed:
       declared: BSD-2-Clause
+  2.1.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
npmconf 2.1.1

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM states BSD
GitHub is BSD-2-Clause: https://github.com/npm/npmconf/blob/v2.1.1/LICENSE


**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [npmconf 2.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/npmconf/2.1.1/2.1.1)