### PR TITLE
Add curation for pypi Pillow

### DIFF
--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -1,7 +1,6 @@
 coordinates:
     type: pypi
     provider: pypi
-    namespace: ""
     name: Pillow
 revisions:
     5.1.0:
@@ -75,4 +74,4 @@ revisions:
             declared: HPND
     10.3.0:
         licensed:
-            declared: HPND License
+            declared: HPND

--- a/curations/pypi/pypi/-/Pillow.yaml
+++ b/curations/pypi/pypi/-/Pillow.yaml
@@ -1,74 +1,78 @@
 coordinates:
-  name: Pillow
-  provider: pypi
-  type: pypi
+    type: pypi
+    provider: pypi
+    namespace: ""
+    name: Pillow
 revisions:
-  5.1.0:
-    licensed:
-      declared: HPND
-  5.2.0:
-    licensed:
-      declared: HPND
-  5.3.0:
-    licensed:
-      declared: HPND
-  5.4.0.dev0:
-    licensed:
-      declared: HPND
-  5.4.1:
-    licensed:
-      declared: HPND
-  6.1.0:
-    licensed:
-      declared: HPND
-  6.2.1:
-    licensed:
-      declared: HPND
-  6.2.2:
-    licensed:
-      declared: HPND
-  7.0.0:
-    licensed:
-      declared: HPND
-  7.1.0:
-    licensed:
-      declared: HPND
-  7.1.1:
-    licensed:
-      declared: HPND
-  7.1.2:
-    licensed:
-      declared: HPND
-  7.2.0:
-    licensed:
-      declared: HPND
-  8.0.0:
-    licensed:
-      declared: HPND
-  8.0.1:
-    licensed:
-      declared: HPND
-  8.1.0:
-    licensed:
-      declared: HPND
-  8.1.1:
-    licensed:
-      declared: HPND
-  8.1.2:
-    licensed:
-      declared: HPND
-  8.2.0:
-    licensed:
-      declared: HPND
-  8.3.0:
-    licensed:
-      declared: HPND
-  8.3.1:
-    licensed:
-      declared: HPND
-  8.3.2:
-    licensed:
-      declared: HPND
-  8.4.0:
-    licensed:
-      declared: HPND
+    5.1.0:
+        licensed:
+            declared: HPND
+    5.2.0:
+        licensed:
+            declared: HPND
+    5.3.0:
+        licensed:
+            declared: HPND
+    5.4.0.dev0:
+        licensed:
+            declared: HPND
+    5.4.1:
+        licensed:
+            declared: HPND
+    6.1.0:
+        licensed:
+            declared: HPND
+    6.2.1:
+        licensed:
+            declared: HPND
+    6.2.2:
+        licensed:
+            declared: HPND
+    7.0.0:
+        licensed:
+            declared: HPND
+    7.1.0:
+        licensed:
+            declared: HPND
+    7.1.1:
+        licensed:
+            declared: HPND
+    7.1.2:
+        licensed:
+            declared: HPND
+    7.2.0:
+        licensed:
+            declared: HPND
+    8.0.0:
+        licensed:
+            declared: HPND
+    8.0.1:
+        licensed:
+            declared: HPND
+    8.1.0:
+        licensed:
+            declared: HPND
+    8.1.1:
+        licensed:
+            declared: HPND
+    8.1.2:
+        licensed:
+            declared: HPND
+    8.2.0:
+        licensed:
+            declared: HPND
+    8.3.0:
+        licensed:
+            declared: HPND
+    8.3.1:
+        licensed:
+            declared: HPND
+    8.3.2:
+        licensed:
+            declared: HPND
+    8.4.0:
+        licensed:
+            declared: HPND
+    10.3.0:
+        licensed:
+            declared: HPND License


### PR DESCRIPTION
The correct license is HPND License which can be found at https://github.com/python-pillow/Pillow/blob/main/LICENSE