### PR TITLE
azureml-dataprep3.1.3

### DIFF
--- a/curations/pypi/pypi/-/azureml-dataprep.yaml
+++ b/curations/pypi/pypi/-/azureml-dataprep.yaml
@@ -228,3 +228,6 @@ revisions:
   3.1.2:
     licensed:
       declared: OTHER
+  3.1.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
azureml-dataprep3.1.3

**Details:**
Declaring OTHER for proprietary license file in the package

**Resolution:**
This software is made available to you on the condition that you agree to
[your agreement][1] governing your use of Azure.
If you do not have an existing agreement governing your use of Azure, you agree that 
your agreement governing use of Azure is the [Microsoft Online Subscription Agreement][2]
(

**Affected definitions**:
- [azureml-dataprep 3.1.3](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-dataprep/3.1.3/3.1.3)