### PR TITLE
Declared License was NOASSERTION.

### DIFF
--- a/curations/git/github/realm/realm-swift.yaml
+++ b/curations/git/github/realm/realm-swift.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: realm-swift
+  namespace: realm
+  provider: github
+  type: git
+revisions:
+  a107f5660b0b6067700923af7f107b6af73c546b:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License was NOASSERTION.

**Details:**
Declared license was no assertion.

**Resolution:**
Updated the correct license as per https://github.com/realm/realm-swift/blob/a107f5660b0b6067700923af7f107b6af73c546b/LICENSE.

**Affected definitions**:
- [realm-swift a107f5660b0b6067700923af7f107b6af73c546b](https://clearlydefined.io/definitions/git/github/realm/realm-swift/a107f5660b0b6067700923af7f107b6af73c546b/a107f5660b0b6067700923af7f107b6af73c546b)