### PR TITLE
Xamarin.AndroidX.CardView1.0.0.9

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.CardView.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.CardView.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.0.6:
     licensed:
       declared: MIT
+  1.0.0.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Xamarin.AndroidX.CardView1.0.0.9

**Details:**
Declared License is MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.CardView/1.0.0.9/License

**Affected definitions**:
- [Xamarin.AndroidX.CardView 1.0.0.9](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.CardView/1.0.0.9/1.0.0.9)