### PR TITLE
SonarAnalyzer.CSharp1.10.0

### DIFF
--- a/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
+++ b/curations/nuget/nuget/-/SonarAnalyzer.CSharp.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: nuget
   type: nuget
 revisions:
+  1.10.0:
+    licensed:
+      declared: LGPL-3.0-only
   1.22.0.1631:
     licensed:
       declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
SonarAnalyzer.CSharp1.10.0

**Details:**
Adding LGPL-3.0-only for Declared License field

**Resolution:**
License link on this version is not found but another version and the project site includes the LGPL-3.0-only license. https://www.nuget.org/packages/SonarAnalyzer.CSharp/9.23.0.88079

**Affected definitions**:
- [SonarAnalyzer.CSharp 1.10.0](https://clearlydefined.io/definitions/nuget/nuget/-/SonarAnalyzer.CSharp/1.10.0/1.10.0)