### PR TITLE
StackExchange.Redis.StrongName 1.0.322

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -6,6 +6,9 @@ revisions:
   1.0.312:
     licensed:
       declared: MIT
+  1.0.322:
+    licensed:
+      declared: MIT
   1.0.330:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
StackExchange.Redis.StrongName 1.0.322

**Details:**
Nuget license link is MIT: https://raw.githubusercontent.com/StackExchange/StackExchange.Redis/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.0.322](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.0.322/1.0.322)