### PR TITLE
nokogiri 1.12.3

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  1.12.3:
+    licensed:
+      declared: MIT
   1.12.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri 1.12.3

**Details:**
The tooling took all the dependency licenses and put them in the declared field.  

**Resolution:**
The declared license is just "MIT" - https://github.com/sparklemotion/nokogiri/blob/daeea44a612b90796805375ce9b7680f34e1cf71/LICENSE.md

**Affected definitions**:
- [nokogiri 1.12.3](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.12.3/1.12.3)