### PR TITLE
junit-addons/junit-addons 1.4

### DIFF
--- a/curations/maven/mavencentral/junit-addons/junit-addons.yaml
+++ b/curations/maven/mavencentral/junit-addons/junit-addons.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: junit-addons
+  namespace: junit-addons
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.4':
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavencentral/junit-addons/junit-addons.yaml
+++ b/curations/maven/mavencentral/junit-addons/junit-addons.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.4':
     licensed:
-      declared: OTHER
+      declared: Apache-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
junit-addons/junit-addons 1.4

**Details:**
Maven pom has no license info
Jar includes license which is OTHER (The JUnit-addons Software License, Version 1.0
 (based on the Apache Software License, Version 1.1)

**Resolution:**
OTHER

**Affected definitions**:
- [junit-addons 1.4](https://clearlydefined.io/definitions/maven/mavencentral/junit-addons/junit-addons/1.4/1.4)