### PR TITLE
org.codehaus.janino/janino/2.7.8

### DIFF
--- a/curations/maven/mavencentral/org.codehaus.janino/janino.yaml
+++ b/curations/maven/mavencentral/org.codehaus.janino/janino.yaml
@@ -10,6 +10,9 @@ revisions:
   2.7.6:
     licensed:
       declared: BSD-3-Clause
+  2.7.8:
+    licensed:
+      declared: BSD-3-Clause
   3.0.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.codehaus.janino/janino/2.7.8

**Details:**
Add BSD-3-Clause

**Resolution:**
Sources.jar file headers state BSD-3-Clause.

**Affected definitions**:
- [janino 2.7.8](https://clearlydefined.io/definitions/maven/mavencentral/org.codehaus.janino/janino/2.7.8)