### PR TITLE
redhat-developer/vscode-java5d224a552cf5f0f8ebccf69e43e2575ed2c13839

### DIFF
--- a/curations/git/github/redhat-developer/vscode-java.yaml
+++ b/curations/git/github/redhat-developer/vscode-java.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: vscode-java
+  namespace: redhat-developer
+  provider: github
+  type: git
+revisions:
+  5d224a552cf5f0f8ebccf69e43e2575ed2c13839:
+    licensed:
+      declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
redhat-developer/vscode-java5d224a552cf5f0f8ebccf69e43e2575ed2c13839

**Details:**
Fixing curation to EPL-2.0 and remove "no assertion"

**Resolution:**
https://github.com/redhat-developer/vscode-java/blob/5d224a552cf5f0f8ebccf69e43e2575ed2c13839/LICENSE

**Affected definitions**:
- [vscode-java 5d224a552cf5f0f8ebccf69e43e2575ed2c13839](https://clearlydefined.io/definitions/git/github/redhat-developer/vscode-java/5d224a552cf5f0f8ebccf69e43e2575ed2c13839/5d224a552cf5f0f8ebccf69e43e2575ed2c13839)