### PR TITLE
AjaxControlToolkit 7.1213.0

### DIFF
--- a/curations/nuget/nuget/-/AjaxControlToolkit.yaml
+++ b/curations/nuget/nuget/-/AjaxControlToolkit.yaml
@@ -33,3 +33,6 @@ revisions:
   4.1.51116:
     licensed:
       declared: BSD-3-Clause
+  7.1213.0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AjaxControlToolkit 7.1213.0

**Details:**
Found link on wayback machine to:
https://web.archive.org/web/20201204222332/https://github.com/DevExpress/AjaxControlToolkit/blob/master/LICENSE.txt

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [AjaxControlToolkit 7.1213.0](https://clearlydefined.io/definitions/nuget/nuget/-/AjaxControlToolkit/7.1213.0/7.1213.0)