### PR TITLE
HotChocolate.Abstractions MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Abstractions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Abstractions.yaml
@@ -36,6 +36,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Abstractions MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Abstractions 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Abstractions/12.18.0/12.18.0)