### PR TITLE
Source Location was missing and the declared license was incorrect.

### DIFF
--- a/curations/pypi/pypi/-/mdv.yaml
+++ b/curations/pypi/pypi/-/mdv.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: mdv
+  provider: pypi
+  type: pypi
+revisions:
+  1.7.4:
+    described:
+      sourceLocation:
+        name: terminal_markdown_viewer
+        namespace: axiros
+        provider: github
+        revision: 978e6d84f154d77f6bb9996e52cc08f7a190e1bc
+        type: git
+        url: 'https://github.com/axiros/terminal_markdown_viewer/commit/978e6d84f154d77f6bb9996e52cc08f7a190e1bc'
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source Location was missing and the declared license was incorrect.

**Details:**
1. Source Location was missing as the version 1.7.4 is not available as a tag in the github repository.
2. The declared license was incorrect "BSD 2-Clause" instead of "BSD 3-Clause".

**Resolution:**
1. Filled in the source location URL.
2. Updated the declared license as per https://github.com/axiros/terminal_markdown_viewer/blob/978e6d84f154d77f6bb9996e52cc08f7a190e1bc/LICENSE.

**Affected definitions**:
- [mdv 1.7.4](https://clearlydefined.io/definitions/pypi/pypi/-/mdv/1.7.4/1.7.4)