### PR TITLE
Source Location was missing and the declared license was incorrect.

### DIFF
--- a/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
+++ b/curations/nuget/nuget/-/DocumentFormat.OpenXml.yaml
@@ -7,8 +7,16 @@ revisions:
     licensed:
       declared: Apache-2.0
   2.5.0:
+    described:
+      sourceLocation:
+        name: open-xml-sdk
+        namespace: officedev
+        provider: github
+        revision: 798250cdf725a0db173888268e60aeca88eff633
+        type: git
+        url: 'https://github.com/officedev/open-xml-sdk/commit/798250cdf725a0db173888268e60aeca88eff633'
     licensed:
-      declared: Apache-2.0
+      declared: MIT
   2.7.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source Location was missing and the declared license was incorrect.

**Details:**
Source location was missing and the declared license was incorrect.

**Resolution:**
1. Filled in the correct source location URL.
2. Updated the declared license as per https://github.com/OfficeDev/Open-XML-SDK/blob/798250cdf725a0db173888268e60aeca88eff633/LICENSE (or https://www.nuget.org/packages/DocumentFormat.OpenXml/). See https://github.com/OfficeDev/Open-XML-SDK/issues/364.

**Affected definitions**:
- [DocumentFormat.OpenXml 2.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/DocumentFormat.OpenXml/2.5.0/2.5.0)