### PR TITLE
ZendeskSDK 1.5.3.1

### DIFF
--- a/curations/pod/cocoapods/-/ZendeskSDK.yaml
+++ b/curations/pod/cocoapods/-/ZendeskSDK.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ZendeskSDK
+  provider: cocoapods
+  type: pod
+revisions:
+  1.5.3.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ZendeskSDK 1.5.3.1

**Details:**
GitHub license is OTHER: https://github.com/zendesk/zendesk_sdk_ios/blob/1.5.3.1/LICENSE.md

**Resolution:**
OTHER

**Affected definitions**:
- [ZendeskSDK 1.5.3.1](https://clearlydefined.io/definitions/pod/cocoapods/-/ZendeskSDK/1.5.3.1/1.5.3.1)