### PR TITLE
getport 0.1.0

### DIFF
--- a/curations/npm/npmjs/-/getport.yaml
+++ b/curations/npm/npmjs/-/getport.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: getport
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
getport 0.1.0

**Details:**
ClearlyDefined package.json is BSD
NPM is BSD 
Curation Guidelines #10 is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [getport 0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/getport/0.1.0/0.1.0)