### PR TITLE
numactl/numactl 841253d1313b01a968c380cae4f498f20c46e5aa

### DIFF
--- a/curations/git/github/numactl/numactl.yaml
+++ b/curations/git/github/numactl/numactl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: numactl
+  namespace: numactl
+  provider: github
+  type: git
+revisions:
+  841253d1313b01a968c380cae4f498f20c46e5aa:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
numactl/numactl 841253d1313b01a968c380cae4f498f20c46e5aa

**Details:**
Readme states GPLv2: https://github.com/numactl/numactl/blob/master/LICENSE.GPL2

**Resolution:**
GPL-2.0-only

**Affected definitions**:
- [numactl 841253d1313b01a968c380cae4f498f20c46e5aa](https://clearlydefined.io/definitions/git/github/numactl/numactl/841253d1313b01a968c380cae4f498f20c46e5aa/841253d1313b01a968c380cae4f498f20c46e5aa)