### PR TITLE
org.junit.platform/junit-platform-engine 1.7.0-M1

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
@@ -31,6 +31,9 @@ revisions:
   1.7.0:
     licensed:
       declared: EPL-2.0
+  1.7.0-M1:
+    licensed:
+      declared: EPL-2.0
   1.7.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.junit.platform/junit-platform-engine 1.7.0-M1

**Details:**
Maven license is EPL-2.0: https://search.maven.org/artifact/org.junit.platform/junit-platform-engine/1.7.0-M1/jar

**Resolution:**
EPL-2.0

**Affected definitions**:
- [junit-platform-engine 1.7.0-M1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-engine/1.7.0-M1/1.7.0-M1)