### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/r-lib/devtools.yaml
+++ b/curations/git/github/r-lib/devtools.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: devtools
+  namespace: r-lib
+  provider: github
+  type: git
+revisions:
+  4564f5930298194376801a4a0beca31235ecd95c:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing.

**Resolution:**
Filled in the declared license as found in https://github.com/r-lib/devtools/blob/4564f5930298194376801a4a0beca31235ecd95c/DESCRIPTION#L48.

**Affected definitions**:
- [devtools 4564f5930298194376801a4a0beca31235ecd95c](https://clearlydefined.io/definitions/git/github/r-lib/devtools/4564f5930298194376801a4a0beca31235ecd95c/4564f5930298194376801a4a0beca31235ecd95c)