### PR TITLE
License does not include GPL 3

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -6,6 +6,9 @@ revisions:
   2.11.1:
     licensed:
       declared: GPL-2.0-only
+  2.14.1:
+    licensed:
+      declared: GPL-2.0-only
   2.3.0:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License does not include GPL 3

**Details:**
It's only GPL 2

**Resolution:**
https://github.com/PyCQA/pylint/blob/v2.14.1/LICENSE

**Affected definitions**:
- [pylint 2.14.1](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.14.1/2.14.1)