### PR TITLE
HotChocolate.AspNetCore.Authorization MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.AspNetCore.Authorization.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.AspNetCore.Authorization.yaml
@@ -30,6 +30,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.AspNetCore.Authorization MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.AspNetCore.Authorization 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.AspNetCore.Authorization/12.18.0/12.18.0)