### PR TITLE
pylint2.15.3

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -12,6 +12,9 @@ revisions:
   2.14.5:
     licensed:
       declared: GPL-2.0-or-later
+  2.15.3:
+    licensed:
+      declared: GPL-2.0-or-later
   2.3.0:
     files:
       - attributions:
@@ -46,12 +49,12 @@ revisions:
   2.5.3:
     licensed:
       declared: GPL-2.0-only
-  2.8.2:
-    licensed:
-      declared: GPL-2.0-or-later
   2.6.0:
     licensed:
       declared: GPL-2.0-only
+  2.8.2:
+    licensed:
+      declared: GPL-2.0-or-later
   2.9.1:
     licensed:
       declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint2.15.3

**Details:**
PKG-INFO and metadata point to GPL-2.0-or-later

**Resolution:**
Removing GPL-3.0 from declared

**Affected definitions**:
- [pylint 2.15.3](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.15.3/2.15.3)