### PR TITLE
System.Diagnostics.DiagnosticSource 4.6.0-rc1.19456.4

### DIFF
--- a/curations/nuget/nuget/-/System.Diagnostics.DiagnosticSource.yaml
+++ b/curations/nuget/nuget/-/System.Diagnostics.DiagnosticSource.yaml
@@ -21,3 +21,6 @@ revisions:
   4.6.0:
     licensed:
       declared: MIT
+  4.6.0-rc1.19456.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Diagnostics.DiagnosticSource 4.6.0-rc1.19456.4

**Details:**
ClearlyDefined license is MIT
Nuget license is MIT

**Resolution:**
MIT

**Affected definitions**:
- [System.Diagnostics.DiagnosticSource 4.6.0-rc1.19456.4](https://clearlydefined.io/definitions/nuget/nuget/-/System.Diagnostics.DiagnosticSource/4.6.0-rc1.19456.4/4.6.0-rc1.19456.4)