### PR TITLE
Declared License Missing

### DIFF
--- a/curations/nuget/nuget/-/SQLite.CodeFirst.yaml
+++ b/curations/nuget/nuget/-/SQLite.CodeFirst.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SQLite.CodeFirst
+  provider: nuget
+  type: nuget
+revisions:
+  1.5.2.28:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
There is Noassertion license declared for the component but the license file consist of the Apache 2.0 
License Path :
https://github.com/msallin/SQLiteCodeFirst/blob/b81233131284a5d73a605dc7e9f0bc0cceb25514/LICENSE

**Resolution:**
Since there is no license specified , it is being curated as Apache-2.0 instead of just  Noassertion license 
https://github.com/msallin/SQLiteCodeFirst/blob/b81233131284a5d73a605dc7e9f0bc0cceb25514/LICENSE

**Affected definitions**:
- [SQLite.CodeFirst 1.5.2.28](https://clearlydefined.io/definitions/nuget/nuget/-/SQLite.CodeFirst/1.5.2.28/1.5.2.28)