### PR TITLE
Update curations/gem/rubygems/-/unicorn.yaml

### DIFF
--- a/curations/gem/rubygems/-/unicorn.yaml
+++ b/curations/gem/rubygems/-/unicorn.yaml
@@ -5,4 +5,10 @@ coordinates:
 revisions:
   5.4.0:
     licensed:
-      declared: GPL-2.0-or-later OR OTHER
+      declared: GPL-2.0-or-later OR Ruby
+  6.0.0:
+    licensed:
+      declared: GPL-2.0-or-later OR Ruby
+  6.0.0:
+    licensed:
+      declared: GPL-2.0-or-later OR Ruby


### PR DESCRIPTION
Harvesting has incorrectly added a whole lot of different licenses here, including the NOASSERTION one, which is clearly wrong. According to my understanding, unicorn is licensed under either GPL-2.0-or-later or Ruby license.

I have only added a couple of latest versions to the curation, but it might make sense to make a similar change for all the older versions as well.