### PR TITLE
CommandLineParser 212.1.0

### DIFF
--- a/curations/nuget/nuget/-/CommandLineParser21.yaml
+++ b/curations/nuget/nuget/-/CommandLineParser21.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CommandLineParser21
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommandLineParser 212.1.0

**Details:**
Nuget links to MIT: https://raw.githubusercontent.com/cosmo0/commandline/master/doc/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [CommandLineParser21 2.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLineParser21/2.1.0/2.1.0)