### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/mperham/sidekiq.yaml
+++ b/curations/git/github/mperham/sidekiq.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sidekiq
+  namespace: mperham
+  provider: github
+  type: git
+revisions:
+  b14d38a9e4dc316ffb05e882884a0a103b65849f:
+    licensed:
+      declared: LGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is no License declared and specified just as SPDX License. But the License file of the Component shows the License declared as LGPLv3 as well as Commercial License EULA

License Path File : https://github.com/mperham/sidekiq/blob/main/LICENSE

https://github.com/mperham/sidekiq/blob/b14d38a9e4

**Resolution:**
Since there is no Declared License and License file shows the appropriate one as LGPL v3 and a Commercial License, it is being curated as LGPL-3.0 Only OR OTHER instead of SPDX un-mentioned License.

License Path File : https://github.com/mperham/sidekiq/blob/main/LICENSE

https://github.com/mperha


**Affected definitions**:
- [sidekiq b14d38a9e4dc316ffb05e882884a0a103b65849f](https://clearlydefined.io/definitions/git/github/mperham/sidekiq/b14d38a9e4dc316ffb05e882884a0a103b65849f/b14d38a9e4dc316ffb05e882884a0a103b65849f)