### PR TITLE
biz.netcentric.aem/aem-nodetypes 6.5.7.0

### DIFF
--- a/curations/maven/mavencentral/biz.netcentric.aem/aem-nodetypes.yaml
+++ b/curations/maven/mavencentral/biz.netcentric.aem/aem-nodetypes.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: aem-nodetypes
+  namespace: biz.netcentric.aem
+  provider: mavencentral
+  type: maven
+revisions:
+  6.5.7.0:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
biz.netcentric.aem/aem-nodetypes 6.5.7.0

**Details:**
License is EPL-1.0: https://search.maven.org/artifact/biz.netcentric.aem/aem-nodetypes/6.5.7.0/jar

**Resolution:**
EPL-1.0

**Affected definitions**:
- [aem-nodetypes 6.5.7.0](https://clearlydefined.io/definitions/maven/mavencentral/biz.netcentric.aem/aem-nodetypes/6.5.7.0/6.5.7.0)