### PR TITLE
HttpClientExtensions 1.0.3

### DIFF
--- a/curations/nuget/nuget/-/HttpClientExtensions.yaml
+++ b/curations/nuget/nuget/-/HttpClientExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: HttpClientExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HttpClientExtensions 1.0.3

**Details:**
Nuget license links to: https://gist.github.com/alexanderpersson/a10ff94f75fd83daaa58

**Resolution:**
MIT

**Affected definitions**:
- [HttpClientExtensions 1.0.3](https://clearlydefined.io/definitions/nuget/nuget/-/HttpClientExtensions/1.0.3/1.0.3)