### PR TITLE
javax.xml/jaxrpc-ap 1.1

### DIFF
--- a/curations/maven/mavencentral/javax.xml/jaxrpc-api.yaml
+++ b/curations/maven/mavencentral/javax.xml/jaxrpc-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jaxrpc-api
+  namespace: javax.xml
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.1':
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.xml/jaxrpc-ap 1.1

**Details:**
Downloaded package and could not find any license info
Maven pom had no license info

**Resolution:**
NONE

**Affected definitions**:
- [jaxrpc-api 1.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.xml/jaxrpc-api/1.1/1.1)