### PR TITLE
Add license for junit-jupiter 5.9.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -40,3 +40,6 @@ revisions:
   5.9.1:
     licensed:
       declared: EPL-2.0
+  5.9.2:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Add license for junit-jupiter 5.9.2

**Details:**
Add EPL-2.0 License

**Resolution:**
License Url:
https://github.com/junit-team/junit5/blob/r5.9.2/LICENSE.md

**Affected definitions**:
- [junit-jupiter 5.9.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.9.2/5.9.2)