### PR TITLE
Updated Declared license

### DIFF
--- a/curations/git/github/ibotpeaches/apktool.yaml
+++ b/curations/git/github/ibotpeaches/apktool.yaml
@@ -8,3 +8,6 @@ revisions:
     files:
       - license: CC-BY-NC-SA-2.0
         path: brut.apktool/apktool-lib/src/test/resources/aapt1/testapp/res/drawable-ldpi/data.jpg
+  66ead001c6d9151968de22346c2618b0c1720fa2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updated Declared license

**Details:**
The declared license is missing from this component.

**Resolution:**
The declared license is updated to Apache 2.0.
Here is the license file for this component version - 
https://github.com/iBotPeaches/Apktool/blob/66ead001c6d9151968de22346c2618b0c1720fa2/LICENSE

**Affected definitions**:
- [apktool 66ead001c6d9151968de22346c2618b0c1720fa2](https://clearlydefined.io/definitions/git/github/ibotpeaches/apktool/66ead001c6d9151968de22346c2618b0c1720fa2/66ead001c6d9151968de22346c2618b0c1720fa2)