### PR TITLE
Willezone.Azure.WebJobs.Extensions.DependencyInjection 1.0.1

### DIFF
--- a/curations/nuget/nuget/-/Willezone.Azure.WebJobs.Extensions.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/Willezone.Azure.WebJobs.Extensions.DependencyInjection.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Willezone.Azure.WebJobs.Extensions.DependencyInjection
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Willezone.Azure.WebJobs.Extensions.DependencyInjection 1.0.1

**Details:**
Nuget indicates MIT: https://github.com/BorisWilhelms/azure-function-dependency-injection/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Willezone.Azure.WebJobs.Extensions.DependencyInjection 1.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Willezone.Azure.WebJobs.Extensions.DependencyInjection/1.0.1/1.0.1)