### PR TITLE
com.google.flatbuffers:flatbuffers-java:23.5.26

### DIFF
--- a/curations/maven/mavencentral/com.google.flatbuffers/flatbuffers-java.yaml
+++ b/curations/maven/mavencentral/com.google.flatbuffers/flatbuffers-java.yaml
@@ -22,3 +22,6 @@ revisions:
   22.10.26:
     licensed:
       declared: Apache-2.0
+  23.5.26:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.flatbuffers:flatbuffers-java:23.5.26

**Details:**
Add Apache-2.0

**Resolution:**
https://github.com/google/flatbuffers/blob/v23.5.26/LICENSE

**Affected definitions**:
- [flatbuffers-java 23.5.26](https://clearlydefined.io/definitions/maven/mavencentral/com.google.flatbuffers/flatbuffers-java/23.5.26)