### PR TITLE
add license for versions 1.0-1.6 for rubygems/-/msgpack

### DIFF
--- a/curations/gem/rubygems/-/msgpack.yaml
+++ b/curations/gem/rubygems/-/msgpack.yaml
@@ -6,12 +6,102 @@ revisions:
   1.0.0:
     licensed:
       declared: Apache-2.0
+  1.0.1:
+    licensed:
+      declared: Apache-2.0
+  1.0.2:
+    licensed:
+      declared: Apache-2.0
   1.0.3:
     licensed:
       declared: Apache-2.0
   1.1.0:
     licensed:
       declared: Apache-2.0
+  1.2.0:
+    licensed:
+      declared: Apache-2.0
+  1.2.1:
+    licensed:
+      declared: Apache-2.0
+  1.2.2:
+    licensed:
+      declared: Apache-2.0
+  1.2.3:
+    licensed:
+      declared: Apache-2.0
   1.2.4:
+    licensed:
+      declared: Apache-2.0
+  1.2.5:
+    licensed:
+      declared: Apache-2.0
+  1.2.6:
+    licensed:
+      declared: Apache-2.0
+  1.2.7:
+    licensed:
+      declared: Apache-2.0
+  1.2.8:
+    licensed:
+      declared: Apache-2.0
+  1.2.9:
+    licensed:
+      declared: Apache-2.0
+  1.2.10:
+    licensed:
+      declared: Apache-2.0
+  1.3.0:
+    licensed:
+      declared: Apache-2.0
+  1.3.1:
+    licensed:
+      declared: Apache-2.0
+  1.3.2:
+    licensed:
+      declared: Apache-2.0
+  1.3.3:
+    licensed:
+      declared: Apache-2.0
+  1.4.0:
+    licensed:
+      declared: Apache-2.0
+  1.4.1:
+    licensed:
+      declared: Apache-2.0
+  1.4.2:
+    licensed:
+      declared: Apache-2.0
+  1.4.3:
+    licensed:
+      declared: Apache-2.0
+  1.4.4:
+    licensed:
+      declared: Apache-2.0
+  1.4.5:
+    licensed:
+      declared: Apache-2.0
+  1.5.0:
+    licensed:
+      declared: Apache-2.0
+  1.5.1:
+    licensed:
+      declared: Apache-2.0
+  1.5.2:
+    licensed:
+      declared: Apache-2.0
+  1.5.3:
+    licensed:
+      declared: Apache-2.0
+  1.5.4:
+    licensed:
+      declared: Apache-2.0
+  1.5.5:
+    licensed:
+      declared: Apache-2.0
+  1.5.6:
+    licensed:
+      declared: Apache-2.0
+  1.6.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION
There were a few versions with the license data curated.  The LICENSE file was added 8 years ago defining the license to be Apache 2.0.  There have been no changes to the license.