### PR TITLE
ch.qos.logback/logback-core1.0.7

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-core.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.0.7:
+    licensed:
+      declared: LGPL-2.1-only OR EPL-1.0
   1.1.1:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ch.qos.logback/logback-core1.0.7

**Details:**
Dual licensed under LGPL-2.1-only OR EPL-1.0

**Resolution:**
https://logback.qos.ch/license.html

**Affected definitions**:
- [logback-core 1.0.7](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-core/1.0.7/1.0.7)