### PR TITLE
astroid3.0.2

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -42,3 +42,6 @@ revisions:
   2.8.0:
     licensed:
       declared: LGPL-2.1-or-later
+  3.0.2:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid3.0.2

**Details:**
Fixing Declared License to LGPL-2.1-or-later

**Resolution:**
https://pypi.org/project/astroid/3.0.2/

**Affected definitions**:
- [astroid 3.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/3.0.2/3.0.2)