### PR TITLE
com.sun.jersey:jersey-core/1.8

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-core.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-core.yaml
@@ -19,6 +19,9 @@ revisions:
   1.19.4:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.8':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.9':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.sun.jersey:jersey-core/1.8

**Details:**
Add CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/com/sun/jersey/jersey-core/1.8/jersey-core-1.8.pom

**Affected definitions**:
- [jersey-core 1.8](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-core/1.8)