### PR TITLE
GCDWebServer 3.4.2

### DIFF
--- a/curations/pod/cocoapods/-/GCDWebServer.yaml
+++ b/curations/pod/cocoapods/-/GCDWebServer.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: cocoapods
   type: pod
 revisions:
+  3.4.2:
+    licensed:
+      declared: BSD-3-Clause
   3.5.4:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GCDWebServer 3.4.2

**Details:**
ClearlyDefined license is BSD-3-CLause
GitHub is BSD-3-Clause: https://github.com/swisspol/GCDWebServer/blob/3.4.2/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [GCDWebServer 3.4.2](https://clearlydefined.io/definitions/pod/cocoapods/-/GCDWebServer/3.4.2/3.4.2)