### PR TITLE
itextsharp.xmlworker5.5.13.2

### DIFF
--- a/curations/nuget/nuget/-/itextsharp.xmlworker.yaml
+++ b/curations/nuget/nuget/-/itextsharp.xmlworker.yaml
@@ -6,3 +6,6 @@ revisions:
   5.5.11:
     licensed:
       declared: AGPL-3.0-only
+  5.5.13.2:
+    licensed:
+      declared: AGPL-3.0-only

--- a/curations/nuget/nuget/-/itextsharp.xmlworker.yaml
+++ b/curations/nuget/nuget/-/itextsharp.xmlworker.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: AGPL-3.0-only
   5.5.13.2:
     licensed:
-      declared: AGPL-3.0-only
+      declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
itextsharp.xmlworker5.5.13.2

**Details:**
ClearlyDefined License file and NuGet license file is AGPL-3.0-only

**Resolution:**
https://clearlydefined.io/file/abf00687d6482774348535c0b24f758bc6ca8d2ff6660d349b06a8f28f1ab41f

**Affected definitions**:
- [itextsharp.xmlworker 5.5.13.2](https://clearlydefined.io/definitions/nuget/nuget/-/itextsharp.xmlworker/5.5.13.2/5.5.13.2)