### PR TITLE
zlib 1.2.8.7

### DIFF
--- a/curations/nuget/nuget/-/zlib.yaml
+++ b/curations/nuget/nuget/-/zlib.yaml
@@ -6,6 +6,9 @@ revisions:
   1.2.8.6:
     licensed:
       declared: Zlib
+  1.2.8.7:
+    licensed:
+      declared: Zlib
   1.2.8.8:
     licensed:
       declared: Zlib


### PR DESCRIPTION

**Type:** Missing

**Summary:**
zlib 1.2.8.7

**Details:**
Nuget license link broken
GitHub license is in readme and is Zlib

**Resolution:**
Zlib

**Affected definitions**:
- [zlib 1.2.8.7](https://clearlydefined.io/definitions/nuget/nuget/-/zlib/1.2.8.7/1.2.8.7)