### PR TITLE
org.tmatesoft.sqljet/sqljet/1.1.10

### DIFF
--- a/curations/maven/mavencentral/org.tmatesoft.sqljet/sqljet.yaml
+++ b/curations/maven/mavencentral/org.tmatesoft.sqljet/sqljet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sqljet
+  namespace: org.tmatesoft.sqljet
+  provider: mavencentral
+  type: maven
+revisions:
+  1.1.10:
+    licensed:
+      declared: GPL-2.0-only

--- a/curations/maven/mavencentral/org.tmatesoft.sqljet/sqljet.yaml
+++ b/curations/maven/mavencentral/org.tmatesoft.sqljet/sqljet.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.1.10:
     licensed:
-      declared: GPL-2.0-only
+      declared: GPL-2.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.tmatesoft.sqljet/sqljet/1.1.10

**Details:**
Pom states "GPL (with dual licensing option)", but I could not find any dual license information. The license file states GPL 2.0  only and the source file headers are the same.

**Resolution:**
GPL-2.0-only

**Affected definitions**:
- [sqljet 1.1.10](https://clearlydefined.io/definitions/maven/mavencentral/org.tmatesoft.sqljet/sqljet/1.1.10/1.1.10)