### PR TITLE
org.junit.jupiter/junit-jupiter5.10.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.10.0:
+    licensed:
+      declared: EPL-2.0
   5.4.0:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.junit.jupiter/junit-jupiter5.10.0

**Details:**
Declared License is EPL-2.0 

**Resolution:**
License noted in POM file and in ClearlyDefined License file

**Affected definitions**:
- [junit-jupiter 5.10.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter/5.10.0/5.10.0)