### PR TITLE
VSSDK.TextManager.Interop.88.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.TextManager.Interop.8.yaml
+++ b/curations/nuget/nuget/-/VSSDK.TextManager.Interop.8.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.TextManager.Interop.8
+  provider: nuget
+  type: nuget
+revisions:
+  8.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
VSSDK.TextManager.Interop.88.0.4

**Details:**
Declaring NONE

**Resolution:**
No license found in ClearlyDefined files, NuGet page or in the package download

**Affected definitions**:
- [VSSDK.TextManager.Interop.8 8.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.TextManager.Interop.8/8.0.4/8.0.4)