### PR TITLE
Jille/raft-grpc-transport v1.4.0

### DIFF
--- a/curations/go/golang/github.com/jille/raft-grpc-transport.yaml
+++ b/curations/go/golang/github.com/jille/raft-grpc-transport.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: raft-grpc-transport
+  namespace: github.com%2Fjille
+  provider: golang
+  type: go
+revisions:
+  v1.4.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION
Type: Missing

Summary:
Add Jille/raft-grpc-transport (https://pkg.go.dev/github.com/Jille/raft-grpc-transport)

Details:
Add BSD-2-Clause License

Resolution:
License Url:
https://github.com/Jille/raft-grpc-transport/blob/master/LICENSE