### PR TITLE
Unofficial.Microsoft.WindowsAzure.ServiceRuntime2.6.0

### DIFF
--- a/curations/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.ServiceRuntime.yaml
+++ b/curations/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.ServiceRuntime.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.6.0:
+    licensed:
+      declared: NONE
   2.7.0:
     licensed:
       declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Unofficial.Microsoft.WindowsAzure.ServiceRuntime2.6.0

**Details:**
Declaring NONE

**Resolution:**
No license found on NuGet page or in package download.

**Affected definitions**:
- [Unofficial.Microsoft.WindowsAzure.ServiceRuntime 2.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Unofficial.Microsoft.WindowsAzure.ServiceRuntime/2.6.0/2.6.0)