### PR TITLE
azureml-core 1.39.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -417,6 +417,9 @@ revisions:
   1.39.0:
     licensed:
       declared: OTHER
+  1.39.0.post1:
+    licensed:
+      declared: OTHER
   1.4.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-core 1.39.0.post1

**Details:**
PyPi license is OTHER: https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-core 1.39.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.39.0.post1/1.39.0.post1)