### PR TITLE
com.github.tomakehurst/wiremock-standalone/2.5.1

### DIFF
--- a/curations/maven/mavencentral/com.github.tomakehurst/wiremock-standalone.yaml
+++ b/curations/maven/mavencentral/com.github.tomakehurst/wiremock-standalone.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: wiremock-standalone
+  namespace: com.github.tomakehurst
+  provider: mavencentral
+  type: maven
+revisions:
+  2.5.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.github.tomakehurst/wiremock-standalone/2.5.1

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/wiremock/wiremock/blob/2.5.1/LICENSE.txt

**Affected definitions**:
- [wiremock-standalone 2.5.1](https://clearlydefined.io/definitions/maven/mavencentral/com.github.tomakehurst/wiremock-standalone/2.5.1)