### PR TITLE
com.perforce/p4java/2015.2.1365273

### DIFF
--- a/curations/maven/mavencentral/com.perforce/p4java.yaml
+++ b/curations/maven/mavencentral/com.perforce/p4java.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: p4java
+  namespace: com.perforce
+  provider: mavencentral
+  type: maven
+revisions:
+  2015.2.1365273:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.perforce/p4java/2015.2.1365273

**Details:**
Sources jar license is BSD-2-Clause.

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [p4java 2015.2.1365273](https://clearlydefined.io/definitions/maven/mavencentral/com.perforce/p4java/2015.2.1365273/2015.2.1365273)