### PR TITLE
org.junit.jupiter/junit-jupiter-api5.10.0

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-api.yaml
@@ -7,6 +7,9 @@ revisions:
   5.0.3:
     licensed:
       declared: EPL-2.0
+  5.10.0:
+    licensed:
+      declared: EPL-2.0
   5.10.1:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
org.junit.jupiter/junit-jupiter-api5.10.0

**Details:**
Adding EPL-2.0 as Declared License

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-api/5.10.0/junit-jupiter-api-5.10.0.pom

**Affected definitions**:
- [junit-jupiter-api 5.10.0](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-api/5.10.0/5.10.0)