### PR TITLE
StructureMap.Microsoft.DependencyInjection 1.3.0

### DIFF
--- a/curations/nuget/nuget/-/StructureMap.Microsoft.DependencyInjection.yaml
+++ b/curations/nuget/nuget/-/StructureMap.Microsoft.DependencyInjection.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.3.0:
+    licensed:
+      declared: MIT
   1.4.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StructureMap.Microsoft.DependencyInjection 1.3.0

**Details:**
Nuget license link is MIT: https://licenses.nuget.org/MIT

**Resolution:**
MIT

**Affected definitions**:
- [StructureMap.Microsoft.DependencyInjection 1.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/StructureMap.Microsoft.DependencyInjection/1.3.0/1.3.0)