### PR TITLE
SpecFlow.MsTest3.9.40

### DIFF
--- a/curations/nuget/nuget/-/SpecFlow.MsTest.yaml
+++ b/curations/nuget/nuget/-/SpecFlow.MsTest.yaml
@@ -84,6 +84,9 @@ revisions:
   3.9.22:
     licensed:
       declared: BSD-3-Clause
+  3.9.40:
+    licensed:
+      declared: BSD-3-Clause
   3.9.50:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SpecFlow.MsTest3.9.40

**Details:**
Declaring BSD-3-Clause

**Resolution:**
https://www.nuget.org/packages/SpecFlow.MsTest/3.9.40/License

**Affected definitions**:
- [SpecFlow.MsTest 3.9.40](https://clearlydefined.io/definitions/nuget/nuget/-/SpecFlow.MsTest/3.9.40/3.9.40)