### PR TITLE
Xamarin.AndroidX.DrawerLayout/1.1.1.3

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.DrawerLayout.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.DrawerLayout.yaml
@@ -33,3 +33,6 @@ revisions:
   1.1.1.2:
     licensed:
       declared: MIT
+  1.1.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.DrawerLayout/1.1.1.3

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.DrawerLayout/1.1.1.3/License

**Affected definitions**:
- [Xamarin.AndroidX.DrawerLayout 1.1.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.DrawerLayout/1.1.1.3)