### PR TITLE
bo-selector 0.0.10

### DIFF
--- a/curations/npm/npmjs/-/bo-selector.yaml
+++ b/curations/npm/npmjs/-/bo-selector.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: bo-selector
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.10:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bo-selector 0.0.10

**Details:**
ClearlyDefined license is BSD-2-Clause
NPM is BSD
GitHub is BSD-3-Clause: https://github.com/featurist/bo-selector/blob/master/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [bo-selector 0.0.10](https://clearlydefined.io/definitions/npm/npmjs/-/bo-selector/0.0.10/0.0.10)