### PR TITLE
net.sourceforge.owlapi/owlapi-api3.5.2

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.owlapi/owlapi-api.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.owlapi/owlapi-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: owlapi-api
+  namespace: net.sourceforge.owlapi
+  provider: mavencentral
+  type: maven
+revisions:
+  3.5.2:
+    licensed:
+      declared: LGPL-3.0-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
net.sourceforge.owlapi/owlapi-api3.5.2

**Details:**
The Maven package is dual licensed - LGPL-3.0-or-later OR Apache-2.0

**Resolution:**
License information can be found in files in sources.jar

**Affected definitions**:
- [owlapi-api 3.5.2](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.owlapi/owlapi-api/3.5.2/3.5.2)