### PR TITLE
@microsoft/office-js 1.1.73

### DIFF
--- a/curations/npm/npmjs/@microsoft/office-js.yaml
+++ b/curations/npm/npmjs/@microsoft/office-js.yaml
@@ -538,6 +538,9 @@ revisions:
   1.1.51:
     licensed:
       declared: OTHER
+  1.1.73:
+    licensed:
+      declared: OTHER
   1.1.8:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/office-js 1.1.73

**Details:**
ClearlyDefined license is OTHER (MSLT)
NPM see license folder

**Resolution:**
OTHER

**Affected definitions**:
- [office-js 1.1.73](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/office-js/1.1.73/1.1.73)