### PR TITLE
mocha-fivemat-progress-reporter 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/mocha-fivemat-progress-reporter.yaml
+++ b/curations/npm/npmjs/-/mocha-fivemat-progress-reporter.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mocha-fivemat-progress-reporter
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
mocha-fivemat-progress-reporter 0.1.0

**Details:**
ClearlyDefined license is Apache-2.0
NPM is Apache-2.0
GitHub is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [mocha-fivemat-progress-reporter 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/mocha-fivemat-progress-reporter/0.1.0/0.1.0)