### PR TITLE
Update faraday-http-cache.yaml

### DIFF
--- a/curations/gem/rubygems/-/faraday-http-cache.yaml
+++ b/curations/gem/rubygems/-/faraday-http-cache.yaml
@@ -21,3 +21,6 @@ revisions:
   2.0.0:
     licensed:
       declared: Apache-2.0
+  2.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Add Apache-2.0 for the version 2.5.0

See documented License file in the repo at https://github.com/sourcelevel/faraday-http-cache/blob/v2.5.0/LICENSE