### PR TITLE
dependabot-git_submodules 0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-git_submodules.yaml
+++ b/curations/gem/rubygems/-/dependabot-git_submodules.yaml
@@ -9,6 +9,9 @@ revisions:
   0.135.0:
     licensed:
       declared: OTHER
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.162.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-git_submodules 0.145.4

**Details:**
NPM indicates Nonstandard
GitHub is non-standard: https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-git_submodules 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-git_submodules/0.145.4/0.145.4)