### PR TITLE
Add curation for gem webmock

### DIFF
--- a/curations/gem/rubygems/-/webmock.yaml
+++ b/curations/gem/rubygems/-/webmock.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: gem
+    provider: rubygems
+    namespace: '-'
+    name: webmock
+revisions:
+    3.21.2:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/bblimke/webmock/blob/master/LICENSE