### PR TITLE
org.apache.hadoop:hadoop-tools/1.2.1

### DIFF
--- a/curations/maven/mavencentral/org.apache.hadoop/hadoop-tools.yaml
+++ b/curations/maven/mavencentral/org.apache.hadoop/hadoop-tools.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hadoop-tools
+  namespace: org.apache.hadoop
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.apache.hadoop:hadoop-tools/1.2.1

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-tools/1.2.1/hadoop-tools-1.2.1.pom

**Affected definitions**:
- [hadoop-tools 1.2.1](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.hadoop/hadoop-tools/1.2.1)