### PR TITLE
org.glassfish.jaxb/jaxb-runtime 2.4.0-b180830.0438

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jaxb/jaxb-runtime.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jaxb/jaxb-runtime.yaml
@@ -19,6 +19,9 @@ revisions:
   2.3.4:
     licensed:
       declared: BSD-3-Clause
+  2.4.0-b180830.0438:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   3.0.2:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.glassfish.jaxb/jaxb-runtime 2.4.0-b180830.0438

**Details:**

Maven POM is: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0: https://repo1.maven.org/maven2/org/glassfish/jaxb/jaxb-runtime/2.4.0-b180830.0438/jaxb-runtime-2.4.0-b180830.0438.pom

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [jaxb-runtime 2.4.0-b180830.0438](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jaxb/jaxb-runtime/2.4.0-b180830.0438/2.4.0-b180830.0438)