### PR TITLE
Add latest versions of wcwidth

### DIFF
--- a/curations/pypi/pypi/-/wcwidth.yaml
+++ b/curations/pypi/pypi/-/wcwidth.yaml
@@ -9,3 +9,22 @@ revisions:
   0.2.6:
     licensed:
       declared: MIT
+  0.2.7:
+    licensed:
+      declared: MIT
+  0.2.8:
+    licensed:
+      declared: MIT
+  0.2.9:
+    licensed:
+      declared: MIT
+  0.2.10:
+    licensed:
+      declared: MIT
+  0.2.11:
+    licensed:
+      declared: MIT
+  0.2.12:
+    licensed:
+      declared: MIT
+  


### PR DESCRIPTION
License file hasn't changed from the currently curated versions.

License text for each version

| Version | License text |
| --- | ---- |
| 0.2.12 | https://github.com/jquast/wcwidth/blob/0.2.12/LICENSE |
| 0.2.11 | https://github.com/jquast/wcwidth/blob/0.2.11/LICENSE |
| 0.2.10 | https://github.com/jquast/wcwidth/blob/0.2.10/LICENSE |
| 0.2.9 | https://github.com/jquast/wcwidth/blob/0.2.9/LICENSE |
| 0.2.8 | https://github.com/jquast/wcwidth/blob/0.2.8/LICENSE |
| 0.2.7 | https://github.com/jquast/wcwidth/blob/0.2.7/LICENSE |