### PR TITLE
ch.qos.logback/logback-core1.4.6

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
@@ -13,3 +13,6 @@ revisions:
   1.2.3:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only
+  1.4.6:
+    licensed:
+      declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ch.qos.logback/logback-core1.4.6

**Details:**
Fixing to reflect dual license

**Resolution:**
See source jar file headers

**Affected definitions**:
- [logback-core 1.4.6](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-core/1.4.6/1.4.6)