### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/cran/formattable.yaml
+++ b/curations/git/github/cran/formattable.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: formattable
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  6c838e625d8f4eec7efe9327c6aa742006334974:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
There is no license declared for the component but in Description file they have mentioned MIT License .
Path: https://github.com/cran/formattable/blob/0.2.0.1/DESCRIPTION

**Resolution:**
Since there is no license specified , it is being curated as MIT instead of just  SPDX license .
Path:
https://github.com/cran/formattable/blob/0.2.0.1/DESCRIPTION

**Affected definitions**:
- [formattable 6c838e625d8f4eec7efe9327c6aa742006334974](https://clearlydefined.io/definitions/git/github/cran/formattable/6c838e625d8f4eec7efe9327c6aa742006334974/6c838e625d8f4eec7efe9327c6aa742006334974)