### PR TITLE
com.hazelcast/hazelcast5.3.6

### DIFF
--- a/curations/maven/mavencentral/com.hazelcast/hazelcast.yaml
+++ b/curations/maven/mavencentral/com.hazelcast/hazelcast.yaml
@@ -7,3 +7,6 @@ revisions:
   5.3.0:
     licensed:
       declared: Apache-2.0
+  5.3.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.hazelcast/hazelcast5.3.6

**Details:**
Fixing Declared License field to Apache-2.0

**Resolution:**
https://clearlydefined.io/definitions/maven/mavencentral/com.hazelcast/hazelcast/5.3.6

**Affected definitions**:
- [hazelcast 5.3.6](https://clearlydefined.io/definitions/maven/mavencentral/com.hazelcast/hazelcast/5.3.6/5.3.6)