### PR TITLE
SmartCTL 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Common-signed.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Common-signed.yaml
@@ -6,3 +6,6 @@ revisions:
   0.2.3:
     licensed:
       declared: MIT
+  0.3.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SmartCTL 1.0.0

**Details:**
Nuget license is MIT
GitHublicense is MIT: https://github.com/Azure/DotNetty/blob/v0.3.2/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [DotNetty.Common-signed 0.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetty.Common-signed/0.3.2/0.3.2)