### PR TITLE
javax.xml.crypto/jsr105-api 1.0.1

### DIFF
--- a/curations/maven/mavencentral/javax.xml.crypto/jsr105-api.yaml
+++ b/curations/maven/mavencentral/javax.xml.crypto/jsr105-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsr105-api
+  namespace: javax.xml.crypto
+  provider: mavencentral
+  type: maven
+revisions:
+  1.0.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
javax.xml.crypto/jsr105-api 1.0.1

**Details:**
Maven includes Manifest that includes:  https://clearlydefined.io/definitions/maven/mavencentral/javax.xml.crypto/jsr105-api/1.0.1

**Resolution:**
Apache-2.0

**Affected definitions**:
- [jsr105-api 1.0.1](https://clearlydefined.io/definitions/maven/mavencentral/javax.xml.crypto/jsr105-api/1.0.1/1.0.1)