### PR TITLE
tomcat/jasper-runtime 5.5.12

### DIFF
--- a/curations/maven/mavencentral/tomcat/jasper-runtime.yaml
+++ b/curations/maven/mavencentral/tomcat/jasper-runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jasper-runtime
+  namespace: tomcat
+  provider: mavencentral
+  type: maven
+revisions:
+  5.5.12:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/tomcat/jasper-runtime.yaml
+++ b/curations/maven/mavencentral/tomcat/jasper-runtime.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   5.5.12:
     licensed:
-      declared: Apache-2.0
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tomcat/jasper-runtime 5.5.12

**Details:**
License is Apache-2.0: https://github.com/sonatype-nexus-community/search-maven-org/blob/master/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jasper-runtime 5.5.12](https://clearlydefined.io/definitions/maven/mavencentral/tomcat/jasper-runtime/5.5.12/5.5.12)