### PR TITLE
hSystem.Memory4.5.0-preview 2-26406-04

### DIFF
--- a/curations/nuget/nuget/-/System.Memory.yaml
+++ b/curations/nuget/nuget/-/System.Memory.yaml
@@ -6,6 +6,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview2-26406-04:
+    licensed:
+      declared: MIT
   4.5.0-rc1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hSystem.Memory4.5.0-preview 2-26406-04

**Details:**
ClearlyDefined is MIT
Nuget is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Memory 4.5.0-preview2-26406-04](https://clearlydefined.io/definitions/nuget/nuget/-/System.Memory/4.5.0-preview2-26406-04/4.5.0-preview2-26406-04)