### PR TITLE
@grafana/ui8.5.4

### DIFF
--- a/curations/npm/npmjs/@grafana/ui.yaml
+++ b/curations/npm/npmjs/@grafana/ui.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: ui
+  namespace: '@grafana'
+  provider: npmjs
+  type: npm
+revisions:
+  8.5.4:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@grafana/ui8.5.4

**Details:**
It looks to me based on the package.json and the LICENSING file in the repo (https://github.com/grafana/grafana/blob/main/LICENSING.md) that this package is meant to just be Apache-2.0.  

**Resolution:**
I think the AGPL "LICENSE" file that is pulled into the package is from the repo, but again, per the "LICESNING" file, these packages are just Apache.

**Affected definitions**:
- [ui 8.5.4](https://clearlydefined.io/definitions/npm/npmjs/@grafana/ui/8.5.4/8.5.4)