### PR TITLE
hotchocolate.language MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.language.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.language.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.language
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.language MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.language 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.language/12.18.0/12.18.0)