### PR TITLE
TestStack.BDDfy4.3.1

### DIFF
--- a/curations/nuget/nuget/-/TestStack.BDDfy.yaml
+++ b/curations/nuget/nuget/-/TestStack.BDDfy.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: MIT
   4.3.1:
     licensed:
-      declared: NONE
+      declared: MIT
   4.3.2:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/TestStack.BDDfy.yaml
+++ b/curations/nuget/nuget/-/TestStack.BDDfy.yaml
@@ -9,6 +9,9 @@ revisions:
   4.2.0:
     licensed:
       declared: MIT
+  4.3.1:
+    licensed:
+      declared: NONE
   4.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
TestStack.BDDfy4.3.1

**Details:**
Declaring NONE

**Resolution:**
No license found in ClearlyDefined files, NuGet page or in the package download

**Affected definitions**:
- [TestStack.BDDfy 4.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/TestStack.BDDfy/4.3.1/4.3.1)