### PR TITLE
org.clapper/grizzled-scala_2.12 4.9.3

### DIFF
--- a/curations/maven/mavencentral/org.clapper/grizzled-scala_2.12.yaml
+++ b/curations/maven/mavencentral/org.clapper/grizzled-scala_2.12.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: grizzled-scala_2.12
+  namespace: org.clapper
+  provider: mavencentral
+  type: maven
+revisions:
+  4.9.3:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.clapper/grizzled-scala_2.12 4.9.3

**Details:**
License linked from: https://search.maven.org/artifact/org.clapper/grizzled-scala_2.12/4.9.3/jar

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [grizzled-scala_2.12 4.9.3](https://clearlydefined.io/definitions/maven/mavencentral/org.clapper/grizzled-scala_2.12/4.9.3/4.9.3)