### PR TITLE
RazorLight 2.0.0-beta

### DIFF
--- a/curations/nuget/nuget/-/RazorLight.yaml
+++ b/curations/nuget/nuget/-/RazorLight.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0-beta1:
+    licensed:
+      declared: Apache-2.0
   2.0.0-beta9:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RazorLight 2.0.0-beta

**Details:**
License is Apache-2.0: https://github.com/toddams/RazorLight/blob/2.0.0-beta1/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [RazorLight 2.0.0-beta1](https://clearlydefined.io/definitions/nuget/nuget/-/RazorLight/2.0.0-beta1/2.0.0-beta1)