### PR TITLE
org.glassfish.jersey.ext/jersey-bean-validation/2.25.1

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.ext/jersey-bean-validation.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.ext/jersey-bean-validation.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-bean-validation
+  namespace: org.glassfish.jersey.ext
+  provider: mavencentral
+  type: maven
+revisions:
+  2.25.1:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.glassfish.jersey.ext/jersey-bean-validation/2.25.1

**Details:**
Add CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/glassfish/jersey/ext/jersey-bean-validation/2.25.1/jersey-bean-validation-2.25.1.pom

**Affected definitions**:
- [jersey-bean-validation 2.25.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.ext/jersey-bean-validation/2.25.1)