### PR TITLE
System.Text.Json 4.6.0-preview7.19362.9

### DIFF
--- a/curations/nuget/nuget/-/System.Text.Json.yaml
+++ b/curations/nuget/nuget/-/System.Text.Json.yaml
@@ -9,3 +9,6 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview7.19362.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Text.Json 4.6.0-preview7.19362.9

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Text.Json 4.6.0-preview7.19362.9](https://clearlydefined.io/definitions/nuget/nuget/-/System.Text.Json/4.6.0-preview7.19362.9/4.6.0-preview7.19362.9)