### PR TITLE
Add license curation for pillow

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -42,3 +42,6 @@ revisions:
   9.5.0:
     licensed:
       declared: HPND
+  10.0.1:
+    licensed:
+      declared: HPND


### PR DESCRIPTION
Summary:
pillow 10.0.1 curation

Details:
pillow is under HPND for the 10.0.1 version
Resolution:
https://github.com/python-pillow/Pillow/blob/10.0.1/LICENSE