### PR TITLE
Update libraries required for MS Dyn365 BC 2023 W2 RC1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Data.SqlClient.SNI.yaml
@@ -30,3 +30,6 @@ revisions:
   4.0.1:
     licensed:
       declared: OTHER
+  5.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
+++ b/curations/nuget/nuget/-/Microsoft.IdentityModel.Clients.ActiveDirectory.yaml
@@ -236,3 +236,6 @@ revisions:
   5.2.9:
     licensed:
       declared: MIT
+  5.3.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.PowerPlatform.Dataverse.Client.yaml
+++ b/curations/nuget/nuget/-/Microsoft.PowerPlatform.Dataverse.Client.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.1:
     licensed:
       declared: OTHER
+  1.0.39:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.SqlServer.Assessment.Authoring.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.Assessment.Authoring.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.280:
     licensed:
       declared: OTHER
+  1.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.SqlServer.Assessment.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.Assessment.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.280:
     licensed:
       declared: OTHER
+  1.1.9:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.Web.WebView2.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Web.WebView2.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.1264.42:
     licensed:
       declared: BSD-3-Clause
+  1.0.864.35:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION
Update license information for components required in the Microsoft Dynamics 365 Business Central 2023 Wave 2 release.