### PR TITLE
System.Interactive 3.1.1

### DIFF
--- a/curations/nuget/nuget/-/System.Interactive.yaml
+++ b/curations/nuget/nuget/-/System.Interactive.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: Apache-2.0
+  3.1.1:
+    licensed:
+      declared: Apache-2.0
   3.2.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Interactive 3.1.1

**Details:**
Nuget license is MIT: https://github.com/dotnet/reactive/blob/main/LICENSE
GitHub license is Apache-2.0: https://github.com/dotnet/reactive/blob/v3.1.1/LICENSE
The Nuget license is later than the release date

**Resolution:**
Apache-2.0

**Affected definitions**:
- [System.Interactive 3.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Interactive/3.1.1/3.1.1)