### PR TITLE
Base32 1.1.2

### DIFF
--- a/curations/pod/cocoapods/-/Base32.yaml
+++ b/curations/pod/cocoapods/-/Base32.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Base32
+  provider: cocoapods
+  type: pod
+revisions:
+  1.1.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Base32 1.1.2

**Details:**
GitHub Readme indicates Public Domain:  https://github.com/ekscrypto/Base32/blob/1.1.2/README.md

**Resolution:**
OTHER

**Affected definitions**:
- [Base32 1.1.2](https://clearlydefined.io/definitions/pod/cocoapods/-/Base32/1.1.2/1.1.2)