### PR TITLE
boost_date_time-vc1421.78.0

### DIFF
--- a/curations/nuget/nuget/-/boost_date_time-vc142.yaml
+++ b/curations/nuget/nuget/-/boost_date_time-vc142.yaml
@@ -9,3 +9,6 @@ revisions:
   1.76.0:
     licensed:
       declared: BSL-1.0
+  1.78.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_date_time-vc1421.78.0

**Details:**
ClearlyDefined downloaded package license indicates BSL-1.0

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_date_time-vc142 1.78.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_date_time-vc142/1.78.0/1.78.0)