### PR TITLE
com.github.tomakehurst/wiremock 2.8.0

### DIFF
--- a/curations/maven/mavencentral/com.github.tomakehurst/wiremock.yaml
+++ b/curations/maven/mavencentral/com.github.tomakehurst/wiremock.yaml
@@ -7,3 +7,6 @@ revisions:
   2.16.0:
     licensed:
       declared: Apache-2.0
+  2.8.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.github.tomakehurst/wiremock 2.8.0

**Details:**
Maven is Apache-2.0
GitHub is Apache-2.0: https://github.com/wiremock/wiremock/blob/2.8.0/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [wiremock 2.8.0](https://clearlydefined.io/definitions/maven/mavencentral/com.github.tomakehurst/wiremock/2.8.0/2.8.0)