### PR TITLE
Declared License was incorrect.

### DIFF
--- a/curations/npm/npmjs/@typescript-eslint/eslint-plugin.yaml
+++ b/curations/npm/npmjs/@typescript-eslint/eslint-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: eslint-plugin
+  namespace: '@typescript-eslint'
+  provider: npmjs
+  type: npm
+revisions:
+  3.8.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was incorrect.

**Details:**
Declared License was incorrect; the static code analysis tool "ESLint" is distributed under MIT license but the typescript version is distributed under BSD 2-Clause "Simplified" License.

**Resolution:**
Corrected the declared license as per https://github.com/typescript-eslint/typescript-eslint/blob/522277d74d15467b9a1ec29fcd0f4eec0b0aaa9d/LICENSE.

**Affected definitions**:
- [eslint-plugin 3.8.0](https://clearlydefined.io/definitions/npm/npmjs/@typescript-eslint/eslint-plugin/3.8.0/3.8.0)