### PR TITLE
tf2onnx1.8.5

### DIFF
--- a/curations/pypi/pypi/-/tf2onnx.yaml
+++ b/curations/pypi/pypi/-/tf2onnx.yaml
@@ -12,6 +12,9 @@ revisions:
   1.6.3:
     licensed:
       declared: MIT
+  1.8.5:
+    licensed:
+      declared: Apache-2.0
   1.9.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
tf2onnx1.8.5

**Details:**
Declaring Apache-2.0

**Resolution:**
https://github.com/onnx/tensorflow-onnx/blob/v1.8.5/LICENSE

**Affected definitions**:
- [tf2onnx 1.8.5](https://clearlydefined.io/definitions/pypi/pypi/-/tf2onnx/1.8.5/1.8.5)