### PR TITLE
@ant-design/charts 0.9.13

### DIFF
--- a/curations/npm/npmjs/@ant-design/charts.yaml
+++ b/curations/npm/npmjs/@ant-design/charts.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: charts
+  namespace: '@ant-design'
+  provider: npmjs
+  type: npm
+revisions:
+  0.9.13:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ant-design/charts 0.9.13

**Details:**
NPM indicates MIT
Respository license is MIT: https://github.com/ant-design/ant-design-charts/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [charts 0.9.13](https://clearlydefined.io/definitions/npm/npmjs/@ant-design/charts/0.9.13/0.9.13)