### PR TITLE
org.osgi/osgi.core 6.0.0

### DIFF
--- a/curations/maven/mavencentral/org.osgi/osgi.core.yaml
+++ b/curations/maven/mavencentral/org.osgi/osgi.core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: osgi.core
+  namespace: org.osgi
+  provider: mavencentral
+  type: maven
+revisions:
+  6.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.osgi/osgi.core 6.0.0

**Details:**
Maven POM is Apache-2.0: https://repo1.maven.org/maven2/org/osgi/org.osgi.core/6.0.0/org.osgi.core-6.0.0.pom

**Resolution:**
Apache-2.0

**Affected definitions**:
- [osgi.core 6.0.0](https://clearlydefined.io/definitions/maven/mavencentral/org.osgi/osgi.core/6.0.0/6.0.0)