### PR TITLE
pillow9.4.0

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -33,3 +33,6 @@ revisions:
   9.3.0:
     licensed:
       declared: HPND
+  9.4.0:
+    licensed:
+      declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow9.4.0

**Details:**
Correcting Declared License to HPND

**Resolution:**
https://github.com/python-pillow/Pillow/blob/9.4.0/LICENSE

**Affected definitions**:
- [pillow 9.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/9.4.0/9.4.0)