### PR TITLE
Fix license type

### DIFF
--- a/curations/git/github/microsoft/plcrashreporter.yaml
+++ b/curations/git/github/microsoft/plcrashreporter.yaml
@@ -18,7 +18,7 @@ revisions:
       declared: MIT
   cfa78077d4ee2b363b60ce03948026b6c4ca1033:
     licensed:
-      declared: MIT
+      declared: Apache-2.0
   d747ab5de269cd44022bbe96ff9609d8626694ab:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Fix license type

**Details:**
From the license file, it's under Apache 2.0 instead of MIT

**Resolution:**
Change the type from MIT to Apache 2.9

**Affected definitions**:
- [plcrashreporter cfa78077d4ee2b363b60ce03948026b6c4ca1033](https://clearlydefined.io/definitions/git/github/microsoft/plcrashreporter/cfa78077d4ee2b363b60ce03948026b6c4ca1033/cfa78077d4ee2b363b60ce03948026b6c4ca1033)