### PR TITLE
@microsoft/sp-odata-types1.8.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-odata-types.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-odata-types.yaml
@@ -22,6 +22,9 @@ revisions:
   1.14.0:
     licensed:
       declared: OTHER
+  1.8.0:
+    licensed:
+      declared: OTHER
   1.8.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@microsoft/sp-odata-types1.8.0

**Details:**
Declaring OTHER for EULA in package

**Resolution:**
https://clearlydefined.io/file/0eda2dd419b4ceb578d77f74231d0e7b6cc6ecebc8804350bbabbe51e3feeea4

https://docs.microsoft.com/en-us/sharepoint/dev/spfx/sharepoint-framework-overview?WT.mc_id=m365-15744-cxa#sharepoint-framework-license

**Affected definitions**:
- [sp-odata-types 1.8.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-odata-types/1.8.0/1.8.0)