### PR TITLE
HtmlAgilityPack1.4.9.3

### DIFF
--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -117,6 +117,9 @@ revisions:
   1.4.9:
     licensed:
       declared: MS-PL
+  1.4.9.3:
+    licensed:
+      declared: NONE
   1.4.9.4:
     licensed:
       declared: MS-PL

--- a/curations/nuget/nuget/-/HtmlAgilityPack.yaml
+++ b/curations/nuget/nuget/-/HtmlAgilityPack.yaml
@@ -119,7 +119,7 @@ revisions:
       declared: MS-PL
   1.4.9.3:
     licensed:
-      declared: NONE
+      declared: MS-PL
   1.4.9.4:
     licensed:
       declared: MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HtmlAgilityPack1.4.9.3

**Details:**
No source license link provided.  Nuspec links to:
http://htmlagilitypack.codeplex.com/license which is no longer accessible. No license info found.

**Resolution:**
NONE

**Affected definitions**:
- [HtmlAgilityPack 1.4.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/HtmlAgilityPack/1.4.9.3/1.4.9.3)