### PR TITLE
Declared License is inappropriate

### DIFF
--- a/curations/git/github/xdrop/fuzzywuzzy.yaml
+++ b/curations/git/github/xdrop/fuzzywuzzy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: fuzzywuzzy
+  namespace: xdrop
+  provider: github
+  type: git
+revisions:
+  3ee0dae4aa43cdc6c1e16e659dd3eb9153ae3308:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Other

**Summary:**
Declared License is inappropriate

**Details:**
Declared License listed different variants of GNU GPL but this version of the FOSS components is distributed under GPL v3 or later.

**Resolution:**
Updated the license as per https://github.com/xdrop/fuzzywuzzy/blob/3ee0dae4aa43cdc6c1e16e659dd3eb9153ae3308/LICENSE.

**Affected definitions**:
- [fuzzywuzzy 3ee0dae4aa43cdc6c1e16e659dd3eb9153ae3308](https://clearlydefined.io/definitions/git/github/xdrop/fuzzywuzzy/3ee0dae4aa43cdc6c1e16e659dd3eb9153ae3308/3ee0dae4aa43cdc6c1e16e659dd3eb9153ae3308)