### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/sourcearchive/mavencentral/org.springframework/spring-context-support.yaml
+++ b/curations/sourcearchive/mavencentral/org.springframework/spring-context-support.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: spring-context-support
+  namespace: org.springframework
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  5.3.21:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is SPDX License specified in the Declared license and the source code repository of the component has the license information given as Apache 2.0 License.
License file Path :
https://github.com/spring-projects/spring-framework/blob/v5.3.21/LICENSE.txt

**Resolution:**
The component is being curated as Apache 2.0 instead of SPDX license as there is license information available in the Source code repository.
License File Path : https://github.com/spring-projects/spring-framework/blob/v5.3.21/LICENSE.txt

**Affected definitions**:
- [spring-context-support 5.3.21](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.springframework/spring-context-support/5.3.21/5.3.21)