### PR TITLE
facebook/zstd63779c798237346c2b245c546c40b72a5a5913fe

### DIFF
--- a/curations/git/github/facebook/zstd.yaml
+++ b/curations/git/github/facebook/zstd.yaml
@@ -13,6 +13,9 @@ revisions:
   52181f877a96ca3feb688820ba852a0c044cc620:
     licensed:
       declared: BSD-3-Clause OR GPL-2.0-only
+  63779c798237346c2b245c546c40b72a5a5913fe:
+    licensed:
+      declared: BSD-3-Clause OR GPL-2.0-only
   645a2975c394dc115b57a652cf175cd4c2b59292:
     licensed:
       declared: BSD-3-Clause OR GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
facebook/zstd63779c798237346c2b245c546c40b72a5a5913fe

**Details:**
Fixing Declared field to BSD-3-Clause OR GPL-2.0-only

**Resolution:**
https://github.com/facebook/zstd/blob/63779c798237346c2b245c546c40b72a5a5913fe/Makefile

**Affected definitions**:
- [zstd 63779c798237346c2b245c546c40b72a5a5913fe](https://clearlydefined.io/definitions/git/github/facebook/zstd/63779c798237346c2b245c546c40b72a5a5913fe/63779c798237346c2b245c546c40b72a5a5913fe)