### PR TITLE
vow-fs 0.3.1

### DIFF
--- a/curations/npm/npmjs/-/vow-fs.yaml
+++ b/curations/npm/npmjs/-/vow-fs.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.3.1:
     licensed:
-      declared: MIT
+      declared: MIT OR GPL-1.0-or-later

--- a/curations/npm/npmjs/-/vow-fs.yaml
+++ b/curations/npm/npmjs/-/vow-fs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: vow-fs
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
vow-fs 0.3.1

**Details:**
ClearlyDefined package.json no license info
NPM Indicates MIT
GitHub is MIT (for version published in 2016 and this package was released in 2014): https://github.com/dfilatov/vow-fs/blob/master/LICENSE 

**Resolution:**
MIT

**Affected definitions**:
- [vow-fs 0.3.1](https://clearlydefined.io/definitions/npm/npmjs/-/vow-fs/0.3.1/0.3.1)