### PR TITLE
Missing "Declared License"

### DIFF
--- a/curations/git/github/ajaxorg/ace-builds.yaml
+++ b/curations/git/github/ajaxorg/ace-builds.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  0982db4853e3c967756b83b70638b9761d7f801d:
+    licensed:
+      declared: BSD-3-Clause
   8a271c3dae5267e4a124f378d940f221cc7b3dab:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing "Declared License"

**Details:**
Declared license is missing.

**Resolution:**
License should be BSD-3 clause

**Affected definitions**:
- [ace-builds 0982db4853e3c967756b83b70638b9761d7f801d](https://clearlydefined.io/definitions/git/github/ajaxorg/ace-builds/0982db4853e3c967756b83b70638b9761d7f801d/0982db4853e3c967756b83b70638b9761d7f801d)