### PR TITLE
node-win-x64/16.14.2

### DIFF
--- a/curations/npm/npmjs/-/node-win-x64.yaml
+++ b/curations/npm/npmjs/-/node-win-x64.yaml
@@ -21,3 +21,6 @@ revisions:
   16.13.2:
     licensed:
       declared: NONE
+  16.14.2:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
node-win-x64/16.14.2

**Details:**
Could not find any declared license info

**Resolution:**
NONE

**Affected definitions**:
- [node-win-x64 16.14.2](https://clearlydefined.io/definitions/npm/npmjs/-/node-win-x64/16.14.2/16.14.2)