### PR TITLE
azureml-pipeline-core 1.39.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-pipeline-core.yaml
+++ b/curations/pypi/pypi/-/azureml-pipeline-core.yaml
@@ -219,6 +219,9 @@ revisions:
   1.38.0:
     licensed:
       declared: OTHER
+  1.39.0:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-pipeline-core 1.39.0

**Details:**
PyPi license is OTHER: https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-pipeline-core 1.39.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-pipeline-core/1.39.0/1.39.0)