### PR TITLE
com.github.jknack/handlebars-helpers/4.0.7

### DIFF
--- a/curations/maven/mavencentral/com.github.jknack/handlebars-helpers.yaml
+++ b/curations/maven/mavencentral/com.github.jknack/handlebars-helpers.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: handlebars-helpers
+  namespace: com.github.jknack
+  provider: mavencentral
+  type: maven
+revisions:
+  4.0.7:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.github.jknack/handlebars-helpers/4.0.7

**Details:**
Add Apache-2.0

**Resolution:**
Sources.jar file headers state Apache 2.0.

**Affected definitions**:
- [handlebars-helpers 4.0.7](https://clearlydefined.io/definitions/maven/mavencentral/com.github.jknack/handlebars-helpers/4.0.7)