### PR TITLE
qcodes 0.22.0

### DIFF
--- a/curations/pypi/pypi/-/qcodes.yaml
+++ b/curations/pypi/pypi/-/qcodes.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: qcodes
+  provider: pypi
+  type: pypi
+revisions:
+  0.22.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
qcodes 0.22.0

**Details:**
ClearlyDefined PKG-INFO indicates MIT
GitHub is MIT: https://github.com/QCoDeS/Qcodes/blob/v0.22.0/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [qcodes 0.22.0](https://clearlydefined.io/definitions/pypi/pypi/-/qcodes/0.22.0/0.22.0)