### PR TITLE
CNTK.CPUOnly 2.0.0-rc1

### DIFF
--- a/curations/nuget/nuget/-/CNTK.CPUOnly.yaml
+++ b/curations/nuget/nuget/-/CNTK.CPUOnly.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0-rc1:
+    licensed:
+      declared: MIT
   2.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CNTK.CPUOnly 2.0.0-rc1

**Details:**
Nuget links to MIT
GitHub links to MIT: https://github.com/microsoft/CNTK/blob/master/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [CNTK.CPUOnly 2.0.0-rc1](https://clearlydefined.io/definitions/nuget/nuget/-/CNTK.CPUOnly/2.0.0-rc1/2.0.0-rc1)