### PR TITLE
chardet5.2.0

### DIFF
--- a/curations/pypi/pypi/-/chardet.yaml
+++ b/curations/pypi/pypi/-/chardet.yaml
@@ -12,3 +12,6 @@ revisions:
   5.1.0:
     licensed:
       declared: LGPL-2.1-or-later
+  5.2.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
chardet5.2.0

**Details:**
Fixing Declared License field to LGPL-2.1-or-later

**Resolution:**
https://pypi.org/project/chardet/5.2.0/

**Affected definitions**:
- [chardet 5.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/chardet/5.2.0/5.2.0)