### PR TITLE
HotChocolate.Language MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.yaml
@@ -39,6 +39,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Language MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Language 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language/12.18.0/12.18.0)