### PR TITLE
org.junit.jupiter/junit-jupiter-api/5.7.0-m1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
@@ -40,6 +40,9 @@ revisions:
   5.7.0:
     licensed:
       declared: EPL-2.0
+  5.7.0-M1:
+    licensed:
+      declared: EPL-2.0
   5.7.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter-api/5.7.0-m1

**Details:**
Included license file and pom state EPL-2.0. The same in the source repo: https://github.com/junit-team/junit5/blob/r5.7.0-M1/LICENSE.md

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter-api 5.7.0-M1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.7.0-M1/5.7.0-M1)