### PR TITLE
org.eclipse.parsson/parsson/1.0.0

### DIFF
--- a/curations/maven/mavencentral/org.eclipse.parsson/parsson.yaml
+++ b/curations/maven/mavencentral/org.eclipse.parsson/parsson.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  1.0.0:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
   1.1.2:
     licensed:
       declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.eclipse.parsson/parsson/1.0.0

**Details:**
Add EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/eclipse/parsson/parsson/1.0.0/parsson-1.0.0.pom

**Affected definitions**:
- [parsson 1.0.0](https://clearlydefined.io/definitions/maven/mavencentral/org.eclipse.parsson/parsson/1.0.0)