### PR TITLE
windowsazure.mediaservices.extensions 3.3.0

### DIFF
--- a/curations/nuget/nuget/-/windowsazure.mediaservices.extensions.yaml
+++ b/curations/nuget/nuget/-/windowsazure.mediaservices.extensions.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.3.0:
+    licensed:
+      declared: Apache-2.0
   4.1.0.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
windowsazure.mediaservices.extensions 3.3.0

**Details:**
GitHub license is Apache-2.0: https://github.com/Azure/azure-sdk-for-media-services-extensions/blob/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [windowsazure.mediaservices.extensions 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/windowsazure.mediaservices.extensions/3.3.0/3.3.0)