### PR TITLE
Update com.google.android.play/integrity curation

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.play/integrity.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/integrity.yaml
@@ -18,3 +18,13 @@ revisions:
   1.1.0:
     licensed:
       declared: OTHER
+  1.2.0:
+    described:
+      releaseDate: '2023-07-21'
+    licensed:
+      declared: OTHER
+  1.3.0:
+    described:
+      releaseDate: '2023-11-10'
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
There have been 2 new major versions for this library, 1.2.0 and 1.3.0 (as per https://mvnrepository.com/artifact/com.google.android.play/integrity and https://maven.google.com/web/index.html#com.google.android.play:integrity)