### PR TITLE
Declared License Missing

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
@@ -7,6 +7,9 @@ revisions:
   '2.17':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  2.21.1:
+    licensed:
+      declared: CDDL-1.0 OR GPL-2.0-with-classpath-exception
   2.22.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb.yaml
@@ -9,7 +9,7 @@ revisions:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.21.1:
     licensed:
-      declared: CDDL-1.0 OR GPL-2.0-with-classpath-exception
+      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.22.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License Should be CDDL-1.0 or GPL 2.0 with classpath exception.

License Path:
https://repo.maven.apache.org/maven2/org/glassfish/jersey/media/jersey-media-jaxb/2.21.1/jersey-media-jaxb-2.21.1.pom

**Resolution:**
https://repo.maven.apache.org/maven2/org/glassfish/jersey/media/jersey-media-jaxb/2.21.1/jersey-media-jaxb-2.21.1.pom

**Affected definitions**:
- [jersey-media-jaxb 2.21.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.media/jersey-media-jaxb/2.21.1/2.21.1)