### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/elastic/elasticsearch.yaml
+++ b/curations/git/github/elastic/elasticsearch.yaml
@@ -10,6 +10,9 @@ revisions:
   1fd8f691bf2e467057b864eea9103a6e3345af3e:
     licensed:
       declared: Apache-2.0
+  747e1cc71def077253878a59143c1f785afa92b9:
+    licensed:
+      declared: Apache-2.0 OR OTHER
   816e6f6a08be821d8ec01b51bf383544d1e341b0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing.

**Resolution:**
Filled in the declared license as per https://github.com/elastic/elasticsearch/blob/747e1cc71def077253878a59143c1f785afa92b9/LICENSE.txt.

**Affected definitions**:
- [elasticsearch 747e1cc71def077253878a59143c1f785afa92b9](https://clearlydefined.io/definitions/git/github/elastic/elasticsearch/747e1cc71def077253878a59143c1f785afa92b9/747e1cc71def077253878a59143c1f785afa92b9)