### PR TITLE
Declared license information was marked as NO ASSERTION

### DIFF
--- a/curations/git/github/eclipse-ee4j/metro-jax-ws.yaml
+++ b/curations/git/github/eclipse-ee4j/metro-jax-ws.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: metro-jax-ws
+  namespace: eclipse-ee4j
+  provider: github
+  type: git
+revisions:
+  7ddc91f783bd3c2d5a5365f7fd2ee1bf47c31cb0:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared license information was marked as NO ASSERTION

**Details:**
The declared license information is updated according to https://github.com/eclipse-ee4j/metro-jax-ws/blob/7ddc91f783bd3c2d5a5365f7fd2ee1bf47c31cb0/LICENSE.md

**Resolution:**
Declared license information updated,.

**Affected definitions**:
- [metro-jax-ws 7ddc91f783bd3c2d5a5365f7fd2ee1bf47c31cb0](https://clearlydefined.io/definitions/git/github/eclipse-ee4j/metro-jax-ws/7ddc91f783bd3c2d5a5365f7fd2ee1bf47c31cb0/7ddc91f783bd3c2d5a5365f7fd2ee1bf47c31cb0)