### PR TITLE
tomcat/jasper-compiler 5.5.12

### DIFF
--- a/curations/maven/mavencentral/tomcat/jasper-compiler.yaml
+++ b/curations/maven/mavencentral/tomcat/jasper-compiler.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jasper-compiler
+  namespace: tomcat
+  provider: mavencentral
+  type: maven
+revisions:
+  5.5.12:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
tomcat/jasper-compiler 5.5.12

**Details:**
No license info found: https://repo1.maven.org/maven2/tomcat/jasper-compiler/5.5.12/

**Resolution:**
NONE

**Affected definitions**:
- [jasper-compiler 5.5.12](https://clearlydefined.io/definitions/maven/mavencentral/tomcat/jasper-compiler/5.5.12/5.5.12)