### PR TITLE
Update junit-jupiter-engine.yaml

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -67,3 +67,6 @@ revisions:
   5.9.1:
     licensed:
       declared: EPL-2.0
+  5.9.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION
Type: Missing

Summary:
org.junit.jupiter:junit-jupiter-engine 5.9.2

Details:
Add EPL-2.0 License

Resolution:
License Url:
https://github.com/junit-team/junit5/blob/r5.9.2/LICENSE.md

Description:

Add license information for org.junit.jupiter:junit-jupiter-engine 5.9.2

Affected definitions:

https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.9.2