### PR TITLE
net.sf.py4j/py4j0.10.9.7

### DIFF
--- a/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
+++ b/curations/maven/mavencentral/net.sf.py4j/py4j.yaml
@@ -28,6 +28,9 @@ revisions:
   0.10.9.5:
     licensed:
       declared: BSD-3-Clause
+  0.10.9.7:
+    licensed:
+      declared: BSD-3-Clause
   0.8.2.1:
     licensed:
       declared: BSD-2-Clause


### PR DESCRIPTION

**Type:** Missing

**Summary:**
net.sf.py4j/py4j0.10.9.7

**Details:**
BSD-3-Clause on pom and file headers

**Resolution:**
BSD-3-Clause

**Affected definitions**:
- [py4j 0.10.9.7](https://clearlydefined.io/definitions/maven/mavencentral/net.sf.py4j/py4j/0.10.9.7/0.10.9.7)