### PR TITLE
update go-vcr license for v2.1.0

### DIFF
--- a/curations/go/golang/github.com/dnaeon/go-vcr.yaml
+++ b/curations/go/golang/github.com/dnaeon/go-vcr.yaml
@@ -22,3 +22,6 @@ revisions:
   v1.2.0:
     licensed:
       declared: BSD-2-Clause
+  v2.0.1:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION
Here is the license text for v2.1.0, https://github.com/dnaeon/go-vcr/blob/v2.0.1/LICENSE

Hasn't changed from previous versions but this version is missing from the curation list.