### PR TITLE
Missing license information

### DIFF
--- a/curations/nuget/nuget/-/Node.js.redist.yaml
+++ b/curations/nuget/nuget/-/Node.js.redist.yaml
@@ -18,6 +18,9 @@ revisions:
   14.2.0:
     licensed:
       declared: MIT
+  16.13.0:
+    licensed:
+      declared: MIT
   16.13.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Missing license information

**Details:**
https://raw.githubusercontent.com/nodejs/node/v16.13.0/LICENSE

**Resolution:**
Adding the link to the license and updating which license it uses.

**Affected definitions**:
- [Node.js.redist 16.13.0](https://clearlydefined.io/definitions/nuget/nuget/-/Node.js.redist/16.13.0/16.13.0)