### PR TITLE
LibGit2Sharp 0.27.0-preview-0156

### DIFF
--- a/curations/nuget/nuget/-/LibGit2Sharp.yaml
+++ b/curations/nuget/nuget/-/LibGit2Sharp.yaml
@@ -99,6 +99,9 @@ revisions:
   0.27.0-preview-0119:
     licensed:
       declared: MIT
+  0.27.0-preview-0156:
+    licensed:
+      declared: MIT
   0.27.0-preview-0158:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LibGit2Sharp 0.27.0-preview-0156

**Details:**
License link on NuGet package page links directly to the MIT license

**Resolution:**
MIT

**Affected definitions**:
- [LibGit2Sharp 0.27.0-preview-0156](https://clearlydefined.io/definitions/nuget/nuget/-/LibGit2Sharp/0.27.0-preview-0156/0.27.0-preview-0156)