### PR TITLE
gym/0.24.0

### DIFF
--- a/curations/pypi/pypi/-/gym.yaml
+++ b/curations/pypi/pypi/-/gym.yaml
@@ -36,3 +36,6 @@ revisions:
   0.23.1:
     licensed:
       declared: MIT
+  0.24.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
gym/0.24.0

**Details:**
Add MIT

**Resolution:**
https://github.com/openai/gym/blob/0.24.0/LICENSE.md

**Affected definitions**:
- [gym 0.24.0](https://clearlydefined.io/definitions/pypi/pypi/-/gym/0.24.0)