### PR TITLE
License for Gremlinq.Providers.WebSocket

### DIFF
--- a/curations/nuget/nuget/-/ExRam.Gremlinq.Providers.WebSocket.yaml
+++ b/curations/nuget/nuget/-/ExRam.Gremlinq.Providers.WebSocket.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ExRam.Gremlinq.Providers.WebSocket
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License for Gremlinq.Providers.WebSocket

**Details:**
License data was missing for version 7.0.6 of Gremlinq.Providers.WebSocket.

**Resolution:**
Declared the license for Gremlinq.Providers.WebSocket.

**Affected definitions**:
- [ExRam.Gremlinq.Providers.WebSocket 7.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/ExRam.Gremlinq.Providers.WebSocket/7.0.6/7.0.6)