### PR TITLE
Emgu.runtime.windows.msvc.rt.x64 19.29.30138

### DIFF
--- a/curations/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x64.yaml
+++ b/curations/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x64.yaml
@@ -6,3 +6,6 @@ revisions:
   19.29.30038.1:
     licensed:
       declared: GPL-3.0-only OR OTHER
+  19.29.30138:
+    licensed:
+      declared: LGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Emgu.runtime.windows.msvc.rt.x64 19.29.30138

**Details:**
NuGet license and ClearlyDefined license file is GPL-3.0-only OR OTHER (for the commercial license option). 

**Resolution:**
GPL-3.0-only OR OTHER

**Affected definitions**:
- [Emgu.runtime.windows.msvc.rt.x64 19.29.30138](https://clearlydefined.io/definitions/nuget/nuget/-/Emgu.runtime.windows.msvc.rt.x64/19.29.30138/19.29.30138)