### PR TITLE
psycopg2-binary2.9.3

### DIFF
--- a/curations/pypi/pypi/-/psycopg2-binary.yaml
+++ b/curations/pypi/pypi/-/psycopg2-binary.yaml
@@ -9,3 +9,6 @@ revisions:
   2.8.5:
     licensed:
       declared: OTHER
+  2.9.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
psycopg2-binary2.9.3

**Details:**
Custom license file that results in "OTHER" as no SPDX match

**Resolution:**
https://github.com/psycopg/psycopg2/blob/2_9_3/LICENSE

**Affected definitions**:
- [psycopg2-binary 2.9.3](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2-binary/2.9.3/2.9.3)