### PR TITLE
exrex0.11.0

### DIFF
--- a/curations/pypi/pypi/-/exrex.yaml
+++ b/curations/pypi/pypi/-/exrex.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: exrex
+  provider: pypi
+  type: pypi
+revisions:
+  0.11.0:
+    licensed:
+      declared: AGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
exrex0.11.0

**Details:**
Fixing Declared License field to AGPL-3.0 or later

**Resolution:**
License text noted on this page https://pypi.org/project/exrex/0.11.0/

**Affected definitions**:
- [exrex 0.11.0](https://clearlydefined.io/definitions/pypi/pypi/-/exrex/0.11.0/0.11.0)