### PR TITLE
K4os.Compression.LZ4.Legacy1.3.5

### DIFF
--- a/curations/nuget/nuget/-/K4os.Compression.LZ4.Legacy.yaml
+++ b/curations/nuget/nuget/-/K4os.Compression.LZ4.Legacy.yaml
@@ -6,3 +6,6 @@ revisions:
   1.2.6:
     licensed:
       declared: MIT
+  1.3.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
K4os.Compression.LZ4.Legacy1.3.5

**Details:**
Adding MIT as Declared License

**Resolution:**
https://github.com/MiloszKrajewski/K4os.Compression.LZ4/blob/1.3.5/LICENSE

**Affected definitions**:
- [K4os.Compression.LZ4.Legacy 1.3.5](https://clearlydefined.io/definitions/nuget/nuget/-/K4os.Compression.LZ4.Legacy/1.3.5/1.3.5)