### PR TITLE
glog 0.3.4

### DIFF
--- a/curations/pod/cocoapods/-/glog.yaml
+++ b/curations/pod/cocoapods/-/glog.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: glog
+  provider: cocoapods
+  type: pod
+revisions:
+  0.3.4:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
glog 0.3.4

**Details:**
ClearlyDefined COPYING file is BSD-3-Clause
GitHub COPYING file is BSD-3-Clause:  https://github.com/google/glog/blob/v0.3.4/COPYING

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [glog 0.3.4](https://clearlydefined.io/definitions/pod/cocoapods/-/glog/0.3.4/0.3.4)