### PR TITLE
MathNet.Numerics 3.13.1

### DIFF
--- a/curations/nuget/nuget/-/MathNet.Numerics.yaml
+++ b/curations/nuget/nuget/-/MathNet.Numerics.yaml
@@ -12,6 +12,9 @@ revisions:
   3.12.0:
     licensed:
       declared: MIT
+  3.13.1:
+    licensed:
+      declared: MIT
   3.17.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
MathNet.Numerics 3.13.1

**Details:**
Nuget license link is MIT: https://licenses.nuget.org/MIT

**Resolution:**
MIT

**Affected definitions**:
- [MathNet.Numerics 3.13.1](https://clearlydefined.io/definitions/nuget/nuget/-/MathNet.Numerics/3.13.1/3.13.1)