### PR TITLE
Add License Info for ValueInjector 3.2.0

### DIFF
--- a/curations/nuget/nuget/-/ValueInjecter.yaml
+++ b/curations/nuget/nuget/-/ValueInjecter.yaml
@@ -6,3 +6,14 @@ revisions:
   3.1.1.5:
     licensed:
       declared: MIT
+  3.2.0:
+    described:
+      sourceLocation:
+        name: valueinjecter
+        namespace: omuleanu
+        provider: github
+        revision: 694300c085bf0eeb1a12b15a2744e41cf72b4029
+        type: git
+        url: 'https://github.com/omuleanu/valueinjecter/commit/694300c085bf0eeb1a12b15a2744e41cf72b4029'
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add License Info for ValueInjector 3.2.0

**Details:**
Add License Info for ValueInjector 3.2.0

**Resolution:**
Add License Info for ValueInjector 3.2.0

**Affected definitions**:
- [ValueInjecter 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/ValueInjecter/3.2.0/3.2.0)