### PR TITLE
Update license information

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-engine.yaml
@@ -49,3 +49,6 @@ revisions:
   1.9.0:
     licensed:
       declared: EPL-2.0
+  1.9.1:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update license information

**Details:**
License was not declared, so I declared it

**Resolution:**
This module is a child module of junit 5. Module source dir:
https://github.com/junit-team/junit5/tree/r5.9.1/junit-platform-engine

Junit5 is EPL 2.0 according to its license text

https://github.com/junit-team/junit5/tree/r5.9.1/junit-platform-engine

**Affected definitions**:
- [junit-platform-engine 1.9.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-engine/1.9.1/1.9.1)