### PR TITLE
paramiko3.2.0

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -51,3 +51,6 @@ revisions:
   3.0.0:
     licensed:
       declared: LGPL-2.1-or-later
+  3.2.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko3.2.0

**Details:**
See setup.py

**Resolution:**
LGPL-2.1-or-later

**Affected definitions**:
- [paramiko 3.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/3.2.0/3.2.0)