### PR TITLE
Ninject.MVC 33.2.0

### DIFF
--- a/curations/nuget/nuget/-/Ninject.MVC3.yaml
+++ b/curations/nuget/nuget/-/Ninject.MVC3.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.2.0:
+    licensed:
+      declared: Apache-2.0 OR MS-PL
   3.2.1:
     licensed:
       declared: Apache-2.0 OR MS-PL


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Ninject.MVC 33.2.0

**Details:**
Github license is Apache-2.0 OR MS-PL: https://github.com/ninject/Ninject/blob/3.2.0-final/LICENSE.txt

**Resolution:**
Apache-2.0 OR MS-PL

**Affected definitions**:
- [Ninject.MVC3 3.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Ninject.MVC3/3.2.0/3.2.0)