### PR TITLE
Unity.Microsoft.DependencyInjection5.9.1

### DIFF
--- a/curations/nuget/nuget/-/Unity.Microsoft.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/Unity.Microsoft.DependencyInjection.yaml
@@ -15,3 +15,6 @@ revisions:
   5.11.5:
     licensed:
       declared: Apache-2.0
+  5.9.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Unity.Microsoft.DependencyInjection5.9.1

**Details:**
Declared License is Apache-2.0

**Resolution:**
https://github.com/unitycontainer/microsoft-dependency-injection/blob/5.9.0.2/LICENSE

**Affected definitions**:
- [Unity.Microsoft.DependencyInjection 5.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/Unity.Microsoft.DependencyInjection/5.9.1/5.9.1)