### PR TITLE
pygithub1.59.1

### DIFF
--- a/curations/pypi/pypi/-/pygithub.yaml
+++ b/curations/pypi/pypi/-/pygithub.yaml
@@ -27,3 +27,6 @@ revisions:
   1.59.0:
     licensed:
       declared: LGPL-3.0-or-later
+  1.59.1:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pygithub1.59.1

**Details:**
Fixing Declared Field to LGPL-3.0-or-later

**Resolution:**
https://github.com/PyGithub/PyGithub/blob/v1.59.1/setup.py

**Affected definitions**:
- [pygithub 1.59.1](https://clearlydefined.io/definitions/pypi/pypi/-/pygithub/1.59.1/1.59.1)