### PR TITLE
RestSharpSigned104.1.0

### DIFF
--- a/curations/nuget/nuget/-/RestSharpSigned.yaml
+++ b/curations/nuget/nuget/-/RestSharpSigned.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  104.1.0:
+    licensed:
+      declared: Apache-2.0
   105.2.3:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RestSharpSigned104.1.0

**Details:**
Declaring Apache-2.0

**Resolution:**
NuGet license links to GitHub repo - 
https://github.com/restsharp/RestSharp/blob/104.1/LICENSE.txt

**Affected definitions**:
- [RestSharpSigned 104.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharpSigned/104.1.0/104.1.0)