### PR TITLE
org.bouncycastle/bcutil-jdk18on1.71

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcutil-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcutil-jdk18on.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: bcutil-jdk18on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.71':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle/bcutil-jdk18on1.71

**Details:**
Declaring MIT

**Resolution:**
Per Maven POM 
https://repo1.maven.org/maven2/org/bouncycastle/bcutil-jdk18on/1.71.1/bcutil-jdk18on-1.71.1.pom

https://www.bouncycastle.org/licence.html

**Affected definitions**:
- [bcutil-jdk18on 1.71](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.71/1.71)