### PR TITLE
org.jfree/jfreechart/1.5.4

### DIFF
--- a/curations/maven/mavencentral/org.jfree/jfreechart.yaml
+++ b/curations/maven/mavencentral/org.jfree/jfreechart.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jfreechart
+  namespace: org.jfree
+  provider: mavencentral
+  type: maven
+revisions:
+  1.5.4:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.jfree/jfreechart/1.5.4

**Details:**
Updating to LGPL 2.1 or later per source file headers.

**Resolution:**
https://github.com/jfree/jfreechart/blob/v1.5.4/src/main/java/org/jfree/chart/ChartColor.java

**Affected definitions**:
- [jfreechart 1.5.4](https://clearlydefined.io/definitions/maven/mavencentral/org.jfree/jfreechart/1.5.4/1.5.4)