### PR TITLE
FsCheck3.0.0-rc1

### DIFF
--- a/curations/nuget/nuget/-/FsCheck.yaml
+++ b/curations/nuget/nuget/-/FsCheck.yaml
@@ -36,3 +36,6 @@ revisions:
   3.0.0-alpha4:
     licensed:
       declared: BSD-3-Clause
+  3.0.0-rc1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
FsCheck3.0.0-rc1

**Details:**
Declared License should be BSD-3-Clause

**Resolution:**
https://github.com/fscheck/FsCheck/blob/3.0.0-rc1/License.txt

**Affected definitions**:
- [FsCheck 3.0.0-rc1](https://clearlydefined.io/definitions/nuget/nuget/-/FsCheck/3.0.0-rc1/3.0.0-rc1)