### PR TITLE
Unity5.1.1

### DIFF
--- a/curations/nuget/nuget/-/Unity.yaml
+++ b/curations/nuget/nuget/-/Unity.yaml
@@ -18,6 +18,9 @@ revisions:
   5.1.0:
     licensed:
       declared: Apache-2.0
+  5.1.1:
+    licensed:
+      declared: Apache-2.0
   5.1.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Unity5.1.1

**Details:**
Declared License is Apache-2.0

**Resolution:**
https://github.com/unitycontainer/unity/blob/5.1.0.296/LICENSE

**Affected definitions**:
- [Unity 5.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity/5.1.1/5.1.1)