### PR TITLE
Baseline 3.2.2

### DIFF
--- a/curations/nuget/nuget/-/Baseline.yaml
+++ b/curations/nuget/nuget/-/Baseline.yaml
@@ -12,3 +12,6 @@ revisions:
   3.2.0:
     licensed:
       declared: Apache-2.0
+  3.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Baseline 3.2.2

**Details:**
Nuget license links is Apache-2.0: https://github.com/JasperFX/Baseline/blob/master/LICENSE
Source project has Apache-2.0 license: https://github.com/JasperFx/baseline/blob/v3.2.2/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Baseline 3.2.2](https://clearlydefined.io/definitions/nuget/nuget/-/Baseline/3.2.2/3.2.2)