### PR TITLE
syntax 1.0.0

### DIFF
--- a/curations/gem/rubygems/-/syntax.yaml
+++ b/curations/gem/rubygems/-/syntax.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.0:
     licensed:
-      declared: NONE
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
syntax 1.0.0

**Details:**
RubyGems indicates N/A
GitHub license is BSD-3-Clause for a later version: https://github.com/dblock/syntax/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [syntax 1.0.0](https://clearlydefined.io/definitions/gem/rubygems/-/syntax/1.0.0/1.0.0)