### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/certifi/python-certifi.yaml
+++ b/curations/git/github/certifi/python-certifi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: python-certifi
+  namespace: certifi
+  provider: github
+  type: git
+revisions:
+  45a64658872a94a83c4b70fce02a96f0f29895e6:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License should be MPL 2.0 instead of SPDX license.
License Path:
https://github.com/certifi/python-certifi/blob/2020.12.05/LICENSE

**Resolution:**
https://github.com/certifi/python-certifi/blob/2020.12.05/LICENSE

**Affected definitions**:
- [python-certifi 45a64658872a94a83c4b70fce02a96f0f29895e6](https://clearlydefined.io/definitions/git/github/certifi/python-certifi/45a64658872a94a83c4b70fce02a96f0f29895e6/45a64658872a94a83c4b70fce02a96f0f29895e6)