### PR TITLE
KIF 3.7.7

### DIFF
--- a/curations/pod/cocoapods/-/KIF.yaml
+++ b/curations/pod/cocoapods/-/KIF.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: KIF
+  provider: cocoapods
+  type: pod
+revisions:
+  3.7.7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
KIF 3.7.7

**Details:**
ClearlyDefined license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [KIF 3.7.7](https://clearlydefined.io/definitions/pod/cocoapods/-/KIF/3.7.7/3.7.7)