### PR TITLE
babel-regenerator-runtime6.5.0

### DIFF
--- a/curations/npm/npmjs/-/babel-regenerator-runtime.yaml
+++ b/curations/npm/npmjs/-/babel-regenerator-runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: babel-regenerator-runtime
+  provider: npmjs
+  type: npm
+revisions:
+  6.5.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
babel-regenerator-runtime6.5.0

**Details:**
ClearlyDefined license file is BSD-2-Clause
GitHub license is MIT: https://github.com/babel/babel/blob/v6.5.0/LICENSE

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [babel-regenerator-runtime 6.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/babel-regenerator-runtime/6.5.0/6.5.0)