### PR TITLE
dependabot-dep/0.145.4

### DIFF
--- a/curations/gem/rubygems/-/dependabot-dep.yaml
+++ b/curations/gem/rubygems/-/dependabot-dep.yaml
@@ -6,6 +6,9 @@ revisions:
   0.129.5:
     licensed:
       declared: OTHER
+  0.145.4:
+    licensed:
+      declared: OTHER
   0.158.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dependabot-dep/0.145.4

**Details:**
Add OTHER

**Resolution:**
https://github.com/dependabot/dependabot-core/blob/v0.145.4/LICENSE

**Affected definitions**:
- [dependabot-dep 0.145.4](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-dep/0.145.4)