### PR TITLE
MicrosoftCognitiveServicesSpeech-iOS 1.9.0

### DIFF
--- a/curations/pod/cocoapods/-/MicrosoftCognitiveServicesSpeech-iOS.yaml
+++ b/curations/pod/cocoapods/-/MicrosoftCognitiveServicesSpeech-iOS.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MicrosoftCognitiveServicesSpeech-iOS
+  provider: cocoapods
+  type: pod
+revisions:
+  1.9.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MicrosoftCognitiveServicesSpeech-iOS 1.9.0

**Details:**
ClearlyDefined license is OTHER (Microsoft SLT)

**Resolution:**
OTHER

**Affected definitions**:
- [MicrosoftCognitiveServicesSpeech-iOS 1.9.0](https://clearlydefined.io/definitions/pod/cocoapods/-/MicrosoftCognitiveServicesSpeech-iOS/1.9.0/1.9.0)