### PR TITLE
estraverse 1.8.0

### DIFF
--- a/curations/npm/npmjs/-/estraverse.yaml
+++ b/curations/npm/npmjs/-/estraverse.yaml
@@ -18,6 +18,9 @@ revisions:
   1.5.1:
     licensed:
       declared: BSD-2-Clause
+  1.8.0:
+    licensed:
+      declared: BSD-2-Clause
   1.9.3:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
estraverse 1.8.0

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM is BSD-2-Clause
GitHub is BSD-2-Clause: https://github.com/estools/estraverse/blob/1.8.0/LICENSE.BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [estraverse 1.8.0](https://clearlydefined.io/definitions/npm/npmjs/-/estraverse/1.8.0/1.8.0)