### PR TITLE
Xamarin.Android.Support.v7.CardView 25.4.0.2

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Android.Support.v7.CardView.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Android.Support.v7.CardView.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  25.4.0.2:
+    licensed:
+      declared: MIT
   26.0.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Android.Support.v7.CardView 25.4.0.2

**Details:**
GitHub license is MIT: https://github.com/xamarin/AndroidSupportComponents/blob/73bff6c5ab2d9441c0f6a0e67de3eb4ee3e957b9/LICENSE.md

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Android.Support.v7.CardView 25.4.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Android.Support.v7.CardView/25.4.0.2/25.4.0.2)