### PR TITLE
MongoDB.Driver.Core2.17.1

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Driver.Core.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Driver.Core.yaml
@@ -96,6 +96,9 @@ revisions:
   2.16.1:
     licensed:
       declared: Apache-2.0
+  2.17.1:
+    licensed:
+      declared: Apache-2.0
   2.8.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
MongoDB.Driver.Core2.17.1

**Details:**
Declared License is Apache-2.0

**Resolution:**
https://www.nuget.org/packages/MongoDB.Driver.Core/2.17.1/License

**Affected definitions**:
- [MongoDB.Driver.Core 2.17.1](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Driver.Core/2.17.1/2.17.1)