### PR TITLE
ServiceStack.Common 5.9.0

### DIFF
--- a/curations/nuget/nuget/-/ServiceStack.Common.yaml
+++ b/curations/nuget/nuget/-/ServiceStack.Common.yaml
@@ -6,6 +6,9 @@ revisions:
   5.11.0:
     licensed:
       declared: OTHER
+  5.9.0:
+    licensed:
+      declared: OTHER
   5.9.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ServiceStack.Common 5.9.0

**Details:**
ClearlyDefined license is OTHER (ServiceStack License Agreement)
Nuget license link is OTHER (same as above)

**Resolution:**
OTHER

**Affected definitions**:
- [ServiceStack.Common 5.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/ServiceStack.Common/5.9.0/5.9.0)