### PR TITLE
markdown-include0.8.0

### DIFF
--- a/curations/pypi/pypi/-/markdown-include.yaml
+++ b/curations/pypi/pypi/-/markdown-include.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: markdown-include
+  provider: pypi
+  type: pypi
+revisions:
+  0.8.0:
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
markdown-include0.8.0

**Details:**
Declaring GPL-3.0-only

**Resolution:**
https://github.com/cmacmackin/markdown-include/blob/v0.8.0/pyproject.toml

**Affected definitions**:
- [markdown-include 0.8.0](https://clearlydefined.io/definitions/pypi/pypi/-/markdown-include/0.8.0/0.8.0)