### PR TITLE
debugpy1.6.6

### DIFF
--- a/curations/pypi/pypi/-/debugpy.yaml
+++ b/curations/pypi/pypi/-/debugpy.yaml
@@ -24,3 +24,6 @@ revisions:
   1.6.0:
     licensed:
       declared: MIT
+  1.6.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
debugpy1.6.6

**Details:**
The declared license looks like just MIT

**Resolution:**
See - https://github.com/microsoft/debugpy/blob/v1.6.6/LICENSE

**Affected definitions**:
- [debugpy 1.6.6](https://clearlydefined.io/definitions/pypi/pypi/-/debugpy/1.6.6/1.6.6)