### PR TITLE
BaselineTypeDiscovery 1.0.1

### DIFF
--- a/curations/nuget/nuget/-/BaselineTypeDiscovery.yaml
+++ b/curations/nuget/nuget/-/BaselineTypeDiscovery.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-2.0
   1.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
BaselineTypeDiscovery 1.0.1

**Details:**
Nuget license link broken
GitHub license is Apache-2.0: https://github.com/JasperFx/baseline/blob/c3625c97488e17e2a7ddf4ed7fc9cd6bf44c128b/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [BaselineTypeDiscovery 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/BaselineTypeDiscovery/1.0.1/1.0.1)