### PR TITLE
nodeapp 1.0.0

### DIFF
--- a/curations/npm/npmjs/-/nodeapp.yaml
+++ b/curations/npm/npmjs/-/nodeapp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: nodeapp
+  provider: npmjs
+  type: npm
+revisions:
+  1.0.0:
+    licensed:
+      declared: BSD-2-Clause

--- a/curations/npm/npmjs/-/nodeapp.yaml
+++ b/curations/npm/npmjs/-/nodeapp.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.0.0:
     licensed:
-      declared: BSD-2-Clause
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
nodeapp 1.0.0

**Details:**
NPM indicates license is BSD

**Resolution:**
BSD-2-Clause

**Affected definitions**:
- [nodeapp 1.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/nodeapp/1.0.0/1.0.0)