### PR TITLE
add license information for test-unit/test-unit versions 3.3.7 and later

### DIFF
--- a/curations/gem/rubygems/-/test-unit.yaml
+++ b/curations/gem/rubygems/-/test-unit.yaml
@@ -1,0 +1,62 @@
+coordinates:
+  name: test-unit
+  provider: rubygems
+  type: gem
+revisions:
+  3.3.7:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.3.8:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.3.9:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.0:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.1:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.2:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.3:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.4:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.5:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.6:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.7:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.8:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.4.9:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.5.0:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.5.1:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.5.2:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.5.3:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.5.4:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+  3.5.5:
+    licensed:
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1  

--- a/curations/gem/rubygems/-/test-unit.yaml
+++ b/curations/gem/rubygems/-/test-unit.yaml
@@ -5,58 +5,58 @@ coordinates:
 revisions:
   3.3.7:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.3.8:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.3.9:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.0:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.1:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.2:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.3:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.4:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.5:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.6:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.7:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.8:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.4.9:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.5.0:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.5.1:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.5.2:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.5.3:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.5.4:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
+      declared: BSD-2-Clause OR Ruby
   3.5.5:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0  
+      declared: BSD-2-Clause OR Ruby  

--- a/curations/gem/rubygems/-/test-unit.yaml
+++ b/curations/gem/rubygems/-/test-unit.yaml
@@ -5,58 +5,58 @@ coordinates:
 revisions:
   3.3.7:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.3.8:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.3.9:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.0:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.1:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.2:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.3:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.4:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.5:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.6:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.7:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.8:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.4.9:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.5.0:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.5.1:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.5.2:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.5.3:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.5.4:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0
   3.5.5:
     licensed:
-      declared: (BSD-2-Clause OR Ruby) AND Python-2.0.1  
+      declared: (BSD-2-Clause OR Ruby) AND Python-2.0  


### PR DESCRIPTION
## Description

Querying Clearly Defined for Ruby GEM test-unit/test-unit at version 3.5.3 returns a license that includes `NOASSERTION` and does not match the expected license.

### Actual License returned from Clearly Defined

```
(BSD-2-Clause AND NOASSERTION) OR (BSD-2-Clause AND Ruby) OR (NOASSERTION AND Python-2.0 AND Ruby) OR (Python-2.0 AND Ruby)
```

### Expected License

```
(BSD-2-Clause OR Ruby) AND Python-2.0.1
```

## Analysis

Applies to versions 3.3.7 and later...

#### README

The license statement in the README is...

> This software is distributed under either the terms of new Ruby License or BSDL. See the file [COPYING](https://github.com/test-unit/test-unit/blob/master/COPYING).
> 
> Exceptions
> 
> * lib/test/unit/diff.rb is a triple license of (the new Ruby license or BSDL) and PSF license.

#### License Files

Licenses Referenced: (tag:3.5.5)
* Ruby - [test-unit: COPYING](https://github.com/test-unit/test-unit/blob/3.5.5/COPYING), [SPDX: Ruby](https://spdx.org/licenses/Ruby.html)
* BSDL - [test-unit: BSDL](https://github.com/test-unit/test-unit/blob/3.5.5/BSDL), [SPDX: BSD-2-Clause](https://spdx.org/licenses/BSD-2-Clause.html) _NOTE: In most places, they simply refer to this as `BSDL`, but in COPYING, they specifically say `2-clause BSDL`_
* PSF - [test-unit: PSFL](https://github.com/test-unit/test-unit/blob/3.5.5/PSFL), [SPDX: PSF-2.0](https://spdx.org/licenses/PSF-2.0.html) _Applies to a single file `lib/test/unit/diff.r`._

Statement in COPYING:

> You can redistribute it and/or modify it under either the terms of the2-clause BSDL (see the file BSDL), or the conditions below: _remainder of file is the Ruby license text_
> 
> Exceptions
> ----------
> * lib/test/unit/diff.rb: This license and PSF license

Statement in [lib/test/unit/diff.rb](https://github.com/test-unit/test-unit/blob/master/lib/test/unit/diff.rb)

> It is free software, and is distributed under (the new Ruby license or BSDL) and the PSF license.

### Summary

The statements in the various files referencing licensing leads to the expected license...

```
(BSD-2-Clause OR Ruby) AND Python-2.0.1
```

----

CC @kou 