### PR TITLE
Polly 5.0.7

### DIFF
--- a/curations/nuget/nuget/-/Polly.yaml
+++ b/curations/nuget/nuget/-/Polly.yaml
@@ -15,6 +15,9 @@ revisions:
   5.0.6:
     licensed:
       declared: BSD-3-Clause
+  5.0.7:
+    licensed:
+      declared: BSD-3-Clause
   5.1.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Polly 5.0.7

**Details:**
Nuget license is BSD-3-Clause: https://raw.githubusercontent.com/App-vNext/Polly/master/LICENSE.txt
GitHub is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Polly 5.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/Polly/5.0.7/5.0.7)