### PR TITLE
Added license information for SpecRun.SpecFlow

### DIFF
--- a/curations/nuget/nuget/-/SpecRun.SpecFlow.yaml
+++ b/curations/nuget/nuget/-/SpecRun.SpecFlow.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   1.6.0:
     licensed:
-      declared: MIT+
+      declared: OTHER
   1.8.5:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/SpecRun.SpecFlow.yaml
+++ b/curations/nuget/nuget/-/SpecRun.SpecFlow.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.6.0:
+    licensed:
+      declared: MIT+
   1.8.5:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added license information for SpecRun.SpecFlow

**Details:**
The license info for SpecRun.SpecFlow was not included.

**Resolution:**
The license was found for SpecRun.SpecFlow (and other SpecRun packages):
https://github.com/SpecFlowOSS/SpecFlow.Rider/blob/master/LICENSE

**Affected definitions**:
- [SpecRun.SpecFlow 1.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/SpecRun.SpecFlow/1.6.0/1.6.0)