### PR TITLE
HotChocolate.Utilities MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Utilities.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Utilities.yaml
@@ -30,6 +30,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Utilities MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Utilities 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Utilities/12.18.0/12.18.0)