### PR TITLE
Machado.Microsoft.TeamFoundation 12.0.0

### DIFF
--- a/curations/nuget/nuget/-/Machado.Microsoft.TeamFoundation.yaml
+++ b/curations/nuget/nuget/-/Machado.Microsoft.TeamFoundation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Machado.Microsoft.TeamFoundation
+  provider: nuget
+  type: nuget
+revisions:
+  12.0.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Machado.Microsoft.TeamFoundation 12.0.0

**Details:**
No license info found

**Resolution:**
NONE

**Affected definitions**:
- [Machado.Microsoft.TeamFoundation 12.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/Machado.Microsoft.TeamFoundation/12.0.0/12.0.0)