### PR TITLE
DotNetCore.CAP 6.1.1

### DIFF
--- a/curations/nuget/nuget/-/DotNetCore.CAP.yaml
+++ b/curations/nuget/nuget/-/DotNetCore.CAP.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DotNetCore.CAP
+  provider: nuget
+  type: nuget
+revisions:
+  6.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetCore.CAP 6.1.1

**Details:**
License link on the nuget page goes to MIT

**Resolution:**
MIT license at the time the package was published

**Affected definitions**:
- [DotNetCore.CAP 6.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetCore.CAP/6.1.1/6.1.1)