### PR TITLE
flake8-isort6.1.1

### DIFF
--- a/curations/pypi/pypi/-/flake8-isort.yaml
+++ b/curations/pypi/pypi/-/flake8-isort.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: flake8-isort
+  provider: pypi
+  type: pypi
+revisions:
+  6.1.1:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
flake8-isort6.1.1

**Details:**
Fixing Declared field to GPL-2.0-only

**Resolution:**
https://github.com/gforcada/flake8-isort/blob/6.1.1/LICENSE

**Affected definitions**:
- [flake8-isort 6.1.1](https://clearlydefined.io/definitions/pypi/pypi/-/flake8-isort/6.1.1/6.1.1)