### PR TITLE
Declared License incorrect 

### DIFF
--- a/curations/git/github/coreos/flannel.yaml
+++ b/curations/git/github/coreos/flannel.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: flannel
+  namespace: coreos
+  provider: github
+  type: git
+revisions:
+  683c6e9eb06d0f49c43eef9ecbb777a3adaeda88:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License incorrect 

**Details:**
Declared License Should be only apache 2.0 license.
https://github.com/flannel-io/flannel/blob/v0.7.1/LICENSE

**Resolution:**
https://github.com/flannel-io/flannel/blob/v0.7.1/LICENSE

**Affected definitions**:
- [flannel 683c6e9eb06d0f49c43eef9ecbb777a3adaeda88](https://clearlydefined.io/definitions/git/github/coreos/flannel/683c6e9eb06d0f49c43eef9ecbb777a3adaeda88/683c6e9eb06d0f49c43eef9ecbb777a3adaeda88)