### PR TITLE
org.junit.jupiter/junit-jupiter5.8.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -31,6 +31,9 @@ revisions:
   5.7.2:
     licensed:
       declared: EPL-2.0
+  5.8.1:
+    licensed:
+      declared: EPL-2.0
   5.8.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.junit.jupiter/junit-jupiter5.8.1

**Details:**
Declared License is EPL-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter/5.8.1/junit-jupiter-5.8.1.pom

**Affected definitions**:
- [junit-jupiter 5.8.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.8.1/5.8.1)