### PR TITLE
add license for versions 1.38-1.39 of rubygems/-/rubocop

### DIFF
--- a/curations/gem/rubygems/-/rubocop.yaml
+++ b/curations/gem/rubygems/-/rubocop.yaml
@@ -1,0 +1,11 @@
+coordinates:
+  name: rubocop
+  provider: rubygems
+  type: gem
+revisions:
+  1.38.0
+    licensed:
+      declared: MIT
+  1.39.0
+    licensed:
+      declared: MIT

--- a/curations/gem/rubygems/-/rubocop.yaml
+++ b/curations/gem/rubygems/-/rubocop.yaml
@@ -3,9 +3,9 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
-  1.38.0
+  1.38.0:
     licensed:
       declared: MIT
-  1.39.0
+  1.39.0:
     licensed:
       declared: MIT


### PR DESCRIPTION
Earlier versions of rubocop return MIT license.  The two latest versions are not returning any license at all.

Side Question:

What is the expected turn around time from a new release (e.g. rubocop gem) in the package system (e.g. rubygems.org) to a license showing up in Clearly Defined?