### PR TITLE
apparentlymart/go-textseg@15.0.0

### DIFF
--- a/curations/go/golang/github.com/apparentlymart/go-textseg/v15.yaml
+++ b/curations/go/golang/github.com/apparentlymart/go-textseg/v15.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: v15
+  namespace: github.com%2Fapparentlymart%2Fgo-textseg
+  provider: golang
+  type: go
+revisions:
+  v15.0.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
**Type**: Missing

**Summary**:
Add v15 to  go-textseg (https://pkg.go.dev/github.com/apparentlymart/go-textseg/v15)

**Details**:
Add MIT License

**Resolution**:
License Url:
https://github.com/apparentlymart/go-textseg/blob/master/LICENSE

Affected definitions:
- [go-textseg 1.0.0](https://clearlydefined.io/definitions/go/golang/github.com%2Fapparentlymart/go-textseg/v1.0.0)