### PR TITLE
NReco.Text.AhoCorasickDoubleArrayTrie1.0.2

### DIFF
--- a/curations/nuget/nuget/-/NReco.Text.AhoCorasickDoubleArrayTrie.yaml
+++ b/curations/nuget/nuget/-/NReco.Text.AhoCorasickDoubleArrayTrie.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NReco.Text.AhoCorasickDoubleArrayTrie
+  provider: nuget
+  type: nuget
+revisions:
+  1.0.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
NReco.Text.AhoCorasickDoubleArrayTrie1.0.2

**Details:**
Declaring Apache-2.0

**Resolution:**
https://github.com/nreco/AhoCorasickDoubleArrayTrie/blob/master/LICENSE

**Affected definitions**:
- [NReco.Text.AhoCorasickDoubleArrayTrie 1.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/NReco.Text.AhoCorasickDoubleArrayTrie/1.0.2/1.0.2)