### PR TITLE
NuGet.Core 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Core.yaml
@@ -15,3 +15,6 @@ revisions:
   2.14.0:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Core 2.2.0

**Details:**
Nuget license link and project link are broken.
Early and later versions of this component are curated as Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Core 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Core/2.2.0/2.2.0)