### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/cran/topicmodels.yaml
+++ b/curations/git/github/cran/topicmodels.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: topicmodels
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  4b9cfb2145fe58fa849a0cf981a9563fb8ba8d4c:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
There is no license declared for the component but the license name is available .
Path:
https://github.com/cran/topicmodels/blob/0.2-6/DESCRIPTION

**Resolution:**
Since there is no license specified , it is being curated as GPL-2.0 or Later instead of just  SPDX license
https://github.com/cran/topicmodels/blob/0.2-6/DESCRIPTION

**Affected definitions**:
- [topicmodels 4b9cfb2145fe58fa849a0cf981a9563fb8ba8d4c](https://clearlydefined.io/definitions/git/github/cran/topicmodels/4b9cfb2145fe58fa849a0cf981a9563fb8ba8d4c/4b9cfb2145fe58fa849a0cf981a9563fb8ba8d4c)