### PR TITLE
Xamarin.Google.Code.FindBugs.JSR3053.0.2.9

### DIFF
--- a/curations/nuget/nuget/-/Xamarin.Google.Code.FindBugs.JSR305.yaml
+++ b/curations/nuget/nuget/-/Xamarin.Google.Code.FindBugs.JSR305.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Xamarin.Google.Code.FindBugs.JSR305
+  provider: nuget
+  type: nuget
+revisions:
+  3.0.2.9:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Xamarin.Google.Code.FindBugs.JSR3053.0.2.9

**Details:**
Declaring MIT

**Resolution:**
https://clearlydefined.io/definitions/nuget/nuget/-/xamarin.google.code.findbugs.jsr305/3.0.2.9

**Affected definitions**:
- [Xamarin.Google.Code.FindBugs.JSR305 3.0.2.9](https://clearlydefined.io/definitions/nuget/nuget/-/Xamarin.Google.Code.FindBugs.JSR305/3.0.2.9/3.0.2.9)