### PR TITLE
Resolve case of SPDX license

### DIFF
--- a/curations/git/github/elastic/beats.yaml
+++ b/curations/git/github/elastic/beats.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  1122568edf4ad039734b5224aece9a6259c72684:
+    licensed:
+      declared: Apache-2.0
   1eea934ce81be553337f2828bd12131896fea8e4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of SPDX license

**Details:**
This component contains Apache license 2.0 hence, marking this as apache license 2.0. Please find the link as below: 
https://github.com/elastic/beats/blob/v6.2.4/LICENSE.txt

**Resolution:**
This component contains Apache license 2.0 hence, marking this as apache license 2.0. Please find the link as below: 
https://github.com/elastic/beats/blob/v6.2.4/LICENSE.txt

**Affected definitions**:
- [beats 1122568edf4ad039734b5224aece9a6259c72684](https://clearlydefined.io/definitions/git/github/elastic/beats/1122568edf4ad039734b5224aece9a6259c72684/1122568edf4ad039734b5224aece9a6259c72684)