### PR TITLE
Adding License info & link to original github

### DIFF
--- a/curations/nuget/nuget/-/AspNetPager.yaml
+++ b/curations/nuget/nuget/-/AspNetPager.yaml
@@ -3,6 +3,17 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  7.4.1:
+    described:
+      sourceLocation:
+        name: aspnetpager
+        namespace: webdiyer
+        provider: github
+        revision: 9771f4d7a70947af0d62a00b994e5301282ee84f
+        type: git
+        url: 'https://github.com/webdiyer/aspnetpager/commit/9771f4d7a70947af0d62a00b994e5301282ee84f'
+    licensed:
+      declared: LGPL-3.0-only
   7.5.1:
     described:
       sourceLocation:

--- a/curations/nuget/nuget/-/AspNetPager.yaml
+++ b/curations/nuget/nuget/-/AspNetPager.yaml
@@ -4,16 +4,8 @@ coordinates:
   type: nuget
 revisions:
   7.4.1:
-    described:
-      sourceLocation:
-        name: aspnetpager
-        namespace: webdiyer
-        provider: github
-        revision: 9771f4d7a70947af0d62a00b994e5301282ee84f
-        type: git
-        url: 'https://github.com/webdiyer/aspnetpager/commit/9771f4d7a70947af0d62a00b994e5301282ee84f'
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later
   7.5.1:
     described:
       sourceLocation:


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Adding License info & link to original github

**Details:**
pre '15 used lgpl  3

**Resolution:**
Fixes lack of license info

**Affected definitions**:
- [AspNetPager 7.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/AspNetPager/7.4.1/7.4.1)