### PR TITLE
pylint 2.6.0

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -46,6 +46,9 @@ revisions:
   2.5.3:
     licensed:
       declared: GPL-2.0-only
+  2.6.0:
+    licensed:
+      declared: GPL-2.0-only
   2.9.1:
     licensed:
       declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint 2.6.0

**Details:**
Fixing mistaken GPL-3.0 included in declared

**Resolution:**
Looks like GPL-2.0-only

**Affected definitions**:
- [pylint 2.6.0](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.6.0/2.6.0)