### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -49,3 +49,6 @@ revisions:
   1.9.0:
     licensed:
       declared: EPL-2.0
+  1.9.1:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update license information

**Details:**
Module of junit 5.9.1

Setting to EPL 2.0

**Resolution:**
This is the source modul
https://github.com/junit-team/junit5/tree/r5.9.1/junit-platform-commons

 Its parent directory is junit5 which is EPL 2.0
according to 
https://github.com/junit-team/junit5/blob/r5.9.1/LICENSE.md


**Affected definitions**:
- [junit-platform-commons 1.9.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.9.1/1.9.1)