### PR TITLE
protobuf/4.25.0

### DIFF
--- a/curations/pypi/pypi/-/protobuf.yaml
+++ b/curations/pypi/pypi/-/protobuf.yaml
@@ -354,6 +354,9 @@ revisions:
   4.23.4:
     licensed:
       declared: BSD-3-Clause
+  4.25.0:
+    licensed:
+      declared: BSD-3-Clause
   4.25.1:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
protobuf/4.25.0

**Details:**
Add BSD-3-Clause

**Resolution:**
https://github.com/protocolbuffers/protobuf/blob/v4.25.0/LICENSE

**Affected definitions**:
- [protobuf 4.25.0](https://clearlydefined.io/definitions/pypi/pypi/-/protobuf/4.25.0)