### PR TITLE
org.locationtech.jts/jts-core 1.15.0

### DIFF
--- a/curations/maven/mavencentral/org.locationtech.jts/jts-core.yaml
+++ b/curations/maven/mavencentral/org.locationtech.jts/jts-core.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1.15.0:
     licensed:
-      declared: EPL-1.0
+      declared: BSD-3-Clause OR EPL-1.0
   1.16.1:
     licensed:
       declared: BSD-3-Clause OR EPL-1.0

--- a/curations/maven/mavencentral/org.locationtech.jts/jts-core.yaml
+++ b/curations/maven/mavencentral/org.locationtech.jts/jts-core.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.15.0:
+    licensed:
+      declared: EPL-1.0
   1.16.1:
     licensed:
       declared: BSD-3-Clause OR EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.locationtech.jts/jts-core 1.15.0

**Details:**
Maven jar includes EPL-1.0 in .java file

**Resolution:**
EPL-1.0

**Affected definitions**:
- [jts-core 1.15.0](https://clearlydefined.io/definitions/maven/mavencentral/org.locationtech.jts/jts-core/1.15.0/1.15.0)