### PR TITLE
HotChocolate.Language.SyntaxTree12.22.0

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
@@ -39,6 +39,9 @@ revisions:
   12.21.0:
     licensed:
       declared: MIT
+  12.22.0:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Language.SyntaxTree12.22.0

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Language.SyntaxTree/12.22.0/License

**Affected definitions**:
- [HotChocolate.Language.SyntaxTree 12.22.0](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.SyntaxTree/12.22.0/12.22.0)