### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/kjur/jsrsasign.yaml
+++ b/curations/git/github/kjur/jsrsasign.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsrsasign
+  namespace: kjur
+  provider: github
+  type: git
+revisions:
+  8f9cb39ecccab8b21b474f0271862550c15e74f2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license was missing because the name of the license could not be recognised by CD although it is MIT license. 

**Resolution:**
Filled in the license as per the file, https://github.com/kjur/jsrsasign/blob/8f9cb39ecccab8b21b474f0271862550c15e74f2/LICENSE.txt and the confirmation from the author at https://github.com/kjur/jsrsasign/issues/359.

**Affected definitions**:
- [jsrsasign 8f9cb39ecccab8b21b474f0271862550c15e74f2](https://clearlydefined.io/definitions/git/github/kjur/jsrsasign/8f9cb39ecccab8b21b474f0271862550c15e74f2/8f9cb39ecccab8b21b474f0271862550c15e74f2)