### PR TITLE
azureml-defaults/1.40.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-defaults.yaml
+++ b/curations/pypi/pypi/-/azureml-defaults.yaml
@@ -234,6 +234,9 @@ revisions:
   1.4.0:
     licensed:
       declared: OTHER
+  1.40.0:
+    licensed:
+      declared: OTHER
   1.5.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-defaults/1.40.0

**Details:**
License points to https://aka.ms/azureml-sdk-license, which is a EULA.

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-defaults 1.40.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-defaults/1.40.0/1.40.0)