### PR TITLE
jHtmlArea0.7.50

### DIFF
--- a/curations/nuget/nuget/-/jHtmlArea.yaml
+++ b/curations/nuget/nuget/-/jHtmlArea.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  0.7.50:
+    licensed:
+      declared: NONE
   0.8.0:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
jHtmlArea0.7.50

**Details:**
Nuspec indicates license at: https://jhtmlarea.codeplex.com  which is no longer accessible.  No license info found.

**Resolution:**
NONE

**Affected definitions**:
- [jHtmlArea 0.7.50](https://clearlydefined.io/definitions/nuget/nuget/-/jHtmlArea/0.7.50/0.7.50)