### PR TITLE
dependabot-npm_and_yarn/0.229.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-npm_and_yarn.yaml
+++ b/curations/gem/rubygems/-/dependabot-npm_and_yarn.yaml
@@ -15,3 +15,6 @@ revisions:
   0.215.0:
     licensed:
       declared: OTHER
+  0.229.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dependabot-npm_and_yarn/0.229.0

**Details:**
Add OTHER

**Resolution:**
https://github.com/dependabot/dependabot-core/blob/v0.229.0/LICENSE

**Affected definitions**:
- [dependabot-npm_and_yarn 0.229.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-npm_and_yarn/0.229.0)