### PR TITLE
Xamarin.Forms 2.3.2.127

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Forms.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Forms.yaml
@@ -15,6 +15,9 @@ revisions:
   2.3.1.114:
     licensed:
       declared: OTHER
+  2.3.2.127:
+    licensed:
+      declared: MIT
   2.3.3.175:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Xamarin.Forms 2.3.2.127

**Details:**
Nuget license link is MIT: https://licenses.nuget.org/MIT

**Resolution:**
MIT

**Affected definitions**:
- [Xamarin.Forms 2.3.2.127](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Forms/2.3.2.127/2.3.2.127)