### PR TITLE
HotChocolate12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.yaml
@@ -60,6 +60,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate12.22.2

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate/12.22.2/License

**Affected definitions**:
- [HotChocolate 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate/12.22.2/12.22.2)