### PR TITLE
HotChocolate.Types/12.22.2

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.yaml
@@ -45,6 +45,9 @@ revisions:
   12.22.0:
     licensed:
       declared: MIT
+  12.22.2:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Types/12.22.2

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Types/12.22.2/License

**Affected definitions**:
- [HotChocolate.Types 12.22.2](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types/12.22.2)