### PR TITLE
astroid2.12.10

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -12,6 +12,9 @@ revisions:
         path: astroid-2.11.7/PKG-INFO
     licensed:
       declared: LGPL-2.1-or-later
+  2.12.10:
+    licensed:
+      declared: LGPL-2.1-only
   2.3.1:
     licensed:
       declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid2.12.10

**Details:**
The package metadata says LGPLv2 and LGPL-2.1-or-later.  However, the main LICENSE file for this version seems to just be LGPL-2.1 and the source files do not say "or later."  

**Resolution:**
So, I'm curating LGPL-2.1-only.  Let me know your thoughts.

**Affected definitions**:
- [astroid 2.12.10](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.12.10/2.12.10)