### PR TITLE
org.xhtmlrenderer/flying-saucer-core 9.1.22

### DIFF
--- a/curations/maven/mavencentral/org.xhtmlrenderer/flying-saucer-core.yaml
+++ b/curations/maven/mavencentral/org.xhtmlrenderer/flying-saucer-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: flying-saucer-core
+  namespace: org.xhtmlrenderer
+  provider: mavencentral
+  type: maven
+revisions:
+  9.1.22:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.xhtmlrenderer/flying-saucer-core 9.1.22

**Details:**
Updating to LGPL-2.1-or-later per included license

**Resolution:**
https://clearlydefined.io/file/a65629d976999099ee35a21f67da038bbaaccd3354504edd0a2928fda04a5e49

**Affected definitions**:
- [flying-saucer-core 9.1.22](https://clearlydefined.io/definitions/maven/mavencentral/org.xhtmlrenderer/flying-saucer-core/9.1.22/9.1.22)