### PR TITLE
pillow10.0.0

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  10.0.0:
+    licensed:
+      declared: HPND
   6.0.0:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow10.0.0

**Details:**
Correcting license

**Resolution:**
Meta
License: Historical Permission Notice and Disclaimer (HPND) (HPND)

**Affected definitions**:
- [pillow 10.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/10.0.0/10.0.0)