### PR TITLE
GreenDonut MIT License

### DIFF
--- a/curations/nuget/nuget/-/GreenDonut.yaml
+++ b/curations/nuget/nuget/-/GreenDonut.yaml
@@ -39,6 +39,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
GreenDonut MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [GreenDonut 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/GreenDonut/12.18.0/12.18.0)