### PR TITLE
osquery/osquerycee7617cfa7339007172ae3f99675146ebdcf74a

### DIFF
--- a/curations/git/github/osquery/osquery.yaml
+++ b/curations/git/github/osquery/osquery.yaml
@@ -7,3 +7,6 @@ revisions:
   5c71654dcf7c12c291a1388c85f498fec1d139e2:
     licensed:
       declared: Apache-2.0 OR GPL-2.0-only
+  cee7617cfa7339007172ae3f99675146ebdcf74a:
+    licensed:
+      declared: Apache-2.0 OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
osquery/osquerycee7617cfa7339007172ae3f99675146ebdcf74a

**Details:**
Fixing Declared field to reflect dual license by changing to "OR"

**Resolution:**
https://github.com/osquery/osquery/blob/cee7617cfa7339007172ae3f99675146ebdcf74a/LICENSE

**Affected definitions**:
- [osquery cee7617cfa7339007172ae3f99675146ebdcf74a](https://clearlydefined.io/definitions/git/github/osquery/osquery/cee7617cfa7339007172ae3f99675146ebdcf74a/cee7617cfa7339007172ae3f99675146ebdcf74a)