### PR TITLE
azureml-dataprep/3.1.2

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -222,3 +222,6 @@ revisions:
   3.1.1:
     licensed:
       declared: OTHER
+  3.1.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-dataprep/3.1.2

**Details:**
License is a EULA

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-dataprep 3.1.2](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/3.1.2/3.1.2)