### PR TITLE
torchvision 0.12.0

### DIFF
--- a/curations/pypi/pypi/-/torchvision.yaml
+++ b/curations/pypi/pypi/-/torchvision.yaml
@@ -33,6 +33,9 @@ revisions:
   0.11.3:
     licensed:
       declared: BSD-3-Clause
+  0.12.0:
+    licensed:
+      declared: BSD-3-Clause
   0.2.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
torchvision 0.12.0

**Details:**
PyPi license is BSD-3-Clause: https://github.com/pytorch/vision/blob/v0.12.0/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [torchvision 0.12.0](https://clearlydefined.io/definitions/pypi/pypi/-/torchvision/0.12.0/0.12.0)