### PR TITLE
python-debian0.1.49

### DIFF
--- a/curations/pypi/pypi/-/python-debian.yaml
+++ b/curations/pypi/pypi/-/python-debian.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: python-debian
+  provider: pypi
+  type: pypi
+revisions:
+  0.1.49:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
python-debian0.1.49

**Details:**
Fixing Declared field

**Resolution:**
License is GPL-2.0-or-later -

https://salsa.debian.org/python-debian-team/python-debian/-/blob/0.1.49/setup.py

**Affected definitions**:
- [python-debian 0.1.49](https://clearlydefined.io/definitions/pypi/pypi/-/python-debian/0.1.49/0.1.49)