### PR TITLE
License for Gremlinq.Providers

### DIFF
--- a/curations/nuget/nuget/-/ExRam.Gremlinq.Providers.yaml
+++ b/curations/nuget/nuget/-/ExRam.Gremlinq.Providers.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ExRam.Gremlinq.Providers
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License for Gremlinq.Providers

**Details:**
Gremlinq.Providers version 7.0.6 was missing its license data.

**Resolution:**
Added license information for Gremlinq.Providers.

**Affected definitions**:
- [ExRam.Gremlinq.Providers 7.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/ExRam.Gremlinq.Providers/7.0.6/7.0.6)