### PR TITLE
org.glassfish.jersey.media/jersey-media-multipart/2.25.1

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart.yaml
@@ -16,3 +16,6 @@ revisions:
   2.22.2:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  2.25.1:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.glassfish.jersey.media/jersey-media-multipart/2.25.1

**Details:**
Add CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/glassfish/jersey/media/jersey-media-multipart/2.25.1/jersey-media-multipart-2.25.1.pom

**Affected definitions**:
- [jersey-media-multipart 2.25.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/2.25.1)