### PR TITLE
org.eclipse.jgit/org.eclipse.jgit/6.7.0.202309050840-r

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.jgit/org.eclipse.jgit.yaml
+++ b/curations/maven/mavencentral/org.eclipse.jgit/org.eclipse.jgit.yaml
@@ -49,3 +49,6 @@ revisions:
   6.6.1.202309021850-r:
     licensed:
       declared: BSD-3-Clause
+  6.7.0.202309050840-r:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.eclipse.jgit/org.eclipse.jgit/6.7.0.202309050840-r

**Details:**
Add BSD-3-Clause

**Resolution:**
https://repo1.maven.org/maven2/org/eclipse/jgit/org.eclipse.jgit/6.7.0.202309050840-r/org.eclipse.jgit-6.7.0.202309050840-r.pom

**Affected definitions**:
- [org.eclipse.jgit 6.7.0.202309050840-r](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.jgit/org.eclipse.jgit/6.7.0.202309050840-r)