### PR TITLE
io.undertow/undertow-servlet2.2.20.Final

### DIFF
--- a/curations/maven/mavencentral/io.undertow/undertow-servlet.yaml
+++ b/curations/maven/mavencentral/io.undertow/undertow-servlet.yaml
@@ -655,6 +655,9 @@ revisions:
   2.2.2.Final:
     licensed:
       declared: Apache-2.0
+  2.2.20.Final:
+    licensed:
+      declared: Apache-2.0
   2.2.3.Final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
io.undertow/undertow-servlet2.2.20.Final

**Details:**
Maven indicates Apache-2.0: https://repo1.maven.org/maven2/io/undertow/undertow-servlet/2.2.20.Final/undertow-servlet-2.2.20.Final.pom

GitHub indicates Apache-2.0: https://github.com/undertow-io/undertow/blob/d0d56e8fb30cb9e71b0fd64ee26e85b2314440c7/LICENSE.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [undertow-servlet 2.2.20.Final](https://clearlydefined.io/definitions/maven/mavencentral/io.undertow/undertow-servlet/2.2.20.Final/2.2.20.Final)