### PR TITLE
azureml-core/1.40.0.post1

### DIFF
--- a/curations/pypi/pypi/-/azureml-core.yaml
+++ b/curations/pypi/pypi/-/azureml-core.yaml
@@ -432,6 +432,9 @@ revisions:
   1.40.0:
     licensed:
       declared: OTHER
+  1.40.0.post1:
+    licensed:
+      declared: OTHER
   1.40.0.post2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-core/1.40.0.post1

**Details:**
License link points to License: https://aka.ms/azureml-sdk-license, which is a EULA.

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-core 1.40.0.post1](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-core/1.40.0.post1/1.40.0.post1)