### PR TITLE
pcf-start 1.12.2

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -15,6 +15,9 @@ revisions:
   1.11.8:
     licensed:
       declared: OTHER
+  1.12.2:
+    licensed:
+      declared: OTHER
   1.2.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pcf-start 1.12.2

**Details:**
ClearlyDefined license is OTHER: https://clearlydefined.io/file/dc0ec69f61019186d491e8d0f63bf194e06fb784ba7a2e3078d25d4d7a8a8dee

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-start 1.12.2](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.12.2/1.12.2)