### PR TITLE
Declared License was Ambiguous

### DIFF
--- a/curations/git/github/java-native-access/jna.yaml
+++ b/curations/git/github/java-native-access/jna.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jna
+  namespace: java-native-access
+  provider: github
+  type: git
+revisions:
+  f9ceb1d14caec1327746b2e23bfd1b0664cac7ed:
+    licensed:
+      declared: LGPL-2.1-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared License was Ambiguous

**Details:**
The license mentioned in declared licenses "Apache-2.0 AND LGPL-2.1-only AND LGPL-2.1-or-later OR Apache-2.0" is ambiguous 

**Resolution:**
The declared license is changed to "LGPL-2.1-or-later OR Apache-2.0" as per https://github.com/java-native-access/jna/blob/f9ceb1d14caec1327746b2e23bfd1b0664cac7ed/LICENSE

**Affected definitions**:
- [jna f9ceb1d14caec1327746b2e23bfd1b0664cac7ed](https://clearlydefined.io/definitions/git/github/java-native-access/jna/f9ceb1d14caec1327746b2e23bfd1b0664cac7ed/f9ceb1d14caec1327746b2e23bfd1b0664cac7ed)