### PR TITLE
VSSDK.TextManager.Interop 7.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.TextManager.Interop.yaml
+++ b/curations/nuget/nuget/-/VSSDK.TextManager.Interop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.TextManager.Interop
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
VSSDK.TextManager.Interop 7.0.4

**Details:**
Nuget license and project links missing.  No license info found in package

**Resolution:**
NONE

**Affected definitions**:
- [VSSDK.TextManager.Interop 7.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.TextManager.Interop/7.0.4/7.0.4)