### PR TITLE
github.com%2Fcoreos/go-systemd/v0.0.0-20180511133405-39ca1b05acc7

### DIFF
--- a/curations/go/golang/github.com/coreos/go-systemd.yaml
+++ b/curations/go/golang/github.com/coreos/go-systemd.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: golang
   type: go
 revisions:
+  v0.0.0-20180511133405-39ca1b05acc7:
+    licensed:
+      declared: Apache-2.0
   v0.0.0-20190321100706-95778dfbb74e:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
github.com%2Fcoreos/go-systemd/v0.0.0-20180511133405-39ca1b05acc7

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/coreos/go-systemd/blob/v17/LICENSE

**Affected definitions**:
- [go-systemd v0.0.0-20180511133405-39ca1b05acc7](https://clearlydefined.io/definitions/go/golang/github.com%2Fcoreos/go-systemd/v0.0.0-20180511133405-39ca1b05acc7)