### PR TITLE
Source Location was missing and the declared license was incorrect.

### DIFF
--- a/curations/nuget/nuget/-/IronPython.StdLib.yaml
+++ b/curations/nuget/nuget/-/IronPython.StdLib.yaml
@@ -7,8 +7,16 @@ revisions:
     licensed:
       declared: OTHER
   2.7.11:
+    described:
+      sourceLocation:
+        name: ironpython2
+        namespace: ironlanguages
+        provider: github
+        revision: c02d86cea702fd6d253e8fb988187789f7a631b7
+        type: git
+        url: 'https://github.com/ironlanguages/ironpython2/commit/c02d86cea702fd6d253e8fb988187789f7a631b7'
     licensed:
-      declared: OTHER
+      declared: Apache-2.0
   2.7.8.1:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/IronPython.StdLib.yaml
+++ b/curations/nuget/nuget/-/IronPython.StdLib.yaml
@@ -16,7 +16,7 @@ revisions:
         type: git
         url: 'https://github.com/ironlanguages/ironpython2/commit/c02d86cea702fd6d253e8fb988187789f7a631b7'
     licensed:
-      declared: Apache-2.0
+      declared: OTHER
   2.7.8.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source Location was missing and the declared license was incorrect.

**Details:**
Source location URL was missing and declared license is incorrect.

**Resolution:**
Filled in the source location URL as per https://www.nuget.org/packages/IronPython.StdLib/2.7.11 --> https://ironpython.net/ --> https://github.com/IronLanguages/ironpython2/tree/c02d86cea702fd6d253e8fb988187789f7a631b7 and the license as per https://github.com/IronLanguages/ironpython2/blob/c02d86.

**Affected definitions**:
- [IronPython.StdLib 2.7.11](https://clearlydefined.io/definitions/nuget/nuget/-/IronPython.StdLib/2.7.11/2.7.11)