### PR TITLE
Declared License Missing

### DIFF
--- a/curations/git/github/pylons/pyramid.yaml
+++ b/curations/git/github/pylons/pyramid.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   c59784ba29598170207646a8d54fdc020e0ab5b0:
     licensed:
-      declared: ZPL-2.1 AND BSD-3-Clause
+      declared: BSD-3-Clause-Modification


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License Missing

**Details:**
Declared License should be ZPL- 2.1 and BSD 3 Clause 
Instead of SPDX license.
License Path:
https://github.com/Pylons/pyramid/blob/1.5.7/LICENSE.txt

**Resolution:**
https://github.com/Pylons/pyramid/blob/1.5.7/LICENSE.txt

**Affected definitions**:
- [pyramid c59784ba29598170207646a8d54fdc020e0ab5b0](https://clearlydefined.io/definitions/git/github/pylons/pyramid/c59784ba29598170207646a8d54fdc020e0ab5b0/c59784ba29598170207646a8d54fdc020e0ab5b0)