### PR TITLE
net.sourceforge.owlapi/owlapi-apibinding3.5.2

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.owlapi/owlapi-apibinding.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.owlapi/owlapi-apibinding.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: owlapi-apibinding
+  namespace: net.sourceforge.owlapi
+  provider: mavencentral
+  type: maven
+revisions:
+  3.5.2:
+    licensed:
+      declared: LGPL-3.0-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
net.sourceforge.owlapi/owlapi-apibinding3.5.2

**Details:**
Dual licensed under LGPL-3.0-or-later OR Apache-2.0

**Resolution:**
Files in sources jar indicate this component is dual-licensed.

**Affected definitions**:
- [owlapi-apibinding 3.5.2](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.owlapi/owlapi-apibinding/3.5.2/3.5.2)