### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/fluxcd/helm-controller.yaml
+++ b/curations/git/github/fluxcd/helm-controller.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: helm-controller
+  namespace: fluxcd
+  provider: github
+  type: git
+revisions:
+  1758df2b5b314a9940a47e3c8cbb6b1faa45b16d:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The Declared license has Apache 2.0 and NOASSERTION wherein the component's source code repository shows no other license other than Apache 2.0.
License File path :https://github.com/fluxcd/helm-controller/blob/v0.23.1/LICENSE

**Resolution:**
The component is being curated as Apache 2.0 only instead of Apache 2.0 and NOASSERTION as there is no other license information is found in the license file
License file path :https://github.com/fluxcd/helm-controller/blob/v0.23.1/LICENSE

**Affected definitions**:
- [helm-controller 1758df2b5b314a9940a47e3c8cbb6b1faa45b16d](https://clearlydefined.io/definitions/git/github/fluxcd/helm-controller/1758df2b5b314a9940a47e3c8cbb6b1faa45b16d/1758df2b5b314a9940a47e3c8cbb6b1faa45b16d)