### PR TITLE
Xamarin.AndroidX.Print/1.0.0.8

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.Print.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.Print.yaml
@@ -30,3 +30,6 @@ revisions:
   1.0.0.7:
     licensed:
       declared: MIT
+  1.0.0.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.Print/1.0.0.8

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.Print/1.0.0.8/License

**Affected definitions**:
- [Xamarin.AndroidX.Print 1.0.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.Print/1.0.0.8)