### PR TITLE
HotChocolate.Utilities.Introspection MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Utilities.Introspection.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Utilities.Introspection.yaml
@@ -27,6 +27,9 @@ revisions:
   12.15.1:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Utilities.Introspection MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Utilities.Introspection 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Utilities.Introspection/12.18.0/12.18.0)