### PR TITLE
shiboken2 5.15.2.1 license correction

### DIFF
--- a/curations/pypi/pypi/-/shiboken2.yaml
+++ b/curations/pypi/pypi/-/shiboken2.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   5.15.2.1:
     licensed:
-      declared: GPL-3.0-only OR LGPL-3.0-only
+      declared: GPL-2.0-only OR GPL-3.0-only OR LGPL-3.0-only OR OTHER

--- a/curations/pypi/pypi/-/shiboken2.yaml
+++ b/curations/pypi/pypi/-/shiboken2.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: shiboken2
+  provider: pypi
+  type: pypi
+revisions:
+  5.15.2.1:
+    licensed:
+      declared: GPL-3.0-only OR LGPL-3.0-only


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
license correction

**Details:**
package is alternatively licensed

**Resolution:**
Attempts to correct declared license. Cannot multi-select more than two licenses, but the actual license is SPDX-License-Identifier: LicenseRef-Qt-Commercial OR LGPL-3.0-only OR GPL-2.0-only OR GPL-3.0-only

**Affected definitions**:
- [shiboken2 5.15.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/shiboken2/5.15.2.1/5.15.2.1)