### PR TITLE
Akka.Cluster 1.4.33

### DIFF
--- a/curations/nuget/nuget/-/Akka.Cluster.yaml
+++ b/curations/nuget/nuget/-/Akka.Cluster.yaml
@@ -15,3 +15,6 @@ revisions:
   1.4.17:
     licensed:
       declared: Apache-2.0
+  1.4.33:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Akka.Cluster 1.4.33

**Details:**
Nuget license link is MIT: https://github.com/akkadotnet/akka.net/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Akka.Cluster 1.4.33](https://clearlydefined.io/definitions/nuget/nuget/-/Akka.Cluster/1.4.33/1.4.33)