### PR TITLE
Microsoft.Data.SqlClient.SNI.runtime Adding GitHub source

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime.yaml
@@ -9,6 +9,15 @@ revisions:
   2.1.1:
     licensed:
       declared: OTHER
+  5.0.1:
+    described:
+      sourceLocation:
+        name: sqlclient
+        namespace: dotnet
+        provider: github
+        revision: 711b72cd2579dd3f84d4e2e2825229ede5fe5fbd
+        type: git
+        url: 'https://github.com/dotnet/sqlclient/commit/711b72cd2579dd3f84d4e2e2825229ede5fe5fbd'
   5.1.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Microsoft.Data.SqlClient.SNI.runtime Adding GitHub source

**Details:**
Adding GitHub source of sqlclient.sni.runtime package.

**Resolution:**
Adds github link to source.

**Affected definitions**:
- [Microsoft.Data.SqlClient.SNI.runtime 5.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.runtime/5.0.1/5.0.1)