### PR TITLE
hotchocolate.fetching MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.fetching.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.fetching.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.fetching
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.fetching MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.fetching 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.fetching/12.18.0/12.18.0)