### PR TITLE
com.hubspot.jinjava/jinjava 2.6.0

### DIFF
--- a/curations/maven/mavencentral/com.hubspot.jinjava/jinjava.yaml
+++ b/curations/maven/mavencentral/com.hubspot.jinjava/jinjava.yaml
@@ -7,3 +7,6 @@ revisions:
   2.5.6:
     licensed:
       declared: Apache-2.0
+  2.6.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
com.hubspot.jinjava/jinjava 2.6.0

**Details:**
GitHub license is Apache-2.0: https://github.com/HubSpot/jinjava/blob/jinjava-2.6.0/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jinjava 2.6.0](https://clearlydefined.io/definitions/maven/mavencentral/com.hubspot.jinjava/jinjava/2.6.0/2.6.0)