### PR TITLE
com.sun.jersey:jersey-json/1.14

### DIFF
--- a/curations/maven/mavencentral/com.sun.jersey/jersey-json.yaml
+++ b/curations/maven/mavencentral/com.sun.jersey/jersey-json.yaml
@@ -7,6 +7,9 @@ revisions:
   '1.13':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  '1.14':
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   '1.19':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.sun.jersey:jersey-json/1.14

**Details:**
Add CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/com/sun/jersey/jersey-json/1.14/jersey-json-1.14.pom

**Affected definitions**:
- [jersey-json 1.14](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jersey/jersey-json/1.14)