### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/eclipse-ee4j/jersey.yaml
+++ b/curations/git/github/eclipse-ee4j/jersey.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey
+  namespace: eclipse-ee4j
+  provider: github
+  type: git
+revisions:
+  ecf14442b636b6c0c865291c1801c43917ed9686:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-with-classpath-exception

--- a/curations/git/github/eclipse-ee4j/jersey.yaml
+++ b/curations/git/github/eclipse-ee4j/jersey.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   ecf14442b636b6c0c865291c1801c43917ed9686:
     licensed:
-      declared: EPL-2.0 OR GPL-2.0-with-classpath-exception
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
The component has one NOASSERTION whereas the component's source code repository has the License information as Dual licensed under EPL 2.0 or GPL 2.0 with classpath exception.
License File path :https://github.com/eclipse-ee4j/jersey/blob/2.36/LICENSE.md
https://github.com/eclipse-ee4j/jersey/blob/

**Resolution:**

The component is being curated as EPL 2.0 OR GPL 2.0 only as there is license information present in the License file and Readme file of the source code repository.
License file path :https://github.com/eclipse-ee4j/jersey/blob/2.36/LICENSE.md
https://github.com/eclipse-ee4j/jersey/blob/2.36/README

**Affected definitions**:
- [jersey ecf14442b636b6c0c865291c1801c43917ed9686](https://clearlydefined.io/definitions/git/github/eclipse-ee4j/jersey/ecf14442b636b6c0c865291c1801c43917ed9686/ecf14442b636b6c0c865291c1801c43917ed9686)