### PR TITLE
eslint-plugin-deprecation1.5.0

### DIFF
--- a/curations/npm/npmjs/-/eslint-plugin-deprecation.yaml
+++ b/curations/npm/npmjs/-/eslint-plugin-deprecation.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: eslint-plugin-deprecation
+  provider: npmjs
+  type: npm
+revisions:
+  1.5.0:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
eslint-plugin-deprecation1.5.0

**Details:**
Fixing Declared License to LGPL-3.0-or-later

**Resolution:**
https://github.com/gund/eslint-plugin-deprecation/blob/v1.5.0/package.json

**Affected definitions**:
- [eslint-plugin-deprecation 1.5.0](https://clearlydefined.io/definitions/npm/npmjs/-/eslint-plugin-deprecation/1.5.0/1.5.0)