### PR TITLE
com.auth0/java-jwt/3.9.0

### DIFF
--- a/curations/maven/mavencentral/com.auth0/java-jwt.yaml
+++ b/curations/maven/mavencentral/com.auth0/java-jwt.yaml
@@ -22,6 +22,9 @@ revisions:
   3.8.3:
     licensed:
       declared: MIT
+  3.9.0:
+    licensed:
+      declared: MIT
   4.0.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.auth0/java-jwt/3.9.0

**Details:**
Add MIT

**Resolution:**
https://github.com/auth0/java-jwt/blob/3.9.0/LICENSE

**Affected definitions**:
- [java-jwt 3.9.0](https://clearlydefined.io/definitions/maven/mavencentral/com.auth0/java-jwt/3.9.0)