### PR TITLE
Add golang.org/x/text

### DIFF
--- a/curations/go/golang/golang.org/x/text.yaml
+++ b/curations/go/golang/golang.org/x/text.yaml
@@ -1,0 +1,36 @@
+coordinates:
+  name: text
+  namespace: golang.org%2Fx
+  provider: golang
+  type: go
+revisions:
+  v0.1.0:
+    licensed:
+      declared: BSD-3-Clause
+  v0.2.0:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.0:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.1:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.2:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.3:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.4:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.5:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.6:
+    licensed:
+      declared: BSD-3-Clause
+  v0.3.7:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/go/golang/golang.org/x/text.yaml
+++ b/curations/go/golang/golang.org/x/text.yaml
@@ -6,31 +6,31 @@ coordinates:
 revisions:
   v0.1.0:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.2.0:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.0:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.1:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.2:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.3:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.4:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.5:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.6:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   v0.3.7:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION
**Type**: Missing

**Summary**:
golang.org/x/text v0.1.0 through v0.3.7

**Details**:
Add BSD-3-Clause License

**Resolution**:
License Url:
https://pkg.go.dev/golang.org/x/text?tab=licenses


**Affected definitions**:
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.1.0
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.2.0
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.0
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.1
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.2
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.3
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.4
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.5
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.6
https://clearlydefined.io/definitions/go/golang/golang.org%2fx/text/v0.3.7
