### PR TITLE
docstring-to-markdown0.12

### DIFF
--- a/curations/pypi/pypi/-/docstring-to-markdown.yaml
+++ b/curations/pypi/pypi/-/docstring-to-markdown.yaml
@@ -9,6 +9,9 @@ revisions:
   '0.11':
     licensed:
       declared: LGPL-2.1-or-later
+  '0.12':
+    licensed:
+      declared: LGPL-2.1-or-later
   '0.7':
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
docstring-to-markdown0.12

**Details:**
Fixing Declared License to LGPL-2.1-or-later

**Resolution:**
https://github.com/python-lsp/docstring-to-markdown/blob/v0.12/setup.cfg

**Affected definitions**:
- [docstring-to-markdown 0.12](https://clearlydefined.io/definitions/pypi/pypi/-/docstring-to-markdown/0.12/0.12)