### PR TITLE
Declared license information missing

### DIFF
--- a/curations/git/github/kentfredric/html-tree.yaml
+++ b/curations/git/github/kentfredric/html-tree.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: html-tree
+  namespace: kentfredric
+  provider: github
+  type: git
+revisions:
+  6ba11171c101895347c5584b5c3b20c4ee0161e2:
+    licensed:
+      declared: Artistic-1.0-Perl OR GPL-1.0-or-later


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared license information missing

**Details:**
This component is released under Perl license which is Artistic license or GPL 1.0 or later.
https://github.com/kentfredric/HTML-Tree/blob/5.07/README.md
https://metacpan.org/pod/HTML::Tree

**Resolution:**
Declared license updated.

**Affected definitions**:
- [html-tree 6ba11171c101895347c5584b5c3b20c4ee0161e2](https://clearlydefined.io/definitions/git/github/kentfredric/html-tree/6ba11171c101895347c5584b5c3b20c4ee0161e2/6ba11171c101895347c5584b5c3b20c4ee0161e2)