### PR TITLE
structuremap.automocking2.6.4.1

### DIFF
--- a/curations/nuget/nuget/-/structuremap.automocking.yaml
+++ b/curations/nuget/nuget/-/structuremap.automocking.yaml
@@ -6,3 +6,6 @@ revisions:
   2.6.3:
     licensed:
       declared: Apache-2.0
+  2.6.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
structuremap.automocking2.6.4.1

**Details:**
Declaring Apache-2.0

**Resolution:**
https://raw.githubusercontent.com/structuremap/structuremap/master/LICENSE.TXT

**Affected definitions**:
- [structuremap.automocking 2.6.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/structuremap.automocking/2.6.4.1/2.6.4.1)