### PR TITLE
boost_chrono-vc1421.78.0

### DIFF
--- a/curations/nuget/nuget/-/boost_chrono-vc142.yaml
+++ b/curations/nuget/nuget/-/boost_chrono-vc142.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_chrono-vc142
+  provider: nuget
+  type: nuget
+revisions:
+  1.78.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_chrono-vc1421.78.0

**Details:**
ClearlyDefined downloaded license indicates BSL-1.0

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_chrono-vc142 1.78.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_chrono-vc142/1.78.0/1.78.0)