### PR TITLE
Declared License is missing

### DIFF
--- a/curations/git/github/scikit-image/scikit-image.yaml
+++ b/curations/git/github/scikit-image/scikit-image.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   5e74a4a3a5149a8a14566b81a32bb15499aa3857:
     licensed:
-      declared: BSD-3-Clause AND BSD-2-Clause AND MIT AND OTHER
+      declared: BSD-3-Clause

--- a/curations/git/github/scikit-image/scikit-image.yaml
+++ b/curations/git/github/scikit-image/scikit-image.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: scikit-image
+  namespace: scikit-image
+  provider: github
+  type: git
+revisions:
+  5e74a4a3a5149a8a14566b81a32bb15499aa3857:
+    licensed:
+      declared: BSD-3-Clause AND BSD-2-Clause AND MIT AND OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Declared License is missing

**Details:**
Declared license was missing.

**Resolution:**
Updated the declared license as per https://github.com/scikit-image/scikit-image/blob/v0.20.0/LICENSE.txt.

**Affected definitions**:
- [scikit-image 5e74a4a3a5149a8a14566b81a32bb15499aa3857](https://clearlydefined.io/definitions/git/github/scikit-image/scikit-image/5e74a4a3a5149a8a14566b81a32bb15499aa3857/5e74a4a3a5149a8a14566b81a32bb15499aa3857)