### PR TITLE
add MIT license for version 1.0 of rubygems/-/hoe-gemspec

### DIFF
--- a/curations/gem/rubygems/-/hoe-gemspec.yaml
+++ b/curations/gem/rubygems/-/hoe-gemspec.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hoe-gemspec
+  provider: rubygems
+  type: gem
+revisions:
+  1.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
hoe-gemspec 1.0.0 is the only released version and was released 09-03-2010.  The MIT LICENSE file and the reference to MIT in the README were added in 2018. It appears that the authors intend for the license to be MIT but are not going to release the gem again just to update the license.

References:
* [rubygems.org/gems/hoe-gemspec](https://rubygems.org/gems/hoe-gemspec)
* [github.com/flavorjones/hoe-gemspec](https://github.com/flavorjones/hoe-gemspec)
    * [commit adding license](https://github.com/flavorjones/hoe-gemspec/commit/f225c132aacde3a8c0c5f10c414dd5e67e1d0e67)
