### PR TITLE
Add license curation for pillow

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -36,3 +36,6 @@ revisions:
   9.4.0:
     licensed:
       declared: HPND
+  9.5.0:
+    licensed:
+      declared: HPND


### PR DESCRIPTION
Summary:
pillow 9.5.0 curation

Details:
pillow is under HPND for the 9.5.0 version(s)
Resolution:
https://github.com/python-pillow/Pillow/blob/main/LICENSE