### PR TITLE
OctoPack/3.6.3

### DIFF
--- a/curations/nuget/nuget/-/OctoPack.yaml
+++ b/curations/nuget/nuget/-/OctoPack.yaml
@@ -6,3 +6,6 @@ revisions:
   3.0.43:
     licensed:
       declared: OTHER
+  3.6.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
OctoPack/3.6.3

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/OctopusDeploy/OctoPack/blob/3.6.3/LICENSE.txt

**Affected definitions**:
- [OctoPack 3.6.3](https://clearlydefined.io/definitions/nuget/nuget/-/OctoPack/3.6.3)