### PR TITLE
SpecFlow.Assist.Dynamic 1.3.1

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.Assist.Dynamic.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.Assist.Dynamic.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SpecFlow.Assist.Dynamic
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecFlow.Assist.Dynamic 1.3.1

**Details:**
Nuget is missing license link
GitHub is MIT: 
https://github.com/marcusoftnet/SpecFlow.Assist.Dynamic/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [SpecFlow.Assist.Dynamic 1.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow.Assist.Dynamic/1.3.1/1.3.1)