### PR TITLE
XmlDoc2CmdletDoc 0.2.3

### DIFF
--- a/curations/nuget/nuget/-/XmlDoc2CmdletDoc.yaml
+++ b/curations/nuget/nuget/-/XmlDoc2CmdletDoc.yaml
@@ -12,6 +12,9 @@ revisions:
   0.2.13:
     licensed:
       declared: BSD-3-Clause
+  0.2.3:
+    licensed:
+      declared: BSD-3-Clause
   0.2.5:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
XmlDoc2CmdletDoc 0.2.3

**Details:**
Nuspec links to: https://github.com/red-gate/XmlDoc2CmdletDoc/blob/master/LICENSE.md

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [XmlDoc2CmdletDoc 0.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/XmlDoc2CmdletDoc/0.2.3/0.2.3)