### PR TITLE
HotChocolate.Utilities.Introspection12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Utilities.Introspection.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Utilities.Introspection.yaml
@@ -39,6 +39,9 @@ revisions:
   12.21.0:
     licensed:
       declared: MIT
+  12.22.0:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Utilities.Introspection12.22.0

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Utilities.Introspection/12.22.0/License

**Affected definitions**:
- [HotChocolate.Utilities.Introspection 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Utilities.Introspection/12.22.0/12.22.0)