### PR TITLE
flatbuffers2.0.4

### DIFF
--- a/curations/npm/npmjs/-/flatbuffers.yaml
+++ b/curations/npm/npmjs/-/flatbuffers.yaml
@@ -12,3 +12,6 @@ revisions:
   1.11.0:
     licensed:
       declared: Apache-2.0
+  2.0.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
flatbuffers2.0.4

**Details:**
Declaring Apache-2.0

**Resolution:**
Apache-2.0 noted on npm page and in repo
https://github.com/google/flatbuffers/blob/v2.0.5/LICENSE.txt


**Affected definitions**:
- [flatbuffers 2.0.4](https://clearlydefined.io/definitions/npm/npmjs/-/flatbuffers/2.0.4/2.0.4)