### PR TITLE
jxck/assert a617d24d4e752e4299a6de4f78b1c23bfa9c49e8

### DIFF
--- a/curations/git/github/jxck/assert.yaml
+++ b/curations/git/github/jxck/assert.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: assert
+  namespace: jxck
+  provider: github
+  type: git
+revisions:
+  a617d24d4e752e4299a6de4f78b1c23bfa9c49e8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jxck/assert a617d24d4e752e4299a6de4f78b1c23bfa9c49e8

**Details:**
Package.json indicates MIT
GitHub Readme indicates MIT: 
https://github.com/jxck/assert/tree/a617d24d4e752e4299a6de4f78b1c23bfa9c49e8

**Resolution:**
MIT

**Affected definitions**:
- [assert a617d24d4e752e4299a6de4f78b1c23bfa9c49e8](https://clearlydefined.io/definitions/git/github/jxck/assert/a617d24d4e752e4299a6de4f78b1c23bfa9c49e8/a617d24d4e752e4299a6de4f78b1c23bfa9c49e8)