### PR TITLE
creationix/http-parser-js/0.5.6

### DIFF
--- a/curations/npm/npmjs/-/http-parser-js.yaml
+++ b/curations/npm/npmjs/-/http-parser-js.yaml
@@ -1,0 +1,14 @@
+coordinates:
+  name: http-parser-js
+  provider: npmjs
+  type: npm
+revisions:
+  0.5.6:
+    described:
+      sourceLocation:
+        name: http-parser-js
+        namespace: creationix
+        provider: github
+        revision: 8a13b79e0d9ddadbb0997eaf3d375aa5bc89e0f1
+        type: git
+        url: 'https://github.com/creationix/http-parser-js/commit/8a13b79e0d9ddadbb0997eaf3d375aa5bc89e0f1'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
creationix/http-parser-js/0.5.6

**Details:**
Add missing source

**Resolution:**
Source:
https://github.com/creationix/http-parser-js/commit/8a13b79e0d9ddadbb0997eaf3d375aa5bc89e0f1

**Affected definitions**:
- [http-parser-js 0.5.6](https://clearlydefined.io/definitions/npm/npmjs/-/http-parser-js/0.5.6/0.5.6)