### PR TITLE
System.Text.Encodings.Web 4.6.0-rc1.19456.4

### DIFF
--- a/curations/nuget/nuget/-/System.Text.Encodings.Web.yaml
+++ b/curations/nuget/nuget/-/System.Text.Encodings.Web.yaml
@@ -15,3 +15,6 @@ revisions:
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT
+  4.6.0-rc1.19456.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Text.Encodings.Web 4.6.0-rc1.19456.4

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Text.Encodings.Web 4.6.0-rc1.19456.4](https://clearlydefined.io/definitions/nuget/nuget/-/System.Text.Encodings.Web/4.6.0-rc1.19456.4/4.6.0-rc1.19456.4)