### PR TITLE
com.jcraft/jsch.agentproxy.svnkit-trilead-ssh2/0.0.7

### DIFF
--- a/curations/maven/mavencentral/com.jcraft/jsch.agentproxy.svnkit-trilead-ssh2.yaml
+++ b/curations/maven/mavencentral/com.jcraft/jsch.agentproxy.svnkit-trilead-ssh2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsch.agentproxy.svnkit-trilead-ssh2
+  namespace: com.jcraft
+  provider: mavencentral
+  type: maven
+revisions:
+  0.0.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.jcraft/jsch.agentproxy.svnkit-trilead-ssh2/0.0.7

**Details:**
Sources jar contains BSD-3-Clause in the file headers.
https://repo1.maven.org/maven2/com/jcraft/jsch.agentproxy.svnkit-trilead-ssh2/0.0.7/

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [jsch.agentproxy.svnkit-trilead-ssh2 0.0.7](https://clearlydefined.io/definitions/maven/mavencentral/com.jcraft/jsch.agentproxy.svnkit-trilead-ssh2/0.0.7/0.0.7)