### PR TITLE
HotChocolate.Language.Visitors/12.6.1

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.Visitors.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.Visitors.yaml
@@ -24,6 +24,9 @@ revisions:
   12.6.0:
     licensed:
       declared: MIT
+  12.6.1:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Language.Visitors/12.6.1

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Language.Visitors/12.6.1/License

**Affected definitions**:
- [HotChocolate.Language.Visitors 12.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.Visitors/12.6.1)