### PR TITLE
Xamarin.AndroidX.Loader/1.1.0.8

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.Loader.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.Loader.yaml
@@ -33,3 +33,6 @@ revisions:
   1.1.0.7:
     licensed:
       declared: MIT
+  1.1.0.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.Loader/1.1.0.8

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.Loader/1.1.0.8/License

**Affected definitions**:
- [Xamarin.AndroidX.Loader 1.1.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.Loader/1.1.0.8)