### PR TITLE
docopt.net/0.8.1

### DIFF
--- a/curations/nuget/nuget/-/docopt.net.yaml
+++ b/curations/nuget/nuget/-/docopt.net.yaml
@@ -9,3 +9,6 @@ revisions:
   0.6.1.9:
     licensed:
       declared: MIT
+  0.8.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
docopt.net/0.8.1

**Details:**
Add MIT

**Resolution:**
https://github.com/docopt/docopt.net/blob/v0.8.1/LICENSE-MIT

**Affected definitions**:
- [docopt.net 0.8.1](https://clearlydefined.io/definitions/nuget/nuget/-/docopt.net/0.8.1)