### PR TITLE
Changed license

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.js/js-scriptengine.yaml
+++ b/curations/maven/mavencentral/org.graalvm.js/js-scriptengine.yaml
@@ -16,3 +16,6 @@ revisions:
   21.0.0:
     licensed:
       declared: UPL-1.0
+  21.3.2:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Other

**Summary:**
Changed license

**Details:**
License documented in source code LICENSE file mentions UPL-1.0

**Resolution:**
build process complained about missing license

**Affected definitions**:
- [js-scriptengine 21.3.2](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.js/js-scriptengine/21.3.2/21.3.2)