### PR TITLE
v22/v22.3.2

### DIFF
--- a/curations/go/golang/github.com/coreos/go-systemd/v22.yaml
+++ b/curations/go/golang/github.com/coreos/go-systemd/v22.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: v22
+  namespace: github.com%2Fcoreos%2Fgo-systemd
+  provider: golang
+  type: go
+revisions:
+  v22.3.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
v22/v22.3.2

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/coreos/go-systemd/blob/v22.3.2/LICENSE

**Affected definitions**:
- [v22 v22.3.2](https://clearlydefined.io/definitions/go/golang/github.com%2Fcoreos%2Fgo-systemd/v22/v22.3.2)