### PR TITLE
Xamarin.Android.Support.Vector.Drawable/25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.Vector.Drawable.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.Vector.Drawable.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  25.4.0.2:
+    licensed:
+      declared: MIT
   26.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.Android.Support.Vector.Drawable/25.4.0.2

**Details:**
Add MIT

**Resolution:**
https://github.com/xamarin/AndroidSupportComponents/blob/25.4.0.2/LICENSE.md

**Affected definitions**:
- [Xamarin.Android.Support.Vector.Drawable 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.Vector.Drawable/25.4.0.2)