### PR TITLE
org.jruby.extras/jnr-netdb0.4

### DIFF
--- a/curations/maven/mavencentral/org.jruby.extras/jnr-netdb.yaml
+++ b/curations/maven/mavencentral/org.jruby.extras/jnr-netdb.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '0.4':
     licensed:
-      declared: LGPL-3.0-or-later
+      declared: LGPL-3.0-only

--- a/curations/maven/mavencentral/org.jruby.extras/jnr-netdb.yaml
+++ b/curations/maven/mavencentral/org.jruby.extras/jnr-netdb.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jnr-netdb
+  namespace: org.jruby.extras
+  provider: mavencentral
+  type: maven
+revisions:
+  '0.4':
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jruby.extras/jnr-netdb0.4

**Details:**
Maven pom indicates: 
LGPL-3.0-or-later

https://repo1.maven.org/maven2/org/jruby/extras/jnr-netdb/0.4/jnr-netdb-0.4.pom

GIthub link broken

**Resolution:**
LGPL-3.0-or-later

**Affected definitions**:
- [jnr-netdb 0.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jruby.extras/jnr-netdb/0.4/0.4)