### PR TITLE
punycode/1.2.4

### DIFF
--- a/curations/npm/npmjs/-/punycode.yaml
+++ b/curations/npm/npmjs/-/punycode.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.2.4:
     licensed:
-      declared: MIT OR NOASSERTION
+      declared: MIT OR GPL-2.0-only

--- a/curations/npm/npmjs/-/punycode.yaml
+++ b/curations/npm/npmjs/-/punycode.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: punycode
+  provider: npmjs
+  type: npm
+revisions:
+  1.2.4:
+    licensed:
+      declared: MIT OR NOASSERTION


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
punycode/1.2.4

**Details:**
States MIT and GPL. License text is GPL 2.0, but couldn't find any info stating "or later".

**Resolution:**
MIT OR GPL-2.0-only

**Affected definitions**:
- [punycode 1.2.4](https://clearlydefined.io/definitions/npm/npmjs/-/punycode/1.2.4/1.2.4)