### PR TITLE
pcf-start 1.11.8

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -12,6 +12,9 @@ revisions:
   1.10.4:
     licensed:
       declared: OTHER
+  1.11.8:
+    licensed:
+      declared: OTHER
   1.2.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 1.11.8

**Details:**
ClearlyDefined license is OTHER (MSLT):  https://clearlydefined.io/file/dc0ec69f61019186d491e8d0f63bf194e06fb784ba7a2e3078d25d4d7a8a8dee
NPM states see license folder


**Resolution:**
OTHER

**Affected definitions**:
- [pcf-start 1.11.8](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.11.8/1.11.8)