### PR TITLE
pylint 2.15.5

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -15,6 +15,9 @@ revisions:
   2.15.3:
     licensed:
       declared: GPL-2.0-or-later
+  2.15.5:
+    licensed:
+      declared: GPL-2.0-or-later
   2.15.9:
     licensed:
       declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint 2.15.5

**Details:**
https://pypi.org/project/astroid/2.12.12/ states: LGPL-2.1-or-later

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [pylint 2.15.5](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/2.15.5/2.15.5)