### PR TITLE
pcf-start/1.9.4

### DIFF
--- a/curations/npm/npmjs/-/pcf-start.yaml
+++ b/curations/npm/npmjs/-/pcf-start.yaml
@@ -48,6 +48,9 @@ revisions:
   1.8.6:
     licensed:
       declared: OTHER
+  1.9.4:
+    licensed:
+      declared: OTHER
   1.9.9:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pcf-start/1.9.4

**Details:**
Included license file is a EULA. package.json states "SEE LICENSE IN LICENSE".

**Resolution:**
OTHER

**Affected definitions**:
- [pcf-start 1.9.4](https://clearlydefined.io/definitions/npm/npmjs/-/pcf-start/1.9.4/1.9.4)