### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/python-pillow/pillow.yaml
+++ b/curations/git/github/python-pillow/pillow.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   4f6145655b6fa35ec8dd3600041418087e399758:
     licensed:
-      declared: HPND
+      declared: MIT-CMU
   58acec3312fb8671c9d84829197e1c8150085589:
     licensed:
-      declared: OTHER
+      declared: MIT-CMU

--- a/curations/git/github/python-pillow/pillow.yaml
+++ b/curations/git/github/python-pillow/pillow.yaml
@@ -7,3 +7,6 @@ revisions:
   4f6145655b6fa35ec8dd3600041418087e399758:
     licensed:
       declared: HPND
+  58acec3312fb8671c9d84829197e1c8150085589:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license is missing possibly because ClearDefined tool could not interpret the license.

**Resolution:**
This component is distributed under Python Imaging Software License which is an MIT-style permissive license. Filled in the correct as per https://github.com/python-pillow/Pillow/blob/58acec3312fb8671c9d84829197e1c8150085589/LICENSE.

**Affected definitions**:
- [pillow 58acec3312fb8671c9d84829197e1c8150085589](https://clearlydefined.io/definitions/git/github/python-pillow/pillow/58acec3312fb8671c9d84829197e1c8150085589/58acec3312fb8671c9d84829197e1c8150085589)