### PR TITLE
HashLib 2.0.1

### DIFF
--- a/curations/nuget/nuget/-/HashLib.yaml
+++ b/curations/nuget/nuget/-/HashLib.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: HashLib
+  provider: nuget
+  type: nuget
+revisions:
+  2.0.1:
+    licensed:
+      declared: CDDL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HashLib 2.0.1

**Details:**
WayBack Machine: https://web.archive.org/web/20171224061447/http://hashlib.codeplex.com/license

**Resolution:**
CDDL-1.0

**Affected definitions**:
- [HashLib 2.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/HashLib/2.0.1/2.0.1)