### PR TITLE
com.hazelcast/hazelcast5.3.0

### DIFF
--- a/curations/maven/mavencentral/com.hazelcast/hazelcast.yaml
+++ b/curations/maven/mavencentral/com.hazelcast/hazelcast.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: hazelcast
+  namespace: com.hazelcast
+  provider: mavencentral
+  type: maven
+revisions:
+  5.3.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.hazelcast/hazelcast5.3.0

**Details:**
Fixing curation for Declared Field to reflect Apache-2.0

**Resolution:**
Apache-2.0 License file is located in sources.jar

https://mvnrepository.com/artifact/com.hazelcast/hazelcast/5.3.0

**Affected definitions**:
- [hazelcast 5.3.0](https://clearlydefined.io/definitions/maven/mavencentral/com.hazelcast/hazelcast/5.3.0/5.3.0)