### PR TITLE
Rx_Experimental-Testing1.1.11111

### DIFF
--- a/curations/nuget/nuget/-/Rx_Experimental-Testing.yaml
+++ b/curations/nuget/nuget/-/Rx_Experimental-Testing.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Rx_Experimental-Testing
+  provider: nuget
+  type: nuget
+revisions:
+  1.1.11111:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Rx_Experimental-Testing1.1.11111

**Details:**
Adding OTHER as Declared License for EULA

**Resolution:**
https://learn.microsoft.com/en-us/previous-versions/ff394099(v=msdn.10)?redirectedfrom=MSDN

**Affected definitions**:
- [Rx_Experimental-Testing 1.1.11111](https://clearlydefined.io/definitions/nuget/nuget/-/Rx_Experimental-Testing/1.1.11111/1.1.11111)