### PR TITLE
NSpec 3.1.0

### DIFF
--- a/curations/nuget/nuget/-/NSpec.yaml
+++ b/curations/nuget/nuget/-/NSpec.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NSpec
+  provider: nuget
+  type: nuget
+revisions:
+  3.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NSpec 3.1.0

**Details:**
License is MIT: https://github.com/nspec/NSpec/blob/v3.1.0/license.txt

**Resolution:**
MIT

**Affected definitions**:
- [NSpec 3.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/NSpec/3.1.0/3.1.0)