### PR TITLE
@ag-grid-enterprise/viewport-row-model25.3.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/viewport-row-model.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/viewport-row-model.yaml
@@ -13,6 +13,9 @@ revisions:
   25.0.1:
     licensed:
       declared: OTHER
+  25.3.0:
+    licensed:
+      declared: OTHER
   26.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/viewport-row-model25.3.0

**Details:**
Declaring OTHER for commercial license

**Resolution:**
https://github.com/ag-grid/ag-grid/blob/v25.3.0/LICENSE.txt

**Affected definitions**:
- [viewport-row-model 25.3.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/viewport-row-model/25.3.0/25.3.0)