### PR TITLE
ch.qos.logback/logback-classic1.4.6

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
@@ -18,7 +18,10 @@ revisions:
       declared: EPL-1.0 OR LGPL-2.1-only
   1.2.9:
     licensed:
-      declared: EPL-1.0 OR LGPL-2.1-only 
+      declared: EPL-1.0 OR LGPL-2.1-only
   1.3.0-alpha4:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only
+  1.4.6:
+    licensed:
+      declared: LGPL-2.1-only OR EPL-1.0

--- a/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
@@ -24,4 +24,4 @@ revisions:
       declared: EPL-1.0 OR LGPL-2.1-only
   1.4.6:
     licensed:
-      declared: LGPL-2.1-only OR EPL-1.0
+      declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ch.qos.logback/logback-classic1.4.6

**Details:**
This is dual licensed

**Resolution:**
See code header

**Affected definitions**:
- [logback-classic 1.4.6](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-classic/1.4.6/1.4.6)