### PR TITLE
org.jruby/jruby 1.7.0

### DIFF
--- a/curations/maven/mavencentral/org.jruby/jruby.yaml
+++ b/curations/maven/mavencentral/org.jruby/jruby.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jruby
+  namespace: org.jruby
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.jruby/jruby 1.7.0

**Details:**
Not sure where the tooling is pulling LGPL-3.0.  The LICENSE and NOTICE both reference Apache-2.0 as the license.

**Resolution:**
Declared = Apache-2.0

**Affected definitions**:
- [jruby 1.7.0](https://clearlydefined.io/definitions/maven/mavencentral/org.jruby/jruby/1.7.0/1.7.0)