### PR TITLE
StronglyTypedId 0.2.1

### DIFF
--- a/curations/nuget/nuget/-/StronglyTypedId.yaml
+++ b/curations/nuget/nuget/-/StronglyTypedId.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StronglyTypedId
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StronglyTypedId 0.2.1

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT
GitHub license is MIT: https://github.com/andrewlock/StronglyTypedId/blob/v0.2.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [StronglyTypedId 0.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/StronglyTypedId/0.2.1/0.2.1)