### PR TITLE
GPUImage 0.1.6

### DIFF
--- a/curations/pod/cocoapods/-/GPUImage.yaml
+++ b/curations/pod/cocoapods/-/GPUImage.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: GPUImage
+  provider: cocoapods
+  type: pod
+revisions:
+  0.1.6:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GPUImage 0.1.6

**Details:**
ClearlyDefined license is BSD-3-Clause
GitHub license is BSD-3-Clause: https://github.com/BradLarson/GPUImage/blob/2c302f9fb168b8e139d2aee9b0047b2a61b9035e/License.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [GPUImage 0.1.6](https://clearlydefined.io/definitions/pod/cocoapods/-/GPUImage/0.1.6/0.1.6)