### PR TITLE
org.apache.httpcomponents/httpclient 4.3.2

### DIFF
--- a/curations/maven/mavencentral/org.apache.httpcomponents/httpclient.yaml
+++ b/curations/maven/mavencentral/org.apache.httpcomponents/httpclient.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  4.3.2:
+    licensed:
+      declared: Apache-2.0
   4.3.3:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.httpcomponents/httpclient 4.3.2

**Details:**
Downloaded JAR file and license is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [httpclient 4.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.httpcomponents/httpclient/4.3.2/4.3.2)