### PR TITLE
Aq.ExpressionJsonSerializer0.18.0

### DIFF
--- a/curations/nuget/nuget/-/Aq.ExpressionJsonSerializer.yaml
+++ b/curations/nuget/nuget/-/Aq.ExpressionJsonSerializer.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Aq.ExpressionJsonSerializer
+  provider: nuget
+  type: nuget
+revisions:
+  0.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Aq.ExpressionJsonSerializer0.18.0

**Details:**
Declaring MIT

**Resolution:**
https://github.com/aquilae/expression-json-serializer/blob/master/LICENSE

**Affected definitions**:
- [Aq.ExpressionJsonSerializer 0.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/Aq.ExpressionJsonSerializer/0.18.0/0.18.0)