### PR TITLE
al/com.jcraft/jsch.agentproxy.sshagent/0.0.7

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.agentproxy.sshagent.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.agentproxy.sshagent.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsch.agentproxy.sshagent
+  namespace: com.jcraft
+  provider: mavencentral
+  type: maven
+revisions:
+  0.0.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
al/com.jcraft/jsch.agentproxy.sshagent/0.0.7

**Details:**
Sources jar has BSD-3-Clause in file header.
https://repo1.maven.org/maven2/com/jcraft/jsch.agentproxy.sshagent/0.0.7/

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jsch.agentproxy.sshagent 0.0.7](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch.agentproxy.sshagent/0.0.7/0.0.7)