### PR TITLE
Declared License was incorrect.

### DIFF
--- a/curations/git/github/orientechnologies/orientdb.yaml
+++ b/curations/git/github/orientechnologies/orientdb.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: orientdb
+  namespace: orientechnologies
+  provider: github
+  type: git
+revisions:
+  da09ce5af52267b70035d8600551a5032065807a:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was incorrect.

**Details:**
Declared license was NOASSERTION.

**Resolution:**
Filled in the correct declared license as per https://github.com/orientechnologies/orientdb/blob/da09ce5af52267b70035d8600551a5032065807a/license.txt.

**Affected definitions**:
- [orientdb da09ce5af52267b70035d8600551a5032065807a](https://clearlydefined.io/definitions/git/github/orientechnologies/orientdb/da09ce5af52267b70035d8600551a5032065807a/da09ce5af52267b70035d8600551a5032065807a)