### PR TITLE
Xamarin.AndroidX.Fragment/1.3.6.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.Fragment.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.Fragment.yaml
@@ -72,3 +72,6 @@ revisions:
   1.3.3:
     licensed:
       declared: MIT
+  1.3.6.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.Fragment/1.3.6.1

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.Fragment/1.3.6.1/License

**Affected definitions**:
- [Xamarin.AndroidX.Fragment 1.3.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.Fragment/1.3.6.1)