### PR TITLE
NuGet.Server 2.2.2

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Server.yaml
+++ b/curations/nuget/nuget/-/NuGet.Server.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.2.2:
     licensed:
-      declared: NONE
+      declared: Apache-2.0

--- a/curations/nuget/nuget/-/NuGet.Server.yaml
+++ b/curations/nuget/nuget/-/NuGet.Server.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NuGet.Server
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Server 2.2.2

**Details:**
Nuget license link is broken
Project link is broken

**Resolution:**
NONE

**Affected definitions**:
- [NuGet.Server 2.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Server/2.2.2/2.2.2)