### PR TITLE
Google.Api.Gax 4.1.1

### DIFF
--- a/curations/nuget/nuget/-/Google.Api.Gax.yaml
+++ b/curations/nuget/nuget/-/Google.Api.Gax.yaml
@@ -81,3 +81,6 @@ revisions:
   4.0.0:
     licensed:
       declared: BSD-3-Clause
+  4.1.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Api.Gax 4.1.1

**Details:**
ClearlyDefined license is BSD-3-Clause: 91fbc1a9b888a07fd788cd24faa60db542f981b56eabe72e4d6439488869c52a

Nuget license is BSD-3-Clause: https://www.nuget.org/packages/Google.Api.Gax/4.3.1/License

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [Google.Api.Gax 4.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Api.Gax/4.1.1/4.1.1)