### PR TITLE
psycopg22.9.7

### DIFF
--- a/curations/pypi/pypi/-/psycopg2.yaml
+++ b/curations/pypi/pypi/-/psycopg2.yaml
@@ -324,3 +324,6 @@ revisions:
   2.9.3:
     licensed:
       declared: OTHER
+  2.9.7:
+    licensed:
+      declared: OTHER

--- a/curations/pypi/pypi/-/psycopg2.yaml
+++ b/curations/pypi/pypi/-/psycopg2.yaml
@@ -17,7 +17,7 @@ revisions:
       declared: OTHER
   2.0.14:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.0.2:
     licensed:
       declared: OTHER
@@ -41,109 +41,109 @@ revisions:
       declared: OTHER
   2.2.0:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.2.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.2.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.3.0:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.3.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.3.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   '2.4':
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.3:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.4:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.5:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.6:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   '2.5':
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.5.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.5.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.5.3:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.5.4:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.5.5:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   '2.6':
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.6.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.6.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   '2.7':
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.3:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.3.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.3.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.4:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.5:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.6:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.6.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.7.7:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   '2.8':
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.8.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.8.2:
     described:
       sourceLocation:
@@ -299,31 +299,31 @@ revisions:
         license: LGPL-3.0-or-later
         path: psycopg2-2.8.2/tests/test_types_extras.py
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.8.3:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.8.4:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.8.5:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.8.6:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   '2.9':
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.9.1:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.9.2:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.9.3:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.9.7:
     licensed:
-      declared: OTHER
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
psycopg22.9.7

**Details:**
Declaring as OTHER for LGPL-3.0-or-later with special linking exception and alternative BSD license for certain files

**Resolution:**
https://github.com/psycopg/psycopg2/blob/2.9.7/LICENSE

**Affected definitions**:
- [psycopg2 2.9.7](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2/2.9.7/2.9.7)