### PR TITLE
Emgu.CV 4.5.5.4823

### DIFF
--- a/curations/nuget/nuget/-/Emgu.CV.yaml
+++ b/curations/nuget/nuget/-/Emgu.CV.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.2.0.2721:
     licensed:
-      declared: GPL-3.0
+      declared: GPL-3.0-only
   4.4.0.4061:
     licensed:
       declared: GPL-3.0-only OR OTHER
@@ -20,7 +20,7 @@ revisions:
       declared: GPL-3.0-only OR OTHER
   4.5.5.4823:
     licensed:
-      declared: OTHER
+      declared: GPL-3.0-only OR OTHER
   4.6.0.5131:
     licensed:
       declared: GPL-3.0-only OR OTHER

--- a/curations/nuget/nuget/-/Emgu.CV.yaml
+++ b/curations/nuget/nuget/-/Emgu.CV.yaml
@@ -18,6 +18,9 @@ revisions:
   4.5.2.4673:
     licensed:
       declared: GPL-3.0-only OR OTHER
+  4.5.5.4823:
+    licensed:
+      declared: OTHER
   4.6.0.5131:
     licensed:
       declared: GPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Other

**Summary:**
Emgu.CV 4.5.5.4823

**Details:**
ClearlyDefined and Nuget both link to OTHER because he license is not an SPDX-identified license.  The readme indicates logic needs to be applied to decide on license: https://clearlydefined.io/file/99f716ddb96ceea2f4d3d2522709eab29c0a938f3e2e2e4385196dfe209026e1

https://www.nuget.org/packages/Emgu

**Resolution:**
OTHER

**Affected definitions**:
- [Emgu.CV 4.5.5.4823](https://clearlydefined.io/definitions/nuget/nuget/-/Emgu.CV/4.5.5.4823/4.5.5.4823)