### PR TITLE
VSSDK.VSLangProj 7.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.VSLangProj.yaml
+++ b/curations/nuget/nuget/-/VSSDK.VSLangProj.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.VSLangProj
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VSSDK.VSLangProj 7.0.4

**Details:**
No license info found on Nuget or CleralyDefined

**Resolution:**
NONE

**Affected definitions**:
- [VSSDK.VSLangProj 7.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.VSLangProj/7.0.4/7.0.4)