### PR TITLE
HotChocolate.Fetching/12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
@@ -42,6 +42,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Fetching/12.22.2

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Fetching/12.22.2/License

**Affected definitions**:
- [HotChocolate.Fetching 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Fetching/12.22.2)