### PR TITLE
Add license curation for github.com/hhatto/gorst@v0.0.0-2018102913320…

### DIFF
--- a/curations/go/golang/github.com%2Fhhatto/gorst.yaml
+++ b/curations/go/golang/github.com%2Fhhatto/gorst.yaml
@@ -6,4 +6,9 @@ coordinates:
 revisions:
   v0.0.0-20181029133204-ca9f730cac5b:
     licensed:
-      declared: BSD-3-Clause AND (GPL-2.0-or-later OR MIT)
+      declared: GPL-2.0-or-later OR MIT
+    facets:
+      core:
+        discovered:
+          expressions:
+            - BSD-3-Clause

--- a/curations/go/golang/github.com%2Fhhatto/gorst.yaml
+++ b/curations/go/golang/github.com%2Fhhatto/gorst.yaml
@@ -7,4 +7,4 @@
     v0.0.0-20181029133204-ca9f730cac5b:
       licensed:
         declared:
-          - BSD-3-Clause
+          - BSD-3-Clause AND (GPL-2.0-or-later OR MIT)

--- a/curations/go/golang/github.com%2Fhhatto/gorst.yaml
+++ b/curations/go/golang/github.com%2Fhhatto/gorst.yaml
@@ -1,10 +1,9 @@
-- coordinates:
-    name: github.com/hhatto/gorst
-    namespace: github.com%2Fhhatto
-    provider: golang
-    type: go
-  revisions:
-    v0.0.0-20181029133204-ca9f730cac5b:
-      licensed:
-        declared:
-          - BSD-3-Clause AND (GPL-2.0-or-later OR MIT)
+coordinates:
+  name: github.com/hhatto/gorst
+  namespace: github.com%2Fhhatto
+  provider: golang
+  type: go
+revisions:
+  v0.0.0-20181029133204-ca9f730cac5b:
+    licensed:
+      declared: BSD-3-Clause AND (GPL-2.0-or-later OR MIT)

--- a/curations/go/golang/github.com%2Fhhatto/gorst.yaml
+++ b/curations/go/golang/github.com%2Fhhatto/gorst.yaml
@@ -1,0 +1,10 @@
+- coordinates:
+    name: github.com/hhatto/gorst
+    namespace: github.com%2Fhhatto
+    provider: golang
+    type: go
+  revisions:
+    v0.0.0-20181029133204-ca9f730cac5b:
+      licensed:
+        declared:
+          - BSD-3-Clause


### PR DESCRIPTION
Summary:
github.com/hhatto/gorst v0.0.0-20181029133204-ca9f730cac5b curation

Details:
github.com/hhatto/gorst is under BSD-3-Clause AND (GPL-2.0-or-later OR MIT) license for the v0.0.0-20181029133204-ca9f730cac5b version
Resolution:
https://github.com/hhatto/gorst/blob/ca9f730cac5b/LICENSE (as does the LICENSE on the master branch) says:
> peg-markdown is released under both the GPL and MIT licenses.
You may pick the license that best fits your needs.