### PR TITLE
Correct Declared License field

### DIFF
--- a/curations/pypi/pypi/-/pyzmq.yaml
+++ b/curations/pypi/pypi/-/pyzmq.yaml
@@ -9,3 +9,6 @@ revisions:
   22.0.2:
     licensed:
       declared: BSD-3-Clause
+  23.2.1:
+    licensed:
+      declared: NOASSERTION AND BSD-3-Clause

--- a/curations/pypi/pypi/-/pyzmq.yaml
+++ b/curations/pypi/pypi/-/pyzmq.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: BSD-3-Clause
   23.2.1:
     licensed:
-      declared: NOASSERTION AND BSD-3-Clause
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Correct Declared License field

**Details:**
The OS package's README file explains that some files are under LGPL-3.0-only and some are under BSD-3-Clause. See https://clearlydefined.io/file/8ec1f2ce30b9e6627f93500bd6036c11e1a7bc1b46621aa5058d8f2a5c0d2133. I tried to update it to LGPL-3.0-only AND BSD-3-Clause, but the UI wouldn't let me

**Resolution:**
Update Declared License field

**Affected definitions**:
- [pyzmq 23.2.1](https://clearlydefined.io/definitions/pypi/pypi/-/pyzmq/23.2.1/23.2.1)