### PR TITLE
org.junit.platform/junit-platform-commons/1.7.0-m1

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -31,6 +31,9 @@ revisions:
   1.7.0:
     licensed:
       declared: EPL-2.0
+  1.7.0-M1:
+    licensed:
+      declared: EPL-2.0
   1.7.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-commons/1.7.0-m1

**Details:**
Pom and included license file state EPL-2.0.
https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.7.0-M1/junit-platform-commons-1.7.0-M1.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-commons 1.7.0-M1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.7.0-M1/1.7.0-M1)