### PR TITLE
Add Sparsify Package license

### DIFF
--- a/curations/gem/rubygems/-/sparsify.yaml
+++ b/curations/gem/rubygems/-/sparsify.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.1.0:
     licensed:
-      declared: APACHE-2.0
+      declared: Apache-2.0

--- a/curations/gem/rubygems/-/sparsify.yaml
+++ b/curations/gem/rubygems/-/sparsify.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sparsify
+  provider: rubygems
+  type: gem
+revisions:
+  1.1.0:
+    licensed:
+      declared: APACHE-2.0


### PR DESCRIPTION
Rubygems says its apache2: https://rubygems.org/gems/sparsify/versions/1.1.0