### PR TITLE
yangson1.4.19

### DIFF
--- a/curations/pypi/pypi/-/yangson.yaml
+++ b/curations/pypi/pypi/-/yangson.yaml
@@ -5,10 +5,10 @@ coordinates:
 revisions:
   1.4.13:
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later
   1.4.14:
     licensed:
-      declared: LGPL-3.0-only
+      declared: LGPL-3.0-or-later
   1.4.19:
     licensed:
       declared: LGPL-3.0-or-later

--- a/curations/pypi/pypi/-/yangson.yaml
+++ b/curations/pypi/pypi/-/yangson.yaml
@@ -3,9 +3,12 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
-  1.4.14:
-    licensed:
-      declared: LGPL-3.0-only
   1.4.13:
     licensed:
       declared: LGPL-3.0-only
+  1.4.14:
+    licensed:
+      declared: LGPL-3.0-only
+  1.4.19:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
yangson1.4.19

**Details:**
Declared License should be LGPL-3.0-or-later

**Resolution:**
https://github.com/CZ-NIC/yangson/blob/1.4.19/yangson/__main__.py

**Affected definitions**:
- [yangson 1.4.19](https://clearlydefined.io/definitions/pypi/pypi/-/yangson/1.4.19/1.4.19)