### PR TITLE
PDFsharp-gdi 1.50.4845-rc2a

### DIFF
--- a/curations/nuget/nuget/-/PDFsharp-gdi.yaml
+++ b/curations/nuget/nuget/-/PDFsharp-gdi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: PDFsharp-gdi
+  provider: nuget
+  type: nuget
+revisions:
+  1.50.4845-rc2a:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
PDFsharp-gdi 1.50.4845-rc2a

**Details:**
Nuget license is MIT: http://www.pdfsharp.net/PDFsharp_License.ashx

**Resolution:**
MIT

**Affected definitions**:
- [PDFsharp-gdi 1.50.4845-rc2a](https://clearlydefined.io/definitions/nuget/nuget/-/PDFsharp-gdi/1.50.4845-rc2a/1.50.4845-rc2a)