### PR TITLE
Adding License info & link to original github

### DIFF
--- a/curations/nuget/nuget/-/AspNetPager.yaml
+++ b/curations/nuget/nuget/-/AspNetPager.yaml
@@ -1,0 +1,16 @@
+coordinates:
+  name: AspNetPager
+  provider: nuget
+  type: nuget
+revisions:
+  7.5.1:
+    described:
+      sourceLocation:
+        name: aspnetpager
+        namespace: webdiyer
+        provider: github
+        revision: 3b21e65349a6f14f5ac4e2319f1f0496307bb904
+        type: git
+        url: 'https://github.com/webdiyer/aspnetpager/commit/3b21e65349a6f14f5ac4e2319f1f0496307bb904'
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding License info & link to original github

**Details:**
Adding License info & link to original github which contains the license info

**Resolution:**
Adding License info & link to original github which contains the license info

**Affected definitions**:
- [AspNetPager 7.5.1](https://clearlydefined.io/definitions/nuget/nuget/-/AspNetPager/7.5.1/7.5.1)