### PR TITLE
mapbox-gl 1.13.2

### DIFF
--- a/curations/npm/npmjs/-/mapbox-gl.yaml
+++ b/curations/npm/npmjs/-/mapbox-gl.yaml
@@ -24,6 +24,9 @@ revisions:
   1.13.1:
     licensed:
       declared: BSD-3-Clause
+  1.13.2:
+    licensed:
+      declared: BSD-3-Clause
   1.3.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mapbox-gl 1.13.2

**Details:**
NPM states see license folder
GitHub is BSD-3-Clause: https://github.com/mapbox/mapbox-gl-js/blob/v0.13.0/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [mapbox-gl 1.13.2](https://clearlydefined.io/definitions/npm/npmjs/-/mapbox-gl/1.13.2/1.13.2)