### PR TITLE
com.google.android.gms/play-services-iid16.0.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-iid.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-iid.yaml
@@ -7,3 +7,6 @@ revisions:
   11.0.2:
     licensed:
       declared: OTHER
+  16.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
com.google.android.gms/play-services-iid16.0.0

**Details:**
Declared License is OTHER for proprietary license

**Resolution:**
https://maven.google.com/web/index.html#com.google.android.gms:play-services-iid:16.0.0

**Affected definitions**:
- [play-services-iid 16.0.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-iid/16.0.0/16.0.0)