### PR TITLE
azureml-defaults1.41.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-defaults.yaml
+++ b/curations/pypi/pypi/-/azureml-defaults.yaml
@@ -237,6 +237,9 @@ revisions:
   1.40.0:
     licensed:
       declared: OTHER
+  1.41.0:
+    licensed:
+      declared: OTHER
   1.42.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
azureml-defaults1.41.0

**Details:**
Declaring OTHER for proprietary license

**Resolution:**
https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-defaults 1.41.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-defaults/1.41.0/1.41.0)