### PR TITLE
ldap32.9.1

### DIFF
--- a/curations/pypi/pypi/-/ldap3.yaml
+++ b/curations/pypi/pypi/-/ldap3.yaml
@@ -9,3 +9,6 @@ revisions:
   '2.9':
     licensed:
       declared: LGPL-3.0-or-later
+  2.9.1:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ldap32.9.1

**Details:**
Fixing Declared License to LGPL-3.0-or-later

**Resolution:**
https://pypi.org/project/ldap3/2.9.1/

https://github.com/cannatag/ldap3/blob/v2.9.1/LICENSE.txt

**Affected definitions**:
- [ldap3 2.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/ldap3/2.9.1/2.9.1)