### PR TITLE
azureml-inference-server-http 0.3.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-inference-server-http.yaml
+++ b/curations/pypi/pypi/-/azureml-inference-server-http.yaml
@@ -6,6 +6,9 @@ revisions:
   0.3.1:
     licensed:
       declared: OTHER
+  0.3.2:
+    licensed:
+      declared: OTHER
   0.4.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-inference-server-http 0.3.2

**Details:**
PyPi license is OTHER: https://github.com/Azure/MachineLearningNotebooks/blob/master/Licenses/sdk-license/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-inference-server-http 0.3.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-inference-server-http/0.3.2/0.3.2)