### PR TITLE
System.Data.SQLite.Linq 1.0.111

### DIFF
--- a/curations/nuget/nuget/-/System.Data.SQLite.Linq.yaml
+++ b/curations/nuget/nuget/-/System.Data.SQLite.Linq.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.108:
     licensed:
       declared: OTHER
+  1.0.111:
+    licensed:
+      declared: OTHER
   1.0.112:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Data.SQLite.Linq 1.0.111

**Details:**
ClearlyDefined license is OTHER (Public Domain)
Nuget is OTHER 


**Resolution:**
OTHER

**Affected definitions**:
- [System.Data.SQLite.Linq 1.0.111](https://clearlydefined.io/definitions/nuget/nuget/-/System.Data.SQLite.Linq/1.0.111/1.0.111)