### PR TITLE
nokogiri 1.13.9

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -12,3 +12,6 @@ revisions:
   1.13.3:
     licensed:
       declared: MIT
+  1.13.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri 1.13.9

**Details:**
ClearlyDefined is picking up all the dependencies license info. 

**Resolution:**
This is just MIT

**Affected definitions**:
- [nokogiri 1.13.9](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.13.9/1.13.9)