### PR TITLE
Add MIT license to pythonnet_py35_dotnet NuGet package

### DIFF
--- a/curations/nuget/nuget/-/pythonnet_py35_dotnet.yaml
+++ b/curations/nuget/nuget/-/pythonnet_py35_dotnet.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pythonnet_py35_dotnet
+  provider: nuget
+  type: nuget
+revisions:
+  2.3.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add MIT license to pythonnet_py35_dotnet NuGet package

**Details:**
NuGet package pythonnet_py35_dotnet had an unassigned license.

**Resolution:**
Assigned the MIT license based on the NuGet page's (https://www.nuget.org/packages/pythonnet_py35_dotnet/) license link (https://github.com/pythonnet/pythonnet/blob/master/LICENSE) pointing to an MIT license.

**Affected definitions**:
- [pythonnet_py35_dotnet 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/pythonnet_py35_dotnet/2.3.0)