### PR TITLE
System.Security.AccessControl4.6.0-preview 5.19224.8

### DIFF
--- a/curations/nuget/nuget/-/System.Security.AccessControl.yaml
+++ b/curations/nuget/nuget/-/System.Security.AccessControl.yaml
@@ -15,10 +15,13 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
-  4.6.0-preview7.19362.9:
+  4.6.0-preview5.19224.8:
     licensed:
       declared: MIT
   4.6.0-preview6.19303.8:
+    licensed:
+      declared: MIT
+  4.6.0-preview7.19362.9:
     licensed:
       declared: MIT
   4.6.0-preview8.19405.3:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.AccessControl4.6.0-preview 5.19224.8

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT
GitHub license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.AccessControl 4.6.0-preview5.19224.8](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.AccessControl/4.6.0-preview5.19224.8/4.6.0-preview5.19224.8)