### PR TITLE
uservoice-iphone-sdk 3.2.12

### DIFF
--- a/curations/pod/cocoapods/-/uservoice-iphone-sdk.yaml
+++ b/curations/pod/cocoapods/-/uservoice-iphone-sdk.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: cocoapods
   type: pod
 revisions:
+  3.2.12:
+    licensed:
+      declared: Apache-2.0
   3.2.3:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
uservoice-iphone-sdk 3.2.12

**Details:**
ClearlyDefined license is Apache-2.0
GitHub license is Apache-2.0: https://github.com/uservoice/uservoice-ios-sdk/blob/3.2.12/LICENSE.md

**Resolution:**
Apache-2.0

**Affected definitions**:
- [uservoice-iphone-sdk 3.2.12](https://clearlydefined.io/definitions/pod/cocoapods/-/uservoice-iphone-sdk/3.2.12/3.2.12)