### PR TITLE
EPPlus 3.1.3.3

### DIFF
--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   3.1.3.3:
     licensed:
-      declared: OTHER
+      declared: LGPL-2.1-or-later
   4.0.1.1:
     licensed:
       declared: LGPL-2.1-or-later

--- a/curations/nuget/nuget/-/EPPlus.yaml
+++ b/curations/nuget/nuget/-/EPPlus.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.1.3.3:
+    licensed:
+      declared: OTHER
   4.0.1.1:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
EPPlus 3.1.3.3

**Details:**
ClearlyDefined license file indicates OTHER

Nuget license links to OTHER: https://www.nuget.org/packages/EPPlus/6.1.2/License

**Resolution:**
OTHER

**Affected definitions**:
- [EPPlus 3.1.3.3](https://clearlydefined.io/definitions/nuget/nuget/-/EPPlus/3.1.3.3/3.1.3.3)