### PR TITLE
azureml-automl-core 1.39.1

### DIFF
--- a/curations/pypi/pypi/-/azureml-automl-core.yaml
+++ b/curations/pypi/pypi/-/azureml-automl-core.yaml
@@ -258,6 +258,9 @@ revisions:
   1.39.0:
     licensed:
       declared: OTHER
+  1.39.1:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-automl-core 1.39.1

**Details:**
PyPi license is OTHER: https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-automl-core 1.39.1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-automl-core/1.39.1/1.39.1)