### PR TITLE
hotchocolate.types.cursorpagination MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.types.cursorpagination.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.types.cursorpagination.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.types.cursorpagination
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.types.cursorpagination MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.types.cursorpagination 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.types.cursorpagination/12.18.0/12.18.0)