### PR TITLE
Autofac.Extras.NLog 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/Autofac.Extras.NLog.yaml
+++ b/curations/nuget/nuget/-/Autofac.Extras.NLog.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Autofac.Extras.NLog
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Autofac.Extras.NLog 1.3.0

**Details:**
Nuget has no license listed
GitHub is MIT: https://github.com/ziyasal/Autofac.Extras.NLog/blob/v1.3.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Autofac.Extras.NLog 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Autofac.Extras.NLog/1.3.0/1.3.0)