### PR TITLE
Source Location was missing and the declared license was incorrect.

### DIFF
--- a/curations/nuget/nuget/-/Extended.Wpf.Toolkit.yaml
+++ b/curations/nuget/nuget/-/Extended.Wpf.Toolkit.yaml
@@ -13,6 +13,14 @@ revisions:
     licensed:
       declared: MS-PL
   3.0.0:
+    described:
+      sourceLocation:
+        name: wpftoolkit
+        namespace: xceedsoftware
+        provider: github
+        revision: 015d89f201800a275feacf8eccedfd58fb1a59ca
+        type: git
+        url: 'https://github.com/xceedsoftware/wpftoolkit/commit/015d89f201800a275feacf8eccedfd58fb1a59ca'
     licensed:
       declared: MS-PL
   3.7.0:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source Location was missing and the declared license was incorrect.

**Details:**
Source location was missing and the declared license became incorrect when the correct source location URL was chosen.

**Resolution:**
Filled in the source location URL and updated the license as MS-PL (based on the information found at https://github.com/xceedsoftware/wpftoolkit/blob/015d89f201800a275feacf8eccedfd58fb1a59ca/ExtendedWPFToolkitSolution/Src/Xceed.Wpf.AvalonDock.Themes.Aero/AssemblyVersionInfo.cs).

**Affected definitions**:
- [Extended.Wpf.Toolkit 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Extended.Wpf.Toolkit/3.0.0/3.0.0)