### PR TITLE
HotChocolate.Types.Mutations12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
@@ -24,10 +24,13 @@ revisions:
   12.18.0:
     licensed:
       declared: MIT
-  12.5.0:
+  12.21.0:
     licensed:
       declared: MIT
-  12.21.0:
+  12.22.0:
+    licensed:
+      declared: MIT
+  12.5.0:
     licensed:
       declared: MIT
   12.6.0:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types.Mutations12.22.0

**Details:**
Declaring MIT

**Resolution:**
There is disclaimer text added to the NuGet license, however, it's been removed in the source repo.

https://clearlydefined.io/file/519d98126c6d890b2ede1ed050c7888c62cf7f26cd6764c9c44b53b887e2f4c6


**Affected definitions**:
- [HotChocolate.Types.Mutations 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.Mutations/12.22.0/12.22.0)