### PR TITLE
GTMAppAuth 0.7.1

### DIFF
--- a/curations/pod/cocoapods/-/GTMAppAuth.yaml
+++ b/curations/pod/cocoapods/-/GTMAppAuth.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: GTMAppAuth
+  provider: cocoapods
+  type: pod
+revisions:
+  0.7.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GTMAppAuth 0.7.1

**Details:**
ClearlyDefined license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/google/GTMAppAuth/blob/0.7.1/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [GTMAppAuth 0.7.1](https://clearlydefined.io/definitions/pod/cocoapods/-/GTMAppAuth/0.7.1/0.7.1)