### PR TITLE
CNTK.CPUOnly/2.0.0

### DIFF
--- a/curations/nuget/nuget/-/CNTK.CPUOnly.yaml
+++ b/curations/nuget/nuget/-/CNTK.CPUOnly.yaml
@@ -3,7 +3,13 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  2.0.0:
+    licensed:
+      declared: MIT
   2.0.0-rc1:
+    licensed:
+      declared: MIT
+  2.3.0:
     licensed:
       declared: MIT
   2.4.0:


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
CNTK.CPUOnly/2.0.0
CNTK.CPUOnly/2.3.0

**Details:**
Add MIT

**Resolution:**
https://github.com/microsoft/CNTK/blob/v2.0/LICENSE.md
https://github.com/microsoft/CNTK/blob/v2.3/LICENSE.md

**Affected definitions**:
- [CNTK.CPUOnly 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/CNTK.CPUOnly/2.0.0)
- [CNTK.CPUOnly 2.3.0](https://clearlydefined.io/definitions/nuget/nuget/-/CNTK.CPUOnly/2.3.0)