### PR TITLE
MarkdownDeep.Full1.5.0

### DIFF
--- a/curations/nuget/nuget/-/MarkdownDeep.Full.yaml
+++ b/curations/nuget/nuget/-/MarkdownDeep.Full.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MarkdownDeep.Full
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MarkdownDeep.Full1.5.0

**Details:**
Not sure why this merged PR is not showing up.  Still says NOASSERTION for declared

**Resolution:**
Apache-2.0

**Affected definitions**:
- [MarkdownDeep.Full 1.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/MarkdownDeep.Full/1.5.0/1.5.0)