### PR TITLE
DotNetty.Handlers-signed 0.3.2

### DIFF
--- a/curations/nuget/nuget/-/DotNetty.Handlers-signed.yaml
+++ b/curations/nuget/nuget/-/DotNetty.Handlers-signed.yaml
@@ -6,3 +6,6 @@ revisions:
   0.2.3:
     licensed:
       declared: MIT
+  0.3.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DotNetty.Handlers-signed 0.3.2

**Details:**
Nuget license links to MIT: https://github.com/Azure/DotNetty/blob/master/LICENSE.txt

**Resolution:**
MIT

**Affected definitions**:
- [DotNetty.Handlers-signed 0.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/DotNetty.Handlers-signed/0.3.2/0.3.2)