### PR TITLE
Akka.Remote 1.4.33

### DIFF
--- a/curations/nuget/nuget/-/Akka.Remote.yaml
+++ b/curations/nuget/nuget/-/Akka.Remote.yaml
@@ -12,3 +12,6 @@ revisions:
   1.4.17:
     licensed:
       declared: Apache-2.0
+  1.4.33:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Remote 1.4.33

**Details:**
Nuget license link is Apache-2.0: https://github.com/akkadotnet/akka.net/blob/master/LICENSE

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Akka.Remote 1.4.33](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Remote/1.4.33/1.4.33)