### PR TITLE
Appboy-iOS-SDK 3.10.0

### DIFF
--- a/curations/pod/cocoapods/-/Appboy-iOS-SDK.yaml
+++ b/curations/pod/cocoapods/-/Appboy-iOS-SDK.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: cocoapods
   type: pod
 revisions:
+  3.10.0:
+    licensed:
+      declared: OTHER
   3.20.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Appboy-iOS-SDK 3.10.0

**Details:**
GitHub license is non-standard OTHER: https://github.com/Appboy/appboy-ios-sdk/blob/3.10.0/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [Appboy-iOS-SDK 3.10.0](https://clearlydefined.io/definitions/pod/cocoapods/-/Appboy-iOS-SDK/3.10.0/3.10.0)