### PR TITLE
Snapshooter.Xunit 0.14.0

### DIFF
--- a/curations/nuget/nuget/-/Snapshooter.Xunit.yaml
+++ b/curations/nuget/nuget/-/Snapshooter.Xunit.yaml
@@ -6,6 +6,9 @@ revisions:
   0.13.0:
     licensed:
       declared: MIT
+  0.14.0:
+    licensed:
+      declared: MIT
   0.5.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Snapshooter.Xunit 0.14.0

**Details:**
MIT

**Resolution:**
https://clearlydefined.io/definitions/nuget/nuget/-/Snapshooter.Xunit/0.14.0

**Affected definitions**:
- [Snapshooter.Xunit 0.14.0](https://clearlydefined.io/definitions/nuget/nuget/-/Snapshooter.Xunit/0.14.0/0.14.0)