### PR TITLE
pyzmq 25.0.2

### DIFF
--- a/curations/pypi/pypi/-/pyzmq.yaml
+++ b/curations/pypi/pypi/-/pyzmq.yaml
@@ -14,4 +14,4 @@ revisions:
       declared: BSD-3-Clause
   25.0.2:
     licensed:
-      declared: MPL-2.0
+      declared: BSD-3-Clause AND OTHER

--- a/curations/pypi/pypi/-/pyzmq.yaml
+++ b/curations/pypi/pypi/-/pyzmq.yaml
@@ -12,3 +12,6 @@ revisions:
   23.2.1:
     licensed:
       declared: BSD-3-Clause
+  25.0.2:
+    licensed:
+      declared: MPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pyzmq 25.0.2

**Details:**
Our thinking is this package was published after the RELICENSE effort in the source repo, which updates the project to MPL-2.0.  Since the package publish date is after that, thinking the curation here should be "MPL-2.0."

**Resolution:**
MPL-2.0

**Affected definitions**:
- [pyzmq 25.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/pyzmq/25.0.2/25.0.2)