### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -58,9 +58,12 @@ revisions:
   5.8.2:
     licensed:
       declared: EPL-2.0
+  5.9.0:
+    licensed:
+      declared: EPL-2.0
   5.9.0-M1:
     licensed:
       declared: EPL-2.0
-  5.9.0:
+  5.9.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update license information

**Details:**
Asserting that it is EPL 2.0

Because its a submodule of Junit 5

**Resolution:**
The license URL is here: https://github.com/junit-team/junit5/blob/r5.9.1/LICENSE.md

The components source URL is here
https://github.com/junit-team/junit5/tree/r5.9.1/junit-jupiter-engine

**Affected definitions**:
- [junit-jupiter-engine 5.9.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.1/5.9.1)