### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/gradle/gradle.yaml
+++ b/curations/git/github/gradle/gradle.yaml
@@ -7,3 +7,6 @@ revisions:
   3b427b1481e46232107303c90be7b05079b05b1c:
     licensed:
       declared: Apache-2.0
+  b29fbb64ad6b068cb3f05f7e40dc670472129bc0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License could not be fetched as the license file is not found in version 2.12 of the github repository for this component.

**Resolution:**
Filled in the correct license as per the license file below:
1. Download https://gradle.org/next-steps/?version=2.12&format=all
2. Extract the zip file and check gradle-2.12/LICENSE. 

**Affected definitions**:
- [gradle b29fbb64ad6b068cb3f05f7e40dc670472129bc0](https://clearlydefined.io/definitions/git/github/gradle/gradle/b29fbb64ad6b068cb3f05f7e40dc670472129bc0/b29fbb64ad6b068cb3f05f7e40dc670472129bc0)