### PR TITLE
Stub.System.Data.SQLite.Core.NetStandard1.0.116

### DIFF
--- a/curations/nuget/nuget/-/Stub.System.Data.SQLite.Core.NetStandard.yaml
+++ b/curations/nuget/nuget/-/Stub.System.Data.SQLite.Core.NetStandard.yaml
@@ -12,3 +12,6 @@ revisions:
   1.0.115.5:
     licensed:
       declared: OTHER
+  1.0.116:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Stub.System.Data.SQLite.Core.NetStandard1.0.116

**Details:**
Declaring OTHER for public domain

**Resolution:**
https://www.sqlite.org/copyright.html

**Affected definitions**:
- [Stub.System.Data.SQLite.Core.NetStandard 1.0.116](https://clearlydefined.io/definitions/nuget/nuget/-/Stub.System.Data.SQLite.Core.NetStandard/1.0.116/1.0.116)