### PR TITLE
Avro-C 1.7.6

### DIFF
--- a/curations/pod/cocoapods/-/Avro-C.yaml
+++ b/curations/pod/cocoapods/-/Avro-C.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.7.6:
     licensed:
-      declared: Apache-2.0 AND BSD-3-Clause AND MIT
+      declared: Apache-2.0 

--- a/curations/pod/cocoapods/-/Avro-C.yaml
+++ b/curations/pod/cocoapods/-/Avro-C.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Avro-C
+  provider: cocoapods
+  type: pod
+revisions:
+  1.7.6:
+    licensed:
+      declared: Apache-2.0 AND BSD-3-Clause AND MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Avro-C 1.7.6

**Details:**
ClearlyDefined license is Apache-2.0 AND BSD-3-Clause AND MIT

**Resolution:**
Apache-2.0 AND BSD-3-Clause AND MIT

**Affected definitions**:
- [Avro-C 1.7.6](https://clearlydefined.io/definitions/pod/cocoapods/-/Avro-C/1.7.6/1.7.6)