### PR TITLE
Update faraday-http-cache to be Apache 2.0

### DIFF
--- a/curations/gem/rubygems/-/faraday-http-cache.yaml
+++ b/curations/gem/rubygems/-/faraday-http-cache.yaml
@@ -3,6 +3,21 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  1.1.0:
+    licensed:
+      declared: Apache-2.0
+  1.1.1:
+    licensed:
+      declared: Apache-2.0
+  1.2.0:
+    licensed:
+      declared: Apache-2.0
+  1.2.2:
+    licensed:
+      declared: Apache-2.0
   1.3.1:
     licensed:
       declared: MIT
+  2.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/gem/rubygems/-/faraday-http-cache.yaml
+++ b/curations/gem/rubygems/-/faraday-http-cache.yaml
@@ -17,7 +17,7 @@ revisions:
       declared: Apache-2.0
   1.3.1:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Update NOASSERTION to be Apache 2.0

**Details:**
The license of the package can be found here: https://github.com/sourcelevel/faraday-http-cache/blob/master/LICENSE

**Resolution:**
This updates the license to be correct

https://github.com/sourcelevel/faraday-http-cache/blob/master/LICENSE

**Affected definitions**:
- [faraday-http-cache 2.0.0](https://clearlydefined.io/definitions/gem/rubygems/-/faraday-http-cache/2.0.0)