### PR TITLE
HotChocolate.Language.SyntaxTree MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
@@ -30,6 +30,9 @@ revisions:
   12.15.2:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Language.SyntaxTree MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Language.SyntaxTree 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.SyntaxTree/12.18.0/12.18.0)