### PR TITLE
boost_system-vc141 1.67.0

### DIFF
--- a/curations/nuget/nuget/-/boost_system-vc141.yaml
+++ b/curations/nuget/nuget/-/boost_system-vc141.yaml
@@ -15,6 +15,9 @@ revisions:
   1.66.0:
     licensed:
       declared: BSL-1.0
+  1.67.0:
+    licensed:
+      declared: BSL-1.0
   1.68.0:
     licensed:
       declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_system-vc141 1.67.0

**Details:**
Nuspec license link is BSL-1.0: https://github.com/sergey-shandar/getboost/blob/master/LICENSE

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_system-vc141 1.67.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_system-vc141/1.67.0/1.67.0)