### PR TITLE
@office-iss/rex-win32 0.0.0-devmain.12823.10000

### DIFF
--- a/curations/npm/npmjs/@office-iss/rex-win32.yaml
+++ b/curations/npm/npmjs/@office-iss/rex-win32.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  0.0.0-devmain.12823.10000:
+    licensed:
+      declared: OTHER
   0.62.12-tenantreactnativewin-13326:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@office-iss/rex-win32 0.0.0-devmain.12823.10000

**Details:**
ClearlyDefined Readme indicates "his package is intended for test purposes only."
NPM license is OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [rex-win32 0.0.0-devmain.12823.10000](https://clearlydefined.io/definitions/npm/npmjs/@office-iss/rex-win32/0.0.0-devmain.12823.10000/0.0.0-devmain.12823.10000)