### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/rubyzip/rubyzip.yaml
+++ b/curations/git/github/rubyzip/rubyzip.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: rubyzip
+  namespace: rubyzip
+  provider: github
+  type: git
+revisions:
+  0b791046d4aa632d1857eab6f415afa041077c95:
+    licensed:
+      declared: Ruby

--- a/curations/git/github/rubyzip/rubyzip.yaml
+++ b/curations/git/github/rubyzip/rubyzip.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   0b791046d4aa632d1857eab6f415afa041077c95:
     licensed:
-      declared: Ruby
+      declared: BSD-2-Clause OR Ruby


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing.

**Resolution:**
Filled in the declared license as per https://github.com/rubyzip/rubyzip/tree/0b791046d4aa632d1857eab6f415afa041077c95#license --> http://www.ruby-lang.org/en/about/license.txt.

**Affected definitions**:
- [rubyzip 0b791046d4aa632d1857eab6f415afa041077c95](https://clearlydefined.io/definitions/git/github/rubyzip/rubyzip/0b791046d4aa632d1857eab6f415afa041077c95/0b791046d4aa632d1857eab6f415afa041077c95)