### PR TITLE
core-common 2.0.3, app-update 2.1.0, and app-update-ktx 2.1.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.play/app-update-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/app-update-ktx.yaml
@@ -10,3 +10,6 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/app-update.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/app-update.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/core-common.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/core-common.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.2:
     licensed:
       declared: OTHER
+  2.0.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
Type: Missing

Summary:
core-common 2.0.3=, app-update 2.1.0, app-update-ktx 2.1.0

Details:
Add Play Core Software Development Kit Terms of Service

Resolution:
License Url:
https://developer.android.com/guide/playcore#license

Description:
Got link via public MVN repository.
https://maven.google.com/web/index.html#com.google.android.play:core-common:2.0.3
https://maven.google.com/web/index.html#com.google.android.play:app-update:2.1.0
https://maven.google.com/web/index.html#com.google.android.play:app-update-ktx:2.1.0

Affected definitions:

com.google.android.play:core-common 2.0.3
com.google.android.play:app-update 2.1.0
com.google.android.play:app-update-ktx 2.1.0