### PR TITLE
com.google.android.gms/play-services-tagmanager-v4-impl18.0.2

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-v4-impl.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-v4-impl.yaml
@@ -10,3 +10,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  18.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.gms/play-services-tagmanager-v4-impl18.0.2

**Details:**
This is under the Android Software Dev Kit License, so should be curated OTHER

**Resolution:**
https://maven.google.com/web/index.html#com.google.android.gms:play-services-tagmanager-v4-impl:18.0.2

**Affected definitions**:
- [play-services-tagmanager-v4-impl 18.0.2](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-v4-impl/18.0.2/18.0.2)