### PR TITLE
JmesPath.Net.Parser1.0.330

### DIFF
--- a/curations/nuget/nuget/-/JmesPath.Net.Parser.yaml
+++ b/curations/nuget/nuget/-/JmesPath.Net.Parser.yaml
@@ -18,3 +18,6 @@ revisions:
   1.0.308:
     licensed:
       declared: Apache-2.0
+  1.0.330:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
JmesPath.Net.Parser1.0.330

**Details:**
Declared License should be Apache-2.0

**Resolution:**
https://github.com/jdevillard/JmesPath.Net/blob/v1.0.330/LICENSE

**Affected definitions**:
- [JmesPath.Net.Parser 1.0.330](https://clearlydefined.io/definitions/nuget/nuget/-/JmesPath.Net.Parser/1.0.330/1.0.330)