### PR TITLE
dependabot-omnibus 0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-omnibus.yaml
+++ b/curations/gem/rubygems/-/dependabot-omnibus.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.162.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-omnibus 0.145.4

**Details:**
RubyGems indicates Nonstandard
GitHub is nonstandard: https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-omnibus 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-omnibus/0.145.4/0.145.4)