### PR TITLE
RequireJS2.1.11

### DIFF
--- a/curations/nuget/nuget/-/RequireJS.yaml
+++ b/curations/nuget/nuget/-/RequireJS.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.1.11:
+    licensed:
+      declared: BSD-3-Clause OR MIT
   2.1.14:
     licensed:
       declared: BSD-3-Clause OR MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
RequireJS2.1.11

**Details:**
Dual-licensed - BSD-3-Clause OR MIT

**Resolution:**
https://github.com/requirejs/requirejs/blob/2.1.11/LICENSE

**Affected definitions**:
- [RequireJS 2.1.11](https://clearlydefined.io/definitions/nuget/nuget/-/RequireJS/2.1.11/2.1.11)