### PR TITLE
Add Licensing info for Imageresizer 4.2.5

### DIFF
--- a/curations/nuget/nuget/-/ImageResizer.yaml
+++ b/curations/nuget/nuget/-/ImageResizer.yaml
@@ -6,3 +6,6 @@ revisions:
   3.4.3:
     licensed:
       declared: OTHER
+  4.2.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Type: Missing

Summary:
ImageResizer

Details:
Add Apache-2.0 License

Resolution:
License Url:
https://imageresizing.net/licenses/apache
https://github.com/imazen/resizer/blob/develop/LICENSE.md

Description:
