### PR TITLE
SpecRun.Runner3.9.31

### DIFF
--- a/curations/nuget/nuget/-/SpecRun.Runner.yaml
+++ b/curations/nuget/nuget/-/SpecRun.Runner.yaml
@@ -69,6 +69,9 @@ revisions:
   3.7.3:
     licensed:
       declared: OTHER
+  3.9.31:
+    licensed:
+      declared: OTHER
   3.9.7:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
SpecRun.Runner3.9.31

**Details:**
Declaring OTHER for EULA

**Resolution:**
https://www.nuget.org/packages/SpecRun.Runner/3.9.31/License

**Affected definitions**:
- [SpecRun.Runner 3.9.31](https://clearlydefined.io/definitions/nuget/nuget/-/SpecRun.Runner/3.9.31/3.9.31)