### PR TITLE
NuGet.VisualStudio2.6.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.VisualStudio.yaml
+++ b/curations/nuget/nuget/-/NuGet.VisualStudio.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.6.0:
     licensed:
-      declared: NONE
+      declared: Apache-2.0
   4.3.0:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/NuGet.VisualStudio.yaml
+++ b/curations/nuget/nuget/-/NuGet.VisualStudio.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.6.0:
+    licensed:
+      declared: NONE
   4.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.VisualStudio2.6.0

**Details:**
No Source link provided. 
 Nuspec license links to: http://nuget.codeplex.com/license which is no longer accessible.  No license info found

**Resolution:**
NONE

**Affected definitions**:
- [NuGet.VisualStudio 2.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.VisualStudio/2.6.0/2.6.0)