### PR TITLE
io.undertow/undertow-core2.3.5.Final

### DIFF
--- a/curations/maven/mavencentral/io.undertow/undertow-core.yaml
+++ b/curations/maven/mavencentral/io.undertow/undertow-core.yaml
@@ -682,6 +682,9 @@ revisions:
   2.2.8.Final:
     licensed:
       declared: Apache-2.0
+  2.3.5.Final:
+    licensed:
+      declared: Apache-2.0
   2.3.5.final:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
io.undertow/undertow-core2.3.5.Final

**Details:**
Declared License should be Apache-2.0

**Resolution:**
https://clearlydefined.io/definitions/maven/mavencentral/io.undertow/undertow-core/2.3.5.final

**Affected definitions**:
- [undertow-core 2.3.5.Final](https://clearlydefined.io/definitions/maven/mavencentral/io.undertow/undertow-core/2.3.5.Final/2.3.5.Final)