### PR TITLE
SignalR0.5.3

### DIFF
--- a/curations/nuget/nuget/-/SignalR.yaml
+++ b/curations/nuget/nuget/-/SignalR.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: SignalR
+  provider: nuget
+  type: nuget
+revisions:
+  0.5.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SignalR0.5.3

**Details:**
Declared License is MIT

**Resolution:**
https://github.com/SignalR/SignalR/blob/0.5.3/LICENSE.md

**Affected definitions**:
- [SignalR 0.5.3](https://clearlydefined.io/definitions/nuget/nuget/-/SignalR/0.5.3/0.5.3)