### PR TITLE
ch.qos.logback/logback-classic1.0.7

### DIFF
--- a/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
+++ b/curations/maven/mavencentral/ch.qos.logback/logback-classic.yaml
@@ -7,6 +7,9 @@ revisions:
   1.0.13:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only
+  1.0.7:
+    licensed:
+      declared: LGPL-2.1-only OR EPL-1.0
   1.1.2:
     licensed:
       declared: EPL-1.0 OR LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
ch.qos.logback/logback-classic1.0.7

**Details:**
Dual licensed and adding EPL-1.0 license to Declared field

**Resolution:**
https://repo1.maven.org/maven2/ch/qos/logback/logback-classic/1.0.7/logback-classic-1.0.7.pom

**Affected definitions**:
- [logback-classic 1.0.7](https://clearlydefined.io/definitions/maven/mavencentral/ch.qos.logback/logback-classic/1.0.7/1.0.7)