### PR TITLE
Add release date and license to scikit-learn 1.1.0

### DIFF
--- a/curations/pypi/pypi/-/scikit-learn.yaml
+++ b/curations/pypi/pypi/-/scikit-learn.yaml
@@ -57,3 +57,8 @@ revisions:
   1.0.2:
     licensed:
       declared: BSD-3-Clause
+  1.1.0:
+    described:
+      releaseDate: '2022-05-12'
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add release date and license to scikit-learn 1.1.0

**Details:**
Add release date and license to scikit-learn 1.1.0

**Resolution:**
Add release date and license to scikit-learn 1.1.0

**Affected definitions**:
- [scikit-learn 1.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/scikit-learn/1.1.0/1.1.0)