### PR TITLE
Snapshooter.Xunit/0.14.1

### DIFF
--- a/curations/nuget/nuget/-/Snapshooter.Xunit.yaml
+++ b/curations/nuget/nuget/-/Snapshooter.Xunit.yaml
@@ -9,6 +9,9 @@ revisions:
   0.14.0:
     licensed:
       declared: MIT
+  0.14.1:
+    licensed:
+      declared: MIT
   0.5.5:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Snapshooter.Xunit/0.14.1

**Details:**
Add MIT

**Resolution:**
https://github.com/SwissLife-OSS/snapshooter/blob/0.14.1/LICENSE

**Affected definitions**:
- [Snapshooter.Xunit 0.14.1](https://clearlydefined.io/definitions/nuget/nuget/-/Snapshooter.Xunit/0.14.1)