### PR TITLE
@apollo/query-planner/2.5.3

### DIFF
--- a/curations/npm/npmjs/@apollo/query-planner.yaml
+++ b/curations/npm/npmjs/@apollo/query-planner.yaml
@@ -16,3 +16,6 @@ revisions:
   2.0.5:
     licensed:
       declared: Elastic-2.0
+  2.5.3:
+    licensed:
+      declared: Elastic-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@apollo/query-planner/2.5.3

**Details:**
Add Elastic-2.0

**Resolution:**
https://github.com/apollographql/federation/blob/%40apollo/query-planner%402.5.3/query-graphs-js/LICENSE

**Affected definitions**:
- [query-planner 2.5.3](https://clearlydefined.io/definitions/npm/npmjs/@apollo/query-planner/2.5.3)