### PR TITLE
Declared License Missing

### DIFF
--- a/curations/sourcearchive/mavencentral/org.eclipse.jetty/jetty-continuation.yaml
+++ b/curations/sourcearchive/mavencentral/org.eclipse.jetty/jetty-continuation.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jetty-continuation
+  namespace: org.eclipse.jetty
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  9.4.39.v20210325:
+    licensed:
+      declared: Apache-2.0 OR EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License Missing license should be Apache 2.0 or EPL- 1.0

Path Location:
https://github.com/eclipse/jetty.project/blob/jetty-9.4.39.v20210325/LICENSE

**Resolution:**
https://github.com/eclipse/jetty.project/blob/jetty-9.4.39.v20210325/LICENSE

**Affected definitions**:
- [jetty-continuation 9.4.39.v20210325](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.eclipse.jetty/jetty-continuation/9.4.39.v20210325/9.4.39.v20210325)