### PR TITLE
HotChocolate.AspNetCore MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.AspNetCore.yaml
@@ -39,6 +39,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.AspNetCore MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license.

**Affected definitions**:
- [HotChocolate.AspNetCore 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.AspNetCore/12.18.0/12.18.0)