### PR TITLE
Microsoft.Data.SqlClient.SNI.runtime MIT License

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
@@ -9,3 +9,6 @@ revisions:
   2.1.1:
     licensed:
       declared: OTHER
+  5.1.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
@@ -11,4 +11,4 @@ revisions:
       declared: OTHER
   5.1.0:
     licensed:
-      declared: MIT
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Data.SqlClient.SNI.runtime MIT License

**Details:**
Add MIT license per Nuget and GitHub Repo https://github.com/dotnet/SqlClient/blob/main/LICENSE

**Resolution:**
Declare MIT license

**Affected definitions**:
- [Microsoft.Data.SqlClient.SNI.runtime 5.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime/5.1.0/5.1.0)