### PR TITLE
org.bouncycastle/bcprov-jdk18on1.71

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk18on.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: bcprov-jdk18on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.71':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.bouncycastle/bcprov-jdk18on1.71

**Details:**
Bouncy Castle license which is the MIT

**Resolution:**
MIT

**Affected definitions**:
- [bcprov-jdk18on 1.71](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.71/1.71)