### PR TITLE
org.bouncycastle/bcpkix-jdk18on1.71

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk18on.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: bcpkix-jdk18on
+  namespace: org.bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.71':
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.bouncycastle/bcpkix-jdk18on1.71

**Details:**
Declaring MIT

**Resolution:**
https://repo1.maven.org/maven2/org/bouncycastle/bcpkix-jdk18on/1.71/bcpkix-jdk18on-1.71.pom

**Affected definitions**:
- [bcpkix-jdk18on 1.71](https://clearlydefined.io/definitions/maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.71/1.71)