### PR TITLE
Declared license was Incorrect

### DIFF
--- a/curations/git/github/javaee/hk2.yaml
+++ b/curations/git/github/javaee/hk2.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
   1083781a1fc8cca06a4550a61d9727cfb3e499dc:
     licensed:
- declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
   600bd7a8ca5648bb9318bab299606a3c60ff40d0:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/git/github/javaee/hk2.yaml
+++ b/curations/git/github/javaee/hk2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hk2
+  namespace: javaee
+  provider: github
+  type: git
+revisions:
+  1083781a1fc8cca06a4550a61d9727cfb3e499dc:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only

--- a/curations/git/github/javaee/hk2.yaml
+++ b/curations/git/github/javaee/hk2.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1083781a1fc8cca06a4550a61d9727cfb3e499dc:
     licensed:
-      declared: CDDL-1.1 OR GPL-2.0-only
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license was Incorrect

**Details:**
Declared License was NOASSERTION

**Resolution:**
Declared license is changed as "CDDL 1.1 or GPL 2.0 only"

**Affected definitions**:
- [hk2 1083781a1fc8cca06a4550a61d9727cfb3e499dc](https://clearlydefined.io/definitions/git/github/javaee/hk2/1083781a1fc8cca06a4550a61d9727cfb3e499dc/1083781a1fc8cca06a4550a61d9727cfb3e499dc)