### PR TITLE
Source location was not pointing to the real source code.

### DIFF
--- a/curations/maven/mavencentral/org.mariadb.jdbc/mariadb-java-client.yaml
+++ b/curations/maven/mavencentral/org.mariadb.jdbc/mariadb-java-client.yaml
@@ -197,6 +197,14 @@ revisions:
     licensed:
       declared: LGPL-2.1-or-later
   2.4.2:
+    described:
+      sourceLocation:
+        name: mariadb-connector-j
+        namespace: mariadb-corporation
+        provider: github
+        revision: c160500cc2e7eb423c37cc72f2c95151e67954f5
+        type: git
+        url: 'https://github.com/mariadb-corporation/mariadb-connector-j/commit/c160500cc2e7eb423c37cc72f2c95151e67954f5'
     licensed:
       declared: LGPL-2.1-or-later
   2.4.3:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Source location was not pointing to the real source code.

**Details:**
Source location was the maven page.

**Resolution:**
Filled in the github link, https://github.com/mariadb-corporation/mariadb-connector-j/tree/c160500cc2e7eb423c37cc72f2c95151e67954f5 as the source URL.

**Affected definitions**:
- [mariadb-java-client 2.4.2](https://clearlydefined.io/definitions/maven/mavencentral/org.mariadb.jdbc/mariadb-java-client/2.4.2/2.4.2)