### PR TITLE
System.IO.Abstractions2.1.0.256

### DIFF
--- a/curations/nuget/nuget/-/System.IO.Abstractions.yaml
+++ b/curations/nuget/nuget/-/System.IO.Abstractions.yaml
@@ -24,6 +24,9 @@ revisions:
   2.1.0.230:
     licensed:
       declared: MIT
+  2.1.0.256:
+    licensed:
+      declared: MIT
   3.0.10:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
System.IO.Abstractions2.1.0.256

**Details:**
Declaring MIT

**Resolution:**
Close commit and to release date
https://github.com/TestableIO/System.IO.Abstractions/blob/v2.1.0.234/LICENSE

**Affected definitions**:
- [System.IO.Abstractions 2.1.0.256](https://clearlydefined.io/definitions/nuget/nuget/-/System.IO.Abstractions/2.1.0.256/2.1.0.256)