### PR TITLE
org.graalvm.js:js-scriptengine:22.0.0.2

### DIFF
--- a/curations/maven/mavencentral/org.graalvm.js/js-scriptengine.yaml
+++ b/curations/maven/mavencentral/org.graalvm.js/js-scriptengine.yaml
@@ -19,3 +19,6 @@ revisions:
   21.3.2:
     licensed:
       declared: UPL-1.0
+  22.0.0.2:
+    licensed:
+      declared: UPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.graalvm.js:js-scriptengine:22.0.0.2

**Details:**
Add UPL-1.0

**Resolution:**
https://repo1.maven.org/maven2/org/graalvm/js/js-scriptengine/22.0.0.2/js-scriptengine-22.0.0.2.pom

**Affected definitions**:
- [js-scriptengine 22.0.0.2](https://clearlydefined.io/definitions/maven/mavencentral/org.graalvm.js/js-scriptengine/22.0.0.2)