### PR TITLE
HotChocolate.AspNetCore.Abstractions/10.5.5

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.AspNetCore.Abstractions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.AspNetCore.Abstractions.yaml
@@ -6,3 +6,6 @@ revisions:
   10.5.2:
     licensed:
       declared: MIT
+  10.5.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.AspNetCore.Abstractions/10.5.5

**Details:**
Add MIT

**Resolution:**
https://github.com/ChilliCream/hotchocolate/blob/10.5.5/LICENSE

**Affected definitions**:
- [HotChocolate.AspNetCore.Abstractions 10.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.AspNetCore.Abstractions/10.5.5)