### PR TITLE
pulse.prometheus1.0.0-alpha.3

### DIFF
--- a/curations/nuget/nuget/-/pulse.prometheus.yaml
+++ b/curations/nuget/nuget/-/pulse.prometheus.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pulse.prometheus
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.0-alpha.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
pulse.prometheus1.0.0-alpha.3

**Details:**
ClearlyDefined license is MIT: https://clearlydefined.io/file/d63f080569efd4ce3e67ae39a1af96da0143a7e21f53be1316fdd4de7fab217a

Nuget license is MIT: https://www.nuget.org/packages/pulse.prometheus/1.0.0/License

**Resolution:**
MIT

**Affected definitions**:
- [pulse.prometheus 1.0.0-alpha.3](https://clearlydefined.io/definitions/nuget/nuget/-/pulse.prometheus/1.0.0-alpha.3/1.0.0-alpha.3)