### PR TITLE
Starscream 3.0.6

### DIFF
--- a/curations/pod/cocoapods/-/Starscream.yaml
+++ b/curations/pod/cocoapods/-/Starscream.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Starscream
+  provider: cocoapods
+  type: pod
+revisions:
+  3.0.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Starscream 3.0.6

**Details:**
GitHub license is Apache-2.0: https://github.com/daltoniam/Starscream/blob/3.0.6/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Starscream 3.0.6](https://clearlydefined.io/definitions/pod/cocoapods/-/Starscream/3.0.6/3.0.6)