### PR TITLE
Add declared license for go/x/crypto

### DIFF
--- a/curations/go/golang/golang.org/x/crypto.yaml
+++ b/curations/go/golang/golang.org/x/crypto.yaml
@@ -7,3 +7,6 @@ revisions:
   v0.0.0-20220315160706-3147a52a75dd:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  v0.0.0-20220321153916-2c7772ba3064:
+    licensed:
+      declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION
Type: Missing

Summary:
golang.org/x/crypto v0.0.0-20220321153916-2c7772ba3064

Details:
Add BSD-3-Clause License

Resolution:
License Url:
https://pkg.go.dev/golang.org/x/crypto?tab=licenses

Description:

Pull request manually opened by @mpcen 

Affected definitions:

[crypto v0.0.0-20220321153916-2c7772ba3064](https://clearlydefined.io/definitions/go/golang/golang.org/x/crypto/v0.0.0-20220321153916-2c7772ba3064)