### PR TITLE
Common.Logging.ApplicationInsights0170 3.4.1

### DIFF
--- a/curations/nuget/nuget/-/Common.Logging.ApplicationInsights0170.yaml
+++ b/curations/nuget/nuget/-/Common.Logging.ApplicationInsights0170.yaml
@@ -6,3 +6,6 @@ revisions:
   3.3.1:
     licensed:
       declared: Apache-2.0
+  3.4.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Common.Logging.ApplicationInsights0170 3.4.1

**Details:**
Nuget links to Apache-2.0: https://net-commons.github.io/common-logging/

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Common.Logging.ApplicationInsights0170 3.4.1](https://clearlydefined.io/definitions/nuget/nuget/-/Common.Logging.ApplicationInsights0170/3.4.1/3.4.1)