### PR TITLE
org.bytedeco:javacpp 1.5.6

### DIFF
--- a/curations/maven/mavencentral/org.bytedeco/javacpp.yaml
+++ b/curations/maven/mavencentral/org.bytedeco/javacpp.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.5.6:
     licensed:
-      declared: Apache-2.0 OR GPL-2.0-with-classpath-exception
+      declared: Apache-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.bytedeco/javacpp.yaml
+++ b/curations/maven/mavencentral/org.bytedeco/javacpp.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: javacpp
+  namespace: org.bytedeco
+  provider: mavencentral
+  type: maven
+revisions:
+  1.5.6:
+    licensed:
+      declared: Apache-2.0 OR GPL-2.0-with-classpath-exception


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.bytedeco:javacpp 1.5.6

**Details:**
It's dual-licensed, Apache 2.0 or GPL 2.0 with classpath exception

**Resolution:**
Added GPL-2.0-with-classpath-exception license.
Repo: https://github.com/bytedeco/javacpp/blob/master/LICENSE.txt
POM: https://github.com/bytedeco/javacpp/blob/master/pom.xml
Bytedeco FAQ: http://bytedeco.org/faq/

**Affected definitions**:
- [javacpp 1.5.6](https://clearlydefined.io/definitions/maven/mavencentral/org.bytedeco/javacpp/1.5.6/1.5.6)