### PR TITLE
pyinstaller 4.8

### DIFF
--- a/curations/pypi/pypi/-/pyinstaller.yaml
+++ b/curations/pypi/pypi/-/pyinstaller.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pyinstaller
+  provider: pypi
+  type: pypi
+revisions:
+  '4.8':
+    licensed:
+      declared: GPL-2.0-or-later

--- a/curations/pypi/pypi/-/pyinstaller.yaml
+++ b/curations/pypi/pypi/-/pyinstaller.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   '4.8':
     licensed:
-      declared: GPL-2.0-or-later
+      declared: GPL-2.0-or-later WITH Bootloader-exception


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pyinstaller 4.8

**Details:**
GPL-2.0-or-later WITH Bootloader-exception

**Resolution:**
See COPYING file in package

**Affected definitions**:
- [pyinstaller 4.8](https://clearlydefined.io/definitions/pypi/pypi/-/pyinstaller/4.8/4.8)