### PR TITLE
hazureml-train-restclients-hyperdrive 1.39.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -216,6 +216,9 @@ revisions:
   1.38.0:
     licensed:
       declared: OTHER
+  1.39.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
hazureml-train-restclients-hyperdrive 1.39.0

**Details:**
PyPi license is OTHER: https://aka.ms/azureml-sdk-license

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.39.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.39.0/1.39.0)