### PR TITLE
Added the Source and License for ApacheOrcDotNet 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/ApacheOrcDotNet.yaml
+++ b/curations/nuget/nuget/-/ApacheOrcDotNet.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: ApacheOrcDotNet
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    described:
+      sourceLocation:
+        name: apacheorcdotnet
+        namespace: ddrinka
+        provider: github
+        revision: e4ed926
+        type: git
+        url: 'https://github.com/ddrinka/apacheorcdotnet/commit/e4ed926'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Added the Source and License for ApacheOrcDotNet 1.0.0

**Details:**
Source and license data was missing for ApacheOrcDotNet.

**Resolution:**
Source and license data was added.
License was here: https://github.com/ddrinka/ApacheOrcDotNet/blob/master/LICENSE

**Affected definitions**:
- [ApacheOrcDotNet 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/ApacheOrcDotNet/1.0.0/1.0.0)