### PR TITLE
astroid3.0.1

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -42,6 +42,9 @@ revisions:
   2.8.0:
     licensed:
       declared: LGPL-2.1-or-later
+  3.0.1:
+    licensed:
+      declared: LGPL-2.1-or-later
   3.0.2:
     licensed:
       declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid3.0.1

**Details:**
Declaring LGPL-2.1-or-later

**Resolution:**
https://clearlydefined.io/file/dd6ec247a90623ac8dcfdefc88b296e7dc6fc65a6eb907dcf4598608fe0d06fa

**Affected definitions**:
- [astroid 3.0.1](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/3.0.1/3.0.1)