### PR TITLE
github.com%2Fcoreos/etcd/v3.3.13+incompatible

### DIFF
--- a/curations/go/golang/github.com/coreos/etcd.yaml
+++ b/curations/go/golang/github.com/coreos/etcd.yaml
@@ -7,3 +7,6 @@ revisions:
   v3.3.10+incompatible:
     licensed:
       declared: Apache-2.0
+  v3.3.13+incompatible:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
github.com%2Fcoreos/etcd/v3.3.13+incompatible

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/etcd-io/etcd/blob/v3.3.13/LICENSE

**Affected definitions**:
- [etcd v3.3.13+incompatible](https://clearlydefined.io/definitions/go/golang/github.com%2Fcoreos/etcd/v3.3.13+incompatible)