### PR TITLE
boost_timer-vc1421.78.0

### DIFF
--- a/curations/nuget/nuget/-/boost_timer-vc142.yaml
+++ b/curations/nuget/nuget/-/boost_timer-vc142.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_timer-vc142
+  provider: nuget
+  type: nuget
+revisions:
+  1.78.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Other

**Summary:**
boost_timer-vc1421.78.0

**Details:**
ClearlyDefined indicates GitHub: https://github.com/sergey-shandar/getboost/blob/master/LICENSE which is BSL-1.0


**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_timer-vc142 1.78.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_timer-vc142/1.78.0/1.78.0)