### PR TITLE
FluentMigrator.Runner.SqlServerCe 3.2.17

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Runner.SqlServerCe.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Runner.SqlServerCe.yaml
@@ -9,3 +9,6 @@ revisions:
   3.2.1:
     licensed:
       declared: Apache-2.0
+  3.2.17:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentMigrator.Runner.SqlServerCe 3.2.17

**Details:**
ClearlyDefined license is Apache-2.0
Nuget is Apache-2.0
GitHub is Apache-2.0: https://github.com/fluentmigrator/fluentmigrator/blob/v3.2.17/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentMigrator.Runner.SqlServerCe 3.2.17](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner.SqlServerCe/3.2.17/3.2.17)