### PR TITLE
org.reflections/reflections 0.9.9

### DIFF
--- a/curations/maven/mavencentral/org.reflections/reflections.yaml
+++ b/curations/maven/mavencentral/org.reflections/reflections.yaml
@@ -13,6 +13,9 @@ revisions:
   0.9.12:
     licensed:
       declared: WTFPL OR BSD-3-Clause
+  0.9.9:
+    licensed:
+      declared: WTFPL OR BSD-3-Clause
   0.9.9-RC2:
     licensed:
       declared: WTFPL OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.reflections/reflections 0.9.9

**Details:**
Maven 
Github: no license at time of release but a later version indicates in the Readme Apache-2.0 OR WTFPL

**Resolution:**
Apache-2.0 OR WTFPL

**Affected definitions**:
- [reflections 0.9.9](https://clearlydefined.io/definitions/maven/mavencentral/org.reflections/reflections/0.9.9/0.9.9)