### PR TITLE
Update mysql-connector-python.yaml

### DIFF
--- a/curations/pypi/pypi/-/mysql-connector-python.yaml
+++ b/curations/pypi/pypi/-/mysql-connector-python.yaml
@@ -3,6 +3,54 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  1.0.10:
+    licensed:
+      declared: OTHER
+  1.0.12:
+    licensed:
+      declared: OTHER
+  1.0.5:
+    licensed:
+      declared: OTHER
+  1.0.5b1:
+    licensed:
+      declared: OTHER
+  1.0.6b2:
+    licensed:
+      declared: OTHER
+  1.0.7:
+    licensed:
+      declared: OTHER
+  1.0.9:
+    licensed:
+      declared: OTHER
+  1.1.4:
+    licensed:
+      declared: OTHER
+  1.1.5:
+    licensed:
+      declared: OTHER
+  1.1.6:
+    licensed:
+      declared: OTHER
+  1.2.2:
+    licensed:
+      declared: OTHER
+  1.2.3:
+    licensed:
+      declared: OTHER
+  2.0.1:
+    licensed:
+      declared: OTHER
+  2.0.2:
+    licensed:
+      declared: OTHER
+  2.0.3:
+    licensed:
+      declared: OTHER
+  2.0.4:
+    licensed:
+      declared: OTHER
   8.0.11:
     licensed:
       declared: OTHER


### PR DESCRIPTION
License includes a FOSS exception, which is different than the Universal-FOSS-exception. It is closer to the DigiRule-FOSS-exception, but due to the matching guidelines, this is OTHER.