### PR TITLE
HotChocolate.Abstractions 12.15.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Abstractions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Abstractions.yaml
@@ -30,6 +30,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.15.2:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Abstractions 12.15.2

**Details:**
Nuget license link is MIT: https://www.nuget.org/packages/HotChocolate.Abstractions/13.0.2/License

**Resolution:**
MIT

**Affected definitions**:
- [HotChocolate.Abstractions 12.15.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Abstractions/12.15.2/12.15.2)