### PR TITLE
@microsoft/sp-build-web 1.14.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-build-web.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-build-web.yaml
@@ -13,6 +13,9 @@ revisions:
   1.12.1:
     licensed:
       declared: OTHER
+  1.14.0:
+    licensed:
+      declared: OTHER
   1.4.1:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@microsoft/sp-build-web 1.14.0

**Details:**
ClearlyDefined EULA is MSLT - OTHER

**Resolution:**
OTHER

**Affected definitions**:
- [sp-build-web 1.14.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-build-web/1.14.0/1.14.0)