### PR TITLE
com.aliyun.oss/aliyun-sdk-oss/3.13.0

### DIFF
--- a/curations/maven/mavencentral/com.aliyun.oss/aliyun-sdk-oss.yaml
+++ b/curations/maven/mavencentral/com.aliyun.oss/aliyun-sdk-oss.yaml
@@ -7,6 +7,9 @@ revisions:
   2.8.3:
     licensed:
       declared: Apache-2.0
+  3.13.0:
+    licensed:
+      declared: Apache-2.0
   3.13.2:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.aliyun.oss/aliyun-sdk-oss/3.13.0

**Details:**
Add Apache-2.0

**Resolution:**
Sources.jar file headers state Apache 2.0

**Affected definitions**:
- [aliyun-sdk-oss 3.13.0](https://clearlydefined.io/definitions/maven/mavencentral/com.aliyun.oss/aliyun-sdk-oss/3.13.0)