### PR TITLE
Rx-Linq 2.0.21114

### DIFF
--- a/curations/nuget/nuget/-/Rx-Linq.yaml
+++ b/curations/nuget/nuget/-/Rx-Linq.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.21114:
+    licensed:
+      declared: Apache-2.0
   2.1.30204:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Linq 2.0.21114

**Details:**
Nuget is MIT: https://github.com/dotnet/reactive/blob/main/LICENSE
GitHub license at time of this build was Apache-2.0: https://github.com/dotnet/reactive/blob/81a7dbb27e9e8524cd02d8d9972ff85e825bba19/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Rx-Linq 2.0.21114](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Linq/2.0.21114/2.0.21114)