### PR TITLE
smuellerdd/jitterentropy-library887c9871ea110e397812ff7f3b28a6269f0a2ffc

### DIFF
--- a/curations/git/github/smuellerdd/jitterentropy-library.yaml
+++ b/curations/git/github/smuellerdd/jitterentropy-library.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jitterentropy-library
+  namespace: smuellerdd
+  provider: github
+  type: git
+revisions:
+  887c9871ea110e397812ff7f3b28a6269f0a2ffc:
+    licensed:
+      declared: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
smuellerdd/jitterentropy-library887c9871ea110e397812ff7f3b28a6269f0a2ffc

**Details:**
Declaring BSD-3-Clause OR GPL-2.0-only

**Resolution:**
https://github.com/smuellerDD/jitterentropy-library/blob/887c9871ea110e397812ff7f3b28a6269f0a2ffc/LICENSE

**Affected definitions**:
- [jitterentropy-library 887c9871ea110e397812ff7f3b28a6269f0a2ffc](https://clearlydefined.io/definitions/git/github/smuellerdd/jitterentropy-library/887c9871ea110e397812ff7f3b28a6269f0a2ffc/887c9871ea110e397812ff7f3b28a6269f0a2ffc)