### PR TITLE
HotChocolate.Stitching.Abstractions12.12.1

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Stitching.Abstractions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Stitching.Abstractions.yaml
@@ -6,6 +6,9 @@ revisions:
   11.0.9:
     licensed:
       declared: MIT
+  12.12.1:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Stitching.Abstractions12.12.1

**Details:**
Declaring MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Stitching.Abstractions/12.12.1/License

**Affected definitions**:
- [HotChocolate.Stitching.Abstractions 12.12.1](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Stitching.Abstractions/12.12.1/12.12.1)