### PR TITLE
pcf-scripts 1.11.8

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -12,6 +12,9 @@ revisions:
   1.10.4:
     licensed:
       declared: OTHER
+  1.11.8:
+    licensed:
+      declared: OTHER
   1.2.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-scripts 1.11.8

**Details:**
ClearlyDefined license is OTHER (MSLT)
NPM indicates see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-scripts 1.11.8](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.11.8/1.11.8)