### PR TITLE
net.sourceforge.owlapi/owlapi-tools3.5.2

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.owlapi/owlapi-tools.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.owlapi/owlapi-tools.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: owlapi-tools
+  namespace: net.sourceforge.owlapi
+  provider: mavencentral
+  type: maven
+revisions:
+  3.5.2:
+    licensed:
+      declared: LGPL-3.0-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
net.sourceforge.owlapi/owlapi-tools3.5.2

**Details:**
Package is dual-licensed under LGPL-3.0-or-later OR Apache-2.0

**Resolution:**
Files in sources.jar indicate this component is dual-licensed.

**Affected definitions**:
- [owlapi-tools 3.5.2](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.owlapi/owlapi-tools/3.5.2/3.5.2)