### PR TITLE
NuGet.Configuration 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/NuGet.Configuration.yaml
+++ b/curations/nuget/nuget/-/NuGet.Configuration.yaml
@@ -6,6 +6,9 @@ revisions:
   3.2.0:
     licensed:
       declared: Apache-2.0
+  3.5.0:
+    licensed:
+      declared: Apache-2.0
   3.5.0-beta-final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NuGet.Configuration 3.5.0

**Details:**
License is Apache-2.0: https://raw.githubusercontent.com/NuGet/NuGet.Client/dev/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [NuGet.Configuration 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/NuGet.Configuration/3.5.0/3.5.0)