### PR TITLE
dependabot-npm_and_yarn 0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-npm_and_yarn.yaml
+++ b/curations/gem/rubygems/-/dependabot-npm_and_yarn.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.162.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-npm_and_yarn 0.145.4

**Details:**
RubyGems states nonstandard
GitHub is non-standard: https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Resolution:**
OTHER

**Affected definitions**:
- [dependabot-npm_and_yarn 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-npm_and_yarn/0.145.4/0.145.4)