### PR TITLE
AdaptiveCards 3.0.0

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveCards.yaml
+++ b/curations/nuget/nuget/-/AdaptiveCards.yaml
@@ -54,3 +54,6 @@ revisions:
   2.7.3:
     licensed:
       declared: OTHER
+  3.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
AdaptiveCards 3.0.0

**Details:**
Nuget license links to: OTHER: https://www.nuget.org/packages/AdaptiveCards/3.0.0/License

**Resolution:**
OTHER

**Affected definitions**:
- [AdaptiveCards 3.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveCards/3.0.0/3.0.0)