### PR TITLE
ts-express 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/ts-express.yaml
+++ b/curations/npm/npmjs/-/ts-express.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ts-express
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ts-express 1.0.0

**Details:**
NPMJS states None
No license info in package.json

**Resolution:**
NONE

**Affected definitions**:
- [ts-express 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/ts-express/1.0.0/1.0.0)