### PR TITLE
hotchocolate.aspnetcore.authorization MIT License

### DIFF
--- a/curations/nuget/nuget/-/hotchocolate.aspnetcore.authorization.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.aspnetcore.authorization.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: hotchocolate.aspnetcore.authorization
+  provider: nuget
+  type: nuget
+revisions:
+  12.18.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
hotchocolate.aspnetcore.authorization MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [hotchocolate.aspnetcore.authorization 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/hotchocolate.aspnetcore.authorization/12.18.0/12.18.0)