### PR TITLE
NUnit.Console3.16.3

### DIFF
--- a/curations/nuget/nuget/-/NUnit.Console.yaml
+++ b/curations/nuget/nuget/-/NUnit.Console.yaml
@@ -12,6 +12,9 @@ revisions:
   3.10.0:
     licensed:
       declared: MIT
+  3.16.3:
+    licensed:
+      declared: MIT
   3.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NUnit.Console3.16.3

**Details:**
Declared License should be MIT

**Resolution:**
https://www.nuget.org/packages/NUnit.Console/3.16.3/License

**Affected definitions**:
- [NUnit.Console 3.16.3](https://clearlydefined.io/definitions/nuget/nuget/-/NUnit.Console/3.16.3/3.16.3)