### PR TITLE
NuGet.LibraryModel/3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.LibraryModel.yaml
+++ b/curations/nuget/nuget/-/NuGet.LibraryModel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
NuGet.LibraryModel/3.5.0

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/NuGet/NuGet.Client/blob/3.5.0-rtm/LICENSE.txt

**Affected definitions**:
- [NuGet.LibraryModel 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.LibraryModel/3.5.0)