### PR TITLE
Google.Cloud.SecurityCenter.V1 3.5.0

### DIFF
--- a/curations/nuget/nuget/-/Google.Cloud.SecurityCenter.V1.yaml
+++ b/curations/nuget/nuget/-/Google.Cloud.SecurityCenter.V1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google.Cloud.SecurityCenter.V1
+  provider: nuget
+  type: nuget
+revisions:
+  3.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Google.Cloud.SecurityCenter.V1 3.5.0

**Details:**
Nuget license is Apache-2.0: https://www.nuget.org/packages/Google.Cloud.SecurityCenter.V1/3.8.0/License

**Resolution:**
Apache-2.0

**Affected definitions**:
- [Google.Cloud.SecurityCenter.V1 3.5.0](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Cloud.SecurityCenter.V1/3.5.0/3.5.0)