### PR TITLE
Microsoft.VisualStudio.Validation17.8.8

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Validation.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Validation.yaml
@@ -21,3 +21,6 @@ revisions:
   17.6.11:
     licensed:
       declared: MIT
+  17.8.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Validation17.8.8

**Details:**
Declared License should be MIT

**Resolution:**
https://www.nuget.org/packages/Microsoft.VisualStudio.Validation/17.8.8

**Affected definitions**:
- [Microsoft.VisualStudio.Validation 17.8.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Validation/17.8.8/17.8.8)