### PR TITLE
HotChocolate.Validation12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Validation.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Validation.yaml
@@ -36,10 +36,13 @@ revisions:
   12.18.0:
     licensed:
       declared: MIT
-  12.5.0:
+  12.21.0:
     licensed:
       declared: MIT
-  12.21.0:
+  12.22.0:
+    licensed:
+      declared: MIT
+  12.5.0:
     licensed:
       declared: MIT
   12.6.0:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Validation12.22.0

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Validation/12.22.0/License

**Affected definitions**:
- [HotChocolate.Validation 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Validation/12.22.0/12.22.0)