### PR TITLE
astroid 3.0.3

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -45,3 +45,6 @@ revisions:
   3.0.2:
     licensed:
       declared: LGPL-2.1-or-later
+  3.0.3:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid 3.0.3

**Details:**
Updating to LGPL-2.1-or-later

**Resolution:**
https://github.com/pylint-dev/astroid/blob/v3.0.3/pyproject.toml#L7

**Affected definitions**:
- [astroid 3.0.3](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/3.0.3/3.0.3)