### PR TITLE
geventhttpclient1.5.4

### DIFF
--- a/curations/pypi/pypi/-/geventhttpclient.yaml
+++ b/curations/pypi/pypi/-/geventhttpclient.yaml
@@ -15,6 +15,9 @@ revisions:
   1.5.3:
     licensed:
       declared: MIT
+  1.5.4:
+    licensed:
+      declared: MIT
   1.5.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
geventhttpclient1.5.4

**Details:**
License file is MIT
Source file links to site with MIT: https://github.com/geventhttpclient/geventhttpclient/blob/master/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [geventhttpclient 1.5.4](https://clearlydefined.io/definitions/pypi/pypi/-/geventhttpclient/1.5.4/1.5.4)