### PR TITLE
fonttools4.37.4

### DIFF
--- a/curations/pypi/pypi/-/fonttools.yaml
+++ b/curations/pypi/pypi/-/fonttools.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: fonttools
+  provider: pypi
+  type: pypi
+revisions:
+  4.37.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
fonttools4.37.4

**Details:**
Declare MIT

**Resolution:**
https://github.com/fonttools/fonttools/blob/main/LICENSE

**Affected definitions**:
- [fonttools 4.37.4](https://clearlydefined.io/definitions/pypi/pypi/-/fonttools/4.37.4/4.37.4)