### PR TITLE
@grafana/e2e-selectors8.4.11

### DIFF
--- a/curations/npm/npmjs/@grafana/e2e-selectors.yaml
+++ b/curations/npm/npmjs/@grafana/e2e-selectors.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: e2e-selectors
+  namespace: '@grafana'
+  provider: npmjs
+  type: npm
+revisions:
+  8.4.11:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@grafana/e2e-selectors8.4.11

**Details:**
It looks to me based on the package.json and the LICENSING file in the repo (https://github.com/grafana/grafana/blob/main/LICENSING.md) that this package is meant to just be Apache-2.0.  

**Resolution:**
I think the AGPL "LICENSE" file that is pulled into the package is from the repo, but again, per the "LICESNING" file, these packages are just Apache.

**Affected definitions**:
- [e2e-selectors 8.4.11](https://clearlydefined.io/definitions/npm/npmjs/@grafana/e2e-selectors/8.4.11/8.4.11)