### PR TITLE
Declared License is wrong

### DIFF
--- a/curations/git/github/drupal/drupal.yaml
+++ b/curations/git/github/drupal/drupal.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: drupal
+  namespace: drupal
+  provider: github
+  type: git
+revisions:
+  62072493fa60368ebb9366bccaf7b5864e897eb8:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License is wrong

**Details:**
Declared license is MIT

**Resolution:**
Declared license should be GPL 2.0 only

**Affected definitions**:
- [drupal 62072493fa60368ebb9366bccaf7b5864e897eb8](https://clearlydefined.io/definitions/git/github/drupal/drupal/62072493fa60368ebb9366bccaf7b5864e897eb8/62072493fa60368ebb9366bccaf7b5864e897eb8)