### PR TITLE
org.openjdk.jmh:jmh-core/1.4.1

### DIFF
--- a/curations/maven/mavencentral/org.openjdk.jmh/jmh-core.yaml
+++ b/curations/maven/mavencentral/org.openjdk.jmh/jmh-core.yaml
@@ -79,3 +79,6 @@ revisions:
   '1.34':
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  1.4.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.openjdk.jmh:jmh-core/1.4.1

**Details:**
Add GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/openjdk/jmh/jmh-core/1.4.1/jmh-core-1.4.1.pom

**Affected definitions**:
- [jmh-core 1.4.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjdk.jmh/jmh-core/1.4.1)