### PR TITLE
org.eclipse.persistence/javax.persistence/2.1.0

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.persistence/javax.persistence.yaml
+++ b/curations/maven/mavencentral/org.eclipse.persistence/javax.persistence.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.0:
     licensed:
       declared: EPL-1.0
+  2.1.0:
+    licensed:
+      declared: BSD-3-Clause OR EPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.eclipse.persistence/javax.persistence/2.1.0

**Details:**
Add BSD-3-Clause OR EPL-1.0

**Resolution:**
https://repo1.maven.org/maven2/org/eclipse/persistence/javax.persistence/2.1.0/javax.persistence-2.1.0.pom

**Affected definitions**:
- [javax.persistence 2.1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.persistence/javax.persistence/2.1.0)