### PR TITLE
FluentValidation-Signed 6.2.1

### DIFF
--- a/curations/nuget/nuget/-/FluentValidation-Signed.yaml
+++ b/curations/nuget/nuget/-/FluentValidation-Signed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: FluentValidation-Signed
+  provider: nuget
+  type: nuget
+revisions:
+  6.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentValidation-Signed 6.2.1

**Details:**
Nuspec file license links to: https://github.com/JeremySkinner/FluentValidation/blob/master/License.txt which is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentValidation-Signed 6.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/FluentValidation-Signed/6.2.1/6.2.1)