### PR TITLE
HotChocolate.Types.Mutations12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
@@ -30,6 +30,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
HotChocolate.Types.Mutations12.22.2

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Types.Mutations/12.22.2/License

**Affected definitions**:
- [HotChocolate.Types.Mutations 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.Mutations/12.22.2/12.22.2)