### PR TITLE
@microsoft/sp-core-library 1.8.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-core-library.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-core-library.yaml
@@ -22,6 +22,9 @@ revisions:
   1.14.0:
     licensed:
       declared: OTHER
+  1.8.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/sp-core-library 1.8.0

**Details:**
ClearlyDefined license is OTHER (MSLT)
NPM indicates see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [sp-core-library 1.8.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-core-library/1.8.0/1.8.0)