### PR TITLE
Declared license information missing

### DIFF
--- a/curations/git/github/mapstruct/mapstruct.yaml
+++ b/curations/git/github/mapstruct/mapstruct.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mapstruct
+  namespace: mapstruct
+  provider: github
+  type: git
+revisions:
+  19973ff818e20531cbd81e5048404fd48c3c7508:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license information missing

**Details:**
The declared license information was missing. It is released under Apache 2.0 which can be confirmed by the below link
https://github.com/mapstruct/mapstruct/blob/19973ff818e20531cbd81e5048404fd48c3c7508/LICENSE.txt

**Resolution:**
The declared license information is updated to Apache 2.0

**Affected definitions**:
- [mapstruct 19973ff818e20531cbd81e5048404fd48c3c7508](https://clearlydefined.io/definitions/git/github/mapstruct/mapstruct/19973ff818e20531cbd81e5048404fd48c3c7508/19973ff818e20531cbd81e5048404fd48c3c7508)