### PR TITLE
CompareNETObjects/3.1.0, CompareNETObjects/3.6.0, CompareNETObjects/4.76.0

### DIFF
--- a/curations/nuget/nuget/-/CompareNETObjects.yaml
+++ b/curations/nuget/nuget/-/CompareNETObjects.yaml
@@ -3,10 +3,16 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  3.1.0:
+    licensed:
+      declared: MS-PL
   3.3.0:
     licensed:
       declared: MS-PL
   3.5.0:
+    licensed:
+      declared: MS-PL
+  3.6.0:
     licensed:
       declared: MS-PL
   4.3.0:
@@ -46,6 +52,9 @@ revisions:
     licensed:
       declared: MS-PL
   4.75.0:
+    licensed:
+      declared: MS-PL
+  4.76.0:
     licensed:
       declared: MS-PL
   4.77.0:


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
CompareNETObjects/3.1.0, CompareNETObjects/3.6.0, CompareNETObjects/4.76.0

**Details:**
Add MS-PL

**Resolution:**
- https://web.archive.org/web/20171224094202/https://comparenetobjects.codeplex.com/license
- https://github.com/GregFinzer/Compare-Net-Objects/wiki/Licensing/dcb4566086529353e6ff62835f0968ab2a483e18
- https://www.nuget.org/packages/CompareNETObjects/4.76.0/License


**Affected definitions**:
- [CompareNETObjects 3.1.0](https://clearlydefined.io/definitions/nuget/nuget/-/CompareNETObjects/3.1.0)
- [CompareNETObjects 3.6.0](https://clearlydefined.io/definitions/nuget/nuget/-/CompareNETObjects/3.6.0)
- [CompareNETObjects 4.76.0](https://clearlydefined.io/definitions/nuget/nuget/-/CompareNETObjects/4.76.0)