### PR TITLE
pycocotools2.0.5

### DIFF
--- a/curations/pypi/pypi/-/pycocotools.yaml
+++ b/curations/pypi/pypi/-/pycocotools.yaml
@@ -12,3 +12,6 @@ revisions:
   2.0.4:
     licensed:
       declared: BSD-2-Clause-Views
+  2.0.5:
+    licensed:
+      declared: BSD-2-Clause-Views


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pycocotools2.0.5

**Details:**
Package just says "FreeBSD"

**Resolution:**
License file in repo is BSD-2-Clause-Views

**Affected definitions**:
- [pycocotools 2.0.5](https://clearlydefined.io/definitions/pypi/pypi/-/pycocotools/2.0.5/2.0.5)