### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-params.yaml
@@ -46,3 +46,6 @@ revisions:
   5.9.0:
     licensed:
       declared: EPL-2.0
+  5.9.1:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update license information

**Details:**
This module is EPL 2.0 as per the License URL of the containing directory.

https://github.com/junit-team/junit5/blob/r5.9.1/LICENSE.md

However there is also an apache 2.0 license inside this directory
https://github.com/junit-team/junit5/tree/r5.9.1/junit-jupiter-params

**Resolution:**
I set to EPL 2.0 because of the parent dir, but I am not completely certain if it should be EPL-2.0,Apache-2.0 or using AND (EPL-2.0 AND Apache-2.0) ?

**Affected definitions**:
- [junit-jupiter-params 5.9.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-params/5.9.1/5.9.1)