### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/gogo/protobuf.yaml
+++ b/curations/git/github/gogo/protobuf.yaml
@@ -13,3 +13,6 @@ revisions:
   b03c65ea87cdc3521ede29f62fe3ce239267c1bc:
     licensed:
       declared: BSD-3-Clause
+  ba06b47c162d49f2af050fb4c75bcbc86a159d5c:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing.

**Resolution:**
Filled in the declared license as per https://github.com/gogo/protobuf/blob/ba06b47c162d49f2af050fb4c75bcbc86a159d5c/LICENSE.

**Affected definitions**:
- [protobuf ba06b47c162d49f2af050fb4c75bcbc86a159d5c](https://clearlydefined.io/definitions/git/github/gogo/protobuf/ba06b47c162d49f2af050fb4c75bcbc86a159d5c/ba06b47c162d49f2af050fb4c75bcbc86a159d5c)