### PR TITLE
@ag-grid-enterprise/multi-filter 25.1.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/multi-filter.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/multi-filter.yaml
@@ -10,6 +10,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.1.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/multi-filter 25.1.0

**Details:**
ClearlyDefined license is OTHER (AG GRID ENTERPRISE EULA v13.0)
NPM states Commercial
GitHub is OTHER: https://github.com/ag-grid/ag-grid/blob/v25.1.0/LICENSE.txt

**Resolution:**
OTHER

**Affected definitions**:
- [multi-filter 25.1.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/multi-filter/25.1.0/25.1.0)