### PR TITLE
Fizzler1.2.1

### DIFF
--- a/curations/nuget/nuget/-/Fizzler.yaml
+++ b/curations/nuget/nuget/-/Fizzler.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Fizzler
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.1:
+    licensed:
+      declared: LGPL-3.0-only

--- a/curations/nuget/nuget/-/Fizzler.yaml
+++ b/curations/nuget/nuget/-/Fizzler.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.2.1:
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Fizzler1.2.1

**Details:**
Declaring LGPL-3.0-only

**Resolution:**
Did not find a reference to a later version of this license in the repo

https://github.com/atifaziz/Fizzler/blob/v1.2.1/COPYING.txt

**Affected definitions**:
- [Fizzler 1.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/Fizzler/1.2.1/1.2.1)