### PR TITLE
javax.jcr/jcr 2.0

### DIFF
--- a/curations/maven/mavencentral/javax.jcr/jcr.yaml
+++ b/curations/maven/mavencentral/javax.jcr/jcr.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jcr
+  namespace: javax.jcr
+  provider: mavencentral
+  type: maven
+revisions:
+  '2.0':
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.jcr/jcr 2.0

**Details:**
Maven pom:  https://repo1.maven.org/maven2/javax/jcr/jcr/2.0/jcr-2.0.pom
indicates Day Specification License
https://developer.adobe.com/experience-manager/reference-materials/spec/jcr/2.0/license.html

**Resolution:**
OTHER

**Affected definitions**:
- [jcr 2.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.jcr/jcr/2.0/2.0)