### PR TITLE
scala-reflect/2.10.5

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-reflect.yaml
@@ -7,6 +7,9 @@ revisions:
   2.10.4:
     licensed:
       declared: BSD-3-Clause
+  2.10.5:
+    licensed:
+      declared: BSD-3-Clause
   2.10.6:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
scala-reflect/2.10.5

**Details:**
Add BSD-3-Clause

**Resolution:**
https://github.com/scala/scala/blob/v2.10.5/docs/LICENSE

**Affected definitions**:
- [scala-reflect 2.10.5](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-reflect/2.10.5)