### PR TITLE
HotChocolate.Language.Visitors MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.Visitors.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.Visitors.yaml
@@ -33,6 +33,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.4.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Language.Visitors MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Language.Visitors 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.Visitors/12.18.0/12.18.0)