### PR TITLE
org.osgi/org.osgi.service.event1.3.1

### DIFF
--- a/curations/maven/mavencentral/org.osgi/org.osgi.service.event.yaml
+++ b/curations/maven/mavencentral/org.osgi/org.osgi.service.event.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: org.osgi.service.event
+  namespace: org.osgi
+  provider: mavencentral
+  type: maven
+revisions:
+  1.3.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.osgi/org.osgi.service.event1.3.1

**Details:**
Declared License is Apache-2.0

**Resolution:**
https://clearlydefined.io/file/cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30

**Affected definitions**:
- [org.osgi.service.event 1.3.1](https://clearlydefined.io/definitions/maven/mavencentral/org.osgi/org.osgi.service.event/1.3.1/1.3.1)