### PR TITLE
jersey-test-framework-provider-inmemory/2.25.1

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.test-framework.providers/jersey-test-framework-provider-inmemory.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.test-framework.providers/jersey-test-framework-provider-inmemory.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jersey-test-framework-provider-inmemory
+  namespace: org.glassfish.jersey.test-framework.providers
+  provider: mavencentral
+  type: maven
+revisions:
+  2.25.1:
+    licensed:
+      declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
jersey-test-framework-provider-inmemory/2.25.1

**Details:**
Add CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/glassfish/jersey/test-framework/providers/jersey-test-framework-provider-inmemory/2.25.1/jersey-test-framework-provider-inmemory-2.25.1.pom

**Affected definitions**:
- [jersey-test-framework-provider-inmemory 2.25.1](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.test-framework.providers/jersey-test-framework-provider-inmemory/2.25.1)