### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/awslabs/amazon-kinesis-producer.yaml
+++ b/curations/git/github/awslabs/amazon-kinesis-producer.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: amazon-kinesis-producer
+  namespace: awslabs
+  provider: github
+  type: git
+revisions:
+  23d4dfd05d836b56d6758b7f4e94fc78f9c4712a:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is one NOASSERTION mentioned, but the component has the Amazon Software License given in the file :
https://github.com/awslabs/amazon-kinesis-producer/blob/v0.10.0/LICENSE

**Resolution:**
Since the License shown in the file is Amazon Software License but there is no option shown in Clearly Defined to select the same, it is being curated as OTHER.

License file : https://github.com/awslabs/amazon-kinesis-producer/blob/v0.10.0/LICENSE

**Affected definitions**:
- [amazon-kinesis-producer 23d4dfd05d836b56d6758b7f4e94fc78f9c4712a](https://clearlydefined.io/definitions/git/github/awslabs/amazon-kinesis-producer/23d4dfd05d836b56d6758b7f4e94fc78f9c4712a/23d4dfd05d836b56d6758b7f4e94fc78f9c4712a)