### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/krb5/krb5.yaml
+++ b/curations/git/github/krb5/krb5.yaml
@@ -148,4 +148,4 @@ revisions:
         path: src/lib/gssapi/krb5/gssapi_krb5.c
   a6566760ec7c5fb8eca6ae3a6f2729d5002b03e0:
     licensed:
-      declared: BSD-2-Clause
+      declared: OTHER

--- a/curations/git/github/krb5/krb5.yaml
+++ b/curations/git/github/krb5/krb5.yaml
@@ -5,7 +5,7 @@ coordinates:
   type: git
 revisions:
   97e3c42b2a89a2ec60eb93d3f974769e3e3cbdc5:
-    files:    
+    files:
       - attributions:
           - 'Copyright 1992-2018 Free Software Foundation, Inc.'
           - 'Copyright (c) 2010, 2011 by the Massachusetts Institute of Technology.'
@@ -146,3 +146,6 @@ revisions:
           - 'Copyright 1993 by OpenVision Technologies, Inc.'
         license: 'HPND-sell-variant AND BSD-3-Clause AND OTHER '
         path: src/lib/gssapi/krb5/gssapi_krb5.c
+  a6566760ec7c5fb8eca6ae3a6f2729d5002b03e0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is one SPDX License mentioned and the License information found from the repository is BSD-2-Clause License.

License File Path : https://github.com/krb5/krb5/blob/krb5-1.18-final/NOTICE 

**Resolution:**
In order to resolve the Unknown SPDX License, it is being curated as BSD-2-Clause License as found from the Source code Repository

License File path : https://github.com/krb5/krb5/blob/krb5-1.18-final/NOTICE

**Affected definitions**:
- [krb5 a6566760ec7c5fb8eca6ae3a6f2729d5002b03e0](https://clearlydefined.io/definitions/git/github/krb5/krb5/a6566760ec7c5fb8eca6ae3a6f2729d5002b03e0/a6566760ec7c5fb8eca6ae3a6f2729d5002b03e0)