### PR TITLE
pillow9.2.0

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -27,3 +27,6 @@ revisions:
   9.1.1:
     licensed:
       declared: HPND
+  9.2.0:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow9.2.0

**Details:**
Declared License is HPND

**Resolution:**
https://github.com/python-pillow/Pillow/blob/9.2.0/LICENSE

**Affected definitions**:
- [pillow 9.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/9.2.0/9.2.0)