### PR TITLE
Xamarin.AndroidX.DocumentFile/1.0.1.8

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.DocumentFile.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.DocumentFile.yaml
@@ -30,3 +30,6 @@ revisions:
   1.0.1.7:
     licensed:
       declared: MIT
+  1.0.1.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.DocumentFile/1.0.1.8

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.DocumentFile/1.0.1.8/License

**Affected definitions**:
- [Xamarin.AndroidX.DocumentFile 1.0.1.8](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.DocumentFile/1.0.1.8)