### PR TITLE
org.antlr/antlr-runtime3.1.3

### DIFF
--- a/curations/maven/mavencentral/org.antlr/antlr-runtime.yaml
+++ b/curations/maven/mavencentral/org.antlr/antlr-runtime.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  3.1.3:
+    licensed:
+      declared: BSD-3-Clause
   '3.3':
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.antlr/antlr-runtime3.1.3

**Details:**
Maven indicdates BSD: https://mvnrepository.com/artifact/org.antlr/antlr-runtime/3.5.3

ANTLR indicates: BSD-3-Clause https://www.antlr.org/license.html

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [antlr-runtime 3.1.3](https://clearlydefined.io/definitions/maven/mavencentral/org.antlr/antlr-runtime/3.1.3/3.1.3)