### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/masteringopencv/code.yaml
+++ b/curations/git/github/masteringopencv/code.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: code
+  namespace: masteringopencv
+  provider: github
+  type: git
+revisions:
+  d1d4d99b5c07c43b50a41e3d02ffc9cae64df242:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is reported as NOASSERTION.

**Resolution:**
This component is distributed under the book author's permission that allows commercial distribution. Filled in the declared license as per https://github.com/MasteringOpenCV/code/blob/d1d4d99b5c07c43b50a41e3d02ffc9cae64df242/LICENSE.txt.

**Affected definitions**:
- [code d1d4d99b5c07c43b50a41e3d02ffc9cae64df242](https://clearlydefined.io/definitions/git/github/masteringopencv/code/d1d4d99b5c07c43b50a41e3d02ffc9cae64df242/d1d4d99b5c07c43b50a41e3d02ffc9cae64df242)