### PR TITLE
Declared License was incorrect.

### DIFF
--- a/curations/git/github/xerial/sqlite-jdbc.yaml
+++ b/curations/git/github/xerial/sqlite-jdbc.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sqlite-jdbc
+  namespace: xerial
+  provider: github
+  type: git
+revisions:
+  cf1c0f0d90b2621f76b16d50b8c471307056a8f6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was incorrect.

**Details:**
Declared License could not be recognised by ClearlyDefined.

**Resolution:**
Updated the correct license as per https://github.com/xerial/sqlite-jdbc/blob/cf1c0f0d90b2621f76b16d50b8c471307056a8f6/LICENSE.

**Affected definitions**:
- [sqlite-jdbc cf1c0f0d90b2621f76b16d50b8c471307056a8f6](https://clearlydefined.io/definitions/git/github/xerial/sqlite-jdbc/cf1c0f0d90b2621f76b16d50b8c471307056a8f6/cf1c0f0d90b2621f76b16d50b8c471307056a8f6)