### PR TITLE
com.google.web.bindery/requestfactory-server/2.9.0

### DIFF
--- a/curations/maven/mavencentral/com.google.web.bindery/requestfactory-server.yaml
+++ b/curations/maven/mavencentral/com.google.web.bindery/requestfactory-server.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: requestfactory-server
+  namespace: com.google.web.bindery
+  provider: mavencentral
+  type: maven
+revisions:
+  2.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.web.bindery/requestfactory-server/2.9.0

**Details:**
Add Apache-2.0

**Resolution:**
Sources.jar file headers state Apache 2.0.

**Affected definitions**:
- [requestfactory-server 2.9.0](https://clearlydefined.io/definitions/maven/mavencentral/com.google.web.bindery/requestfactory-server/2.9.0)