### PR TITLE
Xamarin.AndroidX.VectorDrawable.Animated/1.1.0.8

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.AndroidX.VectorDrawable.Animated.yaml
+++ b/curations/nuget/nuget/-/Xamarin.AndroidX.VectorDrawable.Animated.yaml
@@ -21,3 +21,6 @@ revisions:
   1.1.0.7:
     licensed:
       declared: MIT
+  1.1.0.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.AndroidX.VectorDrawable.Animated/1.1.0.8

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/Xamarin.AndroidX.VectorDrawable.Animated/1.1.0.8/License

**Affected definitions**:
- [Xamarin.AndroidX.VectorDrawable.Animated 1.1.0.8](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.AndroidX.VectorDrawable.Animated/1.1.0.8)