### PR TITLE
org.bouncycastle:bcpkix-jdk15on/1.54

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on.yaml
@@ -7,6 +7,9 @@ revisions:
   '1.53':
     licensed:
       declared: MIT
+  '1.54':
+    licensed:
+      declared: MIT
   '1.56':
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.bouncycastle:bcpkix-jdk15on/1.54

**Details:**
Add MIT

**Resolution:**
http://www.bouncycastle.org/licence.html

**Affected definitions**:
- [bcpkix-jdk15on 1.54](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcpkix-jdk15on/1.54)