### PR TITLE
io.undertow/undertow-websockets-jsr/2.2.28.final

### DIFF
--- a/curations/maven/mavencentral/io.undertow/undertow-websockets-jsr.yaml
+++ b/curations/maven/mavencentral/io.undertow/undertow-websockets-jsr.yaml
@@ -763,6 +763,9 @@ revisions:
   2.2.20.Final:
     licensed:
       declared: Apache-2.0
+  2.2.28.final:
+    licensed:
+      declared: Apache-2.0
   2.2.3.Final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
io.undertow/undertow-websockets-jsr/2.2.28.final

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/io/undertow/undertow-websockets-jsr/2.2.28.Final/undertow-websockets-jsr-2.2.28.Final.pom

**Affected definitions**:
- [undertow-websockets-jsr 2.2.28.final](https://clearlydefined.io/definitions/maven/mavencentral/io.undertow/undertow-websockets-jsr/2.2.28.final)