### PR TITLE
Foil/1.0.37

### DIFF
--- a/curations/nuget/nuget/-/Foil.yaml
+++ b/curations/nuget/nuget/-/Foil.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Foil
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.37:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Foil/1.0.37

**Details:**
No license info in this version, but 1.0.15 lists a project site: https://github.com/moattarwork/foil

**Resolution:**
Apache-2.0
https://github.com/moattarwork/foil/blob/603ec15acd2d8dc9631276ca13246bcf89227ec1/LICENSE

**Affected definitions**:
- [Foil 1.0.37](https://clearlydefined.io/definitions/nuget/nuget/-/Foil/1.0.37/1.0.37)