### PR TITLE
fonttools4.37.1

### DIFF
--- a/curations/pypi/pypi/-/fonttools.yaml
+++ b/curations/pypi/pypi/-/fonttools.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  4.37.1:
+    licensed:
+      declared: MIT
   4.37.4:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
fonttools4.37.1

**Details:**
Declaring MIT

**Resolution:**
https://github.com/fonttools/fonttools/blob/4.37.1/LICENSE

**Affected definitions**:
- [fonttools 4.37.1](https://clearlydefined.io/definitions/pypi/pypi/-/fonttools/4.37.1/4.37.1)