### PR TITLE
javax.measure/unit-api 1.0

### DIFF
--- a/curations/maven/mavencentral/javax.measure/unit-api.yaml
+++ b/curations/maven/mavencentral/javax.measure/unit-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: unit-api
+  namespace: javax.measure
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.measure/unit-api 1.0

**Details:**
ClearlyDefined pom is BSD
GitHub is BSD-3-Clause: https://github.com/unitsofmeasurement/unit-api/blob/1.0/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [unit-api 1.0](https://clearlydefined.io/definitions/maven/mavencentral/javax.measure/unit-api/1.0/1.0)