### PR TITLE
Xamarin.Google.Android.Material 1.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Google.Android.Material.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Google.Android.Material.yaml
@@ -15,3 +15,6 @@ revisions:
   1.3.0:
     licensed:
       declared: MIT
+  1.4.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Google.Android.Material 1.4.0.2

**Details:**
ClearlyDefined license file is MIT
Nuget license is MIT
GitHub license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Google.Android.Material 1.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Google.Android.Material/1.4.0.2/1.4.0.2)