### PR TITLE
bootstrap 3.1.1

### DIFF
--- a/curations/nuget/nuget/-/bootstrap.yaml
+++ b/curations/nuget/nuget/-/bootstrap.yaml
@@ -15,6 +15,9 @@ revisions:
   3.1.0:
     licensed:
       declared: MIT
+  3.1.1:
+    licensed:
+      declared: MIT
   3.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
bootstrap 3.1.1

**Details:**
Nuget license links to MIT: https://licenses.nuget.org/MIT

Github links to MIT: https://github.com/twbs/bootstrap/blob/a365d8689c3f3cee7f1acf86b61270ecca8e106d/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [bootstrap 3.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/bootstrap/3.1.1/3.1.1)