### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/cran/crayon.yaml
+++ b/curations/git/github/cran/crayon.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: crayon
+  namespace: cran
+  provider: github
+  type: git
+revisions:
+  c1b2524e6e7d0e666e425d31424f772647ed4fab:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is SPDX mentioned whereas the license information is given as MIT+license file. But MIT is given in description file
path :https://github.com/cran/crayon/blob/1.3.4/DESCRIPTION

**Resolution:**
The component is being curated as MIT instead of SPDX since the license information is shown as MIT in description file.
Path :https://github.com/cran/crayon/blob/1.3.4/LICENSE
https://github.com/cran/crayon/blob/1.3.4/DESCRIPTION
https://github.com/r-lib/crayon#readme

**Affected definitions**:
- [crayon c1b2524e6e7d0e666e425d31424f772647ed4fab](https://clearlydefined.io/definitions/git/github/cran/crayon/c1b2524e6e7d0e666e425d31424f772647ed4fab/c1b2524e6e7d0e666e425d31424f772647ed4fab)