### PR TITLE
Confluent.Kafka1.9.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -95,6 +95,9 @@ revisions:
   1.8.2:
     licensed:
       declared: Apache-2.0
+  1.9.0:
+    licensed:
+      declared: Apache-2.0
   1.9.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Confluent.Kafka1.9.0

**Details:**
Declaring Apache-2.0

**Resolution:**
https://github.com/confluentinc/confluent-kafka-dotnet/blob/v1.9.0/LICENSE

**Affected definitions**:
- [Confluent.Kafka 1.9.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/1.9.0/1.9.0)