### PR TITLE
Npgsql 3.1.10

### DIFF
--- a/curations/nuget/nuget/-/Npgsql.yaml
+++ b/curations/nuget/nuget/-/Npgsql.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.1.10:
+    licensed:
+      declared: PostgreSQL
   3.2.7:
     licensed:
       declared: PostgreSQL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Npgsql 3.1.10

**Details:**
No license info found in package
GitHub license is: https://github.com/npgsql/npgsql/blob/main/LICENSE
PostgreSQL

**Resolution:**
PostgreSQL

**Affected definitions**:
- [Npgsql 3.1.10](https://clearlydefined.io/definitions/nuget/nuget/-/Npgsql/3.1.10/3.1.10)