### PR TITLE
dependabot-swift/0.229.0

### DIFF
--- a/curations/gem/rubygems/-/dependabot-swift.yaml
+++ b/curations/gem/rubygems/-/dependabot-swift.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: dependabot-swift
+  provider: rubygems
+  type: gem
+revisions:
+  0.229.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dependabot-swift/0.229.0

**Details:**
Add OTHER

**Resolution:**
https://github.com/dependabot/dependabot-core/blob/v0.229.0/LICENSE

**Affected definitions**:
- [dependabot-swift 0.229.0](https://clearlydefined.io/definitions/gem/rubygems/-/dependabot-swift/0.229.0)