### PR TITLE
NuGet.CommandLine4.9.5

### DIFF
--- a/curations/nuget/nuget/-/NuGet.CommandLine.yaml
+++ b/curations/nuget/nuget/-/NuGet.CommandLine.yaml
@@ -42,3 +42,6 @@ revisions:
   4.9.4:
     licensed:
       declared: Apache-2.0
+  4.9.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.CommandLine4.9.5

**Details:**
ClearlyDefined license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.CommandLine 4.9.5](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.CommandLine/4.9.5/4.9.5)