### PR TITLE
System.DirectoryServices.Protocols 4.6.0-preview7.19362.9

### DIFF
--- a/curations/nuget/nuget/-/System.DirectoryServices.Protocols.yaml
+++ b/curations/nuget/nuget/-/System.DirectoryServices.Protocols.yaml
@@ -9,6 +9,9 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-preview7.19362.9:
+    licensed:
+      declared: MIT
   4.6.0-preview8.19405.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.DirectoryServices.Protocols 4.6.0-preview7.19362.9

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [System.DirectoryServices.Protocols 4.6.0-preview7.19362.9](https://clearlydefined.io/definitions/nuget/nuget/-/System.DirectoryServices.Protocols/4.6.0-preview7.19362.9/4.6.0-preview7.19362.9)