### PR TITLE
nlohmann/json69d744867f8847c91a126fa25e9a6a3d67b3be41

### DIFF
--- a/curations/git/github/nlohmann/json.yaml
+++ b/curations/git/github/nlohmann/json.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  69d744867f8847c91a126fa25e9a6a3d67b3be41:
+    licensed:
+      declared: MIT
   9ff0cc0f0212cb1e85b83ce5d2907ba9531b6cae:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nlohmann/json69d744867f8847c91a126fa25e9a6a3d67b3be41

**Details:**
MIT is the Declared license. The other licenses would be discovered licenses.

**Resolution:**
https://github.com/nlohmann/json/blob/69d744867f8847c91a126fa25e9a6a3d67b3be41/LICENSE.MIT

**Affected definitions**:
- [json 69d744867f8847c91a126fa25e9a6a3d67b3be41](https://clearlydefined.io/definitions/git/github/nlohmann/json/69d744867f8847c91a126fa25e9a6a3d67b3be41/69d744867f8847c91a126fa25e9a6a3d67b3be41)