### PR TITLE
Declared license was Incorrect

### DIFF
--- a/curations/git/github/jooq/jooq.yaml
+++ b/curations/git/github/jooq/jooq.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jooq
+  namespace: jooq
+  provider: github
+  type: git
+revisions:
+  962cfecf363fda90646c415c53c4d00a36bb1049:
+    licensed:
+      declared: Apache-2.0

--- a/curations/git/github/jooq/jooq.yaml
+++ b/curations/git/github/jooq/jooq.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   962cfecf363fda90646c415c53c4d00a36bb1049:
     licensed:
-      declared: Apache-2.0
+      declared: Apache-2.0 OR OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license was Incorrect

**Details:**
Declared license was NOASSERTION

**Resolution:**
Updated the license as Apache 2.0 as per /LICENSE file

**Affected definitions**:
- [jooq 962cfecf363fda90646c415c53c4d00a36bb1049](https://clearlydefined.io/definitions/git/github/jooq/jooq/962cfecf363fda90646c415c53c4d00a36bb1049/962cfecf363fda90646c415c53c4d00a36bb1049)