### PR TITLE
functools 0.5

### DIFF
--- a/curations/pypi/pypi/-/functools.yaml
+++ b/curations/pypi/pypi/-/functools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: functools
+  provider: pypi
+  type: pypi
+revisions:
+  '0.5':
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
functools 0.5

**Details:**
PyPi is BSD
Downloaded package and license is BSD-2-Clause (functools-0.5.tar)

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [functools 0.5](https://clearlydefined.io/definitions/pypi/pypi/-/functools/0.5/0.5)