### PR TITLE
NuGet.DependencyResolver.Core 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.DependencyResolver.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.DependencyResolver.Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.DependencyResolver.Core 3.5.0

**Details:**
Nuget is Apache-2.0
GitHub is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/3.5.0-rtm/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.DependencyResolver.Core 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.DependencyResolver.Core/3.5.0/3.5.0)