### PR TITLE
License for Gremlinq.Core

### DIFF
--- a/curations/nuget/nuget/-/ExRam.Gremlinq.Core.yaml
+++ b/curations/nuget/nuget/-/ExRam.Gremlinq.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ExRam.Gremlinq.Core
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License for Gremlinq.Core

**Details:**
Gremlinq.Core version 7.0.6 was missing license definition.

**Resolution:**
Added license information for Gremlinq.Core

**Affected definitions**:
- [ExRam.Gremlinq.Core 7.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/ExRam.Gremlinq.Core/7.0.6/7.0.6)