### PR TITLE
MetroFramework1.2.0.3

### DIFF
--- a/curations/nuget/nuget/-/MetroFramework.yaml
+++ b/curations/nuget/nuget/-/MetroFramework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MetroFramework
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
MetroFramework1.2.0.3

**Details:**
Declared License is MIT on NuGet page and in GitHub repo

**Resolution:**
https://github.com/thielj/MetroFramework/blob/master/LICENSE.md

**Affected definitions**:
- [MetroFramework 1.2.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/MetroFramework/1.2.0.3/1.2.0.3)