### PR TITLE
Add license curation for sidekiq

### DIFF
--- a/curations/gem/rubygems/-/sidekiq.yaml
+++ b/curations/gem/rubygems/-/sidekiq.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: sidekiq
+  namespace: "-"
+  provider: rubygems
+  type: gem
+revisions:
+  6.5.12:
+    licensed:
+      declared: LGPL-3.0-only

--- a/curations/gem/rubygems/-/sidekiq.yaml
+++ b/curations/gem/rubygems/-/sidekiq.yaml
@@ -1,6 +1,5 @@
 coordinates:
   name: sidekiq
-  namespace: "-"
   provider: rubygems
   type: gem
 revisions:


### PR DESCRIPTION
Summary:
sidekiq 6.5.12 curation

Details:
sidekiq is under LGPL-3.0-only for the 6.5.12 version(s)
Resolution:
https://github.com/sidekiq/sidekiq/blob/v6.5.12/LICENSE, which links to https://github.com/sidekiq/sidekiq/blob/v6.5.12/COMM-LICENSE.txt for the separate Sidekiq Pro and Sidekiq Enterprise products.