### PR TITLE
Add missing source location and declared license

### DIFF
--- a/curations/sourcearchive/mavencentral/org.bouncycastle/bcutil-jdk18on.yaml
+++ b/curations/sourcearchive/mavencentral/org.bouncycastle/bcutil-jdk18on.yaml
@@ -1,0 +1,24 @@
+coordinates:
+  name: bcutil-jdk18on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  '1.71':
+    described:
+      facets:
+        dev:
+          - 'https://github.com/bcgit/bc-java/tree/master/util/src/main/java'
+        doc:
+          - 'https://github.com/bcgit/bc-java/tree/master/docs'
+        tests:
+          - 'https://github.com/bcgit/bc-java/tree/master/util/src/test/java'
+      sourceLocation:
+        name: bc-java
+        namespace: bcgit
+        provider: github
+        revision: 1349bb03cff0b0023ef3247690410441f33b05b0
+        type: git
+        url: 'https://github.com/bcgit/bc-java/commit/1349bb03cff0b0023ef3247690410441f33b05b0'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add missing source location and declared license

**Details:**
Missing source location and declared license

**Resolution:**
Add missing source location and declared license

**Affected definitions**:
- [bcutil-jdk18on 1.71](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.bouncycastle/bcutil-jdk18on/1.71/1.71)