### PR TITLE
Declared License was incorrect.

### DIFF
--- a/curations/git/github/typescript-eslint/typescript-eslint.yaml
+++ b/curations/git/github/typescript-eslint/typescript-eslint.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: typescript-eslint
+  namespace: typescript-eslint
+  provider: github
+  type: git
+revisions:
+  fc774f637782f8815616592d6d18be933224c4a2:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was incorrect.

**Details:**
Declared License was incorrect; the static code analysis tool "ESLint" is distributed under MIT license but the typescript version is distributed under BSD 2-Clause "Simplified" License.

**Resolution:**
Corrected the declared license as per https://github.com/typescript-eslint/typescript-eslint/blob/fc774f637782f8815616592d6d18be933224c4a2/LICENSE.

**Affected definitions**:
- [typescript-eslint fc774f637782f8815616592d6d18be933224c4a2](https://clearlydefined.io/definitions/git/github/typescript-eslint/typescript-eslint/fc774f637782f8815616592d6d18be933224c4a2/fc774f637782f8815616592d6d18be933224c4a2)