### PR TITLE
System.Security.Principal.Windows 4.5.0-rc1

### DIFF
--- a/curations/nuget/nuget/-/System.Security.Principal.Windows.yaml
+++ b/curations/nuget/nuget/-/System.Security.Principal.Windows.yaml
@@ -15,6 +15,9 @@ revisions:
   4.5.0-preview1-26216-02:
     licensed:
       declared: MIT
+  4.5.0-rc1:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Security.Principal.Windows 4.5.0-rc1

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT: https://github.com/dotnet/corefx/blob/master/LICENSE.TXT

**Resolution:**
MIT

**Affected definitions**:
- [System.Security.Principal.Windows 4.5.0-rc1](https://clearlydefined.io/definitions/nuget/nuget/-/System.Security.Principal.Windows/4.5.0-rc1/4.5.0-rc1)