### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/pygresql/pygresql.yaml
+++ b/curations/git/github/pygresql/pygresql.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pygresql
+  namespace: pygresql
+  provider: github
+  type: git
+revisions:
+  d648ea72cb76796295bcf247527ca6be150ba282:
+    licensed:
+      declared: PostgreSQL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing.

**Resolution:**
Filled in the correct license as per https://github.com/PyGreSQL/PyGreSQL/blob/d648ea72cb76796295bcf247527ca6be150ba282/LICENSE.txt.

**Affected definitions**:
- [pygresql d648ea72cb76796295bcf247527ca6be150ba282](https://clearlydefined.io/definitions/git/github/pygresql/pygresql/d648ea72cb76796295bcf247527ca6be150ba282/d648ea72cb76796295bcf247527ca6be150ba282)