### PR TITLE
Add metadata and license for microsoft.odata.edm

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
@@ -40,7 +40,7 @@ revisions:
         type: git
         url: 'https://github.com/odata/odata.net/commit/f3bf65a74a7ed4028ff8074ccae31e4c2019772d'
     licensed:
-      declared: CC-BY-3.0 AND MIT
+      declared: MIT
   7.2.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
+++ b/curations/nuget/nuget/-/Microsoft.OData.Edm.yaml
@@ -30,6 +30,17 @@ revisions:
   7.1.1:
     licensed:
       declared: MIT
+  7.12.5:
+    described:
+      sourceLocation:
+        name: odata.net
+        namespace: odata
+        provider: github
+        revision: f3bf65a74a7ed4028ff8074ccae31e4c2019772d
+        type: git
+        url: 'https://github.com/odata/odata.net/commit/f3bf65a74a7ed4028ff8074ccae31e4c2019772d'
+    licensed:
+      declared: CC-BY-3.0 AND MIT
   7.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add metadata and license for microsoft.odata.edm

**Details:**
Add missing license declaration and source tree link in github.

**Resolution:**
Adds missing repo link and license declaration.

**Affected definitions**:
- [Microsoft.OData.Edm 7.12.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.OData.Edm/7.12.5/7.12.5)