### PR TITLE
org.scijava/native-lib-loader 2.0.2

### DIFF
--- a/curations/maven/mavencentral/org.scijava/native-lib-loader.yaml
+++ b/curations/maven/mavencentral/org.scijava/native-lib-loader.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.0.2:
+    licensed:
+      declared: BSD-2-Clause
   2.3.4:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scijava/native-lib-loader 2.0.2

**Details:**
Maven pom had no license info
GitHub license is BSD-2-Clause

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [native-lib-loader 2.0.2](https://clearlydefined.io/definitions/maven/mavencentral/org.scijava/native-lib-loader/2.0.2/2.0.2)