### PR TITLE
uservoice-iphone-sdk3.2.3

### DIFF
--- a/curations/pod/cocoapods/-/uservoice-iphone-sdk.yaml
+++ b/curations/pod/cocoapods/-/uservoice-iphone-sdk.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: uservoice-iphone-sdk
+  provider: cocoapods
+  type: pod
+revisions:
+  3.2.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
uservoice-iphone-sdk3.2.3

**Details:**
Adding Apache-2.0 as Declared License

**Resolution:**
https://cocoapods.org/pods/uservoice-iphone-sdk

https://github.com/uservoice/uservoice-ios-sdk/blob/1eeac7dc835c4f3275eea0281f3fd6c7049f21b0/LICENSE.md

**Affected definitions**:
- [uservoice-iphone-sdk 3.2.3](https://clearlydefined.io/definitions/pod/cocoapods/-/uservoice-iphone-sdk/3.2.3/3.2.3)