### PR TITLE
HotChocolate.Language.Visitors 12.15.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.Visitors.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.Visitors.yaml
@@ -27,6 +27,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.15.2:
+    licensed:
+      declared: MIT
   12.16.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Language.Visitors 12.15.2

**Details:**
Nuget license link is MIT: https://www.nuget.org/packages/HotChocolate.Language.Visitors/13.0.2/License

**Resolution:**
MIT

**Affected definitions**:
- [HotChocolate.Language.Visitors 12.15.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.Visitors/12.15.2/12.15.2)