### PR TITLE
PresentationFramework/4.6.0

### DIFF
--- a/curations/nuget/nuget/-/PresentationFramework.yaml
+++ b/curations/nuget/nuget/-/PresentationFramework.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PresentationFramework
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
PresentationFramework/4.6.0

**Details:**
Add NONE

**Resolution:**
Could not locate license info

**Affected definitions**:
- [PresentationFramework 4.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/PresentationFramework/4.6.0)