### PR TITLE
Declared License was NOASSERTION.

### DIFF
--- a/curations/git/github/google/caja.yaml
+++ b/curations/git/github/google/caja.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: caja
+  namespace: google
+  provider: github
+  type: git
+revisions:
+  43ee1c8f4f6d44032173d1c1da2d04b96f81ecf6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was NOASSERTION.

**Details:**
Declared license was NOASSERTION.

**Resolution:**
Corrected the declared license as per https://github.com/googlearchive/caja/blob/43ee1c8f4f6d44032173d1c1da2d04b96f81ecf6/LICENSE.txt.

**Affected definitions**:
- [caja 43ee1c8f4f6d44032173d1c1da2d04b96f81ecf6](https://clearlydefined.io/definitions/git/github/google/caja/43ee1c8f4f6d44032173d1c1da2d04b96f81ecf6/43ee1c8f4f6d44032173d1c1da2d04b96f81ecf6)