### PR TITLE
Xamarin.Android.Support.Core.UI 25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Core.UI.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Core.UI.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  25.4.0.2:
+    licensed:
+      declared: MIT
   26.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.Core.UI 25.4.0.2

**Details:**
Nuget license is MIT
GitHub license at time of release is MIT: https://github.com/xamarin/AndroidSupportComponents/blob/fc259af90a0dffcd3f55ee7b2159cacc74f594a3/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Android.Support.Core.UI 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Core.UI/25.4.0.2/25.4.0.2)