### PR TITLE
org.junit.jupiter/junit-jupiter-engine5.7.0-M1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -37,6 +37,9 @@ revisions:
   5.7.0:
     licensed:
       declared: EPL-2.0
+  5.7.0-M1:
+    licensed:
+      declared: EPL-2.0
   5.7.0-m1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.jupiter/junit-jupiter-engine5.7.0-M1

**Details:**
Curated under 20329 as EPL-2.0

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-jupiter-engine 5.7.0-M1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.7.0-M1/5.7.0-M1)