### PR TITLE
angular-ui-utils 0.1.1

### DIFF
--- a/curations/npm/npmjs/-/angular-ui-utils.yaml
+++ b/curations/npm/npmjs/-/angular-ui-utils.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: angular-ui-utils
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
angular-ui-utils 0.1.1

**Details:**
NPM license is MIT: https://github.com/angular-ui/ui-utils/blob/master/LICENSE

**Resolution:**
MIT

**Affected definitions**:
- [angular-ui-utils 0.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/angular-ui-utils/0.1.1/0.1.1)