### PR TITLE
CommandLineParser2.0.251-beta

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser.yaml
@@ -15,6 +15,9 @@ revisions:
         url: 'https://github.com/gsscoder/commandline/commit/205094c0c135ab5b6816f3eb0e6a84ddced5b0e2'
     licensed:
       declared: MIT
+  2.0.251-beta:
+    licensed:
+      declared: MIT
   2.0.275-beta:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
CommandLineParser2.0.251-beta

**Details:**
Declaring MIT as the only license in the repo

**Resolution:**
https://github.com/commandlineparser/commandline/blob/master/License.md

**Affected definitions**:
- [CommandLineParser 2.0.251-beta](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser/2.0.251-beta/2.0.251-beta)