### PR TITLE
org.bytedeco:ffmpeg 1.5.6

### DIFF
--- a/curations/maven/mavencentral/org.bytedeco/ffmpeg.yaml
+++ b/curations/maven/mavencentral/org.bytedeco/ffmpeg.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   4.4-1.5.6:
     licensed:
-      declared: (Apache-2.0 OR GPL-2.0-with-classpath-exception) AND (LGPL-2.1-or-later OR GPL-2.0-or-later)
+      declared: Apache-2.0 OR GPL-2.0-or-later WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.bytedeco/ffmpeg.yaml
+++ b/curations/maven/mavencentral/org.bytedeco/ffmpeg.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ffmpeg
+  namespace: org.bytedeco
+  provider: mavencentral
+  type: maven
+revisions:
+  4.4-1.5.6:
+    licensed:
+      declared: (Apache-2.0 OR GPL-2.0-with-classpath-exception) AND (LGPL-2.1-or-later OR GPL-2.0-or-later)


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.bytedeco:ffmpeg 1.5.6

**Details:**
FFmpeg component has multiple artifacts: Java and native OS-specific FFmpeg binaries.
Java and native components have different licenses.
Also Java part is dual-licensed.

**Resolution:**
Added 2 groups: Java and native binaries.
Not sure if it's 100% correct notation for such case, but it looks right to me.
Repo: https://github.com/bytedeco/javacpp-presets/blob/master/LICENSE.txt
Native: https://github.com/bytedeco/javacpp-presets/blob/master/ffmpeg/LICENSE.md

**Affected definitions**:
- [ffmpeg 4.4-1.5.6](https://clearlydefined.io/definitions/maven/mavencentral/org.bytedeco/ffmpeg/4.4-1.5.6/4.4-1.5.6)