### PR TITLE
Declared License was missing

### DIFF
--- a/curations/git/github/prometheus/node_exporter.yaml
+++ b/curations/git/github/prometheus/node_exporter.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: node_exporter
+  namespace: prometheus
+  provider: github
+  type: git
+revisions:
+  006d1c7922b765f458fe9b92ce646641bded0f52:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License was missing

**Details:**
Declared License was missing

**Resolution:**
Adding declared license as "Apache 2.0" from file LICENSE.

**Affected definitions**:
- [node_exporter 006d1c7922b765f458fe9b92ce646641bded0f52](https://clearlydefined.io/definitions/git/github/prometheus/node_exporter/006d1c7922b765f458fe9b92ce646641bded0f52/006d1c7922b765f458fe9b92ce646641bded0f52)