### PR TITLE
Update OSGi R8 Compendium sources

### DIFF
--- a/curations/sourcearchive/mavencentral/org.osgi/org.osgi.service.feature.yaml
+++ b/curations/sourcearchive/mavencentral/org.osgi/org.osgi.service.feature.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: org.osgi.service.feature
+  namespace: org.osgi
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  1.0.0:
+    described:
+      sourceLocation:
+        name: osgi
+        namespace: osgi
+        provider: github
+        revision: db39ce672917cadce15aad14a33795cbed7e8791
+        type: git
+        url: 'https://github.com/osgi/osgi/commit/db39ce672917cadce15aad14a33795cbed7e8791'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update OSGi R8 Compendium sources

**Details:**
Missing source license information for OSGi specification APIs

**Resolution:**
Add a link to the OSGi GitHub repository tag for the R8 compendium

**Affected definitions**:
- [org.osgi.service.feature 1.0.0](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.osgi/org.osgi.service.feature/1.0.0/1.0.0)