### PR TITLE
aws/aws-sdk-go-v2/feature/ec2/imds v1.14.2

### DIFF
--- a/curations/go/golang/github.com/aws/aws-sdk-go-v2/feature/ec2/imds.yaml
+++ b/curations/go/golang/github.com/aws/aws-sdk-go-v2/feature/ec2/imds.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: imds
+  namespace: github.com%2Faws%2Faws-sdk-go-v2%2Ffeature%2Fec2
+  provider: golang
+  type: go
+revisions:
+  v1.14.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
Type: Missing

Summary:
Add aws/aws-sdk-go-v2/feature/ec2/imds v1.14.2 (https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/feature/ec2/imds)

Details:
Add Apache-2.0 License

Resolution:
License Url:
https://github.com/aws/aws-sdk-go-v2/blob/main/feature/ec2/imds/LICENSE.txt