### PR TITLE
RestSharp104.4.0

### DIFF
--- a/curations/nuget/nuget/-/RestSharp.yaml
+++ b/curations/nuget/nuget/-/RestSharp.yaml
@@ -6,6 +6,9 @@ revisions:
   103.4.0:
     licensed:
       declared: Apache-2.0
+  104.4.0:
+    licensed:
+      declared: Apache-2.0
   105.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RestSharp104.4.0

**Details:**
Declared License is Apache-2.0

**Resolution:**
NuGet license and GitHub repo license are both Apache-2.0

https://licenses.nuget.org/Apache-2.0

**Affected definitions**:
- [RestSharp 104.4.0](https://clearlydefined.io/definitions/nuget/nuget/-/RestSharp/104.4.0/104.4.0)