### PR TITLE
com.google.android.gms/play-services-basement18.1.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-basement.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-basement.yaml
@@ -28,3 +28,6 @@ revisions:
   17.6.0:
     licensed:
       declared: OTHER
+  18.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.gms/play-services-basement18.1.0

**Details:**
This is under the "Android Software Development Kit License" 

**Resolution:**
There's no SPDX for the "Android Software Development Kit License" so this is "OTHER"

**Affected definitions**:
- [play-services-basement 18.1.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-basement/18.1.0/18.1.0)