### PR TITLE
Magick.NET-Q16-AnyCPU7.7.

### DIFF
--- a/curations/nuget/nuget/-/Magick.NET-Q16-AnyCPU.yaml
+++ b/curations/nuget/nuget/-/Magick.NET-Q16-AnyCPU.yaml
@@ -6,3 +6,6 @@ revisions:
   7.0.1.101:
     licensed:
       declared: Apache-2.0
+  7.7.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Magick.NET-Q16-AnyCPU7.7.

**Details:**
Declaring Apache-2.0

**Resolution:**
License in zip folder and in repo
https://github.com/dlemstra/Magick.NET/releases/tag/7.7.0.0

https://github.com/dlemstra/Magick.NET/commit/55c8b6eb1d7a38d8c2202c8017ba61ead84b9093


**Affected definitions**:
- [Magick.NET-Q16-AnyCPU 7.7.0](https://clearlydefined.io/definitions/nuget/nuget/-/Magick.NET-Q16-AnyCPU/7.7.0/7.7.0)