### PR TITLE
Xamarin.AndroidX.Core/1.6.0.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.Core.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.Core.yaml
@@ -48,3 +48,6 @@ revisions:
   1.3.2.3:
     licensed:
       declared: MIT
+  1.6.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.Core/1.6.0.1

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.Core/1.6.0.1/License

**Affected definitions**:
- [Xamarin.AndroidX.Core 1.6.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.Core/1.6.0.1)