### PR TITLE
Declared License Missing

### DIFF
--- a/curations/nuget/nuget/-/SlackBotMessages.yaml
+++ b/curations/nuget/nuget/-/SlackBotMessages.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SlackBotMessages
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
There is Noassertion license declared for the component but the license file consist of the MIT
License Path :
https://github.com/prjseal/SlackBotMessages/blob/master/License.md

**Resolution:**
Since there is no license specified , it is being curated as MIT instead of just Noassertion license

https://github.com/prjseal/SlackBotMessages/blob/master/License.md

**Affected definitions**:
- [SlackBotMessages 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/SlackBotMessages/2.1.0/2.1.0)