### PR TITLE
com.sun.jna/jna 3.0.9

### DIFF
--- a/curations/maven/mavencentral/com.sun.jna/jna.yaml
+++ b/curations/maven/mavencentral/com.sun.jna/jna.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jna
+  namespace: com.sun.jna
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.9:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.sun.jna/jna 3.0.9

**Details:**
Found reference to LGPL-2.0-or-later within file:  https://repo1.maven.org/maven2/com/sun/jna/jna/3.0.9/

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [jna 3.0.9](https://clearlydefined.io/definitions/maven/mavencentral/com.sun.jna/jna/3.0.9/3.0.9)