### PR TITLE
net.htmlparser.jericho/jericho-html/3.4

### DIFF
--- a/curations/maven/mavencentral/net.htmlparser.jericho/jericho-html.yaml
+++ b/curations/maven/mavencentral/net.htmlparser.jericho/jericho-html.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jericho-html
+  namespace: net.htmlparser.jericho
+  provider: mavencentral
+  type: maven
+revisions:
+  '3.4':
+    licensed:
+      declared: Apache-2.0 OR EPL-1.0

--- a/curations/maven/mavencentral/net.htmlparser.jericho/jericho-html.yaml
+++ b/curations/maven/mavencentral/net.htmlparser.jericho/jericho-html.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '3.4':
     licensed:
-      declared: Apache-2.0 OR EPL-1.0
+      declared: Apache-2.0 OR EPL-1.0 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.htmlparser.jericho/jericho-html/3.4

**Details:**
Tri-licensed per pom and source file headers.

**Resolution:**
// Jericho HTML Parser - Java based library for analysing and manipulating HTML
// Version 3.4
// Copyright (C) 2004-2013 Martin Jericho
// http://jericho.htmlparser.net/
//
// This library is free software; you can redistribute it and/or
// modify it under the terms of either one of the following l

**Affected definitions**:
- [jericho-html 3.4](https://clearlydefined.io/definitions/maven/mavencentral/net.htmlparser.jericho/jericho-html/3.4/3.4)