### PR TITLE
org.junit.vintage/junit-vintage-engine/5.7.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.vintage/junit-vintage-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.vintage/junit-vintage-engine.yaml
@@ -19,6 +19,9 @@ revisions:
   5.6.3:
     licensed:
       declared: EPL-2.0
+  5.7.0:
+    licensed:
+      declared: EPL-2.0
   5.7.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.vintage/junit-vintage-engine/5.7.0

**Details:**
Included license file and pom state EPL-2.0.
https://repo1.maven.org/maven2/org/junit/vintage/junit-vintage-engine/5.7.0/junit-vintage-engine-5.7.0.pom

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-vintage-engine 5.7.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.vintage/junit-vintage-engine/5.7.0/5.7.0)