### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/elastic/kibana.yaml
+++ b/curations/git/github/elastic/kibana.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kibana
+  namespace: elastic
+  provider: github
+  type: git
+revisions:
+  7bdb99203c3b0d113668b9a96b1daaa920d654a2:
+    licensed:
+      declared: NOASSERTION AND Apache-2.0 AND NOASSERTION

--- a/curations/git/github/elastic/kibana.yaml
+++ b/curations/git/github/elastic/kibana.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   7bdb99203c3b0d113668b9a96b1daaa920d654a2:
     licensed:
-      declared: NOASSERTION AND Apache-2.0 AND NOASSERTION
+      declared: Apache-2.0 AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The Component is Dual Licensed under Apache 2.0 AND Elastic Search License 2.0
File Path : https://github.com/elastic/kibana/blob/main/LICENSE.txt

**Resolution:**
Since there is NOASSERTION in the Declared Licenses, but the Component has the information of Dual License mentioned, it is being curated as Apache 2.0 AND Elastic Search License 2.0 instead of NOASSERTION
License path file :https://github.com/elastic/kibana/blob/main/LICENSE.txt

**Affected definitions**:
- [kibana 7bdb99203c3b0d113668b9a96b1daaa920d654a2](https://clearlydefined.io/definitions/git/github/elastic/kibana/7bdb99203c3b0d113668b9a96b1daaa920d654a2/7bdb99203c3b0d113668b9a96b1daaa920d654a2)