### PR TITLE
Emgu.runtime.windows.msvc.rt.x86 19.29.30138

### DIFF
--- a/curations/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x86.yaml
+++ b/curations/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x86.yaml
@@ -8,4 +8,4 @@ revisions:
       declared: GPL-3.0-only OR OTHER
   19.29.30138:
     licensed:
-      declared: MIT
+      declared: GPL-3.0-only OR OTHER

--- a/curations/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x86.yaml
+++ b/curations/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x86.yaml
@@ -6,3 +6,6 @@ revisions:
   19.29.30038.1:
     licensed:
       declared: GPL-3.0-only OR OTHER
+  19.29.30138:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Emgu.runtime.windows.msvc.rt.x86 19.29.30138

**Details:**
Nuget license is MIT: https://raw.githubusercontent.com/MiloszKrajewski/K4os.Hash.xxHash/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [Emgu.runtime.windows.msvc.rt.x86 19.29.30138](https://clearlydefined.io/definitions/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x86/19.29.30138/19.29.30138)