### PR TITLE
azureml-telemetry1.42.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-telemetry.yaml
+++ b/curations/pypi/pypi/-/azureml-telemetry.yaml
@@ -261,6 +261,9 @@ revisions:
   1.41.0:
     licensed:
       declared: OTHER
+  1.42.0:
+    licensed:
+      declared: OTHER
   1.5.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
azureml-telemetry1.42.0

**Details:**
Declared License is OTHER for proprietary license

**Resolution:**
https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-telemetry 1.42.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-telemetry/1.42.0/1.42.0)