### PR TITLE
LGPL-3.0-or-later

### DIFF
--- a/curations/maven/mavencentral/org.jruby.extras/jffi.yaml
+++ b/curations/maven/mavencentral/org.jruby.extras/jffi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jffi
+  namespace: org.jruby.extras
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.1:
+    licensed:
+      declared: LGPL-3.0-or-later

--- a/curations/maven/mavencentral/org.jruby.extras/jffi.yaml
+++ b/curations/maven/mavencentral/org.jruby.extras/jffi.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.0.1:
     licensed:
-      declared: LGPL-3.0-or-later
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
LGPL-3.0-or-later

**Details:**
POM indicates GNU LGPLv3 and links to license: https://www.gnu.org/licenses/lgpl-3.0.txt

which is LGPL-3.0-or-later

**Resolution:**
LGPL-3.0-or-later

**Affected definitions**:
- [jffi 1.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.jruby.extras/jffi/1.0.1/1.0.1)