### PR TITLE
License for Gremlinq.Providers.CosmosDb

### DIFF
--- a/curations/nuget/nuget/-/ExRam.Gremlinq.Providers.CosmosDb.yaml
+++ b/curations/nuget/nuget/-/ExRam.Gremlinq.Providers.CosmosDb.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ExRam.Gremlinq.Providers.CosmosDb
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License for Gremlinq.Providers.CosmosDb

**Details:**
License data for Gremlinq.Providers.CosmosDb (version 7.0.6) was missing license data.

**Resolution:**
Declared the license for Gremlinq.Providers.CosmosDb

**Affected definitions**:
- [ExRam.Gremlinq.Providers.CosmosDb 7.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/ExRam.Gremlinq.Providers.CosmosDb/7.0.6/7.0.6)