### PR TITLE
add Apache-2.0 license for earlier versions of msgpack

### DIFF
--- a/curations/gem/rubygems/-/msgpack.yaml
+++ b/curations/gem/rubygems/-/msgpack.yaml
@@ -3,6 +3,75 @@ coordinates:
   provider: rubygems
   type: gem
 revisions:
+  0.5.0:
+    licensed:
+      declared: Apache-2.0
+  0.5.1:
+    licensed:
+      declared: Apache-2.0
+  0.5.2:
+    licensed:
+      declared: Apache-2.0
+  0.5.3:
+    licensed:
+      declared: Apache-2.0
+  0.5.4:
+    licensed:
+      declared: Apache-2.0
+  0.5.5:
+    licensed:
+      declared: Apache-2.0
+  0.5.6:
+    licensed:
+      declared: Apache-2.0
+  0.5.7:
+    licensed:
+      declared: Apache-2.0
+  0.5.8:
+    licensed:
+      declared: Apache-2.0
+  0.5.9:
+    licensed:
+      declared: Apache-2.0
+  0.5.10:
+    licensed:
+      declared: Apache-2.0
+  0.5.11:
+    licensed:
+      declared: Apache-2.0
+  0.5.12:
+    licensed:
+      declared: Apache-2.0
+  0.6.0:
+    licensed:
+      declared: Apache-2.0
+  0.6.1:
+    licensed:
+      declared: Apache-2.0
+  0.6.2:
+    licensed:
+      declared: Apache-2.0
+  0.7.0:
+    licensed:
+      declared: Apache-2.0
+  0.7.1:
+    licensed:
+      declared: Apache-2.0
+  0.7.2:
+    licensed:
+      declared: Apache-2.0
+  0.7.3:
+    licensed:
+      declared: Apache-2.0
+  0.7.4:
+    licensed:
+      declared: Apache-2.0
+  0.7.5:
+    licensed:
+      declared: Apache-2.0
+  0.7.6:
+    licensed:
+      declared: Apache-2.0
   1.0.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION
The license has been declared as Apache-2.0 since v0.5.0.

* msgpack included the license in the README starting at v0.5.0
* msgpack added license to the gemspec starting at v0.5.6
* msgpack added a LICENSE file stating at v0.5.12