### PR TITLE
astroid2.15.6

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -27,6 +27,9 @@ revisions:
   2.15.5:
     licensed:
       declared: LGPL-2.1-or-later
+  2.15.6:
+    licensed:
+      declared: LGPL-2.1-or-later
   2.3.1:
     licensed:
       declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid2.15.6

**Details:**
PKG-INFO indicates the license is LGPL-2.1-or-later

**Resolution:**
Not sure where the scanners are picking up GPL-3.0. The declared license is LGPL-2.1-or-later.

**Affected definitions**:
- [astroid 2.15.6](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/2.15.6/2.15.6)