### PR TITLE
com.sshtools/j2ssh-maverick1.5.5

### DIFF
--- a/curations/maven/mavencentral/com.sshtools/j2ssh-maverick.yaml
+++ b/curations/maven/mavencentral/com.sshtools/j2ssh-maverick.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   1.5.5:
     licensed:
-      declared: GPL-3.0-or-later
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.sshtools/j2ssh-maverick1.5.5

**Details:**
Fixing curation to LGPL-3.0-or-later

**Resolution:**
https://repo1.maven.org/maven2/com/sshtools/j2ssh-maverick/1.5.5/j2ssh-maverick-1.5.5.pom

**Affected definitions**:
- [j2ssh-maverick 1.5.5](https://clearlydefined.io/definitions/maven/mavencentral/com.sshtools/j2ssh-maverick/1.5.5/1.5.5)