### PR TITLE
Declared License incorrect 

### DIFF
--- a/curations/git/github/airbrake/airbrake.yaml
+++ b/curations/git/github/airbrake/airbrake.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: airbrake
+  namespace: airbrake
+  provider: github
+  type: git
+revisions:
+  d98d7b4c92e5f15248cfb490805cdd0f1f7f5cfb:
+    licensed:
+      declared: MIT

--- a/curations/git/github/airbrake/airbrake.yaml
+++ b/curations/git/github/airbrake/airbrake.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   d98d7b4c92e5f15248cfb490805cdd0f1f7f5cfb:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License incorrect 

**Details:**
License Should be MIT 
License Path:
https://github.com/airbrake/airbrake/blob/v4.3.6/LICENSE

**Resolution:**
https://github.com/airbrake/airbrake/blob/v4.3.6/LICENSE

**Affected definitions**:
- [airbrake d98d7b4c92e5f15248cfb490805cdd0f1f7f5cfb](https://clearlydefined.io/definitions/git/github/airbrake/airbrake/d98d7b4c92e5f15248cfb490805cdd0f1f7f5cfb/d98d7b4c92e5f15248cfb490805cdd0f1f7f5cfb)