### PR TITLE
org.jboss.marshalling/jboss-marshalling 1.3.14.GA

### DIFF
--- a/curations/maven/mavencentral/org.jboss.marshalling/jboss-marshalling.yaml
+++ b/curations/maven/mavencentral/org.jboss.marshalling/jboss-marshalling.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jboss-marshalling
+  namespace: org.jboss.marshalling
+  provider: mavencentral
+  type: maven
+revisions:
+  1.3.14.GA:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.jboss.marshalling/jboss-marshalling 1.3.14.GA

**Details:**
Maven: https://repo1.maven.org/maven2/org/jboss/marshalling/jboss-marshalling/1.3.14.GA/jboss-marshalling-1.3.14.GA.pom

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [jboss-marshalling 1.3.14.GA](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.marshalling/jboss-marshalling/1.3.14.GA/1.3.14.GA)