### PR TITLE
HotChocolate.Types12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.yaml
@@ -39,10 +39,13 @@ revisions:
   12.18.0:
     licensed:
       declared: MIT
-  12.5.0:
+  12.21.0:
     licensed:
       declared: MIT
-  12.21.0:
+  12.22.0:
+    licensed:
+      declared: MIT
+  12.5.0:
     licensed:
       declared: MIT
   12.6.0:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types12.22.0

**Details:**
Declaring MIT

**Resolution:**
There is disclaimer text in the NuGet license which has been removed in the source repo license.

https://www.nuget.org/packages/HotChocolate.Types/12.22.0/License

**Affected definitions**:
- [HotChocolate.Types 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types/12.22.0/12.22.0)