### PR TITLE
Add licensing info for inherits package

### DIFF
--- a/curations/npm/npmjs/-/inherits.yaml
+++ b/curations/npm/npmjs/-/inherits.yaml
@@ -9,3 +9,6 @@ revisions:
   1.0.2:
     licensed:
       declared: ISC
+  2.0.0:
+    licensed:
+      declared: WTFPL


### PR DESCRIPTION
Type: Missing

Summary:
inherits package

Details:
Add WTFPL License for v2.0.0

Resolution:
License Url:
https://github.com/isaacs/inherits/blob/v2.0.0/LICENSE

Description:
inherits is maintained by isaacs according to npmjs.com and v2.0.0 was released under the SPDX recognized [WTFPL license](https://spdx.org/licenses/WTFPL)

Affected definitions: