### PR TITLE
Selenium.WebDriver.IEDriver 3.6.0

### DIFF
--- a/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
+++ b/curations/nuget/nuget/-/Selenium.WebDriver.IEDriver.yaml
@@ -53,6 +53,9 @@ revisions:
   3.5.1:
     licensed:
       declared: Unlicense
+  3.6.0:
+    licensed:
+      declared: Unlicense
   3.7.0:
     licensed:
       declared: Unlicense


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Selenium.WebDriver.IEDriver 3.6.0

**Details:**
Nuget license link is Unlicense: https://licenses.nuget.org/Unlicense

**Resolution:**
Unlicense

**Affected definitions**:
- [Selenium.WebDriver.IEDriver 3.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/Selenium.WebDriver.IEDriver/3.6.0/3.6.0)