### PR TITLE
HotChocolate.Stitching.Redis/12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Stitching.Redis.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Stitching.Redis.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: HotChocolate.Stitching.Redis
+  provider: nuget
+  type: nuget
+revisions:
+  12.22.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Stitching.Redis/12.22.2

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Stitching.Redis/12.22.2/License

**Affected definitions**:
- [HotChocolate.Stitching.Redis 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Stitching.Redis/12.22.2)