### PR TITLE
Prism.MEFExtensions4.1.0

### DIFF
--- a/curations/nuget/nuget/-/Prism.MEFExtensions.yaml
+++ b/curations/nuget/nuget/-/Prism.MEFExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Prism.MEFExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  4.1.0:
+    licensed:
+      declared: NONE

--- a/curations/nuget/nuget/-/Prism.MEFExtensions.yaml
+++ b/curations/nuget/nuget/-/Prism.MEFExtensions.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   4.1.0:
     licensed:
-      declared: NONE
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Prism.MEFExtensions4.1.0

**Details:**
Could not locate license information at: https://compositewpf.codeplex.com/license or in the Way Back Machine or in downloaded component



**Resolution:**
NONE

**Affected definitions**:
- [Prism.MEFExtensions 4.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Prism.MEFExtensions/4.1.0/4.1.0)