### PR TITLE
NuGet.SolutionRestoreManager.Interop 4.8.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.SolutionRestoreManager.Interop.yaml
+++ b/curations/nuget/nuget/-/NuGet.SolutionRestoreManager.Interop.yaml
@@ -6,3 +6,6 @@ revisions:
   4.3.0:
     licensed:
       declared: Apache-2.0
+  4.8.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.SolutionRestoreManager.Interop 4.8.0

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/NuGet/NuGet.Client/blob/4.8.0.5158/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.SolutionRestoreManager.Interop 4.8.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.SolutionRestoreManager.Interop/4.8.0/4.8.0)