### PR TITLE
textmate/perl.tmbundle 80826abe75250286c2a1a07958e50e8551d3f50c

### DIFF
--- a/curations/git/github/textmate/perl.tmbundle.yaml
+++ b/curations/git/github/textmate/perl.tmbundle.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: perl.tmbundle
+  namespace: textmate
+  provider: github
+  type: git
+revisions:
+  80826abe75250286c2a1a07958e50e8551d3f50c:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
textmate/perl.tmbundle 80826abe75250286c2a1a07958e50e8551d3f50c

**Details:**
ClearlyDefined and GitHub Readme is OTHER: https://github.com/textmate/perl.tmbundle/tree/80826abe75250286c2a1a07958e50e8551d3f50c

**Resolution:**
OTHER

**Affected definitions**:
- [perl.tmbundle 80826abe75250286c2a1a07958e50e8551d3f50c](https://clearlydefined.io/definitions/git/github/textmate/perl.tmbundle/80826abe75250286c2a1a07958e50e8551d3f50c/80826abe75250286c2a1a07958e50e8551d3f50c)