### PR TITLE
Mongo2Go2.2.9

### DIFF
--- a/curations/nuget/nuget/-/Mongo2Go.yaml
+++ b/curations/nuget/nuget/-/Mongo2Go.yaml
@@ -6,3 +6,6 @@ revisions:
   2.2.12:
     licensed:
       declared: MIT
+  2.2.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Mongo2Go2.2.9

**Details:**
Declaring MIT

**Resolution:**
https://github.com/Mongo2Go/Mongo2Go/blob/v2.2.9/LICENSE

**Affected definitions**:
- [Mongo2Go 2.2.9](https://clearlydefined.io/definitions/nuget/nuget/-/Mongo2Go/2.2.9/2.2.9)