### PR TITLE
Aspose.Words22.6.0

### DIFF
--- a/curations/nuget/nuget/-/Aspose.Words.yaml
+++ b/curations/nuget/nuget/-/Aspose.Words.yaml
@@ -45,3 +45,6 @@ revisions:
   21.10.0:
     licensed:
       declared: OTHER
+  22.6.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aspose.Words22.6.0

**Details:**
Declaring OTHER for EULA

**Resolution:**
https://www.nuget.org/packages/Aspose.Words/22.6.0/License

**Affected definitions**:
- [Aspose.Words 22.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aspose.Words/22.6.0/22.6.0)