### PR TITLE
org.ow2.asm/asm-commons 5.0.

### DIFF
--- a/curations/maven/mavencentral/org.ow2.asm/asm-commons.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm-commons.yaml
@@ -7,6 +7,9 @@ revisions:
   5.0.1:
     licensed:
       declared: BSD-3-Clause
+  5.0.2:
+    licensed:
+      declared: BSD-3-Clause
   5.0.3:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.ow2.asm/asm-commons 5.0.

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/org/ow2/asm/asm-commons/5.0.2/asm-commons-5.0.2.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm-commons 5.0.2](https://clearlydefined.io/definitions/maven/mavencentral/org.ow2.asm/asm-commons/5.0.2/5.0.2)