### PR TITLE
Ninject.Extensions.Logging.Log4net3.3.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.Logging.Log4net.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.Logging.Log4net.yaml
@@ -12,3 +12,6 @@ revisions:
   3.2.3:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.3.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Extensions.Logging.Log4net3.3.0

**Details:**
Declaring Apache-2.0 OR MS-PL

**Resolution:**
https://github.com/ninject/Ninject/blob/3.3.0/LICENSE.txt

**Affected definitions**:
- [Ninject.Extensions.Logging.Log4net 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.Logging.Log4net/3.3.0/3.3.0)