### PR TITLE
CSharpFunctionalExtensions2.29.2

### DIFF
--- a/curations/nuget/nuget/-/CSharpFunctionalExtensions.yaml
+++ b/curations/nuget/nuget/-/CSharpFunctionalExtensions.yaml
@@ -9,6 +9,9 @@ revisions:
   2.22.0:
     licensed:
       declared: MIT
+  2.29.2:
+    licensed:
+      declared: MIT
   2.29.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CSharpFunctionalExtensions2.29.2

**Details:**
Declaring MIT

**Resolution:**
https://github.com/vkhorikov/CSharpFunctionalExtensions/blob/v2.29.2/LICENSE

**Affected definitions**:
- [CSharpFunctionalExtensions 2.29.2](https://clearlydefined.io/definitions/nuget/nuget/-/CSharpFunctionalExtensions/2.29.2/2.29.2)