### PR TITLE
MapSuiteDesktopForWinForms-BareBone/10.6.13

### DIFF
--- a/curations/nuget/nuget/-/MapSuiteDesktopForWinForms-BareBone.yaml
+++ b/curations/nuget/nuget/-/MapSuiteDesktopForWinForms-BareBone.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: MapSuiteDesktopForWinForms-BareBone
+  provider: nuget
+  type: nuget
+revisions:
+  10.6.13:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
MapSuiteDesktopForWinForms-BareBone/10.6.13

**Details:**
Add OTHER

**Resolution:**
https://wiki.thinkgeo.com/wiki/map_suite_license_agreement

**Affected definitions**:
- [MapSuiteDesktopForWinForms-BareBone 10.6.13](https://clearlydefined.io/definitions/nuget/nuget/-/MapSuiteDesktopForWinForms-BareBone/10.6.13)