### PR TITLE
Unity.Container5.9.3

### DIFF
--- a/curations/nuget/nuget/-/Unity.Container.yaml
+++ b/curations/nuget/nuget/-/Unity.Container.yaml
@@ -78,6 +78,9 @@ revisions:
   5.9.2:
     licensed:
       declared: Apache-2.0
+  5.9.3:
+    licensed:
+      declared: Apache-2.0
   5.9.5:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Unity.Container5.9.3

**Details:**
Declaring Apache-2.0

**Resolution:**
Apache-2.0 license included in zip folders for packages released before and after version 5.9.3

https://github.com/unitycontainer/unity/releases/tag/5.9.4.724


**Affected definitions**:
- [Unity.Container 5.9.3](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Container/5.9.3/5.9.3)