### PR TITLE
com.google.gwt:gwt-dev:2.9.0

### DIFF
--- a/curations/maven/mavencentral/com.google.gwt/gwt-dev.yaml
+++ b/curations/maven/mavencentral/com.google.gwt/gwt-dev.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: gwt-dev
+  namespace: com.google.gwt
+  provider: mavencentral
+  type: maven
+revisions:
+  2.9.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.gwt:gwt-dev:2.9.0

**Details:**
Add Apache-2.0

**Resolution:**
File headers in sources.jar state Apache 2.0.

**Affected definitions**:
- [gwt-dev 2.9.0](https://clearlydefined.io/definitions/maven/mavencentral/com.google.gwt/gwt-dev/2.9.0)