### PR TITLE
FluentValidation 8.2.3

### DIFF
--- a/curations/nuget/nuget/-/FluentValidation.yaml
+++ b/curations/nuget/nuget/-/FluentValidation.yaml
@@ -48,3 +48,6 @@ revisions:
   8.1.3:
     licensed:
       declared: Apache-2.0
+  8.2.3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FluentValidation 8.2.3

**Details:**
License link is Apache-2.0: https://licenses.nuget.org/Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [FluentValidation 8.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/FluentValidation/8.2.3/8.2.3)