### PR TITLE
Update ruby-terminfo

### DIFF
--- a/curations/gem/rubygems/-/ruby-terminfo.yaml
+++ b/curations/gem/rubygems/-/ruby-terminfo.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ruby-terminfo
+  provider: rubygems
+  type: gem
+revisions:
+  0.1.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Update ruby-terminfo

**Details:**
Adds missing license

**Resolution:**
The license is found in the readme of the repo

**Affected definitions**:
- [ruby-terminfo 0.1.1](https://clearlydefined.io/definitions/gem/rubygems/-/ruby-terminfo/0.1.1)