### PR TITLE
FluentMigrator.Extensions.SqlAnywhere 3.2.17

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Extensions.SqlAnywhere.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Extensions.SqlAnywhere.yaml
@@ -9,3 +9,6 @@ revisions:
   3.2.1:
     licensed:
       declared: Apache-2.0
+  3.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Extensions.SqlAnywhere 3.2.17

**Details:**
Adding Apache-2.0 as Declared License

**Resolution:**
https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.17/LICENSE.txt

**Affected definitions**:
- [FluentMigrator.Extensions.SqlAnywhere 3.2.17](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Extensions.SqlAnywhere/3.2.17/3.2.17)