### PR TITLE
ARSoft.Tools.Net.Core/2.3.0

### DIFF
--- a/curations/nuget/nuget/-/ARSoft.Tools.Net.Core.yaml
+++ b/curations/nuget/nuget/-/ARSoft.Tools.Net.Core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ARSoft.Tools.Net.Core
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ARSoft.Tools.Net.Core/2.3.0

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/mccj/ARSoft.Tools.Net.Core/blob/2.3.0/LICENSE

**Affected definitions**:
- [ARSoft.Tools.Net.Core 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/ARSoft.Tools.Net.Core/2.3.0)