### PR TITLE
dependabot-go_modules/0.229.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-go_modules.yaml
+++ b/curations/gem/rubygems/-/dependabot-go_modules.yaml
@@ -27,3 +27,6 @@ revisions:
   0.215.0:
     licensed:
       declared: OTHER
+  0.229.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dependabot-go_modules/0.229.0

**Details:**
Add OTHER

**Resolution:**
https://github.com/dependabot/dependabot-core/blob/v0.229.0/LICENSE

**Affected definitions**:
- [dependabot-go_modules 0.229.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-go_modules/0.229.0)