### PR TITLE
jQuery.UI.Combined1.10.2

### DIFF
--- a/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
+++ b/curations/nuget/nuget/-/jQuery.UI.Combined.yaml
@@ -6,6 +6,9 @@ revisions:
   1.10.0:
     licensed:
       declared: MIT
+  1.10.2:
+    licensed:
+      declared: MIT
   1.10.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jQuery.UI.Combined1.10.2

**Details:**
Declared License is MIT

**Resolution:**
http://jquery.org/license/

**Affected definitions**:
- [jQuery.UI.Combined 1.10.2](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.UI.Combined/1.10.2/1.10.2)