### PR TITLE
com.brsanthu/migbase 642.2

### DIFF
--- a/curations/maven/mavencentral/com.brsanthu/migbase64.yaml
+++ b/curations/maven/mavencentral/com.brsanthu/migbase64.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '2.2':
     licensed:
-      declared: MIT
+      declared: OTHER

--- a/curations/maven/mavencentral/com.brsanthu/migbase64.yaml
+++ b/curations/maven/mavencentral/com.brsanthu/migbase64.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: migbase64
+  namespace: com.brsanthu
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.2':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.brsanthu/migbase 642.2

**Details:**
ClearlyDefined license is MIT: https://clearlydefined.io/file/93b2ff57c627583a6a83fd937899cfc323fed4a7a0b12a6c365a85a5f18b8710
Nuget is MIT

**Resolution:**
MIT

**Affected definitions**:
- [migbase64 2.2](https://clearlydefined.io/definitions/maven/mavencentral/com.brsanthu/migbase64/2.2/2.2)