### PR TITLE
WindowsAzure.Storage2.0.5

### DIFF
--- a/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
@@ -20,7 +20,7 @@ revisions:
       declared: OTHER
   2.0.5:
     licensed:
-      declared: Apache-2.0
+      declared: OTHER
   2.0.5.1:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
+++ b/curations/nuget/nuget/-/WindowsAzure.Storage.yaml
@@ -18,6 +18,9 @@ revisions:
   2.0.4.1:
     licensed:
       declared: OTHER
+  2.0.5:
+    licensed:
+      declared: Apache-2.0
   2.0.5.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
WindowsAzure.Storage2.0.5

**Details:**
Declared License is Apache-2.0

**Resolution:**
NuGet license links goes to GitHub repo. License was added at setup to the repo 11/8/2013
https://github.com/Azure/azure-storage-net/blob/master/LICENSE.txt


**Affected definitions**:
- [WindowsAzure.Storage 2.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/WindowsAzure.Storage/2.0.5/2.0.5)