### PR TITLE
nokogiri1.16.0

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -39,3 +39,6 @@ revisions:
   1.15.4:
     licensed:
       declared: MIT
+  1.16.0:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri1.16.0

**Details:**
Fixing Declared Field to MIT

**Resolution:**
https://github.com/sparklemotion/nokogiri/blob/v1.16.0/LICENSE.md

**Affected definitions**:
- [nokogiri 1.16.0](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.16.0/1.16.0)