### PR TITLE
commons-discovery/commons-discovery0.2

### DIFF
--- a/curations/maven/mavencentral/commons-discovery/commons-discovery.yaml
+++ b/curations/maven/mavencentral/commons-discovery/commons-discovery.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '0.2':
+    licensed:
+      declared: Apache-2.0
   '0.4':
     licensed:
       declared: Apache-2.0

--- a/curations/maven/mavencentral/commons-discovery/commons-discovery.yaml
+++ b/curations/maven/mavencentral/commons-discovery/commons-discovery.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   '0.2':
     licensed:
-      declared: Apache-2.0
+      declared: Apache-1.1
   '0.4':
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
commons-discovery/commons-discovery0.2

**Details:**
Declaring Apache-2.0

**Resolution:**
Reference to Apache-2.0 and later version have Apache-2.0 license

https://mvnrepository.com/artifact/commons-discovery/commons-discovery/0.2

**Affected definitions**:
- [commons-discovery 0.2](https://clearlydefined.io/definitions/maven/mavencentral/commons-discovery/commons-discovery/0.2/0.2)