### PR TITLE
unidecode1.3.4

### DIFF
--- a/curations/pypi/pypi/-/unidecode.yaml
+++ b/curations/pypi/pypi/-/unidecode.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: unidecode
+  provider: pypi
+  type: pypi
+revisions:
+  1.3.4:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
unidecode1.3.4

**Details:**
Declared License is GPL-2.0-or-later

**Resolution:**
Noted on the copyright section of this page - https://pypi.org/project/Unidecode/1.3.4/

**Affected definitions**:
- [unidecode 1.3.4](https://clearlydefined.io/definitions/pypi/pypi/-/unidecode/1.3.4/1.3.4)