### PR TITLE
MethodDecorator.Fody/1.1.1

### DIFF
--- a/curations/nuget/nuget/-/MethodDecorator.Fody.yaml
+++ b/curations/nuget/nuget/-/MethodDecorator.Fody.yaml
@@ -6,3 +6,6 @@ revisions:
   1.1.0:
     licensed:
       declared: MIT
+  1.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MethodDecorator.Fody/1.1.1

**Details:**
https://github.com/Fody/MethodDecorator/blob/1.1.1/License.txt

**Resolution:**
MIT

**Affected definitions**:
- [MethodDecorator.Fody 1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/MethodDecorator.Fody/1.1.1/1.1.1)