### PR TITLE
python2 2.7.18

### DIFF
--- a/curations/nuget/nuget/-/python2.yaml
+++ b/curations/nuget/nuget/-/python2.yaml
@@ -12,3 +12,6 @@ revisions:
   2.7.17:
     licensed:
       declared: Python-2.0.1
+  2.7.18:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/python2.yaml
+++ b/curations/nuget/nuget/-/python2.yaml
@@ -14,4 +14,4 @@ revisions:
       declared: Python-2.0.1
   2.7.18:
     licensed:
-      declared: OTHER
+      declared: Python-2.0.1


### PR DESCRIPTION

**Type:** Missing

**Summary:**
C:\Users\jherring\Downloads\python 2.2.7.18\tools

**Details:**
License file found in ClearlyDefined in \python2.2.7.18\tools

**Resolution:**
OTHER

**Affected definitions**:
- [python2 2.7.18](https://clearlydefined.io/definitions/nuget/nuget/-/python2/2.7.18/2.7.18)