### PR TITLE
knockout/knockout203e2f35596ce75ee37868c4779c631cc16e6e2c

### DIFF
--- a/curations/git/github/knockout/knockout.yaml
+++ b/curations/git/github/knockout/knockout.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  203e2f35596ce75ee37868c4779c631cc16e6e2c:
+    licensed:
+      declared: MIT
   212376a484f64d32cf49a6aaa4d5eee85aa7653a:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
knockout/knockout203e2f35596ce75ee37868c4779c631cc16e6e2c

**Details:**
Declaring MIT

**Resolution:**
MIT is noted in the Readme and https://github.com/knockout/knockout/blob/203e2f35596ce75ee37868c4779c631cc16e6e2c/build/fragments/version-header.js

**Affected definitions**:
- [knockout 203e2f35596ce75ee37868c4779c631cc16e6e2c](https://clearlydefined.io/definitions/git/github/knockout/knockout/203e2f35596ce75ee37868c4779c631cc16e6e2c/203e2f35596ce75ee37868c4779c631cc16e6e2c)