### PR TITLE
Declared License is inappropriate

### DIFF
--- a/curations/git/github/setasign/fpdf.yaml
+++ b/curations/git/github/setasign/fpdf.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: fpdf
+  namespace: setasign
+  provider: github
+  type: git
+revisions:
+  f4104a04c9a3f95c4c26a0a0531abebcc980987a:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Declared License is inappropriate

**Details:**
Declared license looks like but is not MIT license.

**Resolution:**
Updated the license as per https://github.com/Setasign/FPDF/blob/1.8.5/license.txt. The license is a permissive one but it is not exactly same as the MIT license even if the composer.json file mentions (see http://www.fpdf.org/en/FAQ.php#q1).

**Affected definitions**:
- [fpdf f4104a04c9a3f95c4c26a0a0531abebcc980987a](https://clearlydefined.io/definitions/git/github/setasign/fpdf/f4104a04c9a3f95c4c26a0a0531abebcc980987a/f4104a04c9a3f95c4c26a0a0531abebcc980987a)