### PR TITLE
Fill in the blanks for bouncycastle jdk18on artifacts

### DIFF
--- a/curations/maven/mavencentral/org.bouncycastle/bcmail-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcmail-jdk18on.yaml
@@ -4,9 +4,27 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  '1.71':
+    licensed:
+      declared: MIT
+  '1.71.1':
+    licensed:
+      declared: MIT
+  '1.72':
+    licensed:
+      declared: MIT
+  '1.73':
+    licensed:
+      declared: MIT
+  '1.74':
+    licensed:
+      declared: MIT
   '1.75':
     licensed:
       declared: MIT
   '1.76':
+    licensed:
+      declared: MIT
+  '1.77':
     licensed:
       declared: MIT

--- a/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcpkix-jdk18on.yaml
@@ -7,7 +7,16 @@ revisions:
   '1.71':
     licensed:
       declared: MIT
+  '1.71.1':
+    licensed:
+      declared: MIT
+  '1.72':
+    licensed:
+      declared: MIT
   '1.73':
+    licensed:
+      declared: MIT
+  '1.74':
     licensed:
       declared: MIT
   '1.75':

--- a/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcprov-jdk18on.yaml
@@ -7,7 +7,13 @@ revisions:
   '1.71':
     licensed:
       declared: MIT
+  '1.71.1':
+    licensed:
+      declared: MIT
   '1.72':
+    licensed:
+      declared: MIT
+  '1.73':
     licensed:
       declared: MIT
   '1.74':

--- a/curations/maven/mavencentral/org.bouncycastle/bcutil-jdk18on.yaml
+++ b/curations/maven/mavencentral/org.bouncycastle/bcutil-jdk18on.yaml
@@ -7,6 +7,21 @@ revisions:
   '1.71':
     licensed:
       declared: MIT
+  '1.71.1':
+    licensed:
+      declared: MIT
+  '1.72':
+    licensed:
+      declared: MIT
+  '1.73':
+    licensed:
+      declared: MIT
+  '1.74':
+    licensed:
+      declared: MIT
+  '1.75':
+    licensed:
+      declared: MIT
   '1.76':
     licensed:
       declared: MIT


### PR DESCRIPTION
Type: Missing

Summary:
org.bouncycastle:bcutil-jdk18on
org.bouncycastle:bcprov-jdk18on
org.bouncycastle:bcpkix-jdk18on
org.bouncycastle:bcmail-jdk18on

Details:
Add MIT License

Resolution:
License Url:
https://www.bouncycastle.org/licence.html

Description:
From their website, they state that their license should be treated as an MIT license.