### PR TITLE
License for StreamJsonRpc is MIT

### DIFF
--- a/curations/nuget/nuget/-/StreamJsonRpc.yaml
+++ b/curations/nuget/nuget/-/StreamJsonRpc.yaml
@@ -36,3 +36,6 @@ revisions:
   2.0.123-beta:
     licensed:
       declared: MIT
+  2.14.24:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
License for StreamJsonRpc is MIT

**Details:**
License is incorrectly being flagged

**Resolution:**
License is MIT for both the nuget feed and on the github repo

**Affected definitions**:
- [StreamJsonRpc 2.14.24](https://clearlydefined.io/definitions/nuget/nuget/-/StreamJsonRpc/2.14.24/2.14.24)