### PR TITLE
Xamarin.Android.Support.v7.AppCompat25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.v7.AppCompat.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.v7.AppCompat.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  25.4.0.2:
+    licensed:
+      declared: MIT
   26.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.v7.AppCompat25.4.0.2

**Details:**
Adding MIT as Declared License

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/25.4.0.2/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.v7.AppCompat 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.v7.AppCompat/25.4.0.2/25.4.0.2)