### PR TITLE
springcomp.gppg.runtime/1.2.4

### DIFF
--- a/curations/nuget/nuget/-/springcomp.gppg.runtime.yaml
+++ b/curations/nuget/nuget/-/springcomp.gppg.runtime.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: springcomp.gppg.runtime
+  provider: nuget
+  type: nuget
+revisions:
+  1.2.4:
+    licensed:
+      declared: BSD-2-Clause-Views


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
springcomp.gppg.runtime/1.2.4

**Details:**
Add BSD-2-Clause-Views

**Resolution:**
https://www.nuget.org/packages/Springcomp.GPPG.Runtime/1.2.4/License

**Affected definitions**:
- [springcomp.gppg.runtime 1.2.4](https://clearlydefined.io/definitions/nuget/nuget/-/springcomp.gppg.runtime/1.2.4)