### PR TITLE
nlohmann/json9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03

### DIFF
--- a/curations/git/github/nlohmann/json.yaml
+++ b/curations/git/github/nlohmann/json.yaml
@@ -7,6 +7,9 @@ revisions:
   69d744867f8847c91a126fa25e9a6a3d67b3be41:
     licensed:
       declared: MIT
+  9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03:
+    licensed:
+      declared: MIT
   9ff0cc0f0212cb1e85b83ce5d2907ba9531b6cae:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nlohmann/json9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03

**Details:**
Declaring MIT. 

**Resolution:**
https://github.com/nlohmann/json/blob/9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03/LICENSE.MIT

**Affected definitions**:
- [json 9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03](https://clearlydefined.io/definitions/git/github/nlohmann/json/9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03/9cca280a4d0ccf0c08f47a99aa71d1b0e52f8d03)