### PR TITLE
HotChocolate.Language.SyntaxTree 12.15.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
@@ -27,6 +27,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.15.2:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Language.SyntaxTree 12.15.2

**Details:**
Nuget license link is MIT: https://www.nuget.org/packages/HotChocolate.Language.SyntaxTree/13.0.2/License

**Resolution:**
MIT

**Affected definitions**:
- [HotChocolate.Language.SyntaxTree 12.15.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.SyntaxTree/12.15.2/12.15.2)