### PR TITLE
com.google.gwt/gwt-user/2.9.0

### DIFF
--- a/curations/maven/mavencentral/com.google.gwt/gwt-user.yaml
+++ b/curations/maven/mavencentral/com.google.gwt/gwt-user.yaml
@@ -7,3 +7,6 @@ revisions:
   2.8.2:
     licensed:
       declared: Apache-2.0
+  2.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.gwt/gwt-user/2.9.0

**Details:**
Add Apache-2.0

**Resolution:**
Sources.jar file headers state Apache 2.0.

**Affected definitions**:
- [gwt-user 2.9.0](https://clearlydefined.io/definitions/maven/mavencentral/com.google.gwt/gwt-user/2.9.0)