### PR TITLE
Google.Api.Gax.Grpc.GrpcCore3.3.0

### DIFF
--- a/curations/nuget/nuget/-/Google.Api.Gax.Grpc.GrpcCore.yaml
+++ b/curations/nuget/nuget/-/Google.Api.Gax.Grpc.GrpcCore.yaml
@@ -9,6 +9,9 @@ revisions:
   3.2.0:
     licensed:
       declared: BSD-3-Clause
+  3.3.0:
+    licensed:
+      declared: BSD-3-Clause
   3.5.0:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Google.Api.Gax.Grpc.GrpcCore3.3.0

**Details:**
Declaring BSD-3-Clause

**Resolution:**
https://www.nuget.org/packages/Google.Api.Gax.Grpc.GrpcCore/3.3.0/License

**Affected definitions**:
- [Google.Api.Gax.Grpc.GrpcCore 3.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Api.Gax.Grpc.GrpcCore/3.3.0/3.3.0)