### PR TITLE
Resolve Case of Incorrect License

### DIFF
--- a/curations/git/github/tinymce/tinymce.yaml
+++ b/curations/git/github/tinymce/tinymce.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   7bf9c066a06abe1b478c73628241fad71085da6d:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-only OR OTHER

--- a/curations/git/github/tinymce/tinymce.yaml
+++ b/curations/git/github/tinymce/tinymce.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tinymce
+  namespace: tinymce
+  provider: github
+  type: git
+revisions:
+  7bf9c066a06abe1b478c73628241fad71085da6d:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve Case of Incorrect License

**Details:**
There is Apache 2.0 License in the Declared License and the Component Source Repository shows LGPL 2.1-Only for the version 5.6.2

License file Path :
https://github.com/tinymce/tinymce/blob/5.6.2/LICENSE.TXT

**Resolution:**
The incorrect Apache 2.0 License is being curated as LGPL 2.0-Only instead of Apache 2.0.

License File path : https://github.com/tinymce/tinymce/blob/5.6.2/LICENSE.TXT

**Affected definitions**:
- [tinymce 7bf9c066a06abe1b478c73628241fad71085da6d](https://clearlydefined.io/definitions/git/github/tinymce/tinymce/7bf9c066a06abe1b478c73628241fad71085da6d/7bf9c066a06abe1b478c73628241fad71085da6d)