### PR TITLE
HotChocolate.Types.OffsetPagination MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.OffsetPagination.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.OffsetPagination.yaml
@@ -33,6 +33,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types.OffsetPagination MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Types.OffsetPagination 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.OffsetPagination/12.18.0/12.18.0)