### PR TITLE
openssh/openssh-portable cce8cbe0ed7d1ba3a575310e0b63c193326ae616

### DIFF
--- a/curations/git/github/openssh/openssh-portable.yaml
+++ b/curations/git/github/openssh/openssh-portable.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  cce8cbe0ed7d1ba3a575310e0b63c193326ae616:
+    licensed:
+      declared: SSH-OpenSSH
   ed6bef77f5bb5b8f9ca2914478949e29f2f0a780:
     licensed:
       declared: SSH-OpenSSH


### PR DESCRIPTION

**Type:** Missing

**Summary:**
openssh/openssh-portable cce8cbe0ed7d1ba3a575310e0b63c193326ae616

**Details:**
ClearlyDefined license is SSH-OpenSSH
GitHub is SSH-OpenSSH: https://github.com/openssh/openssh-portable/blob/cce8cbe0ed7d1ba3a575310e0b63c193326ae616/LICENCE

**Resolution:**
SSH-OpenSSH

**Affected definitions**:
- [openssh-portable cce8cbe0ed7d1ba3a575310e0b63c193326ae616](https://clearlydefined.io/definitions/git/github/openssh/openssh-portable/cce8cbe0ed7d1ba3a575310e0b63c193326ae616/cce8cbe0ed7d1ba3a575310e0b63c193326ae616)