### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
@@ -64,3 +64,6 @@ revisions:
   5.9.0-M1:
     licensed:
       declared: EPL-2.0
+  5.9.1:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update license information

**Details:**
The license information for this component is not complete because it doesn't reference the source URL


**Resolution:**
junit-jupiter-api is a module or component of junit5

The license text for junit5 for the specific release tag is here:
https://github.com/junit-team/junit5/blob/r5.9.1/LICENSE.md

The source for the module 
https://github.com/junit-team/junit5/tree/r5.9.1/junit-jupiter-api



**Affected definitions**:
- [junit-jupiter-api 5.9.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.9.1/5.9.1)