### PR TITLE
HotChocolate.Types.CursorPagination MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.CursorPagination.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.CursorPagination.yaml
@@ -30,6 +30,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types.CursorPagination MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Types.CursorPagination 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.CursorPagination/12.18.0/12.18.0)