### PR TITLE
astroid2.12.12

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -15,6 +15,9 @@ revisions:
   2.12.10:
     licensed:
       declared: LGPL-2.1-or-later
+  2.12.12:
+    licensed:
+      declared: LGPL-2.1-or-later
   2.12.13:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid2.12.12

**Details:**
https://pypi.org/project/astroid/2.12.12/ states: LGPL-2.1-or-later

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [astroid 2.12.12](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.12.12/2.12.12)