### PR TITLE
Source Location incorrcet 

### DIFF
--- a/curations/maven/mavencentral/io.prometheus.cloudwatch/cloudwatch_exporter.yaml
+++ b/curations/maven/mavencentral/io.prometheus.cloudwatch/cloudwatch_exporter.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: cloudwatch_exporter
+  namespace: io.prometheus.cloudwatch
+  provider: mavencentral
+  type: maven
+revisions:
+  0.1.0:
+    described:
+      sourceLocation:
+        name: cloudwatch_exporter
+        namespace: prometheus
+        provider: github
+        revision: 8aa4ab117a6934f62c013df50deb6a2d248d30c5
+        type: git
+        url: 'https://github.com/prometheus/cloudwatch_exporter/commit/8aa4ab117a6934f62c013df50deb6a2d248d30c5'


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Source Location incorrcet 

**Details:**
Source Location should be 
https://github.com/prometheus/cloudwatch_exporter/commit/8aa4ab117a6934f62c013df50deb6a2d248d30c5

**Resolution:**
https://github.com/prometheus/cloudwatch_exporter/commit/8aa4ab117a6934f62c013df50deb6a2d248d30c5

**Affected definitions**:
- [cloudwatch_exporter 0.1.0](https://clearlydefined.io/definitions/maven/mavencentral/io.prometheus.cloudwatch/cloudwatch_exporter/0.1.0/0.1.0)