### PR TITLE
HotChocolate12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.yaml
@@ -57,6 +57,9 @@ revisions:
   12.21.0:
     licensed:
       declared: MIT
+  12.22.0:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate12.22.0

**Details:**
Declaring MIT

**Resolution:**
There is disclaimer text in the NuGet license file but I think we would declare as MIT. The disclaimer is removed in the source repo.

https://www.nuget.org/packages/HotChocolate/12.22.0/License

**Affected definitions**:
- [HotChocolate 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate/12.22.0/12.22.0)