### PR TITLE
Unity.Container 5.5.1

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -39,6 +39,9 @@ revisions:
   5.3.2:
     licensed:
       declared: Apache-2.0
+  5.5.1:
+    licensed:
+      declared: Apache-2.0
   5.5.6:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Container 5.5.1

**Details:**
Nuget license is Apache-2.0:   https://www.nuget.org/packages/Unity.Container/5.5.1
GitHub license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Container 5.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.5.1/5.5.1)