### PR TITLE
microsoft/fluentui-android72cb83280b88695b2

### DIFF
--- a/curations/git/github/microsoft/fluentui-android.yaml
+++ b/curations/git/github/microsoft/fluentui-android.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: fluentui-android
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  72cb83280b88695b23cf914cb37d696eb261c90e:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
microsoft/fluentui-android72cb83280b88695b2

**Details:**
Looks like ClearlyDefined took all the notices licenses and put them in the "declared" field.  The "declared" license for this code is "MIT."

**Resolution:**
MIT

**Affected definitions**:
- [fluentui-android 72cb83280b88695b23cf914cb37d696eb261c90e](https://clearlydefined.io/definitions/git/github/microsoft/fluentui-android/72cb83280b88695b23cf914cb37d696eb261c90e/72cb83280b88695b23cf914cb37d696eb261c90e)