### PR TITLE
ldapsdk/ldapsdk 4.1

### DIFF
--- a/curations/maven/mavencentral/ldapsdk/ldapsdk.yaml
+++ b/curations/maven/mavencentral/ldapsdk/ldapsdk.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ldapsdk
+  namespace: ldapsdk
+  provider: mavencentral
+  type: maven
+revisions:
+  '4.1':
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ldapsdk/ldapsdk 4.1

**Details:**
No license info in POM or JAR on Maven: https://mvnrepository.com/artifact/ldapsdk/ldapsdk/4.1

**Resolution:**
NONE

**Affected definitions**:
- [ldapsdk 4.1](https://clearlydefined.io/definitions/maven/mavencentral/ldapsdk/ldapsdk/4.1/4.1)