### PR TITLE
Update Springcomp.GPPG.Runtime.yaml

### DIFF
--- a/curations/nuget/nuget/-/Springcomp.GPPG.Runtime.yaml
+++ b/curations/nuget/nuget/-/Springcomp.GPPG.Runtime.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   1.2.4:
     licensed:
-      declared: BSD-2-Clause-Views
+      declared: OTHER


### PR DESCRIPTION
Correcting to OTHER. Almost matches BSD-2-Clause-Views but is missing the word "provided" in the second bullet. This is not marked as optional on the SPDX template.
<img width="277" alt="image" src="https://github.com/clearlydefined/curated-data/assets/5489711/644d6c6e-2af9-4c92-b629-e4510479e673">
https://www.nuget.org/packages/Springcomp.GPPG.Runtime/1.2.4/License
https://spdx.org/licenses/BSD-2-Clause-Views.html