### PR TITLE
osquery/osquerye75fb8eba8b0a85b4562b6d1d09750903e2b7238

### DIFF
--- a/curations/git/github/osquery/osquery.yaml
+++ b/curations/git/github/osquery/osquery.yaml
@@ -7,3 +7,6 @@ revisions:
   5c71654dcf7c12c291a1388c85f498fec1d139e2:
     licensed:
       declared: Apache-2.0 OR GPL-2.0-only
+  e75fb8eba8b0a85b4562b6d1d09750903e2b7238:
+    licensed:
+      declared: Apache-2.0 OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
osquery/osquerye75fb8eba8b0a85b4562b6d1d09750903e2b7238

**Details:**
Fixing curation to reflect dual license by changing to "OR"

**Resolution:**
https://github.com/osquery/osquery/tree/e75fb8eba8b0a85b4562b6d1d09750903e2b7238

**Affected definitions**:
- [osquery e75fb8eba8b0a85b4562b6d1d09750903e2b7238](https://clearlydefined.io/definitions/git/github/osquery/osquery/e75fb8eba8b0a85b4562b6d1d09750903e2b7238/e75fb8eba8b0a85b4562b6d1d09750903e2b7238)