### PR TITLE
Declared License Missing

### DIFF
--- a/curations/maven/mavencentral/wsdl4j/wsdl4j.yaml
+++ b/curations/maven/mavencentral/wsdl4j/wsdl4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: wsdl4j
+  namespace: wsdl4j
+  provider: mavencentral
+  type: maven
+revisions:
+  1.6.3:
+    licensed:
+      declared: CPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License Should be CPL 1.0 instead of NOASSERTION 

License Path :
https://sourceforge.net/projects/wsdl4j/

https://repo1.maven.org/maven2/wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.pom

**Resolution:**
License Path :
https://sourceforge.net/projects/wsdl4j/

https://repo1.maven.org/maven2/wsdl4j/wsdl4j/1.6.3/wsdl4j-1.6.3.pom

**Affected definitions**:
- [wsdl4j 1.6.3](https://clearlydefined.io/definitions/maven/mavencentral/wsdl4j/wsdl4j/1.6.3/1.6.3)