### PR TITLE
Unity.Abstractions/2.1.0

### DIFF
--- a/curations/nuget/nuget/-/Unity.Abstractions.yaml
+++ b/curations/nuget/nuget/-/Unity.Abstractions.yaml
@@ -6,6 +6,9 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.1.0:
+    licensed:
+      declared: Apache-2.0
   2.2.1:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Abstractions/2.1.0

**Details:**
https://github.com/unitycontainer/abstractions/blob/2.1.0.82/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Unity.Abstractions 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Abstractions/2.1.0/2.1.0)