### PR TITLE
NHunspell 1.2.5359.26126

### DIFF
--- a/curations/nuget/nuget/-/NHunspell.yaml
+++ b/curations/nuget/nuget/-/NHunspell.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.2.5359.26126:
     licensed:
-      declared: (LGPL-2.0-or-later OR GPL-1.0-or-later) OR MPL-1.0
+      declared: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1

--- a/curations/nuget/nuget/-/NHunspell.yaml
+++ b/curations/nuget/nuget/-/NHunspell.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NHunspell
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.5359.26126:
+    licensed:
+      declared: (LGPL-2.0-or-later OR GPL-1.0-or-later) OR MPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NHunspell 1.2.5359.26126

**Details:**
Readme states:  NHunspell is licensed under: GPL/LGPL/MPL. Free use in commercial applications is permitted according to the LGPL and MPL licenses. Your commercial application can link against the NHunspell DLLs.

**Resolution:**
LGPL-2.0-or-later OR GPL-1.0-or-later) OR MPL-1.0

**Affected definitions**:
- [NHunspell 1.2.5359.26126](https://clearlydefined.io/definitions/nuget/nuget/-/NHunspell/1.2.5359.26126/1.2.5359.26126)