### PR TITLE
ncom 1.0.3

### DIFF
--- a/curations/npm/npmjs/-/ncom.yaml
+++ b/curations/npm/npmjs/-/ncom.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ncom
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.3:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ncom 1.0.3

**Details:**
ClearlyDefined package.json has no license info
NPM States NONE
GitHub has no license

**Resolution:**
NONE

**Affected definitions**:
- [ncom 1.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/ncom/1.0.3/1.0.3)