### PR TITLE
@azure/communication-calling1.6.3

### DIFF
--- a/curations/npm/npmjs/@azure/communication-calling.yaml
+++ b/curations/npm/npmjs/@azure/communication-calling.yaml
@@ -58,3 +58,6 @@ revisions:
   1.6.1-beta.1:
     licensed:
       declared: OTHER
+  1.6.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
@azure/communication-calling1.6.3

**Details:**
Declaring OTHER for Microsoft proprietary license. Requires an Azure subscription

**Resolution:**
https://www.npmjs.com/package/@azure/communication-calling/v/1.6.3

**Affected definitions**:
- [communication-calling 1.6.3](https://clearlydefined.io/definitions/npm/npmjs/@azure/communication-calling/1.6.3/1.6.3)