### PR TITLE
dependabot-nuget0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-nuget.yaml
+++ b/curations/gem/rubygems/-/dependabot-nuget.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.158.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
dependabot-nuget0.145.4

**Details:**
Declaring OTHER for The Prosperity Public License

**Resolution:**
https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Affected definitions**:
- [dependabot-nuget 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-nuget/0.145.4/0.145.4)