### PR TITLE
org.glassfish/javax.json1.1.2

### DIFF
--- a/curations/maven/mavencentral/org.glassfish/javax.json.yaml
+++ b/curations/maven/mavencentral/org.glassfish/javax.json.yaml
@@ -13,6 +13,9 @@ revisions:
   '1.1':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  1.1.2:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.1.4:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.glassfish/javax.json1.1.2

**Details:**
License link in manifest file is:  https://oss.oracle.com/licenses/CDDL+GPL-1.1

**Resolution:**
CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Affected definitions**:
- [javax.json 1.1.2](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish/javax.json/1.1.2/1.1.2)