### PR TITLE
pysctp0.7.2

### DIFF
--- a/curations/pypi/pypi/-/pysctp.yaml
+++ b/curations/pypi/pypi/-/pysctp.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pysctp
+  provider: pypi
+  type: pypi
+revisions:
+  0.7.2:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pysctp0.7.2

**Details:**
Fixing license to LGPL-2.1-or-later

**Resolution:**
https://github.com/P1sec/pysctp/blob/v0.7.2/setup.py

**Affected definitions**:
- [pysctp 0.7.2](https://clearlydefined.io/definitions/pypi/pypi/-/pysctp/0.7.2/0.7.2)