### PR TITLE
suds-community1.1.2

### DIFF
--- a/curations/pypi/pypi/-/suds-community.yaml
+++ b/curations/pypi/pypi/-/suds-community.yaml
@@ -6,3 +6,6 @@ revisions:
   0.8.5:
     licensed:
       declared: LGPL-3.0-or-later
+  1.1.2:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
suds-community1.1.2

**Details:**
The license file in the package is LGPL-3.0 and the code headers indicate or-later

**Resolution:**
Downloaded source distro from https://pypi.org/project/suds-community/#files

**Affected definitions**:
- [suds-community 1.1.2](https://clearlydefined.io/definitions/pypi/pypi/-/suds-community/1.1.2/1.1.2)