### PR TITLE
pulse1.0.0-alpha.5

### DIFF
--- a/curations/nuget/nuget/-/pulse.yaml
+++ b/curations/nuget/nuget/-/pulse.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pulse
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-alpha.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pulse1.0.0-alpha.5

**Details:**
ClearlyDefined licens is MIT: https://clearlydefined.io/file/eaee9b578caf72fc763f7ee1fd6f011f375ed4bdfb4966833bf5ff6fee0d2fe0

Nuget license is MIT: https://www.nuget.org/packages/pulse/1.0.0/License

**Resolution:**
MIT

**Affected definitions**:
- [pulse 1.0.0-alpha.5](https://clearlydefined.io/definitions/nuget/nuget/-/pulse/1.0.0-alpha.5/1.0.0-alpha.5)