### PR TITLE
Nodejs.Redist.x64 12.16.1

### DIFF
--- a/curations/nuget/nuget/-/Nodejs.Redist.x64.yaml
+++ b/curations/nuget/nuget/-/Nodejs.Redist.x64.yaml
@@ -6,3 +6,6 @@ revisions:
   11.14.0:
     licensed:
       declared: MIT
+  12.16.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Nodejs.Redist.x64 12.16.1

**Details:**
Nuget license is MIT: https://github.com/nodejs/node/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Nodejs.Redist.x64 12.16.1](https://clearlydefined.io/definitions/nuget/nuget/-/Nodejs.Redist.x64/12.16.1/12.16.1)