### PR TITLE
MongoDB.Libmongocrypt1.5.5

### DIFF
--- a/curations/nuget/nuget/-/MongoDB.Libmongocrypt.yaml
+++ b/curations/nuget/nuget/-/MongoDB.Libmongocrypt.yaml
@@ -18,3 +18,6 @@ revisions:
   1.5.3:
     licensed:
       declared: Apache-2.0
+  1.5.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
MongoDB.Libmongocrypt1.5.5

**Details:**
Declared License is Apache-2.0

**Resolution:**
https://www.nuget.org/packages/MongoDB.Libmongocrypt/1.5.5/License

**Affected definitions**:
- [MongoDB.Libmongocrypt 1.5.5](https://clearlydefined.io/definitions/nuget/nuget/-/MongoDB.Libmongocrypt/1.5.5/1.5.5)