### PR TITLE
Add curation for go cronexpr

### DIFF
--- a/curations/go/golang/github.com/hashicorp/cronexpr.yaml
+++ b/curations/go/golang/github.com/hashicorp/cronexpr.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: go
+    provider: golang
+    namespace: github.com/hashicorp
+    name: cronexpr
+revisions:
+    1.1.1:
+        licensed:
+            declared: Apache-2.0 OR GPL-3.0-only


### PR DESCRIPTION
The correct license is Apache-2.0 OR GPL-3.0-only which can be found at https://github.com/hashicorp/cronexpr/blob/master/README.md#license