### PR TITLE
Newtonsoft.Json 4.5.7

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -54,6 +54,9 @@ revisions:
         url: 'https://github.com/jamesnk/newtonsoft.json/commit/9396ea0994fdfe0fae627b7e63924684ef6ede7f'
     licensed:
       declared: MIT
+  4.5.7:
+    licensed:
+      declared: MIT
   4.5.9:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Newtonsoft.Json 4.5.7

**Details:**
Nuget license link is MIT: https://licenses.nuget.org/MIT

**Resolution:**
MIT

**Affected definitions**:
- [Newtonsoft.Json 4.5.7](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.5.7/4.5.7)