### PR TITLE
HotChocolate.Types.Mutations MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
@@ -15,6 +15,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types.Mutations MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Types.Mutations 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.Mutations/12.18.0/12.18.0)