### PR TITLE
boost_date_time-vc120/1.58.0

### DIFF
--- a/curations/nuget/nuget/-/boost_date_time-vc120.yaml
+++ b/curations/nuget/nuget/-/boost_date_time-vc120.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: boost_date_time-vc120
+  provider: nuget
+  type: nuget
+revisions:
+  1.58.0:
+    licensed:
+      declared: BSL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
boost_date_time-vc120/1.58.0

**Details:**
Add BSL-1.0

**Resolution:**
https://github.com/sergey-shandar/getboost/blob/master/LICENSE

**Affected definitions**:
- [boost_date_time-vc120 1.58.0](https://clearlydefined.io/definitions/nuget/nuget/-/boost_date_time-vc120/1.58.0)