### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/nucleic/kiwi.yaml
+++ b/curations/git/github/nucleic/kiwi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kiwi
+  namespace: nucleic
+  provider: github
+  type: git
+revisions:
+  2005e73aff3ee6538e94b6ac73d39de41137f411:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing.

**Resolution:**
Filled in the declared license as per https://github.com/nucleic/kiwi/blob/2005e73aff3ee6538e94b6ac73d39de41137f411/LICENSE.

**Affected definitions**:
- [kiwi 2005e73aff3ee6538e94b6ac73d39de41137f411](https://clearlydefined.io/definitions/git/github/nucleic/kiwi/2005e73aff3ee6538e94b6ac73d39de41137f411/2005e73aff3ee6538e94b6ac73d39de41137f411)