### PR TITLE
SignalR.Hosting.AspNet0.5.3

### DIFF
--- a/curations/nuget/nuget/-/SignalR.Hosting.AspNet.yaml
+++ b/curations/nuget/nuget/-/SignalR.Hosting.AspNet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SignalR.Hosting.AspNet
+  provider: nuget
+  type: nuget
+revisions:
+  0.5.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SignalR.Hosting.AspNet0.5.3

**Details:**
Declared License is MIT

**Resolution:**
https://github.com/SignalR/SignalR/blob/main/LICENSE.txt

**Affected definitions**:
- [SignalR.Hosting.AspNet 0.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/SignalR.Hosting.AspNet/0.5.3/0.5.3)