### PR TITLE
StronglyTypedId.Attributes 0.2.1

### DIFF
--- a/curations/nuget/nuget/-/StronglyTypedId.Attributes.yaml
+++ b/curations/nuget/nuget/-/StronglyTypedId.Attributes.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: StronglyTypedId.Attributes
+  provider: nuget
+  type: nuget
+revisions:
+  0.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StronglyTypedId.Attributes 0.2.1

**Details:**
Github license is MIT: https://github.com/andrewlock/StronglyTypedId/blob/v0.2.1/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [StronglyTypedId.Attributes 0.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/StronglyTypedId.Attributes/0.2.1/0.2.1)