### PR TITLE
org.xmlunit/xmlunit-legacy 2.5.1

### DIFF
--- a/curations/maven/mavencentral/org.xmlunit/xmlunit-legacy.yaml
+++ b/curations/maven/mavencentral/org.xmlunit/xmlunit-legacy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xmlunit-legacy
+  namespace: org.xmlunit
+  provider: mavencentral
+  type: maven
+revisions:
+  2.5.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.xmlunit/xmlunit-legacy 2.5.1

**Details:**
Maven license is BSD-3-Clause
https://search.maven.org/artifact/org.xmlunit/xmlunit-legacy/2.5.1/jar

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [xmlunit-legacy 2.5.1](https://clearlydefined.io/definitions/maven/mavencentral/org.xmlunit/xmlunit-legacy/2.5.1/2.5.1)