### PR TITLE
FluentMigrator.Runner 3.2.17

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Runner.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Runner.yaml
@@ -15,3 +15,6 @@ revisions:
   3.2.1:
     licensed:
       declared: Apache-2.0
+  3.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Runner 3.2.17

**Details:**
Adding Apache-2.0 as Declared License

**Resolution:**
https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.17/LICENSE.txt

**Affected definitions**:
- [FluentMigrator.Runner 3.2.17](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner/3.2.17/3.2.17)