### PR TITLE
gym 0.20.0

### DIFF
--- a/curations/pypi/pypi/-/gym.yaml
+++ b/curations/pypi/pypi/-/gym.yaml
@@ -27,6 +27,9 @@ revisions:
   0.19.0:
     licensed:
       declared: MIT
+  0.20.0:
+    licensed:
+      declared: MIT
   0.21.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
gym 0.20.0

**Details:**
PyPi indiates unkown
GitHub is MIT: https://github.com/openai/gym/blob/v0.20.0/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [gym 0.20.0](https://clearlydefined.io/definitions/pypi/pypi/-/gym/0.20.0/0.20.0)