### PR TITLE
aws/aws-sdk-go-v2/internal/endpoints/v2 2.5.1

### DIFF
--- a/curations/go/golang/github.com/aws/aws-sdk-go-v2/internal/endpoints/v2.yaml
+++ b/curations/go/golang/github.com/aws/aws-sdk-go-v2/internal/endpoints/v2.yaml
@@ -7,3 +7,6 @@ revisions:
   v2.4.5:
     licensed:
       declared: Apache-2.0
+  v2.5.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Type: Missing

Summary:
Add aws/aws-sdk-go-v2 v2.5.1 (https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/internal/endpoints)

Details:
Add Apache-2.0 License

Resolution:
License Url:
https://github.com/aws/aws-sdk-go-v2/blob/main/internal/endpoints/v2/LICENSE.txt