### PR TITLE
microsoft/fluentui-android42a358c45f5cea07bda86a6262784e2c3846852f

### DIFF
--- a/curations/git/github/microsoft/fluentui-android.yaml
+++ b/curations/git/github/microsoft/fluentui-android.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: github
   type: git
 revisions:
+  42a358c45f5cea07bda86a6262784e2c3846852f:
+    licensed:
+      declared: MIT
   72cb83280b88695b23cf914cb37d696eb261c90e:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
microsoft/fluentui-android42a358c45f5cea07bda86a6262784e2c3846852f

**Details:**
Declared field including all licenses from NOTICE file

**Resolution:**
The license is just "MIT."

**Affected definitions**:
- [fluentui-android 42a358c45f5cea07bda86a6262784e2c3846852f](https://clearlydefined.io/definitions/git/github/microsoft/fluentui-android/42a358c45f5cea07bda86a6262784e2c3846852f/42a358c45f5cea07bda86a6262784e2c3846852f)