### PR TITLE
DotNetty.Buffers-signed 0.3.2

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Buffers-signed.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Buffers-signed.yaml
@@ -6,3 +6,6 @@ revisions:
   0.2.3:
     licensed:
       declared: MIT
+  0.3.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetty.Buffers-signed 0.3.2

**Details:**
NuGet license links to MIT: https://github.com/Azure/DotNetty/blob/master/LICENSE.txt

GitHub license is MIT: https://github.com/Azure/DotNetty/blob/v0.3.2/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [DotNetty.Buffers-signed 0.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetty.Buffers-signed/0.3.2/0.3.2)