### PR TITLE
FluentMigrator.Runner.Firebird 3.2.17

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Runner.Firebird.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Runner.Firebird.yaml
@@ -9,3 +9,6 @@ revisions:
   3.2.1:
     licensed:
       declared: Apache-2.0
+  3.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Runner.Firebird 3.2.17

**Details:**
ClearlyDefined license indicates Apache-2.0
GitHub license is Apache-2.0: https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner.Firebird/3.2.17

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Runner.Firebird 3.2.17](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner.Firebird/3.2.17/3.2.17)