### PR TITLE
dominate2.9.1

### DIFF
--- a/curations/pypi/pypi/-/dominate.yaml
+++ b/curations/pypi/pypi/-/dominate.yaml
@@ -9,3 +9,6 @@ revisions:
   2.7.0:
     licensed:
       declared: LGPL-3.0-or-later
+  2.9.1:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dominate2.9.1

**Details:**
Fixing Declared License field to LGPL-3.0-or-later

**Resolution:**
https://github.com/Knio/dominate/blob/2.9.1/setup/setup.py

**Affected definitions**:
- [dominate 2.9.1](https://clearlydefined.io/definitions/pypi/pypi/-/dominate/2.9.1/2.9.1)