### PR TITLE
License is not GPL 3

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  2.11.5:
+    licensed:
+      declared: LGPL-2.1-only
   2.3.1:
     licensed:
       declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License is not GPL 3

**Details:**
License was mis-identified to include GPL 3, but the license declares explicitly LGPL 2.1.

**Resolution:**
https://github.com/PyCQA/astroid/blob/v2.11.5/LICENSE

**Affected definitions**:
- [astroid 2.11.5](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.11.5/2.11.5)