### PR TITLE
Remove NOASSERTION from declared license

### DIFF
--- a/curations/git/github/etcd-io/etcd.yaml
+++ b/curations/git/github/etcd-io/etcd.yaml
@@ -13,3 +13,6 @@ revisions:
   dd1b699fc4895de8cc23c3cac5a428c37eee384a:
     licensed:
       declared: Apache-2.0
+  e4561dd8cfb1163fb51afceca9c78aa89398e731:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Remove NOASSERTION from declared license

**Details:**
The declared license has Apache 2.0 and NOASSERTION.

**Resolution:**
Removed NOASSERTION from declared license.

**Affected definitions**:
- [etcd e4561dd8cfb1163fb51afceca9c78aa89398e731](https://clearlydefined.io/definitions/git/github/etcd-io/etcd/e4561dd8cfb1163fb51afceca9c78aa89398e731/e4561dd8cfb1163fb51afceca9c78aa89398e731)