### PR TITLE
Resolve case of No assertion

### DIFF
--- a/curations/sourcearchive/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/sourcearchive/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -9,4 +9,4 @@ revisions:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.3.2:
     licensed:
-      declared: CDDL-1.1
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/sourcearchive/mavencentral/javax.annotation/javax.annotation-api.yaml
+++ b/curations/sourcearchive/mavencentral/javax.annotation/javax.annotation-api.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.2':
     licensed:
       declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+  1.3.2:
+    licensed:
+      declared: CDDL-1.1


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of No assertion

**Details:**
This component contains CDDL 1.1 as license however, it is given as No Assertion 

**Resolution:**
CDDL 1.1 https://github.com/javaee/javax.annotation/blob/master/LICENSE

**Affected definitions**:
- [javax.annotation-api 1.3.2](https://clearlydefined.io/definitions/sourcearchive/mavencentral/javax.annotation/javax.annotation-api/1.3.2/1.3.2)