### PR TITLE
typing-utils/0.1.0

### DIFF
--- a/curations/pypi/pypi/-/typing-utils.yaml
+++ b/curations/pypi/pypi/-/typing-utils.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: typing-utils
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
typing-utils/0.1.0

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/bojiang/typing_utils/blob/v0.1.0/LICENSE

**Affected definitions**:
- [typing-utils 0.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/typing-utils/0.1.0)