### PR TITLE
haproxy/haproxy fdd8154ed37fef7f351075caa357917f94704dd7

### DIFF
--- a/curations/git/github/haproxy/haproxy.yaml
+++ b/curations/git/github/haproxy/haproxy.yaml
@@ -7,3 +7,6 @@ revisions:
   6cbbecf09734aeb5fa8bb88f36f06a6f6d35e813:
     licensed:
       declared: OTHER
+  fdd8154ed37fef7f351075caa357917f94704dd7:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
Type: Missing

Summary:
haproxy/haproxy fdd8154ed37fef7f351075caa357917f94704dd7

Following the example of a very similar pull request for curating another haproxy commit:
https://github.com/clearlydefined/curated-data/pull/19559

In case it matters, looks like an additional license file has been added since the previously curated commit:
https://github.com/haproxy/haproxy/blob/fdd8154ed37fef7f351075caa357917f94704dd7/admin/acme.sh/LICENSE

Details:
Add GPL-2.0+ AND LGPL-2.1 License

Resolution:
License Url:
https://github.com/haproxy/haproxy/blob/fdd8154ed37fef7f351075caa357917f94704dd7/LICENSE

Description:
The LICENSE file describes that both GPL and LGPL are used.
"All the files provided in this package are covered by the GPL unless expressly stated otherwise in them." Please read the license to understand the full scope of why some files are licensed with GPL and some with LGPL.

Here are examples of the two different licenses applied to different files:
GPL 2.0 or later example: https://github.com/haproxy/haproxy/blob/fdd8154ed37fef7f351075caa357917f94704dd7/src/arg.c

LGPL 2.1 example: https://github.com/haproxy/haproxy/blob/fdd8154ed37fef7f351075caa357917f94704dd7/src/ebsttree.c

Affected definitions:

[haproxy fdd8154ed37fef7f351075caa357917f94704dd7](https://clearlydefined.io/definitions/git/github/haproxy/haproxy/fdd8154ed37fef7f351075caa357917f94704dd7)