### PR TITLE
CommandLine 1.9.7

### DIFF
--- a/curations/nuget/nuget/-/CommandLine.yaml
+++ b/curations/nuget/nuget/-/CommandLine.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: CommandLine
+  provider: nuget
+  type: nuget
+revisions:
+  1.9.7:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
CommandLine 1.9.7

**Details:**
Nuget had broken GitHub link.  Located owner's repository on GitHub and license is MIT: https://github.com/commandlineparser/commandline/blob/master/License.md

**Resolution:**
MIT

**Affected definitions**:
- [CommandLine 1.9.7](https://clearlydefined.io/definitions/nuget/nuget/-/CommandLine/1.9.7/1.9.7)