### PR TITLE
Declared License is Ambiguous

### DIFF
--- a/curations/git/github/golang/crypto.yaml
+++ b/curations/git/github/golang/crypto.yaml
@@ -31,6 +31,9 @@ revisions:
   227b76d455e791cb042b03e633e2f7fbcfdf74a5:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  32487eceac714ab927b55a454631e9d449a81b55:
+    licensed:
+      declared: BSD-3-Clause
   34f69633bfdcf9db92f698f8487115767eebef81:
     licensed:
       declared: BSD-3-Clause AND OTHER

--- a/curations/git/github/golang/crypto.yaml
+++ b/curations/git/github/golang/crypto.yaml
@@ -33,7 +33,7 @@ revisions:
       declared: BSD-3-Clause AND OTHER
   32487eceac714ab927b55a454631e9d449a81b55:
     licensed:
-      declared: BSD-3-Clause
+      declared: BSD-3-Clause AND OTHER
   34f69633bfdcf9db92f698f8487115767eebef81:
     licensed:
       declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared License is Ambiguous

**Details:**
Declared license was "BSD-3-Clause and NOASSERTION".

**Resolution:**
Removed NOASSERTION from declared license

**Affected definitions**:
- [crypto 32487eceac714ab927b55a454631e9d449a81b55](https://clearlydefined.io/definitions/git/github/golang/crypto/32487eceac714ab927b55a454631e9d449a81b55/32487eceac714ab927b55a454631e9d449a81b55)