### PR TITLE
FreeSpire.XLS 7.9.1

### DIFF
--- a/curations/nuget/nuget/-/FreeSpire.XLS.yaml
+++ b/curations/nuget/nuget/-/FreeSpire.XLS.yaml
@@ -12,6 +12,9 @@ revisions:
   7.9.0:
     licensed:
       declared: OTHER
+  7.9.1:
+    licensed:
+      declared: OTHER
   9.10.11:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
FreeSpire.XLS 7.9.1

**Details:**
Nuget license is OTHER: https://www.nuget.org/packages/FreeSpire.XLS/12.7.0/License

**Resolution:**
OTHER

**Affected definitions**:
- [FreeSpire.XLS 7.9.1](https://clearlydefined.io/definitions/nuget/nuget/-/FreeSpire.XLS/7.9.1/7.9.1)