### PR TITLE
pylint 2.8.2

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -46,6 +46,9 @@ revisions:
   2.5.3:
     licensed:
       declared: GPL-2.0-only
+  2.8.2:
+    licensed:
+      declared: GPL-2.0-or-later
   2.9.1:
     licensed:
       declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint 2.8.2

**Details:**
Removing incorrect "GPL-3.0" from the declared field.  On PKG-INFO for this version of the package, it says the license is "GPL-2.0-or-later."

**Resolution:**
Note: some versions of this package just say "GPL" on the PKG-INFO and some versions say "GPL-2.0-or-later."

**Affected definitions**:
- [pylint 2.8.2](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.8.2/2.8.2)