### PR TITLE
org.openjdk.jmh/jmh-generator-annprocess 1.4.1

### DIFF
--- a/curations/maven/mavencentral/org.openjdk.jmh/jmh-generator-annprocess.yaml
+++ b/curations/maven/mavencentral/org.openjdk.jmh/jmh-generator-annprocess.yaml
@@ -22,3 +22,6 @@ revisions:
   '1.33':
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  1.4.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.openjdk.jmh/jmh-generator-annprocess 1.4.1

**Details:**
ClearlyDefined license is GPL-2.0-only WITH Classpath-exception-2.0
Maven pom is same as above: https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-generator-annprocess/1.4.1/jmh-generator-annprocess-1.4.1.pom

**Resolution:**
GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jmh-generator-annprocess 1.4.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjdk.jmh/jmh-generator-annprocess/1.4.1/1.4.1)