### PR TITLE
com.nimbusds/oauth2-oidc-sdk 8.36.2

### DIFF
--- a/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
+++ b/curations/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk.yaml
@@ -667,6 +667,9 @@ revisions:
   8.36.1:
     licensed:
       declared: Apache-2.0
+  8.36.2:
+    licensed:
+      declared: Apache-2.0
   '8.4':
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.nimbusds/oauth2-oidc-sdk 8.36.2

**Details:**
License is Apache-2.0: https://search.maven.org/artifact/com.nimbusds/oauth2-oidc-sdk/8.36.2/jar

**Resolution:**
Apache-2.0

**Affected definitions**:
- [oauth2-oidc-sdk 8.36.2](https://clearlydefined.io/definitions/maven/mavencentral/com.nimbusds/oauth2-oidc-sdk/8.36.2/8.36.2)