### PR TITLE
licensed to LGPL v3 only

### DIFF
--- a/curations/git/github/i-m-c/jenkins-inheritance-plugin.yaml
+++ b/curations/git/github/i-m-c/jenkins-inheritance-plugin.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jenkins-inheritance-plugin
+  namespace: i-m-c
+  provider: github
+  type: git
+revisions:
+  6e6233506a9aed7989cb5668a32f9e979632107a:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
licensed to LGPL v3 only

**Details:**
licensed to LGPL v3 only

**Resolution:**
change to LGPL v2 only for its main license.

**Affected definitions**:
- [jenkins-inheritance-plugin 6e6233506a9aed7989cb5668a32f9e979632107a](https://clearlydefined.io/definitions/git/github/i-m-c/jenkins-inheritance-plugin/6e6233506a9aed7989cb5668a32f9e979632107a/6e6233506a9aed7989cb5668a32f9e979632107a)