### PR TITLE
protobuf - declare BSD-3-Clause license

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -297,3 +297,6 @@ revisions:
   4.21.2:
     licensed:
       declared: BSD-3-Clause
+  4.21.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION
**Type:** Missing

**Summary:**
protobuf - declare BSD-3-Clause license

**Details:**
The protobuf 4.21.3 pypi package doesn't have declared license.

**Resolution:**
The license is updated to BSD-3-Clause. The license is declared in the protobuf repository https://github.com/protocolbuffers/protobuf/blob/main/LICENSE


**Affected definitions**:
- [protobuf 4.21.3](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/4.21.3/4.21.3)