### PR TITLE
modernizr/modernizr 87c723720a48254ae37ffd56829e32a96f5c5496

### DIFF
--- a/curations/git/github/modernizr/modernizr.yaml
+++ b/curations/git/github/modernizr/modernizr.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  87c723720a48254ae37ffd56829e32a96f5c5496:
+    licensed:
+      declared: MIT OR BSD-3-Clause
   d6bb30c0f12ebb3ddd01e90b0bf435e1c34e6f11:
     licensed:
       declared: MIT OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
modernizr/modernizr 87c723720a48254ae37ffd56829e32a96f5c5496

**Details:**
The license at time of release was dual license BSD-3-Clause OR MIT: https://github.com/Modernizr/Modernizr/blob/307c272b02c46971f4add5a6c550b27a95359a0f/LICENSE


**Resolution:**
BSD-3-Clause OR MIT

**Affected definitions**:
- [modernizr 87c723720a48254ae37ffd56829e32a96f5c5496](https://clearlydefined.io/definitions/git/github/modernizr/modernizr/87c723720a48254ae37ffd56829e32a96f5c5496/87c723720a48254ae37ffd56829e32a96f5c5496)