### PR TITLE
@microsoft/sp-listview-extensibility 1.11.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-listview-extensibility.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-listview-extensibility.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.11.0:
+    licensed:
+      declared: OTHER
   1.12.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/sp-listview-extensibility 1.11.0

**Details:**
ClearlyDefined EULA is OTHER (MSLT)
NPM states Unlicensed

**Resolution:**
OTHER

**Affected definitions**:
- [sp-listview-extensibility 1.11.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-listview-extensibility/1.11.0/1.11.0)