### PR TITLE
Declared license is missing for graal-sdk 22.1.0

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
+++ b/curations/maven/mavencentral/org.graalvm.sdk/graal-sdk.yaml
@@ -88,3 +88,6 @@ revisions:
   22.0.0.2:
     licensed:
       declared: UPL-1.0
+  22.1.0:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Declared license is missing for graal-sdk 22.1.0

**Details:**
The declared license is missing

**Resolution:**
Set declared license to UPL-1.0 as this seems to be the license used, according to https://github.com/oracle/graal/blob/vm-ce-22.1.0/sdk/LICENSE.md

**Affected definitions**:
- [graal-sdk 22.1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.sdk/graal-sdk/22.1.0/22.1.0)