### PR TITLE
License Data for LanguageExt.Core/3.3.28

### DIFF
--- a/curations/nuget/nuget/-/LanguageExt.Core.yaml
+++ b/curations/nuget/nuget/-/LanguageExt.Core.yaml
@@ -21,6 +21,9 @@ revisions:
   3.1.15:
     licensed:
       declared: MIT
+  3.3.28:
+    licensed:
+      declared: MIT
   3.4.15:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
License Data for LanguageExt.Core/3.3.28

**Details:**
The license data for LanguageExt.Core (version 3.3.28) was missing license data.

**Resolution:**
Found the license and added it to the site. It looks like MIT.
Found here: https://github.com/louthy/language-ext/blob/main/LICENSE.md

**Affected definitions**:
- [LanguageExt.Core 3.3.28](https://clearlydefined.io/definitions/nuget/nuget/-/LanguageExt.Core/3.3.28/3.3.28)