### PR TITLE
hotchocolate.types.offsetpagination MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.types.offsetpagination.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.types.offsetpagination.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.types.offsetpagination
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.types.offsetpagination MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.types.offsetpagination 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.types.offsetpagination/12.18.0/12.18.0)