### PR TITLE
ch.qos.logback/logback-classic1.2.9

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
@@ -18,7 +18,7 @@ revisions:
       declared: EPL-1.0 OR LGPL-2.1-only
   1.2.9:
     licensed:
-      declared: LGPL-2.1-only OR EPL-1.0
+      declared: EPL-1.0 OR LGPL-2.1-only 
   1.3.0-alpha4:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only

--- a/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
@@ -16,6 +16,9 @@ revisions:
   1.2.3:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only
+  1.2.9:
+    licensed:
+      declared: LGPL-2.1-only OR EPL-1.0
   1.3.0-alpha4:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ch.qos.logback/logback-classic1.2.9

**Details:**
Opened sources.jar and didnt see a license file but the java files had a license header that said EPL-1.0 or LGPL-2.1

**Resolution:**
EPL-1.0 OR LGPL-2.1-only

**Affected definitions**:
- [logback-classic 1.2.9](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-classic/1.2.9/1.2.9)