### PR TITLE
BouncyCastle.NetCore/2.2.1

### DIFF
--- a/curations/nuget/nuget/-/BouncyCastle.NetCore.yaml
+++ b/curations/nuget/nuget/-/BouncyCastle.NetCore.yaml
@@ -27,3 +27,6 @@ revisions:
   1.9.0:
     licensed:
       declared: MIT
+  2.2.1:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
BouncyCastle.NetCore/2.2.1

**Details:**
Add MIT

**Resolution:**
https://github.com/chrishaly/bc-csharp/blob/release-2.2.1-pack/LICENSE.md

**Affected definitions**:
- [BouncyCastle.NetCore 2.2.1](https://clearlydefined.io/definitions/nuget/nuget/-/BouncyCastle.NetCore/2.2.1)