### PR TITLE
Resolve case of SPDX license

### DIFF
--- a/curations/git/github/elastic/beats.yaml
+++ b/curations/git/github/elastic/beats.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  154d2d0e10f36edac6bf0fb782cfa82d550c8974:
+    licensed:
+      declared: Apache-2.0
   1eea934ce81be553337f2828bd12131896fea8e4:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve case of SPDX license

**Details:**
This component contains Apache license-2.0 hence, adding this as curation.
https://github.com/elastic/beats/blob/v6.0.1/LICENSE.txt

**Resolution:**
This component contains Apache license-2.0 hence, adding this as curation.
https://github.com/elastic/beats/blob/v6.0.1/LICENSE.txt

**Affected definitions**:
- [beats 154d2d0e10f36edac6bf0fb782cfa82d550c8974](https://clearlydefined.io/definitions/git/github/elastic/beats/154d2d0e10f36edac6bf0fb782cfa82d550c8974/154d2d0e10f36edac6bf0fb782cfa82d550c8974)