### PR TITLE
Declared License was ambiguous.

### DIFF
--- a/curations/git/github/golang/go.yaml
+++ b/curations/git/github/golang/go.yaml
@@ -7,6 +7,9 @@ revisions:
   a5bfd9da1d1b24f326399b6b75558ded14514f23:
     licensed:
       declared: BSD-3-Clause AND OTHER
+  de4748c47c67392a57f250714509f590f68ad395:
+    licensed:
+      declared: BSD-3-Clause
   eab99a8d548f8ba864647ab171a44f0a5376a6b3:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Ambiguous

**Summary:**
Declared License was ambiguous.

**Details:**
Declared license was ambiguous although the license mentioned in source code repository is clear.

**Resolution:**
Updated the license since the license is BSD 3-Clause only (see https://github.com/golang/go/blob/de4748c47c67392a57f250714509f590f68ad395/LICENSE).

**Affected definitions**:
- [go de4748c47c67392a57f250714509f590f68ad395](https://clearlydefined.io/definitions/git/github/golang/go/de4748c47c67392a57f250714509f590f68ad395/de4748c47c67392a57f250714509f590f68ad395)