### PR TITLE
HotChocolate.Stitching.Abstractions/12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Stitching.Abstractions.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Stitching.Abstractions.yaml
@@ -9,6 +9,9 @@ revisions:
   12.12.1:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Stitching.Abstractions/12.22.2

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Stitching.Abstractions/12.22.2/License

**Affected definitions**:
- [HotChocolate.Stitching.Abstractions 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Stitching.Abstractions/12.22.2)