### PR TITLE
pcf-scripts1.13.6

### DIFF
--- a/curations/npm/npmjs/-/pcf-scripts.yaml
+++ b/curations/npm/npmjs/-/pcf-scripts.yaml
@@ -18,6 +18,9 @@ revisions:
   1.12.2:
     licensed:
       declared: OTHER
+  1.13.6:
+    licensed:
+      declared: OTHER
   1.2.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
pcf-scripts1.13.6

**Details:**
Declaring OTHER for EULA in package

**Resolution:**
https://clearlydefined.io/file/dc0ec69f61019186d491e8d0f63bf194e06fb784ba7a2e3078d25d4d7a8a8dee

**Affected definitions**:
- [pcf-scripts 1.13.6](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-scripts/1.13.6/1.13.6)