### PR TITLE
HotChocolate.Abstractions12.6.1

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Abstractions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Abstractions.yaml
@@ -24,6 +24,9 @@ revisions:
   12.6.0:
     licensed:
       declared: MIT
+  12.6.1:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Abstractions12.6.1

**Details:**
Declaring MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Abstractions/12.6.1/License

**Affected definitions**:
- [HotChocolate.Abstractions 12.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Abstractions/12.6.1/12.6.1)