### PR TITLE
google/googletestec 44c6c1675c25b9827aacd08c02433cccde7780

### DIFF
--- a/curations/git/github/google/googletest.yaml
+++ b/curations/git/github/google/googletest.yaml
@@ -10,6 +10,9 @@ revisions:
   c3bb0ee2a63279a803aaad956b9b26d74bf9e6e2:
     licensed:
       declared: BSD-3-Clause
+  ec44c6c1675c25b9827aacd08c02433cccde7780:
+    licensed:
+      declared: BSD-3-Clause
   f5e592d8ee5ffb1d9af5be7f715ce3576b8bf9c4:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
google/googletestec 44c6c1675c25b9827aacd08c02433cccde7780

**Details:**
Github license is BSD-3-Clause:
https://github.com/google/googletest/blob/main/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [googletest ec44c6c1675c25b9827aacd08c02433cccde7780](https://clearlydefined.io/definitions/git/github/google/googletest/ec44c6c1675c25b9827aacd08c02433cccde7780/ec44c6c1675c25b9827aacd08c02433cccde7780)