### PR TITLE
wsgiref 0.1.2

### DIFF
--- a/curations/pypi/pypi/-/wsgiref.yaml
+++ b/curations/pypi/pypi/-/wsgiref.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wsgiref
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.2:
+    licensed:
+      declared: PSF-2.0 OR ZPL-1.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
wsgiref 0.1.2

**Details:**
Researched and discussed during ClearlyDefined Curation Sync.  PyPi license field indicates PSF and ZPL.  Based on information and date released we concluded PSF-2.0 OR ZPL-1.1 is the appropriate curation.

**Resolution:**
PSF-2.0 OR ZPL-1.1

**Affected definitions**:
- [wsgiref 0.1.2](https://clearlydefined.io/definitions/pypi/pypi/-/wsgiref/0.1.2/0.1.2)