### PR TITLE
boost_thread-vc141 1.68.0

### DIFF
--- a/curations/nuget/nuget/-/boost_thread-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_thread-vc141.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.68.0:
+    licensed:
+      declared: BSL-1.0
   1.69.0:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_thread-vc141 1.68.0

**Details:**
Nuget license is BSL-1.0
GitHub license at time of package was Apache-2.0 but later changed to BSL-1.0

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_thread-vc141 1.68.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_thread-vc141/1.68.0/1.68.0)