### PR TITLE
@azure/communication-calling 1.4.4

### DIFF
--- a/curations/npm/npmjs/@azure/communication-calling.yaml
+++ b/curations/npm/npmjs/@azure/communication-calling.yaml
@@ -43,3 +43,6 @@ revisions:
   1.4.1-beta.1:
     licensed:
       declared: OTHER
+  1.4.4:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@azure/communication-calling 1.4.4

**Details:**
ClearlyDefined license is MSLT (aka EULA): OTHER
NPM states same as above

**Resolution:**
OTHER

**Affected definitions**:
- [communication-calling 1.4.4](https://clearlydefined.io/definitions/npm/npmjs/@azure/communication-calling/1.4.4/1.4.4)