### PR TITLE
org.junit.jupiter/junit-jupiter-params/5.6.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -16,6 +16,9 @@ revisions:
   5.5.2:
     licensed:
       declared: EPL-2.0
+  5.6.0:
+    licensed:
+      declared: EPL-2.0
   5.6.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.junit.jupiter/junit-jupiter-params/5.6.0

**Details:**
Add EPL-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-params/5.6.0/junit-jupiter-params-5.6.0.pom

**Affected definitions**:
- [junit-jupiter-params 5.6.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.6.0)