### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/akka/akka.yaml
+++ b/curations/git/github/akka/akka.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: akka
+  namespace: akka
+  provider: github
+  type: git
+revisions:
+  d879d0809442dc82b38a4003faab7a3f90a16cbd:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared license should be Apache 2.0 instead of Noassertion .
License Path :
https://github.com/akka/akka/blob/v2.5.2/LICENSE

**Resolution:**
https://github.com/akka/akka/blob/v2.5.2/LICENSE

**Affected definitions**:
- [akka d879d0809442dc82b38a4003faab7a3f90a16cbd](https://clearlydefined.io/definitions/git/github/akka/akka/d879d0809442dc82b38a4003faab7a3f90a16cbd/d879d0809442dc82b38a4003faab7a3f90a16cbd)