### PR TITLE
Serilog.Enrichers.Context/4.6.5

### DIFF
--- a/curations/nuget/nuget/-/Serilog.Enrichers.Context.yaml
+++ b/curations/nuget/nuget/-/Serilog.Enrichers.Context.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Serilog.Enrichers.Context
+  provider: nuget
+  type: nuget
+revisions:
+  4.6.5:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Serilog.Enrichers.Context/4.6.5

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Serilog.Enrichers.Context/4.6.5/License

**Affected definitions**:
- [Serilog.Enrichers.Context 4.6.5](https://clearlydefined.io/definitions/nuget/nuget/-/Serilog.Enrichers.Context/4.6.5)