### PR TITLE
FluentMigrator.Extensions.Postgres 3.2.17

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Extensions.Postgres.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Extensions.Postgres.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FluentMigrator.Extensions.Postgres
+  provider: nuget
+  type: nuget
+revisions:
+  3.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Extensions.Postgres 3.2.17

**Details:**
ClearlyDefined license file indicates Apache-2.0
GitHub license is Apache-2.0: https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.17/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Extensions.Postgres 3.2.17](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Extensions.Postgres/3.2.17/3.2.17)