### PR TITLE
Resolve Case of Incorrect License

### DIFF
--- a/curations/git/github/ckeditor/ckeditor-dev.yaml
+++ b/curations/git/github/ckeditor/ckeditor-dev.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   8a12b041718e05eeffb62a931d95995ac72cbe22:
     licensed:
-      declared: MPL-1.1
+      declared: GPL-2.0-or-later OR LGPL-2.1-or-later OR MPL-1.1

--- a/curations/git/github/ckeditor/ckeditor-dev.yaml
+++ b/curations/git/github/ckeditor/ckeditor-dev.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ckeditor-dev
+  namespace: ckeditor
+  provider: github
+  type: git
+revisions:
+  8a12b041718e05eeffb62a931d95995ac72cbe22:
+    licensed:
+      declared: MPL-1.1


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Resolve Case of Incorrect License

**Details:**
There is GPL AND LGPL AND MPL mentioned whereas the license file of the source repository says either of GPL or LGPL or MPL-1.1 can be chosen as the license.
Path : https://github.com/ckeditor/ckeditor4/blob/master/LICENSE.md

**Resolution:**
The component is being curated as MPL-1.1 instead of GPL AND LGPL AND MPL-1.1 as per the information given in license file of source repo.
Since we choose a lower risk license over high risk one it is being curated wih MPL-1.1.
Path : https://github.com/ckeditor/ckeditor4/blob/master/LICENSE.md

**Affected definitions**:
- [ckeditor-dev 8a12b041718e05eeffb62a931d95995ac72cbe22](https://clearlydefined.io/definitions/git/github/ckeditor/ckeditor-dev/8a12b041718e05eeffb62a931d95995ac72cbe22/8a12b041718e05eeffb62a931d95995ac72cbe22)