### PR TITLE
Microsoft.CodeCoverage/17.3.2 MIT license

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.CodeCoverage.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeCoverage.yaml
@@ -15,3 +15,6 @@ revisions:
   17.2.0:
     licensed:
       declared: OTHER
+  17.3.2:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.CodeCoverage.yaml
+++ b/curations/nuget/nuget/-/Microsoft.CodeCoverage.yaml
@@ -17,4 +17,4 @@ revisions:
       declared: OTHER
   17.3.2:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Microsoft.CodeCoverage/17.3.2 MIT license

**Details:**
Declare MIT license as present in repo root

**Resolution:**
Declares MIT license.

**Affected definitions**:
- [Microsoft.CodeCoverage 17.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.CodeCoverage/17.3.2/17.3.2)