### PR TITLE
com.google.testing.platform:android-driver-instrumentation 0.0.8-alpha08

### DIFF
--- a/curations/maven/mavengoogle/com.google.testing.platform/android-driver-instrumentation.yaml
+++ b/curations/maven/mavengoogle/com.google.testing.platform/android-driver-instrumentation.yaml
@@ -7,3 +7,6 @@ revisions:
   0.0.8-alpha07:
     licensed:
       declared: OTHER
+  0.0.8-alpha08:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
Type: Missing

Summary:
com.google.testing.platform:android-driver-instrumentation 0.0.8-alpha08

Details:
Add OTHER License

Resolution:
License Url:
https://developer.android.com/studio/terms

Description:
https://maven.google.com/web/index.html?q=com.google.testing.platform#com.google.testing.platform:android-driver-instrumentation:0.0.8-alpha08

Pull request generated by Microsoft tooling.

Affected definitions:

[android-driver-instrumentation 0.0.8-alpha08](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.testing.platform/android-driver-instrumentation/0.0.8-alpha08)