### PR TITLE
HotChocolate.Diagnostics/12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Diagnostics.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Diagnostics.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  12.22.2:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Diagnostics/12.22.2

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Diagnostics/12.22.2/License

**Affected definitions**:
- [HotChocolate.Diagnostics 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Diagnostics/12.22.2)