### PR TITLE
org.kohsuke/asm5 5.0.1

### DIFF
--- a/curations/maven/mavencentral/org.kohsuke/asm5.yaml
+++ b/curations/maven/mavencentral/org.kohsuke/asm5.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: asm5
+  namespace: org.kohsuke
+  provider: mavencentral
+  type: maven
+revisions:
+  5.0.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.kohsuke/asm5 5.0.1

**Details:**
Maven pom is BSD-3-Clause: https://repo1.maven.org/maven2/org/ow2/asm/asm/5.0.1/asm-5.0.1.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [asm5 5.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.kohsuke/asm5/5.0.1/5.0.1)