### PR TITLE
Xamarin.Android.Support.Core.Utils 25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Core.Utils.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  25.4.0.2:
+    licensed:
+      declared: MIT
   26.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.Core.Utils 25.4.0.2

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/xamarin/AndroidSupportComponents/blob/25.4.0.2/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Android.Support.Core.Utils 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Core.Utils/25.4.0.2/25.4.0.2)