### PR TITLE
requirejs2.1.11

### DIFF
--- a/curations/npm/npmjs/-/requirejs.yaml
+++ b/curations/npm/npmjs/-/requirejs.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.1.11:
     licensed:
-      declared: NOASSERTION OR MIT
+      declared: MIT OR BSD-3-Clause
   2.1.20:
     licensed:
       declared: MIT OR BSD-3-Clause

--- a/curations/npm/npmjs/-/requirejs.yaml
+++ b/curations/npm/npmjs/-/requirejs.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  2.1.11:
+    licensed:
+      declared: NOASSERTION OR MIT
   2.1.20:
     licensed:
       declared: MIT OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
requirejs2.1.11

**Details:**
Declaring BSD-3-Clause OR MIT

**Resolution:**
The tooling won't accept the dual licensing. I am manually making the change to the file.

https://github.com/requirejs/r.js/blob/2.1.11/LICENSE

**Affected definitions**:
- [requirejs 2.1.11](https://clearlydefined.io/definitions/npm/npmjs/-/requirejs/2.1.11/2.1.11)