### PR TITLE
Declared License was incorrect.

### DIFF
--- a/curations/git/github/confluentinc/ksql.yaml
+++ b/curations/git/github/confluentinc/ksql.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ksql
+  namespace: confluentinc
+  provider: github
+  type: git
+revisions:
+  07dc42506990e5c13019b10a7db433f8d1c78f86:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was incorrect.

**Details:**
Declared license was NOASSERTION because ClearlyDefined could not recognise the Confluent Community License Version 1.0.

**Resolution:**
Updated the Declared License to OTHER based on https://github.com/confluentinc/ksql/blob/07dc42506990e5c13019b10a7db433f8d1c78f86/LICENSE.

**Affected definitions**:
- [ksql 07dc42506990e5c13019b10a7db433f8d1c78f86](https://clearlydefined.io/definitions/git/github/confluentinc/ksql/07dc42506990e5c13019b10a7db433f8d1c78f86/07dc42506990e5c13019b10a7db433f8d1c78f86)