### PR TITLE
com.google.android.gms/play-services-auth20.7.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-auth.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-auth.yaml
@@ -37,3 +37,6 @@ revisions:
   20.3.0:
     licensed:
       declared: OTHER
+  20.7.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.gms/play-services-auth20.7.0

**Details:**
Declaring OTHER

**Resolution:**
This component is under the Android SDK License per POM file

**Affected definitions**:
- [play-services-auth 20.7.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-auth/20.7.0/20.7.0)