### PR TITLE
Delete hotchocolate.types.scalars.upload.yaml

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.Scalars.Upload.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.Scalars.Upload.yaml
@@ -27,6 +27,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT

--- a/curations/nuget/nuget/-/hotchocolate.types.scalars.upload.yaml
+++ b/curations/nuget/nuget/-/hotchocolate.types.scalars.upload.yaml
@@ -1,8 +1,0 @@
-coordinates:
-  name: hotchocolate.types.scalars.upload
-  provider: nuget
-  type: nuget
-revisions:
-  12.18.0:
-    licensed:
-      declared: MIT


### PR DESCRIPTION
Incorrect casing. Deleting file since file with correct casing already exists.