### PR TITLE
DPDK-stable

### DIFF
--- a/curations/git/github/dpdk/dpdk-stable.yaml
+++ b/curations/git/github/dpdk/dpdk-stable.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dpdk-stable
+  namespace: dpdk
+  provider: github
+  type: git
+revisions:
+  7bcd45ce824d0ea2a9f30d16855613a93521851b:
+    licensed:
+      declared: BSD-3-Clause AND GPL-2.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
DPDK-stable

**Details:**
Add license as BSD-3-Clause AND GPL-2.0-only

**Resolution:**
https://github.com/DPDK/dpdk-stable/tree/v21.11.2/license

**Affected definitions**:
- [dpdk-stable 7bcd45ce824d0ea2a9f30d16855613a93521851b](https://clearlydefined.io/definitions/git/github/dpdk/dpdk-stable/7bcd45ce824d0ea2a9f30d16855613a93521851b/7bcd45ce824d0ea2a9f30d16855613a93521851b)