### PR TITLE
nokogiri1.16.2

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -42,3 +42,6 @@ revisions:
   1.16.0:
     licensed:
       declared: MIT
+  1.16.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri1.16.2

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://github.com/sparklemotion/nokogiri/blob/v1.16.2/LICENSE.md

**Affected definitions**:
- [nokogiri 1.16.2](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.16.2/1.16.2)