### PR TITLE
Emgu.CV.Bitmap 4.5.5.4823

### DIFF
--- a/curations/nuget/nuget/-/Emgu.CV.Bitmap.yaml
+++ b/curations/nuget/nuget/-/Emgu.CV.Bitmap.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   4.5.5.4823:
     licensed:
-      declared: OTHER
+      declared: GPL-3.0-only OR OTHER
   4.6.0.5131:
     licensed:
       declared: GPL-3.0-only OR OTHER

--- a/curations/nuget/nuget/-/Emgu.CV.Bitmap.yaml
+++ b/curations/nuget/nuget/-/Emgu.CV.Bitmap.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  4.5.5.4823:
+    licensed:
+      declared: OTHER
   4.6.0.5131:
     licensed:
       declared: GPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Emgu.CV.Bitmap 4.5.5.4823

**Details:**
ClearlyDefined and Nuget both link to OTHER because he license is not an SPDX-identified license. The readme indicates logic needs to be applied to decide on license: https://www.nuget.org/packages/Emgu.CV.Bitmap/4.6.0.5131/License

https://clearlydefined.io/file/99f716ddb96ceea2f4d3d2522709eab29c0a

**Resolution:**
OTHER

**Affected definitions**:
- [Emgu.CV.Bitmap 4.5.5.4823](https://clearlydefined.io/definitions/nuget/nuget/-/Emgu.CV.Bitmap/4.5.5.4823/4.5.5.4823)