### PR TITLE
com.sun.mail/jakarta.mail1.6.7

### DIFF
--- a/curations/maven/mavencentral/com.sun.mail/jakarta.mail.yaml
+++ b/curations/maven/mavencentral/com.sun.mail/jakarta.mail.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1.6.7:
     licensed:
-      declared: NOASSERTION OR EPL-2.0
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   2.0.1:
     licensed:
       declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/com.sun.mail/jakarta.mail.yaml
+++ b/curations/maven/mavencentral/com.sun.mail/jakarta.mail.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.6.7:
+    licensed:
+      declared: NOASSERTION OR EPL-2.0
   2.0.1:
     licensed:
       declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.sun.mail/jakarta.mail1.6.7

**Details:**
I tried to curate this several times and it won't take the intended curation

**Resolution:**
EPL-2.0 OR GPL-2.0-or-later WITH Classpath-Exception-2.0

**Affected definitions**:
- [jakarta.mail 1.6.7](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.mail/jakarta.mail/1.6.7/1.6.7)