### PR TITLE
rome/rome 1.0

### DIFF
--- a/curations/maven/mavencentral/rome/rome.yaml
+++ b/curations/maven/mavencentral/rome/rome.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: rome
+  namespace: rome
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.0':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
rome/rome 1.0

**Details:**
Maven is Apache-2.0: https://search.maven.org/artifact/com.sixdimensions.commons.osgi.wrapper/rome

**Resolution:**
Apache-2.0

**Affected definitions**:
- [rome 1.0](https://clearlydefined.io/definitions/maven/mavencentral/rome/rome/1.0/1.0)