### PR TITLE
Noksa.WebDriver.ScreenshotsExtensions 0.1.5.4

### DIFF
--- a/curations/nuget/nuget/-/Noksa.WebDriver.ScreenshotsExtensions.yaml
+++ b/curations/nuget/nuget/-/Noksa.WebDriver.ScreenshotsExtensions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Noksa.WebDriver.ScreenshotsExtensions
+  provider: nuget
+  type: nuget
+revisions:
+  0.1.5.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Noksa.WebDriver.ScreenshotsExtensions 0.1.5.4

**Details:**
Nuget links to Github source with MIT license: https://github.com/Noksa/WebDriver.Screenshots.Extensions/blob/0.1.5.4/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Noksa.WebDriver.ScreenshotsExtensions 0.1.5.4](https://clearlydefined.io/definitions/nuget/nuget/-/Noksa.WebDriver.ScreenshotsExtensions/0.1.5.4/0.1.5.4)