### PR TITLE
Bond.Runtime.CSharp4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
+++ b/curations/nuget/nuget/-/Bond.Runtime.CSharp.yaml
@@ -45,6 +45,9 @@ revisions:
   4.0.2:
     licensed:
       declared: MIT
+  4.1.0:
+    licensed:
+      declared: MIT
   4.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Bond.Runtime.CSharp4.1.0

**Details:**
Declared License is MIT

**Resolution:**
https://github.com/Microsoft/bond/blob/4.1.0/LICENSE

**Affected definitions**:
- [Bond.Runtime.CSharp 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Bond.Runtime.CSharp/4.1.0/4.1.0)