### PR TITLE
Newtonsoft.Json 4.5.4

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -37,6 +37,9 @@ revisions:
   4.5.11:
     licensed:
       declared: MIT
+  4.5.4:
+    licensed:
+      declared: MIT
   4.5.6:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json 4.5.4

**Details:**
GitHub license is MIT: https://github.com/JamesNK/Newtonsoft.Json/blob/415b563806c218e9270331ea98c584fe84e58880/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Newtonsoft.Json 4.5.4](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.5.4/4.5.4)