### PR TITLE
Resolve Case of Incorrect License

### DIFF
--- a/curations/git/github/git/git.yaml
+++ b/curations/git/github/git/git.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   a42a58d7b62cc1d6301440e81a83feed9d7c118c:
     licensed:
-      declared: GPL-2.0-or-later AND LGPL-2.1-or-later
+      declared: GPL-2.0-only

--- a/curations/git/github/git/git.yaml
+++ b/curations/git/github/git/git.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: git
+  namespace: git
+  provider: github
+  type: git
+revisions:
+  a42a58d7b62cc1d6301440e81a83feed9d7c118c:
+    licensed:
+      declared: GPL-2.0-or-later AND LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve Case of Incorrect License

**Details:**
There are multiple GPL versions licensed specified in whereas the license information from source repo shows it is under GPL 2.0 or later and also LGPL 2.1 or later for some of the files and code.
Path : https://github.com/git/git/blob/v2.16.4/COPYING
https://github.com/git/git/blob/v2.16.4/LGPL-2.1

**Resolution:**
The component is being curated as GPL 2.0 or later AND LGPL 2.1 or later as per the information in the source repository.
Path : https://github.com/git/git/blob/v2.16.4/LGPL-2.1
https://github.com/git/git/blob/v2.16.4/COPYING

**Affected definitions**:
- [git a42a58d7b62cc1d6301440e81a83feed9d7c118c](https://clearlydefined.io/definitions/git/github/git/git/a42a58d7b62cc1d6301440e81a83feed9d7c118c/a42a58d7b62cc1d6301440e81a83feed9d7c118c)