### PR TITLE
Confluent.Kafka 1.5.1

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -74,6 +74,9 @@ revisions:
   1.5.0:
     licensed:
       declared: Apache-2.0
+  1.5.1:
+    licensed:
+      declared: Apache-2.0
   1.5.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Confluent.Kafka 1.5.1

**Details:**
GitHub license is Apache-2.0: https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.5.1/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Confluent.Kafka 1.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.5.1/1.5.1)