### PR TITLE
HotChocolate.Fetching12.6.1

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
@@ -21,6 +21,9 @@ revisions:
   12.6.0:
     licensed:
       declared: MIT
+  12.6.1:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Fetching12.6.1

**Details:**
Declaring MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Fetching/12.6.1/License

**Affected definitions**:
- [HotChocolate.Fetching 12.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Fetching/12.6.1/12.6.1)