### PR TITLE
com.google.android.play/core-common2.0.2

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.play/core-common.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/core-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: core-common
+  namespace: com.google.android.play
+  provider: mavengoogle
+  type: maven
+revisions:
+  2.0.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.play/core-common2.0.2

**Details:**
Should be OTHER for Play Core Software Development Kit Terms of Service

**Resolution:**
https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.play/core-common/2.0.2

**Affected definitions**:
- [core-common 2.0.2](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.play/core-common/2.0.2/2.0.2)