### PR TITLE
HotChocolate.Subscriptions.InMemory MIT License

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Subscriptions.InMemory.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Subscriptions.InMemory.yaml
@@ -33,6 +33,9 @@ revisions:
   12.16.0:
     licensed:
       declared: MIT
+  12.18.0:
+    licensed:
+      declared: MIT
   12.6.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Subscriptions.InMemory MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo

**Resolution:**
Declare MIT license

**Affected definitions**:
- [HotChocolate.Subscriptions.InMemory 12.18.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Subscriptions.InMemory/12.18.0/12.18.0)