### PR TITLE
LtiLibrary.Core1.6.1

### DIFF
--- a/curations/nuget/nuget/-/LtiLibrary.Core.yaml
+++ b/curations/nuget/nuget/-/LtiLibrary.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: LtiLibrary.Core
+  provider: nuget
+  type: nuget
+revisions:
+  1.6.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
LtiLibrary.Core1.6.1

**Details:**
Declared License is Apache-2.0

**Resolution:**
NuGet license links to GitHub repo
https://github.com/LtiLibrary/LtiLibrary/blob/v1.6.1/LICENSE

**Affected definitions**:
- [LtiLibrary.Core 1.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/LtiLibrary.Core/1.6.1/1.6.1)