### PR TITLE
astroid 2.11.7

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -6,6 +6,10 @@ revisions:
   2.11.5:
     licensed:
       declared: LGPL-2.1-only
+  2.11.7:
+    files:
+      - license: LGPL-2.1-or-later
+        path: astroid-2.11.7/PKG-INFO
   2.3.1:
     licensed:
       declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid 2.11.7

**Details:**
Doing more of a test here if we can curate at the file level.  Updating the PKG-INFO to what it says in the "License" field - LGPL-2.1-or-later

**Resolution:**
This is a test.

**Affected definitions**:
- [astroid 2.11.7](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.11.7/2.11.7)