### PR TITLE
logkit/logkit 1.0.1

### DIFF
--- a/curations/maven/mavencentral/logkit/logkit.yaml
+++ b/curations/maven/mavencentral/logkit/logkit.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-1.1
   '2.0':
     licensed:
       declared: ISC


### PR DESCRIPTION

**Type:** Missing

**Summary:**
logkit/logkit 1.0.1

**Details:**
Sources JAR is a file that states Apache-1.1
https://repo1.maven.org/maven2/logkit/logkit/1.0.1/

**Resolution:**
Apache-1.1

**Affected definitions**:
- [logkit 1.0.1](https://clearlydefined.io/definitions/maven/mavencentral/logkit/logkit/1.0.1/1.0.1)