### PR TITLE
xunit.assert2.2.0-beta4-build3444

### DIFF
--- a/curations/nuget/nuget/-/xunit.assert.yaml
+++ b/curations/nuget/nuget/-/xunit.assert.yaml
@@ -24,6 +24,9 @@ revisions:
   2.2.0-beta2-build3300:
     licensed:
       declared: Apache-2.0
+  2.2.0-beta4-build3444:
+    licensed:
+      declared: Apache-2.0
   2.2.0-beta5-build3474:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
xunit.assert2.2.0-beta4-build3444

**Details:**
Declaring Apache-2.0

**Resolution:**
https://github.com/xunit/xunit/blob/2.2-beta4/license.txt

**Affected definitions**:
- [xunit.assert 2.2.0-beta4-build3444](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.assert/2.2.0-beta4-build3444/2.2.0-beta4-build3444)