### PR TITLE
RichardSzalay.MockHttp 1.3.1

### DIFF
--- a/curations/nuget/nuget/-/RichardSzalay.MockHttp.yaml
+++ b/curations/nuget/nuget/-/RichardSzalay.MockHttp.yaml
@@ -9,6 +9,9 @@ revisions:
   1.2.2:
     licensed:
       declared: MIT
+  1.3.1:
+    licensed:
+      declared: MIT
   1.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
RichardSzalay.MockHttp 1.3.1

**Details:**
License links to MIT: https://github.com/richardszalay/mockhttp/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [RichardSzalay.MockHttp 1.3.1](https://clearlydefined.io/definitions/nuget/nuget/-/RichardSzalay.MockHttp/1.3.1/1.3.1)