### PR TITLE
curator-test 57 2.2.0-incubating

### DIFF
--- a/curations/maven/mavencentral/org.apache.curator/curator-test.yaml
+++ b/curations/maven/mavencentral/org.apache.curator/curator-test.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.2.0-incubating:
+    licensed:
+      declared: Apache-2.0
   2.6.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
curator-test 57 2.2.0-incubating

**Details:**
Maven is Apache-2.0:
https://search.maven.org/artifact/org.apache.curator/curator-test/2.2.0-incubating/jar

**Resolution:**
Apache-2.0

**Affected definitions**:
- [curator-test 2.2.0-incubating](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.curator/curator-test/2.2.0-incubating/2.2.0-incubating)