### PR TITLE
com.google.android.play/review-ktx2.0.1

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.play/review-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/review-ktx.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.0:
     licensed:
       declared: OTHER
+  2.0.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.play/review-ktx2.0.1

**Details:**
Non-oss license - see https://maven.google.com/web/index.html#com.google.android.play:review-ktx:2.0.1

**Resolution:**
OTHER

**Affected definitions**:
- [review-ktx 2.0.1](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.play/review-ktx/2.0.1/2.0.1)