### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/cran/openair.yaml
+++ b/curations/git/github/cran/openair.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: openair
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  573bbc1c72958690b1e740be154d07e7ee649ab6:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
There is no license declared for the component but the license name GPL-2.0 or later in Description file .
Path:
https://github.com/cran/openair/blob/2.7-2/DESCRIPTION

**Resolution:**
Since there is no license specified , it is being curated as GPL-2.0 or later 
Path:
https://github.com/cran/openair/blob/2.7-2/DESCRIPTION

**Affected definitions**:
- [openair 573bbc1c72958690b1e740be154d07e7ee649ab6](https://clearlydefined.io/definitions/git/github/cran/openair/573bbc1c72958690b1e740be154d07e7ee649ab6/573bbc1c72958690b1e740be154d07e7ee649ab6)