### PR TITLE
Source location was missing.

### DIFF
--- a/curations/sourcearchive/mavencentral/org.springframework.boot/spring-boot-starter-actuator.yaml
+++ b/curations/sourcearchive/mavencentral/org.springframework.boot/spring-boot-starter-actuator.yaml
@@ -1,0 +1,15 @@
+coordinates:
+  name: spring-boot-starter-actuator
+  namespace: org.springframework.boot
+  provider: mavencentral
+  type: sourcearchive
+revisions:
+  2.7.3:
+    described:
+      sourceLocation:
+        name: spring-boot
+        namespace: spring-projects
+        provider: github
+        revision: bff9b3924ffb042c67612d8617110edd6f680917
+        type: git
+        url: 'https://github.com/spring-projects/spring-boot/commit/bff9b3924ffb042c67612d8617110edd6f680917'


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Source location was missing.

**Details:**
Source location was missing.

**Resolution:**
Updated the correct homepage.

**Affected definitions**:
- [spring-boot-starter-actuator 2.7.3](https://clearlydefined.io/definitions/sourcearchive/mavencentral/org.springframework.boot/spring-boot-starter-actuator/2.7.3/2.7.3)