### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/spreadsheetlab/xlparser.yaml
+++ b/curations/git/github/spreadsheetlab/xlparser.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: xlparser
+  namespace: spreadsheetlab
+  provider: github
+  type: git
+revisions:
+  401d8cbb04a511e2f7b45aabddd34ce201d4f9be:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is NOASSERTION mentioned whereas the license info is present in the source code repository as MPL 2.0
Path : https://github.com/spreadsheetlab/XLParser/blob/v1.2.4/LICENSE.md

**Resolution:**
The component is being curated as MPL 2.0 instead of NOASSERTION as the license information is present in the source repo.
Path : https://github.com/spreadsheetlab/XLParser/blob/v1.2.4/LICENSE.md

**Affected definitions**:
- [xlparser 401d8cbb04a511e2f7b45aabddd34ce201d4f9be](https://clearlydefined.io/definitions/git/github/spreadsheetlab/xlparser/401d8cbb04a511e2f7b45aabddd34ce201d4f9be/401d8cbb04a511e2f7b45aabddd34ce201d4f9be)