### PR TITLE
System.IO.Abstractions 2.1.0.227

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -18,6 +18,9 @@ revisions:
   2.1.0.178:
     licensed:
       declared: MS-PL
+  2.1.0.227:
+    licensed:
+      declared: MIT
   2.1.0.230:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.IO.Abstractions 2.1.0.227

**Details:**
Nuget license is MIT: https://github.com/TestableIO/System.IO.Abstractions/blob/main/LICENSE
GitHub license is MIT 

**Resolution:**
MIT

**Affected definitions**:
- [System.IO.Abstractions 2.1.0.227](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/2.1.0.227/2.1.0.227)