### PR TITLE
scp0.14.5

### DIFF
--- a/curations/pypi/pypi/-/scp.yaml
+++ b/curations/pypi/pypi/-/scp.yaml
@@ -12,3 +12,6 @@ revisions:
   0.13.6:
     licensed:
       declared: LGPL-2.1-or-later
+  0.14.5:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
scp0.14.5

**Details:**
Fixing Declared License field to LGPL-2.1-or-later

**Resolution:**
https://github.com/jbardin/scp.py/blob/v0.14.5/LICENSE.txt

**Affected definitions**:
- [scp 0.14.5](https://clearlydefined.io/definitions/pypi/pypi/-/scp/0.14.5/0.14.5)