### PR TITLE
Declared license in incorrect.

### DIFF
--- a/curations/git/github/sap/ui5-webcomponents-react.yaml
+++ b/curations/git/github/sap/ui5-webcomponents-react.yaml
@@ -7,3 +7,6 @@ revisions:
   46a0a0bc82e1d5fea86328bf40e69b35c5dbcbb3:
     licensed:
       declared: Apache-2.0
+  71539dbb7dc3258172f34cacc54860afcfcd761d:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license in incorrect.

**Details:**
Declared license should be Apache 2.0 only instead of "Apache 2.0 AND MIT".

**Resolution:**
Updated the declared license as per https://github.com/SAP/ui5-webcomponents-react/blob/71539dbb7dc3258172f34cacc54860afcfcd761d/LICENSE.

**Affected definitions**:
- [ui5-webcomponents-react 71539dbb7dc3258172f34cacc54860afcfcd761d](https://clearlydefined.io/definitions/git/github/sap/ui5-webcomponents-react/71539dbb7dc3258172f34cacc54860afcfcd761d/71539dbb7dc3258172f34cacc54860afcfcd761d)