### PR TITLE
@grafana/runtime9.1.0

### DIFF
--- a/curations/npm/npmjs/@grafana/runtime.yaml
+++ b/curations/npm/npmjs/@grafana/runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: runtime
+  namespace: '@grafana'
+  provider: npmjs
+  type: npm
+revisions:
+  9.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@grafana/runtime9.1.0

**Details:**
It looks to me based on the package.json and the LICENSING file in the repo (https://github.com/grafana/grafana/blob/main/LICENSING.md) that this package is meant to just be Apache-2.0.  

**Resolution:**
I think the AGPL "LICENSE" file that is pulled into the package is from the repo, but again, per the "LICESNING" file, these packages are just Apache.

**Affected definitions**:
- [runtime 9.1.0](https://clearlydefined.io/definitions/npm/npmjs/@grafana/runtime/9.1.0/9.1.0)