### PR TITLE
@ag-grid-enterprise/server-side-row-model 27.3.0

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/server-side-row-model.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/server-side-row-model.yaml
@@ -31,6 +31,9 @@ revisions:
   27.0.0:
     licensed:
       declared: OTHER
+  27.3.0:
+    licensed:
+      declared: OTHER
   28.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/server-side-row-model 27.3.0

**Details:**
ClearlyDefined license is AG GRID LTD. license: https://clearlydefined.io/file/546dc55ca066619102b67b0d5083e23cd2199f89905bf3fcb43b4ea38dda16a2

**Resolution:**
OTHER

**Affected definitions**:
- [server-side-row-model 27.3.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/server-side-row-model/27.3.0/27.3.0)