### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/phpoffice/phpexcel.yaml
+++ b/curations/git/github/phpoffice/phpexcel.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: phpexcel
+  namespace: phpoffice
+  provider: github
+  type: git
+revisions:
+  23fe9937fe5e814f9055f053d40e0825e54e1b8c:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared license should be LGPL 2.1 or later 
License Path:
https://github.com/phpoffice/phpexcel/blob/1.7.8rc2/changelog.txt

https://github.com/phpoffice/phpexcel/blob/1.7.8rc2/license.md

**Resolution:**
License Path:
https://github.com/phpoffice/phpexcel/blob/1.7.8rc2/changelog.txt

https://github.com/phpoffice/phpexcel/blob/1.7.8rc2/license.md

**Affected definitions**:
- [phpexcel 23fe9937fe5e814f9055f053d40e0825e54e1b8c](https://clearlydefined.io/definitions/git/github/phpoffice/phpexcel/23fe9937fe5e814f9055f053d40e0825e54e1b8c/23fe9937fe5e814f9055f053d40e0825e54e1b8c)