### PR TITLE
xunit.categories 2.0.6

### DIFF
--- a/curations/nuget/nuget/-/xunit.categories.yaml
+++ b/curations/nuget/nuget/-/xunit.categories.yaml
@@ -9,3 +9,6 @@ revisions:
   2.0.5:
     licensed:
       declared: Apache-2.0
+  2.0.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
xunit.categories 2.0.6

**Details:**
Github license is Apache-2.0: https://github.com/brendanconnolly/Xunit.Categories/blob/v2.0.6/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [xunit.categories 2.0.6](https://clearlydefined.io/definitions/nuget/nuget/-/xunit.categories/2.0.6/2.0.6)