### PR TITLE
Declared license is Apache 2.0 only.

### DIFF
--- a/curations/git/github/sap/ui5-webcomponents-react.yaml
+++ b/curations/git/github/sap/ui5-webcomponents-react.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ui5-webcomponents-react
+  namespace: sap
+  provider: github
+  type: git
+revisions:
+  46a0a0bc82e1d5fea86328bf40e69b35c5dbcbb3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license is Apache 2.0 only.

**Details:**
Declared license says Apache 2.0 and MIT, but this FOSS component version is distributed under Apache 2.0 only, although some (dependency) files are under MIT that are reported in Discovered Licenses correctly.

**Resolution:**
Updated the declared license as per https://github.com/SAP/ui5-webcomponents-react/blob/46a0a0bc82e1d5fea86328bf40e69b35c5dbcbb3/LICENSE.

**Affected definitions**:
- [ui5-webcomponents-react 46a0a0bc82e1d5fea86328bf40e69b35c5dbcbb3](https://clearlydefined.io/definitions/git/github/sap/ui5-webcomponents-react/46a0a0bc82e1d5fea86328bf40e69b35c5dbcbb3/46a0a0bc82e1d5fea86328bf40e69b35c5dbcbb3)