### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/nginx/nginx.yaml
+++ b/curations/git/github/nginx/nginx.yaml
@@ -7,3 +7,6 @@ revisions:
   1d2f499889a192a66c5407d634c9c697edc341cf:
     licensed:
       declared: BSD-2-Clause
+  9334b482677844dc7f0bdfc82b717dc70912e62c:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing.

**Resolution:**
Filled in the correct license as per the file nginx-1.16.1/LICENSE downloaded and extracted from http://nginx.org/en/download.html.

**Affected definitions**:
- [nginx 9334b482677844dc7f0bdfc82b717dc70912e62c](https://clearlydefined.io/definitions/git/github/nginx/nginx/9334b482677844dc7f0bdfc82b717dc70912e62c/9334b482677844dc7f0bdfc82b717dc70912e62c)