### PR TITLE
CefSharp.WinForms98.1.210

### DIFF
--- a/curations/nuget/nuget/-/CefSharp.WinForms.yaml
+++ b/curations/nuget/nuget/-/CefSharp.WinForms.yaml
@@ -20,3 +20,6 @@ revisions:
   88.2.90:
     licensed:
       declared: BSD-3-Clause
+  98.1.210:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CefSharp.WinForms98.1.210

**Details:**
Declaring BSD-3-Clause

**Resolution:**
https://github.com/cefsharp/CefSharp/blob/v98.1.210/LICENSE

**Affected definitions**:
- [CefSharp.WinForms 98.1.210](https://clearlydefined.io/definitions/nuget/nuget/-/CefSharp.WinForms/98.1.210/98.1.210)