### PR TITLE
org.keycloak/keycloak-sssd-federation22.0.3

### DIFF
--- a/curations/maven/mavencentral/org.keycloak/keycloak-sssd-federation.yaml
+++ b/curations/maven/mavencentral/org.keycloak/keycloak-sssd-federation.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   22.0.3:
     licensed:
-      declared: AFL-2.1 AND LGPL-2.1-only
+      declared: AFL-2.1 OR LGPL-2.1-only

--- a/curations/maven/mavencentral/org.keycloak/keycloak-sssd-federation.yaml
+++ b/curations/maven/mavencentral/org.keycloak/keycloak-sssd-federation.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: keycloak-sssd-federation
+  namespace: org.keycloak
+  provider: mavencentral
+  type: maven
+revisions:
+  22.0.3:
+    licensed:
+      declared: AFL-2.1 AND LGPL-2.1-or-later

--- a/curations/maven/mavencentral/org.keycloak/keycloak-sssd-federation.yaml
+++ b/curations/maven/mavencentral/org.keycloak/keycloak-sssd-federation.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   22.0.3:
     licensed:
-      declared: AFL-2.1 AND LGPL-2.1-or-later
+      declared: AFL-2.1 AND LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.keycloak/keycloak-sssd-federation22.0.3

**Details:**
Fixing curation to AFL-2.1 OR LGPL-2.1-only

**Resolution:**
License file in Maven sources.jar indicates the license options are Academic Free License 2.1 OR LGPL-2.0. I think we would Declare "AFL-2.1 OR LGPL-2.1-only. 

**Affected definitions**:
- [keycloak-sssd-federation 22.0.3](https://clearlydefined.io/definitions/maven/mavencentral/org.keycloak/keycloak-sssd-federation/22.0.3/22.0.3)