### PR TITLE
Newtonsoft.Json4.5.9

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -51,6 +51,9 @@ revisions:
         url: 'https://github.com/jamesnk/newtonsoft.json/commit/9396ea0994fdfe0fae627b7e63924684ef6ede7f'
     licensed:
       declared: MIT
+  4.5.9:
+    licensed:
+      declared: MIT
   5.0.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Newtonsoft.Json4.5.9

**Details:**
Declared License is MIT

**Resolution:**
https://licenses.nuget.org/MIT

**Affected definitions**:
- [Newtonsoft.Json 4.5.9](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.5.9/4.5.9)