### PR TITLE
HotChocolate.Subscriptions MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Subscriptions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Subscriptions.yaml
@@ -33,6 +33,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Subscriptions MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Subscriptions 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Subscriptions/12.18.0/12.18.0)