### PR TITLE
Newtonsoft.Json4.0.5

### DIFF
--- a/curations/nuget/nuget/-/Newtonsoft.Json.yaml
+++ b/curations/nuget/nuget/-/Newtonsoft.Json.yaml
@@ -34,6 +34,9 @@ revisions:
   3.5.8:
     licensed:
       declared: MIT
+  4.0.5:
+    licensed:
+      declared: MIT
   4.5.1:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
Newtonsoft.Json4.0.5

**Details:**
Adding MIT as Declared License

**Resolution:**
https://github.com/JamesNK/Newtonsoft.Json/tree/4.0.5/Doc

**Affected definitions**:
- [Newtonsoft.Json 4.0.5](https://clearlydefined.io/definitions/nuget/nuget/-/Newtonsoft.Json/4.0.5/4.0.5)