### PR TITLE
NuGet.Packaging.Core4.9.2

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
+++ b/curations/nuget/nuget/-/NuGet.Packaging.Core.yaml
@@ -30,6 +30,9 @@ revisions:
   4.8.0:
     licensed:
       declared: Apache-2.0
+  4.9.2:
+    licensed:
+      declared: Apache-2.0
   4.9.4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NuGet.Packaging.Core4.9.2

**Details:**
Declaring Apache-2.0

**Resolution:**
Close commit

https://github.com/NuGet/NuGet.Client/blob/4.9.2.5706/LICENSE.txt

**Affected definitions**:
- [NuGet.Packaging.Core 4.9.2](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Packaging.Core/4.9.2/4.9.2)