### PR TITLE
AdaptiveCards.Templating1.3.2

### DIFF
--- a/curations/nuget/nuget/-/AdaptiveCards.Templating.yaml
+++ b/curations/nuget/nuget/-/AdaptiveCards.Templating.yaml
@@ -12,3 +12,6 @@ revisions:
   1.3.1:
     licensed:
       declared: OTHER
+  1.3.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
AdaptiveCards.Templating1.3.2

**Details:**
Declaring OTHER for EULA

**Resolution:**
NuGet Gallery | License of AdaptiveCards.Templating 1.3.2

**Affected definitions**:
- [AdaptiveCards.Templating 1.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/AdaptiveCards.Templating/1.3.2/1.3.2)