### PR TITLE
azureml-inference-server-http/0.4.13

### DIFF
--- a/curations/pypi/pypi/-/azureml-inference-server-http.yaml
+++ b/curations/pypi/pypi/-/azureml-inference-server-http.yaml
@@ -18,6 +18,9 @@ revisions:
   0.4.11:
     licensed:
       declared: OTHER
+  0.4.13:
+    licensed:
+      declared: OTHER
   0.4.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
azureml-inference-server-http/0.4.13

**Details:**
License points to https://aka.ms/azureml-sdk-license, which is a EULA.

**Resolution:**
OTHER

**Affected definitions**:
- [azureml-inference-server-http 0.4.13](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-inference-server-http/0.4.13/0.4.13)