### PR TITLE
HotChocolate.Types.Mutations/12.6.1

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
@@ -6,6 +6,9 @@ revisions:
   12.6.0:
     licensed:
       declared: MIT
+  12.6.1:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Types.Mutations/12.6.1

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Types.Mutations/12.6.1/License

**Affected definitions**:
- [HotChocolate.Types.Mutations 12.6.1](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.Mutations/12.6.1)