### PR TITLE
Add entry for src-d/enry v2.1.0

### DIFF
--- a/curations/go/golang/github.com/src-d/enry/v2.yaml
+++ b/curations/go/golang/github.com/src-d/enry/v2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: v2
+  namespace: github.com%2fsrc-d%2fenry
+  provider: golang
+  type: go
+revisions:
+  v2.1.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
License text available at https://github.com/src-d/enry/blob/v2.1.0/LICENSE