### PR TITLE
org.eclipse.persistence:eclipselink/2.5.2

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
+++ b/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.5.2:
+    licensed:
+      declared: EPL-1.0 OR BSD-3-Clause
   2.6.4-RC1:
     licensed:
       declared: EPL-1.0 AND BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.eclipse.persistence:eclipselink/2.5.2

**Details:**
Add EPL-1.0 OR BSD-3-Clause

**Resolution:**
https://repo1.maven.org/maven2/org/eclipse/persistence/eclipselink/2.5.2/eclipselink-2.5.2.pom

**Affected definitions**:
- [eclipselink 2.5.2](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.persistence/eclipselink/2.5.2)