### PR TITLE
Bootstrap.Switch3.3.2.1

### DIFF
--- a/curations/nuget/nuget/-/Bootstrap.Switch.yaml
+++ b/curations/nuget/nuget/-/Bootstrap.Switch.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Bootstrap.Switch
+  provider: nuget
+  type: nuget
+revisions:
+  3.3.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Bootstrap.Switch3.3.2.1

**Details:**
Adding Apache-2.0 as Declared License

**Resolution:**
https://github.com/Bttstrp/bootstrap-switch/blob/v3.3.2/LICENSE

[License changed in 2017 to MIT in repo]

**Affected definitions**:
- [Bootstrap.Switch 3.3.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Bootstrap.Switch/3.3.2.1/3.3.2.1)