### PR TITLE
ADALiOS/1.2.10

### DIFF
--- a/curations/pod/cocoapods/-/ADALiOS.yaml
+++ b/curations/pod/cocoapods/-/ADALiOS.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ADALiOS
+  provider: cocoapods
+  type: pod
+revisions:
+  1.2.10:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ADALiOS/1.2.10

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/AzureAD/azure-activedirectory-library-for-objc/blob/1.2.10/LICENSE.txt

**Affected definitions**:
- [ADALiOS 1.2.10](https://clearlydefined.io/definitions/pod/cocoapods/-/ADALiOS/1.2.10)