### PR TITLE
Xamarin.TestCloud.Agent0.23.1

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.TestCloud.Agent.yaml
+++ b/curations/nuget/nuget/-/Xamarin.TestCloud.Agent.yaml
@@ -18,3 +18,6 @@ revisions:
   0.22.2:
     licensed:
       declared: EPL-1.0
+  0.23.1:
+    licensed:
+      declared: EPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.TestCloud.Agent0.23.1

**Details:**
Declaring EPL-1.0

**Resolution:**
https://github.com/calabash/calabash-ios-server/blob/0.23.1/LICENSE

**Affected definitions**:
- [Xamarin.TestCloud.Agent 0.23.1](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.TestCloud.Agent/0.23.1/0.23.1)