### PR TITLE
Newtonsoft.Json.dll 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.dll.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.dll.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Newtonsoft.Json.dll
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json.dll 1.0.0

**Details:**
Nuget license and project links were not included
No license info found in ClearlyDefined package

**Resolution:**
NONE

**Affected definitions**:
- [Newtonsoft.Json.dll 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json.dll/1.0.0/1.0.0)