### PR TITLE
OfficeUIFabric 2.6.3

### DIFF
--- a/curations/nuget/nuget/-/OfficeUIFabric.yaml
+++ b/curations/nuget/nuget/-/OfficeUIFabric.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: OfficeUIFabric
+  provider: nuget
+  type: nuget
+revisions:
+  2.6.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
OfficeUIFabric 2.6.3

**Details:**
Nuget license is MIT
GitHub license is MIT: https://github.com/OfficeDev/office-ui-fabric-core/blob/2.6.3/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [OfficeUIFabric 2.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/OfficeUIFabric/2.6.3/2.6.3)