### PR TITLE
com.thoughtworks.paranamer/paranamer/2.5.5

### DIFF
--- a/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
+++ b/curations/maven/mavencentral/com.thoughtworks.paranamer/paranamer.yaml
@@ -7,6 +7,9 @@ revisions:
   '2.3':
     licensed:
       declared: BSD-3-Clause
+  2.5.5:
+    licensed:
+      declared: BSD-3-Clause
   '2.6':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.thoughtworks.paranamer/paranamer/2.5.5

**Details:**
Add BSD-3-Clause

**Resolution:**
Sources.jar file headers state BSD-3-Clause.

**Affected definitions**:
- [paranamer 2.5.5](https://clearlydefined.io/definitions/maven/mavencentral/com.thoughtworks.paranamer/paranamer/2.5.5)