### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/cran/robustbase.yaml
+++ b/curations/git/github/cran/robustbase.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: robustbase
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  d5c7990559d5cab8ce95bcbc079545ac4052d247:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
There is no license declared for the component but the license name mentioned GPL-2.0 or later .
Path:https://github.com/cran/robustbase/blob/0.93-4/DESCRIPTION

**Resolution:**
Since there is no license specified , it is being curated as GPL 2.0 or later instead of just  SPDX license.
Path:
https://github.com/cran/robustbase/blob/0.93-4/DESCRIPTION

**Affected definitions**:
- [robustbase d5c7990559d5cab8ce95bcbc079545ac4052d247](https://clearlydefined.io/definitions/git/github/cran/robustbase/d5c7990559d5cab8ce95bcbc079545ac4052d247/d5c7990559d5cab8ce95bcbc079545ac4052d247)