### PR TITLE
boostorg/chrono license information

### DIFF
--- a/curations/git/github/boostorg/chrono.yaml
+++ b/curations/git/github/boostorg/chrono.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  5885f9ef0e02b2be1730380c99b2cde3d03cdcd1:
+    licensed:
+      declared: BSL-1.0
   aa51cbd5121ed29093484f53e5f96e13a9a915b4:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boostorg/chrono license information

**Details:**
The README mentions the software is distributed under BSL-1.0 license

**Resolution:**
Declare the license to be BSL-1.0

**Affected definitions**:
- [chrono 5885f9ef0e02b2be1730380c99b2cde3d03cdcd1](https://clearlydefined.io/definitions/git/github/boostorg/chrono/5885f9ef0e02b2be1730380c99b2cde3d03cdcd1/5885f9ef0e02b2be1730380c99b2cde3d03cdcd1)