### PR TITLE
matplotlib 2.1.0

### DIFF
--- a/curations/pypi/pypi/-/matplotlib.yaml
+++ b/curations/pypi/pypi/-/matplotlib.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.1.0:
     licensed:
-      declared: OTHER
+      declared: PSF-2.0
   2.2.2:
     licensed:
       declared: PSF-2.0

--- a/curations/pypi/pypi/-/matplotlib.yaml
+++ b/curations/pypi/pypi/-/matplotlib.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  2.1.0:
+    licensed:
+      declared: OTHER
   2.2.2:
     licensed:
       declared: PSF-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
matplotlib 2.1.0

**Details:**
PyPi indicates  Python Software Foundation License (BSD)
Matplotlib readme states: Matplotlib only uses BSD compatible code, and its license is based on the PSF license. See the Open Source Initiative licenses page for details on individual licenses. 
DiffTool indicates nonstandard SPDX

**Resolution:**
OTHER

**Affected definitions**:
- [matplotlib 2.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/matplotlib/2.1.0/2.1.0)