### PR TITLE
com.hubspot.jackson/jackson-datatype-protobuf/0.9.9-jackson2.9-proto3

### DIFF
--- a/curations/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf.yaml
+++ b/curations/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf.yaml
@@ -13,3 +13,6 @@ revisions:
   0.9.9-jackson2.9-proto2:
     licensed:
       declared: Apache-2.0
+  0.9.9-jackson2.9-proto3:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.hubspot.jackson/jackson-datatype-protobuf/0.9.9-jackson2.9-proto3

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/HubSpot/jackson-datatype-protobuf/blob/963a0895a4e8dd458a99036961a4d4895434ea0c/LICENSE.txt

**Affected definitions**:
- [jackson-datatype-protobuf 0.9.9-jackson2.9-proto3](https://clearlydefined.io/definitions/maven/mavencentral/com.hubspot.jackson/jackson-datatype-protobuf/0.9.9-jackson2.9-proto3)