### PR TITLE
HotChocolate.Language 12.15.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.yaml
@@ -33,6 +33,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.15.2:
+    licensed:
+      declared: MIT
   12.16.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Language 12.15.2

**Details:**
Nuget license link is MIT: https://www.nuget.org/packages/HotChocolate.Language/13.0.2/License

**Resolution:**
MIT

**Affected definitions**:
- [HotChocolate.Language 12.15.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language/12.15.2/12.15.2)