### PR TITLE
org.xhtmlrenderer/flying-saucer-pdf9.4.1

### DIFF
--- a/curations/maven/mavencentral/org.xhtmlrenderer/flying-saucer-pdf.yaml
+++ b/curations/maven/mavencentral/org.xhtmlrenderer/flying-saucer-pdf.yaml
@@ -7,3 +7,6 @@ revisions:
   9.1.22:
     licensed:
       declared: LGPL-2.1-or-later
+  9.4.1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.xhtmlrenderer/flying-saucer-pdf9.4.1

**Details:**
Fixing Declared License to LGPL-2.1-or-later

**Resolution:**
https://repo1.maven.org/maven2/org/xhtmlrenderer/flying-saucer-pdf/9.4.1/flying-saucer-pdf-9.4.1.pom

**Affected definitions**:
- [flying-saucer-pdf 9.4.1](https://clearlydefined.io/definitions/maven/mavencentral/org.xhtmlrenderer/flying-saucer-pdf/9.4.1/9.4.1)