### PR TITLE
Resolve case of No assertion

### DIFF
--- a/curations/git/github/golang/text.yaml
+++ b/curations/git/github/golang/text.yaml
@@ -10,6 +10,9 @@ revisions:
   383b2e75a7a4198c42f8f87833eefb772868a56f:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  5cec4b58c438bd98288aeb248bab2c1840713d21:
+    licensed:
+      declared: BSD-3-Clause
   75a595aef632b07c6eeaaa805adb6f0f66e4130e:
     licensed:
       declared: BSD-3-Clause AND OTHER

--- a/curations/git/github/golang/text.yaml
+++ b/curations/git/github/golang/text.yaml
@@ -12,7 +12,7 @@ revisions:
       declared: BSD-3-Clause AND OTHER
   5cec4b58c438bd98288aeb248bab2c1840713d21:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   75a595aef632b07c6eeaaa805adb6f0f66e4130e:
     licensed:
       declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve case of No assertion

**Details:**
This component contains only BSD-3 clause license however, it's mentioned as No assertion

**Resolution:**
Github link: https://github.com/golang/text/blob/5cec4b58c438bd98288aeb248bab2c1840713d21/LICENSE

Please approve this curation

**Affected definitions**:
- [text 5cec4b58c438bd98288aeb248bab2c1840713d21](https://clearlydefined.io/definitions/git/github/golang/text/5cec4b58c438bd98288aeb248bab2c1840713d21/5cec4b58c438bd98288aeb248bab2c1840713d21)