### PR TITLE
Resolve Case of NOASSERTION

### DIFF
--- a/curations/nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL.yaml
+++ b/curations/nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.1.0:
+    licensed:
+      declared: PostgreSQL
   2.0.2:
     licensed:
       declared: PostgreSQL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of NOASSERTION

**Details:**
There is NOASSERTION mentioned whereas the license information is mentioned in the license file of source code repo as PostgreSQL.
Path :https://github.com/npgsql/efcore.pg/blob/main/LICENSE

**Resolution:**
The component is being curated as PostgreSQL instead of NOASSERTION as per the license information available in source code repo.
Path : https://github.com/npgsql/efcore.pg/blob/main/LICENSE

**Affected definitions**:
- [Npgsql.EntityFrameworkCore.PostgreSQL 1.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Npgsql.EntityFrameworkCore.PostgreSQL/1.1.0/1.1.0)