### PR TITLE
HotChocolate.Fetching MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
@@ -27,6 +27,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Fetching MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Fetching 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Fetching/12.18.0/12.18.0)