### PR TITLE
Emgu.CV.runtime.windows 4.5.5.4823

### DIFF
--- a/curations/nuget/nuget/-/Emgu.CV.runtime.windows.yaml
+++ b/curations/nuget/nuget/-/Emgu.CV.runtime.windows.yaml
@@ -6,6 +6,9 @@ revisions:
   4.4.0.4099:
     licensed:
       declared: GPL-3.0-only OR OTHER
+  4.5.5.4823:
+    licensed:
+      declared: GPL-3.0-only OR OTHER
   4.6.0.5131:
     licensed:
       declared: GPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Emgu.CV.runtime.windows 4.5.5.4823

**Details:**
NuGet license and ClearlyDefined license file is GPL-3.0-only OR OTHER (for the commercial license option)

**Resolution:**
GPL-3.0-only OR OTHER

**Affected definitions**:
- [Emgu.CV.runtime.windows 4.5.5.4823](https://clearlydefined.io/definitions/nuget/nuget/-/Emgu.CV.runtime.windows/4.5.5.4823/4.5.5.4823)