### PR TITLE
MvcThrottle2.1.3

### DIFF
--- a/curations/nuget/nuget/-/MvcThrottle.yaml
+++ b/curations/nuget/nuget/-/MvcThrottle.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.5:
     licensed:
       declared: MIT
+  2.1.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
MvcThrottle2.1.3

**Details:**
Adding MIT as Declared License

**Resolution:**
https://github.com/stefanprodan/MvcThrottle/blob/v2.1.0/LICENSE.md

**Affected definitions**:
- [MvcThrottle 2.1.3](https://clearlydefined.io/definitions/nuget/nuget/-/MvcThrottle/2.1.3/2.1.3)