### PR TITLE
Selenium.WebDriver.ChromeDriver 2.25.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.ChromeDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.ChromeDriver.yaml
@@ -6,6 +6,9 @@ revisions:
   2.24.0:
     licensed:
       declared: Unlicense
+  2.25.0:
+    licensed:
+      declared: Unlicense
   2.26.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.ChromeDriver 2.25.0

**Details:**
Nuget is Unlicense:  https://unlicense.org/
Github is Unlicense: https://github.com/jsakamoto/nupkg-selenium-webdriver-chromedriver/blob/v.2.25.0.0/LICENSE

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.WebDriver.ChromeDriver 2.25.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.ChromeDriver/2.25.0/2.25.0)