### PR TITLE
Declared License was ambiguous.

### DIFF
--- a/curations/git/github/drakkan/sftpgo.yaml
+++ b/curations/git/github/drakkan/sftpgo.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sftpgo
+  namespace: drakkan
+  provider: github
+  type: git
+revisions:
+  1ac4baa00a06247d372f2913a38e451c560d97ca:
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared License was ambiguous.

**Details:**
Declared License said GPL-3.0 AND GPL-3.0-ONLY

**Resolution:**
Updated the declared license as per https://github.com/drakkan/sftpgo/blob/1ac4baa00a06247d372f2913a38e451c560d97ca/LICENSE.

**Affected definitions**:
- [sftpgo 1ac4baa00a06247d372f2913a38e451c560d97ca](https://clearlydefined.io/definitions/git/github/drakkan/sftpgo/1ac4baa00a06247d372f2913a38e451c560d97ca/1ac4baa00a06247d372f2913a38e451c560d97ca)