### PR TITLE
pyuwsgi 2.0.21

### DIFF
--- a/curations/pypi/pypi/-/pyuwsgi.yaml
+++ b/curations/pypi/pypi/-/pyuwsgi.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   2.0.21:
     licensed:
-      declared: GPL-2.0-only
+      declared: GPL-2.0-only WITH GCC-exception-2.0

--- a/curations/pypi/pypi/-/pyuwsgi.yaml
+++ b/curations/pypi/pypi/-/pyuwsgi.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pyuwsgi
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.21:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pyuwsgi 2.0.21

**Details:**
I think this meets the matching guidelines for WITH GCC Runtime Library exception 2.0.

**Resolution:**
Should be GPL-2.0-only WITH GCC Runtime Library exception 2.0

**Affected definitions**:
- [pyuwsgi 2.0.21](https://clearlydefined.io/definitions/pypi/pypi/-/pyuwsgi/2.0.21/2.0.21)