### PR TITLE
Declared License was NOASSERTION.

### DIFF
--- a/curations/git/github/vladjerca/noto-fontface-cjk-jp.yaml
+++ b/curations/git/github/vladjerca/noto-fontface-cjk-jp.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: noto-fontface-cjk-jp
+  namespace: vladjerca
+  provider: github
+  type: git
+revisions:
+  492a703135697b1b9851312d9d05cf0dc34a6994:
+    licensed:
+      declared: OFL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was NOASSERTION.

**Details:**
Declared license was NOASSERTION.

**Resolution:**
Corrected the license as per https://github.com/vladjerca/noto-fontface-cjk-jp/blob/492a703135697b1b9851312d9d05cf0dc34a6994/package.json#L21 --> https://github.com/vladjerca/noto-fontface-cjk-jp/blob/492a703135697b1b9851312d9d05cf0dc34a6994/fonts/LICENSE_OFL.txt.

**Affected definitions**:
- [noto-fontface-cjk-jp 492a703135697b1b9851312d9d05cf0dc34a6994](https://clearlydefined.io/definitions/git/github/vladjerca/noto-fontface-cjk-jp/492a703135697b1b9851312d9d05cf0dc34a6994/492a703135697b1b9851312d9d05cf0dc34a6994)