### PR TITLE
pcf-start 1.5.4

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -30,6 +30,9 @@ revisions:
   1.5.3:
     licensed:
       declared: OTHER
+  1.5.4:
+    licensed:
+      declared: OTHER
   1.5.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 1.5.4

**Details:**
ClearlyDefined licnese is OTHER (MSLT: https://clearlydefined.io/file/dc0ec69f61019186d491e8d0f63bf194e06fb784ba7a2e3078d25d4d7a8a8dee)
NPM states see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-start 1.5.4](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.5.4/1.5.4)