### PR TITLE
cartopy 0.22.0

### DIFF
--- a/curations/pypi/pypi/-/cartopy.yaml
+++ b/curations/pypi/pypi/-/cartopy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: cartopy
+  provider: pypi
+  type: pypi
+revisions:
+  0.22.0:
+    licensed:
+      declared: LGPL-3.0-or-later

--- a/curations/pypi/pypi/-/cartopy.yaml
+++ b/curations/pypi/pypi/-/cartopy.yaml
@@ -3,6 +3,60 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  0.11.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.12.0.4:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.12.0.5:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.13.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.13.1:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.14.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.14.2:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.15.1:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.16.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.17.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.18.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.19.0.post1:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.20.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.20.1:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.20.2:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.20.3:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.21.0:
+    licensed:
+      declared: LGPL-3.0-or-later
+  0.21.1:
+    licensed:
+      declared: LGPL-3.0-or-later
   0.22.0:
     licensed:
       declared: LGPL-3.0-or-later

--- a/curations/pypi/pypi/-/cartopy.yaml
+++ b/curations/pypi/pypi/-/cartopy.yaml
@@ -36,9 +36,6 @@ revisions:
   0.18.0:
     licensed:
       declared: LGPL-3.0-or-later
-  0.19.0.post1:
-    licensed:
-      declared: LGPL-3.0-or-later
   0.20.0:
     licensed:
       declared: LGPL-3.0-or-later


### PR DESCRIPTION
Type: Missing

Summary:
cartopy 0.22.0

Details:
The cartopy repo is a bit messy. It included both the full GPL-3.0 text and the LGPL-3.0 addition (which is based on GPL-3.0).

The correct license is LGPL-3 or later. See, for example: https://github.com/SciTools/cartopy/blob/v0.22.0/COPYING.LESSER. If you go back in history long enough (is 12 years enough?), you will see it seemed to have always been LGPL-3: https://github.com/SciTools/cartopy/blob/v0.4.0rc1/COPYING.LESSER

This means all cartopy were released as LGPL-3.0, but some tools might misidentify it as GPL-3.0.

(Versions later than 0.22.0 will be BSD-based, FYI.)

Resolution:
 - https://pypi.org/project/Cartopy/0.22.0/
 - https://pypi.org/project/Cartopy/0.21.1/
 - https://pypi.org/project/Cartopy/0.21.0/
 - https://pypi.org/project/Cartopy/0.20.3/
 - https://pypi.org/project/Cartopy/0.20.2/
 - https://pypi.org/project/Cartopy/0.20.1/
 - https://pypi.org/project/Cartopy/0.20.0/
 - https://pypi.org/project/Cartopy/0.18.0/
 - https://pypi.org/project/Cartopy/0.17.0/
 - https://pypi.org/project/Cartopy/0.16.0/
 - https://pypi.org/project/Cartopy/0.15.1/
 - https://pypi.org/project/Cartopy/0.14.2/
 - https://pypi.org/project/Cartopy/0.14.0/
 - https://pypi.org/project/Cartopy/0.13.1/
 - https://pypi.org/project/Cartopy/0.13.0/
 - https://pypi.org/project/Cartopy/0.12.0.5/
 - https://pypi.org/project/Cartopy/0.12.0.4/
 - https://pypi.org/project/Cartopy/0.11.0/