### PR TITLE
Ninject.Web.Common 3.3.2

### DIFF
--- a/curations/nuget/nuget/-/Ninject.Web.Common.yaml
+++ b/curations/nuget/nuget/-/Ninject.Web.Common.yaml
@@ -21,3 +21,6 @@ revisions:
   3.3.1:
     licensed:
       declared: Apache-2.0 OR MS-PL
+  3.3.2:
+    licensed:
+      declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.Web.Common 3.3.2

**Details:**
ClearlyDefined license is:
Apache-2.0 OR MS-PL
https://clearlydefined.io/file/93ebaf152f6b24117d27ef2bc99d154a96ad6c22d74665f3ca889453691d6fa0

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.Web.Common 3.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.Web.Common/3.3.2/3.3.2)