### PR TITLE
javax.sip/jain-sip-api1.2

### DIFF
--- a/curations/maven/mavencentral/javax.sip/jain-sip-api.yaml
+++ b/curations/maven/mavencentral/javax.sip/jain-sip-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.2':
     licensed:
-      declared: NONE
+      declared: OTHER

--- a/curations/maven/mavencentral/javax.sip/jain-sip-api.yaml
+++ b/curations/maven/mavencentral/javax.sip/jain-sip-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jain-sip-api
+  namespace: javax.sip
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.2':
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
javax.sip/jain-sip-api1.2

**Details:**
Declaring NONE

**Resolution:**
I did not find a license in the POM, sources jar and in other versions of this package on Maven. I searched the web and didn't find another reference to this exact package.

**Affected definitions**:
- [jain-sip-api 1.2](https://clearlydefined.io/definitions/maven/mavencentral/javax.sip/jain-sip-api/1.2/1.2)