### PR TITLE
System.Net.WebSockets.Client.Managed 1.0.22

### DIFF
--- a/curations/nuget/nuget/-/System.Net.WebSockets.Client.Managed.yaml
+++ b/curations/nuget/nuget/-/System.Net.WebSockets.Client.Managed.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: System.Net.WebSockets.Client.Managed
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.22:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
System.Net.WebSockets.Client.Managed 1.0.22

**Details:**
License is MIT: https://github.com/PingmanTools/System.Net.WebSockets.Client.Managed/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [System.Net.WebSockets.Client.Managed 1.0.22](https://clearlydefined.io/definitions/nuget/nuget/-/System.Net.WebSockets.Client.Managed/1.0.22/1.0.22)