### PR TITLE
Snappy.Sharp1.0.0

### DIFF
--- a/curations/nuget/nuget/-/Snappy.Sharp.yaml
+++ b/curations/nuget/nuget/-/Snappy.Sharp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Snappy.Sharp
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Snappy.Sharp1.0.0

**Details:**
Declaring Apache-2.0

**Resolution:**
NuGet license link goes to GitHub repo. 

https://github.com/jeffesp/Snappy.Sharp/blob/master/License.txt

**Affected definitions**:
- [Snappy.Sharp 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Snappy.Sharp/1.0.0/1.0.0)