### PR TITLE
org.jruby.extras/jaffl 0.5.1

### DIFF
--- a/curations/maven/mavencentral/org.jruby.extras/jaffl.yaml
+++ b/curations/maven/mavencentral/org.jruby.extras/jaffl.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   0.5.1:
     licensed:
-      declared: GPL-3.0-or-later
+      declared: LGPL-3.0-only

--- a/curations/maven/mavencentral/org.jruby.extras/jaffl.yaml
+++ b/curations/maven/mavencentral/org.jruby.extras/jaffl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jaffl
+  namespace: org.jruby.extras
+  provider: mavencentral
+  type: maven
+revisions:
+  0.5.1:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jruby.extras/jaffl 0.5.1

**Details:**
POM indicates GPL-3.0-or-later: https://www.gnu.org/licenses/lgpl-3.0.txt

**Resolution:**
GPL-3.0-or-later

**Affected definitions**:
- [jaffl 0.5.1](https://clearlydefined.io/definitions/maven/mavencentral/org.jruby.extras/jaffl/0.5.1/0.5.1)