### PR TITLE
org.jvnet.mimepull/mimepull/1.9.6

### DIFF
--- a/curations/maven/mavencentral/org.jvnet.mimepull/mimepull.yaml
+++ b/curations/maven/mavencentral/org.jvnet.mimepull/mimepull.yaml
@@ -7,3 +7,6 @@ revisions:
   1.9.3:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  1.9.6:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.jvnet.mimepull/mimepull/1.9.6

**Details:**
Add CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/jvnet/mimepull/mimepull/1.9.6/mimepull-1.9.6.pom

**Affected definitions**:
- [mimepull 1.9.6](https://clearlydefined.io/definitions/maven/mavencentral/org.jvnet.mimepull/mimepull/1.9.6)