### PR TITLE
Google-Maps-iOS-Utils 2.1.0

### DIFF
--- a/curations/pod/cocoapods/-/Google-Maps-iOS-Utils.yaml
+++ b/curations/pod/cocoapods/-/Google-Maps-iOS-Utils.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google-Maps-iOS-Utils
+  provider: cocoapods
+  type: pod
+revisions:
+  2.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google-Maps-iOS-Utils 2.1.0

**Details:**
GitHub license is Apache-2.0: https://github.com/googlemaps/google-maps-ios-utils/blob/v2.1.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Google-Maps-iOS-Utils 2.1.0](https://clearlydefined.io/definitions/pod/cocoapods/-/Google-Maps-iOS-Utils/2.1.0/2.1.0)