### PR TITLE
HotChocolate.AspNetCore/12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.AspNetCore.yaml
@@ -51,6 +51,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.AspNetCore/12.22.2

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.AspNetCore/12.22.2/License

**Affected definitions**:
- [HotChocolate.AspNetCore 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.AspNetCore/12.22.2)