### PR TITLE
utilities 0.0.37

### DIFF
--- a/curations/npm/npmjs/-/utilities.yaml
+++ b/curations/npm/npmjs/-/utilities.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.37:
+    licensed:
+      declared: Apache-2.0
   1.0.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
utilities 0.0.37

**Details:**
ClearlyDefined package.json has no license info
NPM states NONE
GitHub is Apache-2.0: https://github.com/mde/utilities/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [utilities 0.0.37](https://clearlydefined.io/definitions/npm/npmjs/-/utilities/0.0.37/0.0.37)