### PR TITLE
azureml-train-restclients-hyperdrive/1.42.0

### DIFF
--- a/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
+++ b/curations/pypi/pypi/-/azureml-train-restclients-hyperdrive.yaml
@@ -228,6 +228,9 @@ revisions:
   1.41.0:
     licensed:
       declared: OTHER
+  1.42.0:
+    licensed:
+      declared: OTHER
   1.5.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
azureml-train-restclients-hyperdrive/1.42.0

**Details:**
Add OTHER

**Resolution:**
https://aka.ms/azureml-sdk-license

**Affected definitions**:
- [azureml-train-restclients-hyperdrive 1.42.0](https://clearlydefined.io/definitions/pypi/pypi/-/azureml-train-restclients-hyperdrive/1.42.0)