### PR TITLE
microsoft/symcrypt69dbff3352f42bd6d47112a2223145a0e3021a9e

### DIFF
--- a/curations/git/github/microsoft/symcrypt.yaml
+++ b/curations/git/github/microsoft/symcrypt.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: symcrypt
+  namespace: microsoft
+  provider: github
+  type: git
+revisions:
+  69dbff3352f42bd6d47112a2223145a0e3021a9e:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
microsoft/symcrypt69dbff3352f42bd6d47112a2223145a0e3021a9e

**Details:**
Declared erroneously picking up NOTICE file licenses.  Top level is just MIT

**Resolution:**
MIT

**Affected definitions**:
- [symcrypt 69dbff3352f42bd6d47112a2223145a0e3021a9e](https://clearlydefined.io/definitions/git/github/microsoft/symcrypt/69dbff3352f42bd6d47112a2223145a0e3021a9e/69dbff3352f42bd6d47112a2223145a0e3021a9e)