### PR TITLE
com.google.android.libraries.identity.googleid/googleid1.1.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.libraries.identity.googleid/googleid.yaml
+++ b/curations/maven/mavengoogle/com.google.android.libraries.identity.googleid/googleid.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: googleid
+  namespace: com.google.android.libraries.identity.googleid
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
com.google.android.libraries.identity.googleid/googleid1.1.0

**Details:**
Declaring OTHER for Android Software Development Kit

**Resolution:**
https://maven.google.com/web/index.html#com.google.android.libraries.identity.googleid:googleid:1.1.0

**Affected definitions**:
- [googleid 1.1.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.libraries.identity.googleid/googleid/1.1.0/1.1.0)