### PR TITLE
Updated Declared license

### DIFF
--- a/curations/git/github/brianc/node-postgres.yaml
+++ b/curations/git/github/brianc/node-postgres.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: node-postgres
+  namespace: brianc
+  provider: github
+  type: git
+revisions:
+  4c81c6da252fbda16f9aea48ae4972f1b3850356:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Updated Declared license

**Details:**
The declared license information is missing.
It has been updated to MIT as per the information provided in readme file of this component.
Here is the link to it - https://github.com/brianc/node-postgres/blob/4c81c6da252fbda16f9aea48ae4972f1b3850356/README.md#license

**Resolution:**
The license is updated to MIT as per https://github.com/brianc/node-postgres/blob/4c81c6da252fbda16f9aea48ae4972f1b3850356/README.md#license and also reverfied from this URL https://www.npmjs.com/package/pg/v/3.4.2

**Affected definitions**:
- [node-postgres 4c81c6da252fbda16f9aea48ae4972f1b3850356](https://clearlydefined.io/definitions/git/github/brianc/node-postgres/4c81c6da252fbda16f9aea48ae4972f1b3850356/4c81c6da252fbda16f9aea48ae4972f1b3850356)