### PR TITLE
org.apache.axis/axis 1.4

### DIFF
--- a/curations/maven/mavencentral/org.apache.axis/axis.yaml
+++ b/curations/maven/mavencentral/org.apache.axis/axis.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: axis
+  namespace: org.apache.axis
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.4':
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.apache.axis/axis 1.4

**Details:**
Downloaded package and files include Apache-2.0 header: 

**Resolution:**
Apache-2.0

**Affected definitions**:
- [axis 1.4](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.axis/axis/1.4/1.4)