### PR TITLE
SixLabors.ImageSharp 3.1.1

### DIFF
--- a/curations/nuget/nuget/-/SixLabors.ImageSharp.yaml
+++ b/curations/nuget/nuget/-/SixLabors.ImageSharp.yaml
@@ -18,6 +18,9 @@ revisions:
   3.1.0:
     licensed:
       declared: OTHER
+  3.1.1:
+    licensed:
+      declared: MIT
   3.1.2:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
SixLabors.ImageSharp 3.1.1

**Details:**
OTHER

**Resolution:**
https://www.nuget.org/packages/SixLabors.ImageSharp/3.1.1/License

**Affected definitions**:
- [SixLabors.ImageSharp 3.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/SixLabors.ImageSharp/3.1.1/3.1.1)