### PR TITLE
Add license

### DIFF
--- a/curations/nuget/nuget/-/BitFaster.Caching.yaml
+++ b/curations/nuget/nuget/-/BitFaster.Caching.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: BitFaster.Caching
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Add license

**Details:**
Did not detect license as MIT

**Resolution:**
Declared license as MIT

**Affected definitions**:
- [BitFaster.Caching 2.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/BitFaster.Caching/2.1.1/2.1.1)