### PR TITLE
System.Linq.Dynamic.Core 1.0.8.18

### DIFF
--- a/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
+++ b/curations/nuget/nuget/-/System.Linq.Dynamic.Core.yaml
@@ -26,3 +26,6 @@ revisions:
   1.0.8.16:
     licensed:
       declared: Apache-2.0
+  1.0.8.18:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Linq.Dynamic.Core 1.0.8.18

**Details:**
Nuget license link is broken
GitHub is Apache-2.0: https://github.com/zzzprojects/System.Linq.Dynamic.Core/blob/1.0.8.18/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [System.Linq.Dynamic.Core 1.0.8.18](https://clearlydefined.io/definitions/nuget/nuget/-/System.Linq.Dynamic.Core/1.0.8.18/1.0.8.18)