### PR TITLE
Helpshift 7.6.3

### DIFF
--- a/curations/pod/cocoapods/-/Helpshift.yaml
+++ b/curations/pod/cocoapods/-/Helpshift.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   7.6.3:
     licensed:
-      declared: Apache-2.0
+      declared: OTHER

--- a/curations/pod/cocoapods/-/Helpshift.yaml
+++ b/curations/pod/cocoapods/-/Helpshift.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Helpshift
+  provider: cocoapods
+  type: pod
+revisions:
+  7.6.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Helpshift 7.6.3

**Details:**
GitHub license is Apache-2.0: https://github.com/helpshift/helpshift-api

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Helpshift 7.6.3](https://clearlydefined.io/definitions/pod/cocoapods/-/Helpshift/7.6.3/7.6.3)