### PR TITLE
javax.measure/jsr-275/0.9.1

### DIFF
--- a/curations/maven/mavencentral/javax.measure/jsr-275.yaml
+++ b/curations/maven/mavencentral/javax.measure/jsr-275.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  0.9.1:
+    licensed:
+      declared: BSD-2-Clause
   0.9.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.measure/jsr-275/0.9.1

**Details:**
License link in pom goes to BSD-2-Clause. The file headers in the sources jar also state the same.

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [jsr-275 0.9.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.measure/jsr-275/0.9.1/0.9.1)