### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -37,3 +37,6 @@ revisions:
   5.8.2:
     licensed:
       declared: EPL-2.0
+  5.9.1:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update license information

**Details:**
The license info does not reference the git URL of the license

The Jupiter code base is in the Junit5 repo from what I can see

This is the license URL for Junit .. from release tag for 5.9.1




**Resolution:**
My suggestion is that we reference the git repo with a tagged commit for the license URL

https://github.com/junit-team/junit5/blob/r5.9.1/LICENSE.md

Jupiter itself is just a "module"  or component of Junit 5

https://github.com/junit-team/junit5/tree/r5.9.1/junit-jupiter

**Affected definitions**:
- [junit-jupiter 5.9.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.1/5.9.1)