### PR TITLE
Xamarin.AndroidX.Arch.Core.Common2.1.0.9

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.Arch.Core.Common.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.Arch.Core.Common.yaml
@@ -33,3 +33,6 @@ revisions:
   2.1.0.8:
     licensed:
       declared: MIT
+  2.1.0.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.AndroidX.Arch.Core.Common2.1.0.9

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.Arch.Core.Common/2.1.0.9/License

**Affected definitions**:
- [Xamarin.AndroidX.Arch.Core.Common 2.1.0.9](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.Arch.Core.Common/2.1.0.9/2.1.0.9)