### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/seleniumhq/selenium.yaml
+++ b/curations/git/github/seleniumhq/selenium.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  a88d25fe6b71a9b200480374462078614f5319ac:
+    licensed:
+      declared: Apache-2.0
   aacccce032ad8cda9fc15ecabfbd844c87db5497:
     files:
       - attributions:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing.

**Resolution:**
Filled in the declared license as per https://github.com/SeleniumHQ/selenium/blob/a88d25fe6b71a9b200480374462078614f5319ac/LICENSE.

**Affected definitions**:
- [selenium a88d25fe6b71a9b200480374462078614f5319ac](https://clearlydefined.io/definitions/git/github/seleniumhq/selenium/a88d25fe6b71a9b200480374462078614f5319ac/a88d25fe6b71a9b200480374462078614f5319ac)