### PR TITLE
confluent.libzstd.redist 1.3.8-g9f9630f4-test1

### DIFF
--- a/curations/nuget/nuget/-/confluent.libzstd.redist.yaml
+++ b/curations/nuget/nuget/-/confluent.libzstd.redist.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: confluent.libzstd.redist
+  provider: nuget
+  type: nuget
+revisions:
+  1.3.8-g9f9630f4-test1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
confluent.libzstd.redist 1.3.8-g9f9630f4-test1

**Details:**
ClearlyDefined license is BSD-3-Clause: https://clearlydefined.io/file/2c1a7fa704df8f3a606f6fc010b8b5aaebf403f3aeec339a12048f1ba7331a0b

Nuget links to Github license is BSD-3-Clause:  https://github.com/facebook/zstd/blob/dev/LICENSE

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [confluent.libzstd.redist 1.3.8-g9f9630f4-test1](https://clearlydefined.io/definitions/nuget/nuget/-/confluent.libzstd.redist/1.3.8-g9f9630f4-test1/1.3.8-g9f9630f4-test1)