### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/composite-primary-keys/composite_primary_keys.yaml
+++ b/curations/git/github/composite-primary-keys/composite_primary_keys.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: composite_primary_keys
+  namespace: composite-primary-keys
+  provider: github
+  type: git
+revisions:
+  c50642f95574e3cd920154cba1e4c80476549e8f:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is one SPDX mentioned and there is MIT License information in the Component as seen below :
https://github.com/composite-primary-keys/composite_primary_keys/blob/v9.0.4/composite_primary_keys.gemspec

**Resolution:**
Since there is MIT License information mentioned in the component's file, it is being curated as MIT instead of SPDX License.

License file path : https://github.com/composite-primary-keys/composite_primary_keys/blob/v9.0.4/composite_primary_keys.gemspec

**Affected definitions**:
- [composite_primary_keys c50642f95574e3cd920154cba1e4c80476549e8f](https://clearlydefined.io/definitions/git/github/composite-primary-keys/composite_primary_keys/c50642f95574e3cd920154cba1e4c80476549e8f/c50642f95574e3cd920154cba1e4c80476549e8f)