### PR TITLE
org.scala-lang/scala-compiler 2.12.7

### DIFF
--- a/curations/maven/mavencentral/org.scala-lang/scala-compiler.yaml
+++ b/curations/maven/mavencentral/org.scala-lang/scala-compiler.yaml
@@ -16,3 +16,6 @@ revisions:
   2.11.8:
     licensed:
       declared: BSD-3-Clause
+  2.12.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.scala-lang/scala-compiler 2.12.7

**Details:**
POM indicates BSD-3-Clause: https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.7/scala-compiler-2.12.7.pom

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [scala-compiler 2.12.7](https://clearlydefined.io/definitions/maven/mavencentral/org.scala-lang/scala-compiler/2.12.7/2.12.7)