### PR TITLE
hotchocolate.language.utf8 MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.language.utf8.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.language.utf8.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.language.utf8
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.language.utf8 MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.language.utf8 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.language.utf8/12.18.0/12.18.0)