### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/luisgoncalves/xades4j.yaml
+++ b/curations/git/github/luisgoncalves/xades4j.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   388c7ea01cbe7a2514436bf5bc4ba2b9b28d8348:
     licensed:
-      declared: LGPL-3.0-only AND GPL-3.0-only
+      declared: LGPL-3.0-or-later

--- a/curations/git/github/luisgoncalves/xades4j.yaml
+++ b/curations/git/github/luisgoncalves/xades4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xades4j
+  namespace: luisgoncalves
+  provider: github
+  type: git
+revisions:
+  388c7ea01cbe7a2514436bf5bc4ba2b9b28d8348:
+    licensed:
+      declared: LGPL-3.0-only AND GPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License should be LGPL 3.0 and GPL 3.0 instead of NOASSERTION 
License Path:
https://github.com/luisgoncalves/xades4j/blob/v1.3.2/license.txt


https://github.com/luisgoncalves/xades4j/blob/v1.3.2/gpl-3.0.txt

**Resolution:**
License Path:
https://github.com/luisgoncalves/xades4j/blob/v1.3.2/license.txt


https://github.com/luisgoncalves/xades4j/blob/v1.3.2/gpl-3.0.txt

**Affected definitions**:
- [xades4j 388c7ea01cbe7a2514436bf5bc4ba2b9b28d8348](https://clearlydefined.io/definitions/git/github/luisgoncalves/xades4j/388c7ea01cbe7a2514436bf5bc4ba2b9b28d8348/388c7ea01cbe7a2514436bf5bc4ba2b9b28d8348)