### PR TITLE
Updating Python license "OTHER" to "Python-2.0.1"

### DIFF
--- a/curations/git/github/python/cpython.yaml
+++ b/curations/git/github/python/cpython.yaml
@@ -6,46 +6,46 @@ coordinates:
 revisions:
   02dff8b01100e7cd6d4c93be27202ccb4ea05811:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   1a79785e3e8fea80bcf6a800b45a04e06c787480:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   1e5d33e9b9b8631b36f061103a30208b206fd03a:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   2cd268a3a9340346dd86b66db2e9b428b3f878fc:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   426b022776672fdf3d71ddd98d89af341c88080f:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   439c93d51f45c50541fc755b597725168ecd939a:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   5fd33b5926eb8c9352bf5718369b4a8d72c4bb44:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   6503f05dd59e26a9986bdea097b3da9b3546f45b:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   9a3ffc0492d1310ead9ce8f5ee678c26b20a338d:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   9cf6752276e6fcfd0c23fdb064ad27f448aaaf75:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   a58ebcc701dd6c43630df941481475ff0f615a81:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   aa73e1722eb9835dc99fd8983885a141112ee4ab:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   c0a9afe2ac1820409e6173bd1893ebee2cf50270:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   db455296be5f792b8c12b7cd7f3962b52e4f44ee:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   e5f6aba872e66bfd86eb592214696a519cded197:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/git/github/test-unit/test-unit.yaml
+++ b/curations/git/github/test-unit/test-unit.yaml
@@ -9,7 +9,7 @@ revisions:
       - attributions:
           - Copyright (c) 2001-2008 Python Software Foundation
           - Copyright (c) 2008-2011 Kouhei Sutou
-        license: GPL-2.0-only OR LGPL-2.1-or-later OR OTHER OR Ruby
+        license: GPL-2.0-only OR LGPL-2.1-or-later OR Python-2.0.1 OR Ruby
         path: lib/test/unit/diff.rb
       - attributions:
           - Copyright (c) 2012-2015 Kouhei Sutou <kou@clear-code.com>

--- a/curations/nuget/nuget/-/IronPython.StdLib.yaml
+++ b/curations/nuget/nuget/-/IronPython.StdLib.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.7.10:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   2.7.11:
     described:
       sourceLocation:
@@ -16,7 +16,7 @@ revisions:
         type: git
         url: 'https://github.com/ironlanguages/ironpython2/commit/c02d86cea702fd6d253e8fb988187789f7a631b7'
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   2.7.8.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/nuget/nuget/-/Python.Included.yaml
+++ b/curations/nuget/nuget/-/Python.Included.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.7.3.13:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.3.4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/nuget/nuget/-/python.yaml
+++ b/curations/nuget/nuget/-/python.yaml
@@ -5,79 +5,79 @@ coordinates:
 revisions:
   3.10.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.10.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.10.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.10.4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.11.0-a2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.11.0-a5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.5.4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.8:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.7:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.8:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.9:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.10:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.3:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.6:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.7:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.8:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.9:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.9.0-a4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.9.5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.9.6:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.9.7:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/nuget/nuget/-/python2.yaml
+++ b/curations/nuget/nuget/-/python2.yaml
@@ -5,10 +5,10 @@ coordinates:
 revisions:
   2.7.12:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   2.7.13:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   2.7.17:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/nuget/nuget/-/python2x86.yaml
+++ b/curations/nuget/nuget/-/python2x86.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.7.18:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/nuget/nuget/-/pythonarm64.yaml
+++ b/curations/nuget/nuget/-/pythonarm64.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.11.0-a2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/nuget/nuget/-/pythonx86.yaml
+++ b/curations/nuget/nuget/-/pythonx86.yaml
@@ -5,31 +5,31 @@ coordinates:
 revisions:
   3.10.0-a7:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.11.0-a2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.5.4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.8:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.7:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.9:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.10:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.8.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.9.0-a4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.9.5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/argparse.yaml
+++ b/curations/pypi/pypi/-/argparse.yaml
@@ -8,7 +8,7 @@ revisions:
       declared: Apache-2.0
   1.2.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   1.4.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/flickrapi.yaml
+++ b/curations/pypi/pypi/-/flickrapi.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.4.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/importlib.yaml
+++ b/curations/pypi/pypi/-/importlib.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.4:
     licensed:
-      declared: Python-2.0
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/random2.yaml
+++ b/curations/pypi/pypi/-/random2.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.1:
     licensed:
-      declared: Python-2.0
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/subprocess32.yaml
+++ b/curations/pypi/pypi/-/subprocess32.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   3.5.4:
     licensed:
-      declared: Python-2.0
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -5,54 +5,54 @@ coordinates:
 revisions:
   3.10.0.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.10.0.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.10.0.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.2.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.5:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.6.6:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.4:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.4.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.4.2:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   3.7.4.3:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   4.0.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   4.0.1:
     described:
       releaseDate: '2021-11-30'
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   4.1.1:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   4.2.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1
   4.3.0:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1

--- a/curations/pypi/pypi/-/uuid.yaml
+++ b/curations/pypi/pypi/-/uuid.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   '1.30':
     licensed:
-      declared: Python-2.0
+      declared: Python-2.0.1


### PR DESCRIPTION
Updating "OTHER" curations with licenses that pointed to the full Python license to "Python-2.0.1". This identifier has been added with SPDX license list 3.18.