### PR TITLE
Unity.Abstractions 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Unity.Abstractions.yaml
@@ -18,6 +18,9 @@ revisions:
   3.1.3:
     licensed:
       declared: Apache-2.0
+  3.2.0:
+    licensed:
+      declared: Apache-2.0
   3.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Abstractions 3.2.0

**Details:**
Nuget license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/unitycontainer/abstractions/blob/3.2.0.182/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Abstractions 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Abstractions/3.2.0/3.2.0)