### PR TITLE
StackExchange.Redis.StrongName1.0.371

### DIFF
--- a/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
+++ b/curations/nuget/nuget/-/StackExchange.Redis.StrongName.yaml
@@ -15,6 +15,9 @@ revisions:
   1.0.333:
     licensed:
       declared: MIT
+  1.0.371:
+    licensed:
+      declared: MIT
   1.0.394:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
StackExchange.Redis.StrongName1.0.371

**Details:**
Adding MIT to Declared License field

**Resolution:**
https://raw.githubusercontent.com/StackExchange/StackExchange.Redis/master/LICENSE

**Affected definitions**:
- [StackExchange.Redis.StrongName 1.0.371](https://clearlydefined.io/definitions/nuget/nuget/-/StackExchange.Redis.StrongName/1.0.371/1.0.371)