### PR TITLE
Emgu.CV.runtime.windows 4.4.0.4099

### DIFF
--- a/curations/nuget/nuget/-/Emgu.CV.runtime.windows.yaml
+++ b/curations/nuget/nuget/-/Emgu.CV.runtime.windows.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Emgu.CV.runtime.windows
+  provider: nuget
+  type: nuget
+revisions:
+  4.4.0.4099:
+    licensed:
+      declared: GPL-3.0-or-later OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Emgu.CV.runtime.windows 4.4.0.4099

**Details:**
ClearlyDefined license is GPL-3.0-or-later OR OTHER
Nuget is same as above: https://www.nuget.org/packages/Emgu.CV.runtime.windows/4.4.0.4099/License
GitHub is same as above

**Resolution:**
GPL-3.0-or-later OR OTHER

**Affected definitions**:
- [Emgu.CV.runtime.windows 4.4.0.4099](https://clearlydefined.io/definitions/nuget/nuget/-/Emgu.CV.runtime.windows/4.4.0.4099/4.4.0.4099)