### PR TITLE
Declared License was missing

### DIFF
--- a/curations/sourcearchive/mavencentral/org.elasticsearch/elasticsearch.yaml
+++ b/curations/sourcearchive/mavencentral/org.elasticsearch/elasticsearch.yaml
@@ -1,0 +1,17 @@
+coordinates:
+  name: elasticsearch
+  namespace: org.elasticsearch
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  5.6.4:
+    described:
+      sourceLocation:
+        name: elasticsearch
+        namespace: elastic
+        provider: github
+        revision: 8bbedf5fe55fa22888e107898e5c16ca7f82c636
+        type: git
+        url: 'https://github.com/elastic/elasticsearch/commit/8bbedf5fe55fa22888e107898e5c16ca7f82c636'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was missing

**Details:**
Declared License was missing

**Resolution:**
Updated the declared license as per https://github.com/elastic/elasticsearch/blob/v5.6.4/LICENSE.txt

**Affected definitions**:
- [elasticsearch 5.6.4](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.elasticsearch/elasticsearch/5.6.4/5.6.4)