### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/sourcearchive/mavencentral/com.google.code.gson/gson.yaml
+++ b/curations/sourcearchive/mavencentral/com.google.code.gson/gson.yaml
@@ -15,3 +15,6 @@ revisions:
         url: 'https://github.com/google/gson/tree/gson-1.7.1'
     licensed:
       declared: Apache-2.0
+  2.9.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
The component has SPDX License specified, but the source code repository has the license information given as Apache 2.0 as the main license.
License file path :https://github.com/google/gson/blob/gson-parent-2.9.1/LICENSE

**Resolution:**
The component is being curated as Apache 2.0 instead of SPDX license as the license information is available.
License file path :https://github.com/google/gson/blob/gson-parent-2.9.1/LICENSE

**Affected definitions**:
- [gson 2.9.1](https://clearlydefined.io/definitions/sourcearchive/mavencentral/com.google.code.gson/gson/2.9.1/2.9.1)