### PR TITLE
nokogiri 1.14.2

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -15,3 +15,6 @@ revisions:
   1.13.9:
     licensed:
       declared: MIT
+  1.14.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri 1.14.2

**Details:**
The declared license looks like MIT

**Resolution:**
MIT

**Affected definitions**:
- [nokogiri 1.14.2](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.14.2/1.14.2)