### PR TITLE
com.google.android.gms/play-services-auth-base18.0.9

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-base.yaml
@@ -16,3 +16,6 @@ revisions:
   18.0.5:
     licensed:
       declared: OTHER
+  18.0.9:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.gms/play-services-auth-base18.0.9

**Details:**
See https://maven.google.com/web/index.html#com.google.android.gms:play-services-auth-base:18.0.9

**Resolution:**
Android Software Development Kit License = OTHER

**Affected definitions**:
- [play-services-auth-base 18.0.9](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-auth-base/18.0.9/18.0.9)