### PR TITLE
github.com%2Fcoreos/go-oidc/v2.1.0+incompatible

### DIFF
--- a/curations/go/golang/github.com/coreos/go-oidc.yaml
+++ b/curations/go/golang/github.com/coreos/go-oidc.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: go-oidc
+  namespace: github.com%2Fcoreos
+  provider: golang
+  type: go
+revisions:
+  v2.1.0+incompatible:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
github.com%2Fcoreos/go-oidc/v2.1.0+incompatible

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/coreos/go-oidc/blob/v2.1.0/LICENSE

**Affected definitions**:
- [go-oidc v2.1.0+incompatible](https://clearlydefined.io/definitions/go/golang/github.com%2Fcoreos/go-oidc/v2.1.0+incompatible)