### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/arteam/unitils.yaml
+++ b/curations/git/github/arteam/unitils.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: unitils
+  namespace: arteam
+  provider: github
+  type: git
+revisions:
+  50c949eb613f61cc18a192ec4b60319905876448:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is one NOASSERTION and the Component shows the License file with Apache 2.0.
License File Path : https://github.com/arteam/unitils/blob/3.4.2/LICENSE.txt

**Resolution:**
To resolve the NOSSERTION ,missing Declared License the Component is being curated as Apache 2.0 instead of NOASSERTION since there is Apache 2.0 License information provided in the License Text file.
License Path File : https://github.com/arteam/unitils/blob/3.4.2/LICENSE.txt

**Affected definitions**:
- [unitils 50c949eb613f61cc18a192ec4b60319905876448](https://clearlydefined.io/definitions/git/github/arteam/unitils/50c949eb613f61cc18a192ec4b60319905876448/50c949eb613f61cc18a192ec4b60319905876448)