### PR TITLE
boost_date_time-vc1421.72.0

### DIFF
--- a/curations/nuget/nuget/-/boost_date_time-vc142.yaml
+++ b/curations/nuget/nuget/-/boost_date_time-vc142.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.72.0:
+    licensed:
+      declared: BSL-1.0
   1.76.0:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
boost_date_time-vc1421.72.0

**Details:**
Declaring BSL-1.0

**Resolution:**
Author confirmed BSL-1.0 was intended license

https://github.com/sergey-shandar/getboost/issues/64

**Affected definitions**:
- [boost_date_time-vc142 1.72.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_date_time-vc142/1.72.0/1.72.0)