### PR TITLE
WinPixEventRuntime/1.0.210209001

### DIFF
--- a/curations/nuget/nuget/-/WinPixEventRuntime.yaml
+++ b/curations/nuget/nuget/-/WinPixEventRuntime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: WinPixEventRuntime
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.210209001:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
WinPixEventRuntime/1.0.210209001

**Details:**
Add OTHER

**Resolution:**
https://www.nuget.org/packages/WinPixEventRuntime/1.0.210209001/License

**Affected definitions**:
- [WinPixEventRuntime 1.0.210209001](https://clearlydefined.io/definitions/nuget/nuget/-/WinPixEventRuntime/1.0.210209001)