### PR TITLE
HotChocolate.Types.CursorPagination12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.CursorPagination.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.CursorPagination.yaml
@@ -36,10 +36,13 @@ revisions:
   12.18.0:
     licensed:
       declared: MIT
-  12.5.0:
+  12.21.0:
     licensed:
       declared: MIT
-  12.21.0:
+  12.22.0:
+    licensed:
+      declared: MIT
+  12.5.0:
     licensed:
       declared: MIT
   12.6.0:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types.CursorPagination12.22.0

**Details:**
Declaring MIT

**Resolution:**
There is disclaimer text in the NuGet license but it has been removed from the license in the source repo.

https://clearlydefined.io/file/519d98126c6d890b2ede1ed050c7888c62cf7f26cd6764c9c44b53b887e2f4c6

**Affected definitions**:
- [HotChocolate.Types.CursorPagination 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.CursorPagination/12.22.0/12.22.0)