### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/cran/timedate.yaml
+++ b/curations/git/github/cran/timedate.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: timedate
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  5f9ac8ba8d085de1ea66afafc2c454c3232a318e:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION
**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared license should be GPL 2.0 or later 
License Path
https://github.com/cran/timeDate/blob/3043.102/DESCRIPTION

**Resolution:**
License Path:
https://github.com/cran/timeDate/blob/3043.102/DESCRIPTION

**Affected definitions**:
- [timedate 5f9ac8ba8d085de1ea66afafc2c454c3232a318e](https://clearlydefined.io/definitions/git/github/cran/timedate/5f9ac8ba8d085de1ea66afafc2c454c3232a318e/5f9ac8ba8d085de1ea66afafc2c454c3232a318e)