### PR TITLE
com.google.android.play/core1.10.3

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.play/core.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/core.yaml
@@ -10,6 +10,9 @@ revisions:
   1.10.2:
     licensed:
       declared: OTHER
+  1.10.3:
+    licensed:
+      declared: OTHER
   1.7.3:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.play/core1.10.3

**Details:**
Declared field pulling in discovered license. Package underPlay Core Software Development Kit Terms of Service, so would be curated OTHER

**Resolution:**
https://maven.google.com/web/index.html#com.google.android.play:core:1.10.3

**Affected definitions**:
- [core 1.10.3](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.play/core/1.10.3/1.10.3)