### PR TITLE
Declared license is MIT

### DIFF
--- a/curations/git/github/edazdarevic/cidrutils.yaml
+++ b/curations/git/github/edazdarevic/cidrutils.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: cidrutils
+  namespace: edazdarevic
+  provider: github
+  type: git
+revisions:
+  b20614c147997bc0fb204cbba425be2d6811c0a8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license is MIT

**Details:**
No declared license identified here.

**Resolution:**
I checked the repository and the OS license for this is MIT

**Affected definitions**:
- [cidrutils b20614c147997bc0fb204cbba425be2d6811c0a8](https://clearlydefined.io/definitions/git/github/edazdarevic/cidrutils/b20614c147997bc0fb204cbba425be2d6811c0a8/b20614c147997bc0fb204cbba425be2d6811c0a8)