### PR TITLE
Resolve Case of SPDX License missing

### DIFF
--- a/curations/git/github/aws/aws-cli.yaml
+++ b/curations/git/github/aws/aws-cli.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: aws-cli
+  namespace: aws
+  provider: github
+  type: git
+revisions:
+  7e67308d07d06f89bc7b5dd0a5d3723aca18f724:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve Case of SPDX License missing

**Details:**
There is SPDX mentioned whereas the license information is given as Apache 2.0 in the source code repo.
Path : https://github.com/aws/aws-cli/blob/1.11.17/LICENSE.txt

**Resolution:**
The component is being curated as Apache 2.0 instead of SPDX as per the license information available in license file of source code repository.
Path :https://github.com/aws/aws-cli/blob/1.11.17/LICENSE.txt

**Affected definitions**:
- [aws-cli 7e67308d07d06f89bc7b5dd0a5d3723aca18f724](https://clearlydefined.io/definitions/git/github/aws/aws-cli/7e67308d07d06f89bc7b5dd0a5d3723aca18f724/7e67308d07d06f89bc7b5dd0a5d3723aca18f724)