### PR TITLE
Grpc.Core1.14.1

### DIFF
--- a/curations/nuget/nuget/-/Grpc.Core.yaml
+++ b/curations/nuget/nuget/-/Grpc.Core.yaml
@@ -15,6 +15,9 @@ revisions:
   1.13.1:
     licensed:
       declared: Apache-2.0
+  1.14.1:
+    licensed:
+      declared: Apache-2.0
   1.16.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Grpc.Core1.14.1

**Details:**
Declaring Apache-2.0

**Resolution:**
https://github.com/grpc/grpc/blob/v1.14.1/LICENSE

**Affected definitions**:
- [Grpc.Core 1.14.1](https://clearlydefined.io/definitions/nuget/nuget/-/Grpc.Core/1.14.1/1.14.1)