### PR TITLE
Manual creation of the @ag-grid-community/styles.yaml

### DIFF
--- a/curations/npm/npmjs/@ag-grid-community/styles.yaml
+++ b/curations/npm/npmjs/@ag-grid-community/styles.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: styles
+  namespace: '@ag-grid-community'
+  provider: npmjs
+  type: npm
+revisions:
+  29.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
ClearlyDefinied.io cannot harvest this information and adding a new version does not enable the contribute button so the tool cannot be used for this specific package. Related to this issue https://github.com/clearlydefined/service/issues/981. MIT License is referenced here: https://github.com/ag-grid/ag-grid/tree/latest/grid-community-modules/styles