### PR TITLE
com.ibm.db2:jcc:11.5.6.0

### DIFF
--- a/curations/maven/mavencentral/com.ibm.db2/jcc.yaml
+++ b/curations/maven/mavencentral/com.ibm.db2/jcc.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  11.5.6.0:
+    licensed:
+      declared: OTHER
   11.5.8.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.ibm.db2:jcc:11.5.6.0

**Details:**
Add OTHER

**Resolution:**
https://www.ibm.com/support/customer/csol/terms/?id=L-MSAI-BZKTF7&lc=en

**Affected definitions**:
- [jcc 11.5.6.0](https://clearlydefined.io/definitions/maven/mavencentral/com.ibm.db2/jcc/11.5.6.0)