### PR TITLE
Update tweetnacl.yaml

### DIFF
--- a/curations/npm/npmjs/-/tweetnacl.yaml
+++ b/curations/npm/npmjs/-/tweetnacl.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: OTHER
   0.14.4:
     licensed:
-      declared: Unlicense
+      declared: OTHER


### PR DESCRIPTION
Fixing mistake. This version was still under "Public Domain". They switched to Unlicense with 0.14.5.