### PR TITLE
org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec/1.0.1.final

### DIFF
--- a/curations/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec.yaml
+++ b/curations/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.0.1.final:
+    licensed:
+      declared: CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.1.1.Final:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0 OR CDDL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec/1.0.1.final

**Details:**
Add CDDL-1.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/jboss/spec/javax/transaction/jboss-transaction-api_1.2_spec/1.0.1.Final/jboss-transaction-api_1.2_spec-1.0.1.Final.pom

**Affected definitions**:
- [jboss-transaction-api_1.2_spec 1.0.1.final](https://clearlydefined.io/definitions/maven/mavencentral/org.jboss.spec.javax.transaction/jboss-transaction-api_1.2_spec/1.0.1.final)