### PR TITLE
HotChocolate.Server/10.5.5

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Server.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Server.yaml
@@ -6,3 +6,6 @@ revisions:
   10.5.2:
     licensed:
       declared: MIT
+  10.5.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Server/10.5.5

**Details:**
Add MIT

**Resolution:**
https://github.com/ChilliCream/hotchocolate/blob/10.5.5/LICENSE

**Affected definitions**:
- [HotChocolate.Server 10.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Server/10.5.5)