### PR TITLE
com.github.tomakehurst/wiremock-jre8/2.21.0

### DIFF
--- a/curations/maven/mavencentral/com.github.tomakehurst/wiremock-jre8.yaml
+++ b/curations/maven/mavencentral/com.github.tomakehurst/wiremock-jre8.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.21.0:
+    licensed:
+      declared: Apache-2.0
   2.32.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.github.tomakehurst/wiremock-jre8/2.21.0

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/wiremock/wiremock/blob/2.21.0/LICENSE.txt

**Affected definitions**:
- [wiremock-jre8 2.21.0](https://clearlydefined.io/definitions/maven/mavencentral/com.github.tomakehurst/wiremock-jre8/2.21.0)