### PR TITLE
Akka.Remote 1.4.17

### DIFF
--- a/curations/nuget/nuget/-/Akka.Remote.yaml
+++ b/curations/nuget/nuget/-/Akka.Remote.yaml
@@ -5,7 +5,10 @@ coordinates:
 revisions:
   1.3.10:
     licensed:
-      declared: Apache-2.0  
+      declared: Apache-2.0
   1.3.15:
+    licensed:
+      declared: Apache-2.0
+  1.4.17:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Remote 1.4.17

**Details:**
ClearlyDefined lciense is Apache-2.0
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/dev/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Remote 1.4.17](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Remote/1.4.17/1.4.17)