### PR TITLE
jQuery.BlockUI2.66.0

### DIFF
--- a/curations/nuget/nuget/-/jQuery.BlockUI.yaml
+++ b/curations/nuget/nuget/-/jQuery.BlockUI.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.66.0:
     licensed:
-      declared: MIT OR GPL-2.0-or-later
+      declared: MIT OR GPL-2.0-only
   2.70.0:
     licensed:
       declared: MIT OR GPL-2.0-only

--- a/curations/nuget/nuget/-/jQuery.BlockUI.yaml
+++ b/curations/nuget/nuget/-/jQuery.BlockUI.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.66.0:
+    licensed:
+      declared: MIT OR GPL-2.0-or-later
   2.70.0:
     licensed:
       declared: MIT OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
jQuery.BlockUI2.66.0

**Details:**
Declaring MIT OR GPL-2.0-or-later
"GPL-2.0 licenses" is mentioned at the link

**Resolution:**
https://github.com/malsup/blockui/commit/0199171ccb92bec29c1a83ac9ab5c6394fe1185b

**Affected definitions**:
- [jQuery.BlockUI 2.66.0](https://clearlydefined.io/definitions/nuget/nuget/-/jQuery.BlockUI/2.66.0/2.66.0)