### PR TITLE
NuGet.Packaging.Core 4.4.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
@@ -21,6 +21,9 @@ revisions:
   4.2.0:
     licensed:
       declared: Apache-2.0
+  4.4.0:
+    licensed:
+      declared: Apache-2.0
   4.7.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Packaging.Core 4.4.0

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0:
https://github.com/NuGet/NuGet.Client/blob/4.4.0.4365/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Packaging.Core 4.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core/4.4.0/4.4.0)