### PR TITLE
astroid2.11.7

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.11.5:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-or-later
   2.11.7:
     files:
       - license: LGPL-2.1-or-later
@@ -20,7 +20,7 @@ revisions:
       declared: LGPL-2.1-only
   2.7.3:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-or-later
   2.8.0:
     licensed:
-      declared: LGPL-2.1-only
+      declared: LGPL-2.1-or-later

--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -10,6 +10,8 @@ revisions:
     files:
       - license: LGPL-2.1-or-later
         path: astroid-2.11.7/PKG-INFO
+    licensed:
+      declared: LGPL-2.1-or-later
   2.3.1:
     licensed:
       declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid2.11.7

**Details:**
Declared field including GPL-3.0.  Assume this is same old bug with pypi packages picking up GPL-3.0.  

**Resolution:**
PKG-INFO says LGPL-2.1-or-later.  LICENSE file is LGPL-2.1.

**Affected definitions**:
- [astroid 2.11.7](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.11.7/2.11.7)