### PR TITLE
boostorg/math/3c4d1804e1556ccebb54fe6e823a66020526e6ae

### DIFF
--- a/curations/git/github/boostorg/math.yaml
+++ b/curations/git/github/boostorg/math.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  3c4d1804e1556ccebb54fe6e823a66020526e6ae:
+    licensed:
+      declared: BSL-1.0
   a0a97b768afd4188c2985081fab937c0b655df4a:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
boostorg/math/3c4d1804e1556ccebb54fe6e823a66020526e6ae

**Details:**
Add BSL-1.0

**Resolution:**
https://github.com/boostorg/math/blob/3c4d1804e1556ccebb54fe6e823a66020526e6ae/index.html

**Affected definitions**:
- [math 3c4d1804e1556ccebb54fe6e823a66020526e6ae](https://clearlydefined.io/definitions/git/github/boostorg/math/3c4d1804e1556ccebb54fe6e823a66020526e6ae)