### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/javaee/glassfish-ha-api.yaml
+++ b/curations/git/github/javaee/glassfish-ha-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: glassfish-ha-api
+  namespace: javaee
+  provider: github
+  type: git
+revisions:
+  93ce3d738e4e48e95b4ddf67f8cd71fc5af56813:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-with-classpath-exception


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is SPDX mentioned whereas the source repository has the license info as CDDL 1.1 or GPL v2 w/classpath exception
Path:https://github.com/javaee/glassfish-ha-api/blob/3.1.11/src/main/java/org/glassfish/ha/store/annotations/Attribute.java


**Resolution:**
The component is being curated as CDDL 1.1 or GPL v2 W/classpath exception as per the license information provided.
Path :https://github.com/javaee/glassfish-ha-api/blob/3.1.11/LICENSE

**Affected definitions**:
- [glassfish-ha-api 93ce3d738e4e48e95b4ddf67f8cd71fc5af56813](https://clearlydefined.io/definitions/git/github/javaee/glassfish-ha-api/93ce3d738e4e48e95b4ddf67f8cd71fc5af56813/93ce3d738e4e48e95b4ddf67f8cd71fc5af56813)