### PR TITLE
owl.carousel 2.3.4

### DIFF
--- a/curations/npm/npmjs/-/owl.carousel.yaml
+++ b/curations/npm/npmjs/-/owl.carousel.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: owl.carousel
+  provider: npmjs
+  type: npm
+revisions:
+  2.3.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
owl.carousel 2.3.4

**Details:**
NPM license field states see license folder
GitHub is MIT: https://github.com/OwlCarousel2/OwlCarousel2/blob/2.3.4/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [owl.carousel 2.3.4](https://clearlydefined.io/definitions/npm/npmjs/-/owl.carousel/2.3.4/2.3.4)