### PR TITLE
GreenDonut12.22.2

### DIFF
--- a/curations/nuget/nuget/-/GreenDonut.yaml
+++ b/curations/nuget/nuget/-/GreenDonut.yaml
@@ -54,6 +54,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Missing

**Summary:**
GreenDonut12.22.2

**Details:**
Adding MIT as Declared License

**Resolution:**
https://www.nuget.org/packages/GreenDonut/12.22.2/License

**Affected definitions**:
- [GreenDonut 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/GreenDonut/12.22.2/12.22.2)