### PR TITLE
EPPlus4.0.1.1

### DIFF
--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.0.1.1:
+    licensed:
+      declared: NONE
   4.0.4:
     licensed:
       declared: LGPL-2.1-or-later

--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -5,13 +5,13 @@ coordinates:
 revisions:
   4.0.1.1:
     licensed:
-      declared: NONE
+      declared: LGPL-2.1-or-later
   4.0.4:
     licensed:
       declared: LGPL-2.1-or-later
   4.0.5:
     licensed:
-      declared: OTHER
+      declared: LGPL-2.1-or-later
   4.1.0:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EPPlus4.0.1.1

**Details:**
Nuspec license link is:
http://epplus.codeplex.com/license which is no longer accessible.  No license info found.

**Resolution:**
NONE

**Affected definitions**:
- [EPPlus 4.0.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/EPPlus/4.0.1.1/4.0.1.1)