### PR TITLE
HotChocolate.Language.Utf8 12.15.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.Utf8.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.Utf8.yaml
@@ -27,6 +27,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.15.2:
+    licensed:
+      declared: MIT
   12.16.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Language.Utf8 12.15.2

**Details:**
License links to MIT: https://www.nuget.org/packages/HotChocolate.Language.Utf8/13.0.2/License

**Resolution:**
MIT

**Affected definitions**:
- [HotChocolate.Language.Utf8 12.15.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.Utf8/12.15.2/12.15.2)