### PR TITLE
RequireJS.Text2.0.7

### DIFF
--- a/curations/nuget/nuget/-/RequireJS.Text.yaml
+++ b/curations/nuget/nuget/-/RequireJS.Text.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: RequireJS.Text
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.7:
+    licensed:
+      declared: BSD-3-Clause OR MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RequireJS.Text2.0.7

**Details:**
Dual-licensed - BSD-3-Clause OR MIT

**Resolution:**
https://github.com/requirejs/text/blob/2.0.7/LICENSE

**Affected definitions**:
- [RequireJS.Text 2.0.7](https://clearlydefined.io/definitions/nuget/nuget/-/RequireJS.Text/2.0.7/2.0.7)