### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/elastic/kibana.yaml
+++ b/curations/git/github/elastic/kibana.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   e13d5b1fed429df03e29af259ffccd6453250947:
     licensed:
-      declared: NOASSERTION AND Apache-2.0 AND NOASSERTION
+      declared: Apache-2.0 AND OTHER

--- a/curations/git/github/elastic/kibana.yaml
+++ b/curations/git/github/elastic/kibana.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kibana
+  namespace: elastic
+  provider: github
+  type: git
+revisions:
+  e13d5b1fed429df03e29af259ffccd6453250947:
+    licensed:
+      declared: NOASSERTION AND Apache-2.0 AND NOASSERTION


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is NOASSERTION, but the component ha the information of the Dual License under Apache 2.0 AMD Elastic Search 2.0.
License File path : https://github.com/elastic/kibana/blob/main/LICENSE.txt

**Resolution:**
Since there is Dual License information, it is being Curated as Apache 2.0 AND Elastic Search 2.0 instead of NOASSERTION.
License File : https://github.com/elastic/kibana/blob/main/LICENSE.txt

**Affected definitions**:
- [kibana e13d5b1fed429df03e29af259ffccd6453250947](https://clearlydefined.io/definitions/git/github/elastic/kibana/e13d5b1fed429df03e29af259ffccd6453250947/e13d5b1fed429df03e29af259ffccd6453250947)