### PR TITLE
HotChocolate.Types.OffsetPagination12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.OffsetPagination.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.OffsetPagination.yaml
@@ -45,6 +45,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
HotChocolate.Types.OffsetPagination12.22.2

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Types.OffsetPagination/12.22.2/License

**Affected definitions**:
- [HotChocolate.Types.OffsetPagination 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.OffsetPagination/12.22.2/12.22.2)