### PR TITLE
boost_log_setup-vc1421.78.0

### DIFF
--- a/curations/nuget/nuget/-/boost_log_setup-vc142.yaml
+++ b/curations/nuget/nuget/-/boost_log_setup-vc142.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_log_setup-vc142
+  provider: nuget
+  type: nuget
+revisions:
+  1.78.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
boost_log_setup-vc1421.78.0

**Details:**
Nuget license links is BSL-1.0: https://github.com/sergey-shandar/getboost/blob/master/LICENSE

**Resolution:**
BSL-1.0

**Affected definitions**:
- [boost_log_setup-vc142 1.78.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_log_setup-vc142/1.78.0/1.78.0)