### PR TITLE
thrift/0.16.0

### DIFF
--- a/curations/pypi/pypi/-/thrift.yaml
+++ b/curations/pypi/pypi/-/thrift.yaml
@@ -21,6 +21,9 @@ revisions:
   0.15.0:
     licensed:
       declared: Apache-2.0
+  0.16.0:
+    licensed:
+      declared: Apache-2.0
   0.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
thrift/0.16.0

**Details:**
setup.py, README and file headers declare Apache 2.0. 

**Resolution:**
Apache-2.0

**Affected definitions**:
- [thrift 0.16.0](https://clearlydefined.io/definitions/pypi/pypi/-/thrift/0.16.0/0.16.0)