### PR TITLE
FluentMigrator.Runner.SQLite3.3.2

### DIFF
--- a/curations/nuget/nuget/-/FluentMigrator.Runner.SQLite.yaml
+++ b/curations/nuget/nuget/-/FluentMigrator.Runner.SQLite.yaml
@@ -12,3 +12,6 @@ revisions:
   3.2.17:
     licensed:
       declared: Apache-2.0
+  3.3.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
FluentMigrator.Runner.SQLite3.3.2

**Details:**
Declaring Apache-2.0

**Resolution:**
https://github.com/fluentmigrator/fluentmigrator/blob/v3.3.2/LICENSE.txt

**Affected definitions**:
- [FluentMigrator.Runner.SQLite 3.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/FluentMigrator.Runner.SQLite/3.3.2/3.3.2)