### PR TITLE
pylint/3.0.2

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -64,6 +64,9 @@ revisions:
   2.9.1:
     licensed:
       declared: GPL-2.0-or-later
+  3.0.2:
+    licensed:
+      declared: GPL-2.0-or-later
   3.0.3:
     licensed:
       declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint/3.0.2

**Details:**
Correcting to GPL-2.0-or-later

**Resolution:**
https://github.com/pylint-dev/pylint/blob/v3.0.2/pyproject.toml

**Affected definitions**:
- [pylint 3.0.2](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/3.0.2/3.0.2)