### PR TITLE
Xamarin.AndroidX.Annotation 1.2.0

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.Annotation.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.Annotation.yaml
@@ -36,6 +36,9 @@ revisions:
   1.1.0.9:
     licensed:
       declared: MIT
+  1.2.0:
+    licensed:
+      declared: MIT
   1.2.0-alpha01:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.AndroidX.Annotation 1.2.0

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT
GitHub license is MIT: https://github.com/xamarin/AndroidX/blob/28fb9b174d1af8615fe6dabc62abc9582f9444a5/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.AndroidX.Annotation 1.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.Annotation/1.2.0/1.2.0)