### PR TITLE
net.sf.py4j/py4j 0.8.2.1

### DIFF
--- a/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
+++ b/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
@@ -25,3 +25,6 @@ revisions:
   0.10.9.3:
     licensed:
       declared: BSD-3-Clause
+  0.8.2.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
net.sf.py4j/py4j 0.8.2.1

**Details:**
Maven indicates BSD-2-Clause: https://search.maven.org/artifact/net.sf.py4j/py4j/0.8.2.1/jar

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [py4j 0.8.2.1](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.py4j/py4j/0.8.2.1/0.8.2.1)