### PR TITLE
trilead-ssh2/1.0.0-build220

### DIFF
--- a/curations/maven/mavencentral/com.trilead/trilead-ssh2.yaml
+++ b/curations/maven/mavencentral/com.trilead/trilead-ssh2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: trilead-ssh2
+  namespace: com.trilead
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.0-build220:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
trilead-ssh2/1.0.0-build220

**Details:**
Included license is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [trilead-ssh2 1.0.0-build220](https://clearlydefined.io/definitions/maven/mavencentral/com.trilead/trilead-ssh2/1.0.0-build220/1.0.0-build220)