### PR TITLE
semantic-kernel/0.3.13.dev0

### DIFF
--- a/curations/pypi/pypi/-/semantic-kernel.yaml
+++ b/curations/pypi/pypi/-/semantic-kernel.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: pypi
   type: pypi
 revisions:
+  0.3.13.dev0:
+    licensed:
+      declared: MIT
   0.4.5.dev0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
semantic-kernel/0.3.13.dev0

**Details:**
Add MIT

**Resolution:**
https://github.com/microsoft/semantic-kernel/blob/python-0.3.13.dev/LICENSE

**Affected definitions**:
- [semantic-kernel 0.3.13.dev0](https://clearlydefined.io/definitions/pypi/pypi/-/semantic-kernel/0.3.13.dev0)