### PR TITLE
Update ag-grid server-side-row-model license

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/server-side-row-model.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/server-side-row-model.yaml
@@ -46,3 +46,6 @@ revisions:
   28.2.1:
     licensed:
       declared: OTHER
+  29.0.0:
+    licensed:
+      declared: OTHER+

--- a/curations/npm/npmjs/@ag-grid-enterprise/server-side-row-model.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/server-side-row-model.yaml
@@ -48,4 +48,4 @@ revisions:
       declared: OTHER
   29.0.0:
     licensed:
-      declared: OTHER+
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Update ag-grid server-side-row-model license

**Details:**
License is not set.

**Resolution:**
Resolves issues with Notice generation for this component.

**Affected definitions**:
- [server-side-row-model 29.0.0](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/server-side-row-model/29.0.0/29.0.0)