### PR TITLE
hotchocolate.subscriptions MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.subscriptions.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.subscriptions.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.subscriptions
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.subscriptions MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.subscriptions 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.subscriptions/12.18.0/12.18.0)