### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/jacoco/jacoco.yaml
+++ b/curations/git/github/jacoco/jacoco.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jacoco
+  namespace: jacoco
+  provider: github
+  type: git
+revisions:
+  d19ea595a67af6f16d76b49ccdc12858c3570298:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
The component has SPDX license specified but the source code repository has the license information as EPL 2.0.
License File Path : https://github.com/jacoco/jacoco/blob/v0.8.7/LICENSE.md

**Resolution:**
The component is being curated as EPL 2.0 instead of SPDX License since there is license information specified in the License file of the source code repository.
License file path : https://github.com/jacoco/jacoco/blob/v0.8.7/LICENSE.md

**Affected definitions**:
- [jacoco d19ea595a67af6f16d76b49ccdc12858c3570298](https://clearlydefined.io/definitions/git/github/jacoco/jacoco/d19ea595a67af6f16d76b49ccdc12858c3570298/d19ea595a67af6f16d76b49ccdc12858c3570298)