### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/flyingsaucerproject/flyingsaucer.yaml
+++ b/curations/git/github/flyingsaucerproject/flyingsaucer.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: flyingsaucer
+  namespace: flyingsaucerproject
+  provider: github
+  type: git
+revisions:
+  b73073224e7dc82cf36481acdd8a564190bee60a:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is one NOASSERTION and the declared license from the Component's License File specifies GNU LGPLv2.1 or Later.

License Path  File : https://github.com/flyingsaucerproject/flyingsaucer/blob/master/LICENSE

**Resolution:**
Since there is Declared License Information given in the Component's License information, it is being curated as GNU LGPL v2.1 or Later instead of NOSASSERTION

License Path File : https://github.com/flyingsaucerproject/flyingsaucer/blob/master/LICENSE

**Affected definitions**:
- [flyingsaucer b73073224e7dc82cf36481acdd8a564190bee60a](https://clearlydefined.io/definitions/git/github/flyingsaucerproject/flyingsaucer/b73073224e7dc82cf36481acdd8a564190bee60a/b73073224e7dc82cf36481acdd8a564190bee60a)