### PR TITLE
com.github.pagehelper/pagehelper 5.3.1

### DIFF
--- a/curations/maven/mavencentral/com.github.pagehelper/pagehelper.yaml
+++ b/curations/maven/mavencentral/com.github.pagehelper/pagehelper.yaml
@@ -7,3 +7,6 @@ revisions:
   5.1.0:
     licensed:
       declared: MIT
+  5.3.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.github.pagehelper/pagehelper 5.3.1

**Details:**
Pom indicates MIT: https://repo1.maven.org/maven2/com/github/pagehelper/pagehelper/5.3.1/pagehelper-5.3.1.pom

**Resolution:**
MIT

**Affected definitions**:
- [pagehelper 5.3.1](https://clearlydefined.io/definitions/maven/mavencentral/com.github.pagehelper/pagehelper/5.3.1/5.3.1)