### PR TITLE
ch.qos.logback/logback-classic1.1.2

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
@@ -7,6 +7,9 @@ revisions:
   1.0.13:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only
+  1.1.2:
+    licensed:
+      declared: EPL-1.0 OR LGPL-2.1-only
   1.2.11:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
ch.qos.logback/logback-classic1.1.2

**Details:**
Adding dual license info

**Resolution:**
EPL 1.0 OR LGPL-2.1-only

**Affected definitions**:
- [logback-classic 1.1.2](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-classic/1.1.2/1.1.2)