### PR TITLE
IdentityServer4 2.2.0

### DIFF
--- a/curations/nuget/nuget/-/IdentityServer4.yaml
+++ b/curations/nuget/nuget/-/IdentityServer4.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: IdentityServer4
+  provider: nuget
+  type: nuget
+revisions:
+  2.2.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
IdentityServer4 2.2.0

**Details:**
License is Apache-2.0: https://github.com/IdentityServer/IdentityServer4/blob/2.2.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [IdentityServer4 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/IdentityServer4/2.2.0/2.2.0)