### PR TITLE
io.undertow/undertow-core/2.3.5.final

### DIFF
--- a/curations/maven/mavencentral/io.undertow/undertow-core.yaml
+++ b/curations/maven/mavencentral/io.undertow/undertow-core.yaml
@@ -682,3 +682,6 @@ revisions:
   2.2.8.Final:
     licensed:
       declared: Apache-2.0
+  2.3.5.final:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
io.undertow/undertow-core/2.3.5.final

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/io/undertow/undertow-core/2.3.5.Final/undertow-core-2.3.5.Final.pom

**Affected definitions**:
- [undertow-core 2.3.5.final](https://clearlydefined.io/definitions/maven/mavencentral/io.undertow/undertow-core/2.3.5.final)