### PR TITLE
uk.org.lidalia/sysout-over-slf4j1 .0.2

### DIFF
--- a/curations/maven/mavencentral/uk.org.lidalia/sysout-over-slf4j.yaml
+++ b/curations/maven/mavencentral/uk.org.lidalia/sysout-over-slf4j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sysout-over-slf4j
+  namespace: uk.org.lidalia
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
uk.org.lidalia/sysout-over-slf4j1 .0.2

**Details:**
ClearlyDefined pom: <name>MIT X11 License</name>
			<url>http://github.com/Mahoney/sysout-over-slf4j/raw/master/LICENSE.txt</url>

**Resolution:**
MIT

**Affected definitions**:
- [sysout-over-slf4j 1.0.2](https://clearlydefined.io/definitions/maven/mavencentral/uk.org.lidalia/sysout-over-slf4j/1.0.2/1.0.2)