### PR TITLE
Magick.NET-Q8-AnyCPU 7.9.0

### DIFF
--- a/curations/nuget/nuget/-/Magick.NET-Q8-AnyCPU.yaml
+++ b/curations/nuget/nuget/-/Magick.NET-Q8-AnyCPU.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Magick.NET-Q8-AnyCPU
+  provider: nuget
+  type: nuget
+revisions:
+  7.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Magick.NET-Q8-AnyCPU 7.9.0

**Details:**
Nuget indicates Apache-2.0: https://licenses.nuget.org/Apache-2.0
GitHub indicates: Apache-2.0: https://github.com/dlemstra/Magick.NET/blob/7.9.0.0/License.txt

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Magick.NET-Q8-AnyCPU 7.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/Magick.NET-Q8-AnyCPU/7.9.0/7.9.0)