### PR TITLE
scottjehl/respond b21c5785e8442cca651f532ce72e6e515817ad3d

### DIFF
--- a/curations/git/github/scottjehl/respond.yaml
+++ b/curations/git/github/scottjehl/respond.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   b21c5785e8442cca651f532ce72e6e515817ad3d:
     licensed:
-      declared: MIT
+      declared: GPL-2.0-only OR MIT

--- a/curations/git/github/scottjehl/respond.yaml
+++ b/curations/git/github/scottjehl/respond.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: respond
+  namespace: scottjehl
+  provider: github
+  type: git
+revisions:
+  b21c5785e8442cca651f532ce72e6e515817ad3d:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
scottjehl/respond b21c5785e8442cca651f532ce72e6e515817ad3d

**Details:**
At the time of the release 2012 there doesn't appear to have been a license but MIT with a 2012 copyright date was added in 2013
GitHub license is MIT: https://github.com/scottjehl/Respond/blob/0ce59f0847d7f9a243db6a81616fcf9e21f3724f/LICENSE-MIT

**Resolution:**
MIT

**Affected definitions**:
- [respond b21c5785e8442cca651f532ce72e6e515817ad3d](https://clearlydefined.io/definitions/git/github/scottjehl/respond/b21c5785e8442cca651f532ce72e6e515817ad3d/b21c5785e8442cca651f532ce72e6e515817ad3d)