### PR TITLE
System.Runtime.WindowsRuntime.UI.Xaml4.6.0-preview 4.19212.13

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.WindowsRuntime.UI.Xaml.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.WindowsRuntime.UI.Xaml.yaml
@@ -6,6 +6,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview4.19212.13:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Runtime.WindowsRuntime.UI.Xaml4.6.0-preview 4.19212.13

**Details:**
Nuget license links is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
GitHub is MIT at time of release

**Resolution:**
MIT

**Affected definitions**:
- [System.Runtime.WindowsRuntime.UI.Xaml 4.6.0-preview4.19212.13](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.WindowsRuntime.UI.Xaml/4.6.0-preview4.19212.13/4.6.0-preview4.19212.13)