### PR TITLE
Complete metadata for microsoft.spatial

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Spatial.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Spatial.yaml
@@ -6,6 +6,17 @@ revisions:
   6.13.0:
     licensed:
       declared: MIT
+  7.12.5:
+    described:
+      sourceLocation:
+        name: odata.net
+        namespace: odata
+        provider: github
+        revision: f3bf65a74a7ed4028ff8074ccae31e4c2019772d
+        type: git
+        url: 'https://github.com/odata/odata.net/commit/f3bf65a74a7ed4028ff8074ccae31e4c2019772d'
+    licensed:
+      declared: CC-BY-3.0 AND MIT
   7.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Complete metadata for microsoft.spatial

**Details:**
added license and tag/repo link to metadata

**Resolution:**
added license and tag/repo link to metadata

**Affected definitions**:
- [Microsoft.Spatial 7.12.5](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Spatial/7.12.5/7.12.5)