### PR TITLE
Mpir.NET0.4.0

### DIFF
--- a/curations/nuget/nuget/-/Mpir.NET.yaml
+++ b/curations/nuget/nuget/-/Mpir.NET.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Mpir.NET
+  provider: nuget
+  type: nuget
+revisions:
+  0.4.0:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Mpir.NET0.4.0

**Details:**
Declaring LGPL-3.0-or-later

**Resolution:**
https://github.com/wezeku/Mpir.NET/blob/master/src/Mpir.NET/mpir.cs

**Affected definitions**:
- [Mpir.NET 0.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/Mpir.NET/0.4.0/0.4.0)