### PR TITLE
microsoft/onnxruntime-extensions0a9a3a9b2ff80e1

### DIFF
--- a/curations/git/github/microsoft/onnxruntime-extensions.yaml
+++ b/curations/git/github/microsoft/onnxruntime-extensions.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: onnxruntime-extensions
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  0a9a3a9b2ff80e187f99c8266a89bc64ba44bc13:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
microsoft/onnxruntime-extensions0a9a3a9b2ff80e1

**Details:**
NOTICE file licenses erroneously being included in "declared" field (should be in discovered field)

**Resolution:**
Fixing to MIT for declared

**Affected definitions**:
- [onnxruntime-extensions 0a9a3a9b2ff80e187f99c8266a89bc64ba44bc13](https://clearlydefined.io/definitions/git/github/microsoft/onnxruntime-extensions/0a9a3a9b2ff80e187f99c8266a89bc64ba44bc13/0a9a3a9b2ff80e187f99c8266a89bc64ba44bc13)