### PR TITLE
net.sourceforge.plantuml/plantuml/1.2023.10

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.plantuml/plantuml.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.plantuml/plantuml.yaml
@@ -7,3 +7,6 @@ revisions:
   1.2021.10:
     licensed:
       declared: GPL-3.0-or-later
+  1.2023.10:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.sourceforge.plantuml/plantuml/1.2023.10

**Details:**
Add GPL-3.0-or-later

**Resolution:**
Sources.jar file headers that GPL 3.0 or later.

**Affected definitions**:
- [plantuml 1.2023.10](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.plantuml/plantuml/1.2023.10)