### PR TITLE
io.undertow/undertow-servlet/2.2.28.final

### DIFF
--- a/curations/maven/mavencentral/io.undertow/undertow-servlet.yaml
+++ b/curations/maven/mavencentral/io.undertow/undertow-servlet.yaml
@@ -661,6 +661,9 @@ revisions:
   2.2.20.Final:
     licensed:
       declared: Apache-2.0
+  2.2.28.final:
+    licensed:
+      declared: Apache-2.0
   2.2.3.Final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
io.undertow/undertow-servlet/2.2.28.final

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/io/undertow/undertow-servlet/2.2.28.Final/undertow-servlet-2.2.28.Final.pom

**Affected definitions**:
- [undertow-servlet 2.2.28.final](https://clearlydefined.io/definitions/maven/mavencentral/io.undertow/undertow-servlet/2.2.28.final)