### PR TITLE
Resolve Case of Incorrect License

### DIFF
--- a/curations/npm/npmjs/-/ui5-task-zipper.yaml
+++ b/curations/npm/npmjs/-/ui5-task-zipper.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ui5-task-zipper
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.4:
+    licensed:
+      declared: Apache-2.0 OR Beerware

--- a/curations/npm/npmjs/-/ui5-task-zipper.yaml
+++ b/curations/npm/npmjs/-/ui5-task-zipper.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.1.4:
     licensed:
-      declared: Apache-2.0 OR Beerware
+      declared: Apache-2.0 OR OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve Case of Incorrect License

**Details:**
The declared license is shown as Apache 2.0 only whereas the license information in source repo and readme file shows it is  dual licensed and can choose wither of Apache 2.0 or Beerware license.
Path :https://github.com/ui5-community/ui5-ecosystem-showcase/blob/ui5-task-zipper%400.1.4/LICENSE


**Resolution:**
The component is being curated as Apache 2.0 or Beerware license as per the information in the source repo license and read me file. Path :https://github.com/ui5-community/ui5-ecosystem-showcase/blob/ui5-task-zipper%400.1.4/README.md

**Affected definitions**:
- [ui5-task-zipper 0.1.4](https://clearlydefined.io/definitions/npm/npmjs/-/ui5-task-zipper/0.1.4/0.1.4)