### PR TITLE
Added license information.

### DIFF
--- a/curations/nuget/nuget/-/SpecRun.Runner.yaml
+++ b/curations/nuget/nuget/-/SpecRun.Runner.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.6.0:
     licensed:
-      declared: MIT+
+      declared: OTHER
   1.8.5:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/SpecRun.Runner.yaml
+++ b/curations/nuget/nuget/-/SpecRun.Runner.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.6.0:
+    licensed:
+      declared: MIT+
   1.8.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added license information.

**Details:**
The license for SpecRun.Runner was not included.

**Resolution:**
The license was found for SpecRun.Runner (and other SpecRun packages):
https://github.com/SpecFlowOSS/SpecFlow.Rider/blob/master/LICENSE

**Affected definitions**:
- [SpecRun.Runner 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/SpecRun.Runner/1.6.0/1.6.0)