### PR TITLE
de.regnis.q.sequence/sequence-library/1.0.3

### DIFF
--- a/curations/maven/mavencentral/de.regnis.q.sequence/sequence-library.yaml
+++ b/curations/maven/mavencentral/de.regnis.q.sequence/sequence-library.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sequence-library
+  namespace: de.regnis.q.sequence
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
de.regnis.q.sequence/sequence-library/1.0.3

**Details:**
Included license is BSD-3-Clause

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [sequence-library 1.0.3](https://clearlydefined.io/definitions/maven/mavencentral/de.regnis.q.sequence/sequence-library/1.0.3/1.0.3)