### PR TITLE
Declared license information missing

### DIFF
--- a/curations/git/github/fasterxml/jackson-dataformats-text.yaml
+++ b/curations/git/github/fasterxml/jackson-dataformats-text.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jackson-dataformats-text
+  namespace: fasterxml
+  provider: github
+  type: git
+revisions:
+  0cf35b4af00bbdacefbe3fb66173219e62fc80f9:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license information missing

**Details:**
Declared license information is missing.

**Resolution:**
Update declared license to Apache - https://github.com/FasterXML/jackson-dataformats-text/blob/0cf35b4af00bbdacefbe3fb66173219e62fc80f9/README.md#license

**Affected definitions**:
- [jackson-dataformats-text 0cf35b4af00bbdacefbe3fb66173219e62fc80f9](https://clearlydefined.io/definitions/git/github/fasterxml/jackson-dataformats-text/0cf35b4af00bbdacefbe3fb66173219e62fc80f9/0cf35b4af00bbdacefbe3fb66173219e62fc80f9)