### PR TITLE
HotChocolate.Language.Utf812.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.Utf8.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.Utf8.yaml
@@ -36,10 +36,13 @@ revisions:
   12.18.0:
     licensed:
       declared: MIT
-  12.5.0:
-     licensed:
-      declared: MIT 
   12.21.0:
+    licensed:
+      declared: MIT
+  12.22.0:
+    licensed:
+      declared: MIT
+  12.5.0:
     licensed:
       declared: MIT
   12.6.0:


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Language.Utf812.22.0

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Language.Utf8/12.22.0/License

**Affected definitions**:
- [HotChocolate.Language.Utf8 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.Utf8/12.22.0/12.22.0)