### PR TITLE
Declared License was incorrect.

### DIFF
--- a/curations/git/github/prometheus-operator/prometheus-operator.yaml
+++ b/curations/git/github/prometheus-operator/prometheus-operator.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: prometheus-operator
+  namespace: prometheus-operator
+  provider: github
+  type: git
+revisions:
+  d2e3dc38e43b5a4b28fcea013fd8facf39a7e6fa:
+    licensed:
+      declared: Apache-2.0 AND NOASSERTION

--- a/curations/git/github/prometheus-operator/prometheus-operator.yaml
+++ b/curations/git/github/prometheus-operator/prometheus-operator.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   d2e3dc38e43b5a4b28fcea013fd8facf39a7e6fa:
     licensed:
-      declared: Apache-2.0 AND NOASSERTION
+      declared: Apache-2.0 


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
Declared License was incorrect.

**Details:**
Declared License contains NOASSERTION along with Apache 2.0 but the component is under Apache-2.0 only.

**Resolution:**
Corrected the license as per https://github.com/prometheus-operator/prometheus-operator/blob/d2e3dc38e43b5a4b28fcea013fd8facf39a7e6fa/LICENSE.

**Affected definitions**:
- [prometheus-operator d2e3dc38e43b5a4b28fcea013fd8facf39a7e6fa](https://clearlydefined.io/definitions/git/github/prometheus-operator/prometheus-operator/d2e3dc38e43b5a4b28fcea013fd8facf39a7e6fa/d2e3dc38e43b5a4b28fcea013fd8facf39a7e6fa)