### PR TITLE
hotchocolate.language.visitors MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.language.visitors.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.language.visitors.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.language.visitors
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.language.visitors MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.language.visitors 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.language.visitors/12.18.0/12.18.0)