### PR TITLE
Add license curation for chardet@5.1.0

### DIFF
--- a/curations/pypi/pypi/-/chardet.yaml
+++ b/curations/pypi/pypi/-/chardet.yaml
@@ -9,3 +9,6 @@ revisions:
   4.0.0:
     licensed:
       declared: LGPL-2.1-only
+  5.1.0:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION
Summary:
chardet 5.1.0 curation

Details:
chardet is under LGPL-2.1-only for the 5.1.0 version
Resolution:
LGPL license here: https://github.com/chardet/chardet/blob/8087f0015184cf9569d00970a2acf1e1d3e80feb/LICENSE