### PR TITLE
azureml-dataprep/3.0.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -219,6 +219,9 @@ revisions:
   3.0.1:
     licensed:
       declared: OTHER
+  3.0.2:
+    licensed:
+      declared: OTHER
   3.1.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep/3.0.2

**Details:**
License is a EULA.

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 3.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/3.0.2/3.0.2)