### PR TITLE
hotchocolate.utilities MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.utilities.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.utilities.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.utilities
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.utilities MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.utilities 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.utilities/12.18.0/12.18.0)