### PR TITLE
com.h2database/h2 2.1.214

### DIFF
--- a/curations/maven/mavencentral/com.h2database/h2.yaml
+++ b/curations/maven/mavencentral/com.h2database/h2.yaml
@@ -48,3 +48,6 @@ revisions:
   2.1.212:
     licensed:
       declared: MPL-2.0 OR EPL-1.0
+  2.1.214:
+    licensed:
+      declared: MPL-2.0 OR EPL-1.0


### PR DESCRIPTION
**Type:** Missing

**Summary:**
com.h2database/h2 2.1.214

**Details:**
Maven license is MPL-2.0 OR EPL-1.0: http://h2database.com/html/license.html

**Resolution:**
MPL-2.0 OR EPL-1.0

**Affected definitions:**

[h2 2.1.214](https://clearlydefined.io/definitions/maven/mavencentral/com.h2database/h2/2.1.214/2.1.214)