### PR TITLE
boost_thread-vc1421.78.0

### DIFF
--- a/curations/nuget/nuget/-/boost_thread-vc142.yaml
+++ b/curations/nuget/nuget/-/boost_thread-vc142.yaml
@@ -6,3 +6,6 @@ revisions:
   1.72.0:
     licensed:
       declared: Apache-2.0
+  1.78.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_thread-vc1421.78.0

**Details:**
ClearlyDefined downloaded package inidcates BSL-1.0

**Resolution:**
 BSL-1.0

**Affected definitions**:
- [boost_thread-vc142 1.78.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_thread-vc142/1.78.0/1.78.0)