### PR TITLE
Clarius.TransformOnBuild1.1.12

### DIFF
--- a/curations/nuget/nuget/-/Clarius.TransformOnBuild.yaml
+++ b/curations/nuget/nuget/-/Clarius.TransformOnBuild.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.12:
+    licensed:
+      declared: Apache-2.0
   1.22.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Clarius.TransformOnBuild1.1.12

**Details:**
No source link provided.  Nuspec license link is:
https://github.com/clariuslabs/TransformOnBuild/blob/master/LICENSE which is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Clarius.TransformOnBuild 1.1.12](https://clearlydefined.io/definitions/nuget/nuget/-/Clarius.TransformOnBuild/1.1.12/1.1.12)