### PR TITLE
Valet 2.2.1

### DIFF
--- a/curations/pod/cocoapods/-/Valet.yaml
+++ b/curations/pod/cocoapods/-/Valet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Valet
+  provider: cocoapods
+  type: pod
+revisions:
+  2.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Valet 2.2.1

**Details:**
ClearlyDefined license is Apache-2.0
GitHub is Apache-2.0: https://github.com/square/Valet/blob/2.2.1/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Valet 2.2.1](https://clearlydefined.io/definitions/pod/cocoapods/-/Valet/2.2.1/2.2.1)