### PR TITLE
dependabot-git_submodules/0.229.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-git_submodules.yaml
+++ b/curations/gem/rubygems/-/dependabot-git_submodules.yaml
@@ -30,3 +30,6 @@ revisions:
   0.215.0:
     licensed:
       declared: OTHER
+  0.229.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dependabot-git_submodules/0.229.0

**Details:**
Add OTHER

**Resolution:**
https://github.com/dependabot/dependabot-core/blob/v0.229.0/LICENSE

**Affected definitions**:
- [dependabot-git_submodules 0.229.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-git_submodules/0.229.0)