### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/git/github/swagger-api/swagger-core.yaml
+++ b/curations/git/github/swagger-api/swagger-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: swagger-core
+  namespace: swagger-api
+  provider: github
+  type: git
+revisions:
+  f2de9e88e7778e84751e4c7e8a210bae5ee1752e:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is NOASSERTION mentioned whereas the license information is present in the source repository as Apache 2.0.
Path : https://github.com/swagger-api/swagger-core/blob/v1.6.0/LICENSE

**Resolution:**
The component is being curated as Apache 2.0 instead of NOASSERTION as the license information is given in the source repo.
Path : https://github.com/swagger-api/swagger-core/blob/v1.6.0/LICENSE

**Affected definitions**:
- [swagger-core f2de9e88e7778e84751e4c7e8a210bae5ee1752e](https://clearlydefined.io/definitions/git/github/swagger-api/swagger-core/f2de9e88e7778e84751e4c7e8a210bae5ee1752e/f2de9e88e7778e84751e4c7e8a210bae5ee1752e)