### PR TITLE
Ninject.Extensions.Logging 3.3.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Extensions.Logging.yaml
+++ b/curations/nuget/nuget/-/Ninject.Extensions.Logging.yaml
@@ -12,6 +12,9 @@ revisions:
   3.2.3:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.3.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL
   3.3.0-beta1:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Extensions.Logging 3.3.0

**Details:**
Nuget license is Apache-2.0 OR MS-PL
GitHub license is Apache-2.0 OR MS-PL: https://github.com/ninject/Ninject.Extensions.Logging/blob/3.3.0/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.Extensions.Logging 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Extensions.Logging/3.3.0/3.3.0)