### PR TITLE
pygithub 1.58.2

### DIFF
--- a/curations/pypi/pypi/-/pygithub.yaml
+++ b/curations/pypi/pypi/-/pygithub.yaml
@@ -21,3 +21,6 @@ revisions:
   '1.56':
     licensed:
       declared: LGPL-3.0-or-later
+  1.58.2:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pygithub 1.58.2

**Details:**
Declared license is just LGPL-3.0-or-later

**Resolution:**
"Or later" info found on files - e.g. https://github.com/PyGithub/PyGithub/blob/v1.58.2/github/CheckRunOutput.py

**Affected definitions**:
- [pygithub 1.58.2](https://clearlydefined.io/definitions/pypi/pypi/-/pygithub/1.58.2/1.58.2)