### PR TITLE
SmartCTL 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/SmartCTL.yaml
+++ b/curations/nuget/nuget/-/SmartCTL.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SmartCTL
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SmartCTL 1.0.0

**Details:**
Nuget has no license and no project link.  No license information found in the package

**Resolution:**
NONE

**Affected definitions**:
- [SmartCTL 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/SmartCTL/1.0.0/1.0.0)