### PR TITLE
com.google.guava/guava - v31.1

### DIFF
--- a/curations/maven/mavencentral/com.google.guava/guava.yml
+++ b/curations/maven/mavencentral/com.google.guava/guava.yml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
-  31.1:
+  31.1-jre:
+    licensed:
+      declared: Apache-2.0
+  31.1-android:
     licensed:
       declared: Apache-2.0

--- a/curations/maven/mavencentral/com.google.guava/guava.yml
+++ b/curations/maven/mavencentral/com.google.guava/guava.yml
@@ -1,0 +1,9 @@
+coordinates:
+  name: guava
+  namespace: com.google.guava
+  provider: mavencentral
+  type: maven
+revisions:
+  31.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Missing licensing for `com.google.guava:guava`.

- https://github.com/google/guava/blob/master/LICENSE (since January 2004)
