### PR TITLE
Snapshooter.Xunit0.7.1

### DIFF
--- a/curations/nuget/nuget/-/Snapshooter.Xunit.yaml
+++ b/curations/nuget/nuget/-/Snapshooter.Xunit.yaml
@@ -12,3 +12,6 @@ revisions:
   0.6.1:
     licensed:
       declared: MIT
+  0.7.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Snapshooter.Xunit0.7.1

**Details:**
Declaring MIT

**Resolution:**
https://github.com/SwissLife-OSS/Snapshooter/blob/0.7.1/LICENSE

**Affected definitions**:
- [Snapshooter.Xunit 0.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/Snapshooter.Xunit/0.7.1/0.7.1)