### PR TITLE
nokogiri 1.13.3

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -9,3 +9,6 @@ revisions:
   1.12.5:
     licensed:
       declared: MIT
+  1.13.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri 1.13.3

**Details:**
The tooling took all the dependency licenses and put them in the declared field.

**Resolution:**
The declared license is just "MIT" -
https://github.com/sparklemotion/nokogiri/blob/v1.13.3/LICENSE.md

**Affected definitions**:
- [nokogiri 1.13.3](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.13.3/1.13.3)