### PR TITLE
paramiko2.10.4

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  2.10.4:
+    licensed:
+      declared: LGPL-2.1-or-later
   2.4.3:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko2.10.4

**Details:**
Fixing Declared License to LGPL-2.1-or-later

**Resolution:**
https://github.com/paramiko/paramiko/blob/2.10.4/setup.py

**Affected definitions**:
- [paramiko 2.10.4](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/2.10.4/2.10.4)