### PR TITLE
Declared License is Ambiguous

### DIFF
--- a/curations/git/github/cwbudde/cordova-plugin-wkwebview-inject-cookie.yaml
+++ b/curations/git/github/cwbudde/cordova-plugin-wkwebview-inject-cookie.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cordova-plugin-wkwebview-inject-cookie
+  namespace: cwbudde
+  provider: github
+  type: git
+revisions:
+  bb6ad7245194abadce1b6b50db64a1d809c3c4df:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared License is Ambiguous

**Details:**
Declared License contained "Apache 2.0 and Unlicense".

**Resolution:**
Correcting the license to only "Apache 2.0"

**Affected definitions**:
- [cordova-plugin-wkwebview-inject-cookie bb6ad7245194abadce1b6b50db64a1d809c3c4df](https://clearlydefined.io/definitions/git/github/cwbudde/cordova-plugin-wkwebview-inject-cookie/bb6ad7245194abadce1b6b50db64a1d809c3c4df/bb6ad7245194abadce1b6b50db64a1d809c3c4df)