### PR TITLE
aws/smithy-go@1.16.0

### DIFF
--- a/curations/go/golang/github.com/aws/smithy-go.yaml
+++ b/curations/go/golang/github.com/aws/smithy-go.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: smithy-go
+  namespace: github.com%2Faws
+  provider: golang
+  type: go
+revisions:
+  v1.16.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
**Type**: Missing

**Summary:**
Add aws/smithy-go (https://pkg.go.dev/github.com/aws/smithy-go)

**Details:**
Add Apache 2.0 License

**Resolution:**
License Url:
https://github.com/aws/smithy-go/blob/main/LICENSE

