### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/nlog/nlog.yaml
+++ b/curations/git/github/nlog/nlog.yaml
@@ -7,3 +7,6 @@ revisions:
   808874fbbe43b398326cd6e637199f4ff040a0ac:
     licensed:
       declared: BSD-3-Clause
+  cca7dcd37b8537b75b3477bf96482dfd8b06f234:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared License is missing.

**Resolution:**
Updated the declared license as per https://github.com/NLog/NLog/blob/cca7dcd37b8537b75b3477bf96482dfd8b06f234/LICENSE.txt.

**Affected definitions**:
- [nlog cca7dcd37b8537b75b3477bf96482dfd8b06f234](https://clearlydefined.io/definitions/git/github/nlog/nlog/cca7dcd37b8537b75b3477bf96482dfd8b06f234/cca7dcd37b8537b75b3477bf96482dfd8b06f234)