### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/spring-projects/spring-boot.yaml
+++ b/curations/git/github/spring-projects/spring-boot.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: spring-boot
+  namespace: spring-projects
+  provider: github
+  type: git
+revisions:
+  c99c82a18ec0ed3051b65f1b5c25868ee4942a4e:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is SPDX mentioned whereas the license information is present in the source repo as Apache 2.0.
Path : https://github.com/spring-projects/spring-boot/blob/v2.3.4.RELEASE/LICENSE.txt

**Resolution:**
The component is being curated as Apache 2.0 instead of SPDX as per the license information provided in the license file of the source repository.
Path : https://github.com/spring-projects/spring-boot/blob/v2.3.4.RELEASE/LICENSE.txt

**Affected definitions**:
- [spring-boot c99c82a18ec0ed3051b65f1b5c25868ee4942a4e](https://clearlydefined.io/definitions/git/github/spring-projects/spring-boot/c99c82a18ec0ed3051b65f1b5c25868ee4942a4e/c99c82a18ec0ed3051b65f1b5c25868ee4942a4e)