### PR TITLE
Xamarin.Android.Support.v4 25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.v4.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.v4.yaml
@@ -6,6 +6,9 @@ revisions:
   25.1.0:
     licensed:
       declared: MIT
+  25.4.0.2:
+    licensed:
+      declared: MIT
   26.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.v4 25.4.0.2

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/xamarin/AndroidSupportComponents/blob/25.4.0.2/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Android.Support.v4 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.v4/25.4.0.2/25.4.0.2)