### PR TITLE
pillow10.3.0

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -12,6 +12,9 @@ revisions:
   10.2.0:
     licensed:
       declared: HPND
+  10.3.0:
+    licensed:
+      declared: HPND
   6.0.0:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow10.3.0

**Details:**
We have been Declaring as HPND

**Resolution:**
https://pypi.org/project/pillow/10.3.0/

**Affected definitions**:
- [pillow 10.3.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/10.3.0/10.3.0)