### PR TITLE
Declared License is Ambiguous

### DIFF
--- a/curations/git/github/golang/crypto.yaml
+++ b/curations/git/github/golang/crypto.yaml
@@ -12,7 +12,7 @@ revisions:
       declared: BSD-3-Clause AND OTHER
   06a226fb4e3765ef3f48aa2852b401bc7b98e981:
     licensed:
-      declared: BSD-3-Clause AND OTHER
+      declared: BSD-3-Clause
   0a08dada0ff98d02f3864a23ae8d27cb8fba5303:
     licensed:
       declared: BSD-3-Clause AND OTHER


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared License is Ambiguous

**Details:**
Declared license was "BSD-3-Clause and OTHER"

**Resolution:**
Removed OTHER from declared license.

**Affected definitions**:
- [crypto 06a226fb4e3765ef3f48aa2852b401bc7b98e981](https://clearlydefined.io/definitions/git/github/golang/crypto/06a226fb4e3765ef3f48aa2852b401bc7b98e981/06a226fb4e3765ef3f48aa2852b401bc7b98e981)