### PR TITLE
Hangfire.AspNetCore1.7.30

### DIFF
--- a/curations/nuget/nuget/-/Hangfire.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Hangfire.AspNetCore.yaml
@@ -15,6 +15,9 @@ revisions:
   1.7.27:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER
+  1.7.30:
+    licensed:
+      declared: LGPL-3.0-or-later OR OTHER
   1.7.31:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Hangfire.AspNetCore1.7.30

**Details:**
Declaring LGPL-3.0-or-later OR OTHER (for commercial license option)

**Resolution:**
https://github.com/HangfireIO/Hangfire/blob/v1.7.30/LICENSE.md

**Affected definitions**:
- [Hangfire.AspNetCore 1.7.30](https://clearlydefined.io/definitions/nuget/nuget/-/Hangfire.AspNetCore/1.7.30/1.7.30)