### PR TITLE
org.tmatesoft.svnkit/svnkit/1.8.12

### DIFF
--- a/curations/maven/mavencentral/org.tmatesoft.svnkit/svnkit.yaml
+++ b/curations/maven/mavencentral/org.tmatesoft.svnkit/svnkit.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: svnkit
+  namespace: org.tmatesoft.svnkit
+  provider: mavencentral
+  type: maven
+revisions:
+  1.8.12:
+    licensed:
+      declared: TMate


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.tmatesoft.svnkit/svnkit/1.8.12

**Details:**
Pom and included license file state TMate Open Source  license.

https://repo1.maven.org/maven2/org/tmatesoft/svnkit/svnkit/1.8.12/

**Resolution:**
TMate

**Affected definitions**:
- [svnkit 1.8.12](https://clearlydefined.io/definitions/maven/mavencentral/org.tmatesoft.svnkit/svnkit/1.8.12/1.8.12)