### PR TITLE
DeploymentUtilities 1.0.0

### DIFF
--- a/curations/nuget/nuget/-/DeploymentUtilities.yaml
+++ b/curations/nuget/nuget/-/DeploymentUtilities.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: DeploymentUtilities
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DeploymentUtilities 1.0.0

**Details:**
No license info in Nuspec or downoad or on Github

**Resolution:**
NONE

**Affected definitions**:
- [DeploymentUtilities 1.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/DeploymentUtilities/1.0.0/1.0.0)