### PR TITLE
NSwag.CodeGeneration 11.12.7

### DIFF
--- a/curations/nuget/nuget/-/NSwag.CodeGeneration.yaml
+++ b/curations/nuget/nuget/-/NSwag.CodeGeneration.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NSwag.CodeGeneration
+  provider: nuget
+  type: nuget
+revisions:
+  11.12.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correct licensing

**Details:**
License was listed as NOASSERTION but was in fact MIT.

**Resolution:**
Change licensing to MIT as per the pkg nuspec license URL https://github.com/NSwag/NSwag/blob/master/LICENSE.md

**Affected definitions**:
- [NSwag.CodeGeneration 11.12.7](https://clearlydefined.io/definitions/nuget/nuget/-/NSwag.CodeGeneration/11.12.7/11.12.7)