### PR TITLE
Confluent.Kafka/2.2.0

### DIFF
--- a/curations/nuget/nuget/-/Confluent.Kafka.yaml
+++ b/curations/nuget/nuget/-/Confluent.Kafka.yaml
@@ -110,6 +110,9 @@ revisions:
   2.1.1:
     licensed:
       declared: Apache-2.0
+  2.2.0:
+    licensed:
+      declared: Apache-2.0
   2.3.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Confluent.Kafka/2.2.0

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/confluentinc/confluent-kafka-dotnet/blob/v2.2.0/LICENSE

**Affected definitions**:
- [Confluent.Kafka 2.2.0](https://clearlydefined.io/definitions/nuget/nuget/-/Confluent.Kafka/2.2.0)