### PR TITLE
com.sun.xml.bind.external/relaxng-datatype3.0.2

### DIFF
--- a/curations/maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype.yaml
+++ b/curations/maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype.yaml
@@ -7,3 +7,6 @@ revisions:
   2.3.2:
     licensed:
       declared: BSD-3-Clause
+  3.0.2:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
com.sun.xml.bind.external/relaxng-datatype3.0.2

**Details:**
Declaring BSD-3-Clause

**Resolution:**
https://repo1.maven.org/maven2/com/sun/xml/bind/external/relaxng-datatype/3.0.2/relaxng-datatype-3.0.2.pom

**Affected definitions**:
- [relaxng-datatype 3.0.2](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.xml.bind.external/relaxng-datatype/3.0.2/3.0.2)