### PR TITLE
Third-Party Asset Catalogues  (Ray Cobo - InXile)

### DIFF
--- a/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
+++ b/curations/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe.yaml
@@ -9,6 +9,9 @@ revisions:
   4.5.0:
     licensed:
       declared: MIT
+  4.5.0-preview2-26406-04:
+    licensed:
+      declared: MIT
   4.5.0-rc1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Third-Party Asset Catalogues  (Ray Cobo - InXile)

**Details:**
ClearlyDefined license file is MIT: https://clearlydefined.io/file/d7a68596ab69b06f51ca278a6545148e4269a9381c26d597c13df5d88e08cf5b

**Resolution:**
MIT

**Affected definitions**:
- [System.Runtime.CompilerServices.Unsafe 4.5.0-preview2-26406-04](https://clearlydefined.io/definitions/nuget/nuget/-/System.Runtime.CompilerServices.Unsafe/4.5.0-preview2-26406-04/4.5.0-preview2-26406-04)