### PR TITLE
Rx-Core 2.0.21114

### DIFF
--- a/curations/nuget/nuget/-/Rx-Core.yaml
+++ b/curations/nuget/nuget/-/Rx-Core.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.21114:
+    licensed:
+      declared: MIT
   2.1.30204:
     licensed:
       declared: Apache-2.0

--- a/curations/nuget/nuget/-/Rx-Core.yaml
+++ b/curations/nuget/nuget/-/Rx-Core.yaml
@@ -5,7 +5,7 @@ coordinates:
 revisions:
   2.0.21114:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   2.1.30204:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Rx-Core 2.0.21114

**Details:**
Nuget license is MIT: https://github.com/dotnet/reactive/blob/main/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Rx-Core 2.0.21114](https://clearlydefined.io/definitions/nuget/nuget/-/Rx-Core/2.0.21114/2.0.21114)