### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/jquery/jquery-migrate.yaml
+++ b/curations/git/github/jquery/jquery-migrate.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jquery-migrate
+  namespace: jquery
+  provider: github
+  type: git
+revisions:
+  e692fe75efebabc05b2354f15bae9704d747d636:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is SPDX license specified and the Public source code repository has the license information specified as MIT in the below mentioned path.
License file path : https://github.com/jquery/jquery-migrate/blob/3.4.0/LICENSE.txt

**Resolution:**
The component is being curated as MIT instead of SPDX License as the License information is present in the source code repository.
License file path :https://github.com/jquery/jquery-migrate/blob/3.4.0/LICENSE.txt

**Affected definitions**:
- [jquery-migrate e692fe75efebabc05b2354f15bae9704d747d636](https://clearlydefined.io/definitions/git/github/jquery/jquery-migrate/e692fe75efebabc05b2354f15bae9704d747d636/e692fe75efebabc05b2354f15bae9704d747d636)