### PR TITLE
com.adobe.xmp/xmpcore 5.1.3

### DIFF
--- a/curations/maven/mavencentral/com.adobe.xmp/xmpcore.yaml
+++ b/curations/maven/mavencentral/com.adobe.xmp/xmpcore.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   5.1.3:
     licensed:
-      declared: OTHER
+      declared: BSD-3-Clause

--- a/curations/maven/mavencentral/com.adobe.xmp/xmpcore.yaml
+++ b/curations/maven/mavencentral/com.adobe.xmp/xmpcore.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xmpcore
+  namespace: com.adobe.xmp
+  provider: mavencentral
+  type: maven
+revisions:
+  5.1.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.adobe.xmp/xmpcore 5.1.3

**Details:**
ClearlyDefined license is OTHER: https://clearlydefined.io/file/f41f302101f73610a975b06ec4bf31f7dc121dd623035435bd48b5638bc9e442
Maven pom indicates BSD

**Resolution:**
OTHER

**Affected definitions**:
- [xmpcore 5.1.3](https://clearlydefined.io/definitions/maven/mavencentral/com.adobe.xmp/xmpcore/5.1.3/5.1.3)