### PR TITLE
boost_thread-vc1411.64.0

### DIFF
--- a/curations/nuget/nuget/-/boost_thread-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_thread-vc141.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.64.0:
+    licensed:
+      declared: BSL-1.0
   1.68.0:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
boost_thread-vc1411.64.0

**Details:**
Declaring BSL-1.0

**Resolution:**
Author clarified license should be BSL-1.0
https://github.com/sergey-shandar/getboost/issues/64

**Affected definitions**:
- [boost_thread-vc141 1.64.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_thread-vc141/1.64.0/1.64.0)