### PR TITLE
Declared License was not accurate.

### DIFF
--- a/curations/git/github/kjur/jsrsasign.yaml
+++ b/curations/git/github/kjur/jsrsasign.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsrsasign
+  namespace: kjur
+  provider: github
+  type: git
+revisions:
+  1d40a8a1ff41680e5aa8b313b7281807ba11b4bd:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was not accurate.

**Details:**
The license of this FOSS component version is named as "The 'jsrsasign'(RSA-Sign JavaScript Library) License" which is an MIT-style license.

**Resolution:**
Updated the license from NOASSERTION to MIT as per https://github.com/kjur/jsrsasign/blob/1d40a8a1ff41680e5aa8b313b7281807ba11b4bd/LICENSE.txt.

**Affected definitions**:
- [jsrsasign 1d40a8a1ff41680e5aa8b313b7281807ba11b4bd](https://clearlydefined.io/definitions/git/github/kjur/jsrsasign/1d40a8a1ff41680e5aa8b313b7281807ba11b4bd/1d40a8a1ff41680e5aa8b313b7281807ba11b4bd)