### PR TITLE
org.eclipse.persistence/eclipselink 2.7.10

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
+++ b/curations/maven/mavencentral/org.eclipse.persistence/eclipselink.yaml
@@ -10,3 +10,6 @@ revisions:
   2.6.4-RC1:
     licensed:
       declared: EPL-1.0 AND BSD-3-Clause
+  2.7.10:
+    licensed:
+      declared: EPL-2.0 OR BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.eclipse.persistence/eclipselink 2.7.10

**Details:**
Maven POM indicates: EPL-2.0 OR BSD-3-Clause
https://repo1.maven.org/maven2/org/eclipse/persistence/eclipselink/2.7.10/eclipselink-2.7.10.pom

**Resolution:**
EPL-2.0 OR BSD-3-Clause

**Affected definitions**:
- [eclipselink 2.7.10](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.persistence/eclipselink/2.7.10/2.7.10)