### PR TITLE
@microsoft/sp-diagnostics 1.8.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-diagnostics.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-diagnostics.yaml
@@ -22,6 +22,9 @@ revisions:
   1.14.0:
     licensed:
       declared: OTHER
+  1.8.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/sp-diagnostics 1.8.0

**Details:**
ClearlyDefined EULA is OTHER (MSLT)
NPM license states see license file

**Resolution:**
OTHER

**Affected definitions**:
- [sp-diagnostics 1.8.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-diagnostics/1.8.0/1.8.0)