### PR TITLE
HotChocolate.Language.SyntaxTree12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
@@ -42,6 +42,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Language.SyntaxTree12.22.2

**Details:**
Adding OTHER for Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Language.SyntaxTree/12.22.2/License

**Affected definitions**:
- [HotChocolate.Language.SyntaxTree 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.SyntaxTree/12.22.2/12.22.2)