### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/nginx/nginx.yaml
+++ b/curations/git/github/nginx/nginx.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  1b8771ddcbc53dee494aeae1449f3b6403e7299d:
+    licensed:
+      declared: BSD-2-Clause
   1d2f499889a192a66c5407d634c9c697edc341cf:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
The component has no license specified and just mentioned as SPDX License.
But the component has the License mentioned in the Github source code repository as BSD-2-Clause License.
License Path file : https://github.com/nginx/nginx/blob/release-1.19.8/docs/text/LICENSE

**Resolution:**
The component is being curated as BSD-2-Clause License instead of SPDX License due to the License information present in the source code repository.
License Path File : https://github.com/nginx/nginx/blob/release-1.19.8/docs/text/LICENSE

**Affected definitions**:
- [nginx 1b8771ddcbc53dee494aeae1449f3b6403e7299d](https://clearlydefined.io/definitions/git/github/nginx/nginx/1b8771ddcbc53dee494aeae1449f3b6403e7299d/1b8771ddcbc53dee494aeae1449f3b6403e7299d)