### PR TITLE
VSSDK.OLE.Interop7.0.4

### DIFF
--- a/curations/nuget/nuget/-/VSSDK.OLE.Interop.yaml
+++ b/curations/nuget/nuget/-/VSSDK.OLE.Interop.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: VSSDK.OLE.Interop
+  provider: nuget
+  type: nuget
+revisions:
+  7.0.4:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
VSSDK.OLE.Interop7.0.4

**Details:**
Declaring NONE

**Resolution:**
No license on NuGet page or in download package.

**Affected definitions**:
- [VSSDK.OLE.Interop 7.0.4](https://clearlydefined.io/definitions/nuget/nuget/-/VSSDK.OLE.Interop/7.0.4/7.0.4)