### PR TITLE
org.jmock:jmock-junit4:2.12.0

### DIFF
--- a/curations/maven/mavencentral/org.jmock/jmock-junit4.yaml
+++ b/curations/maven/mavencentral/org.jmock/jmock-junit4.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  2.12.0:
+    licensed:
+      declared: BSD-3-Clause
   2.8.4:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.jmock:jmock-junit4:2.12.0

**Details:**
Add BSD-3-Clause

**Resolution:**
http://jmock.org/license.html

**Affected definitions**:
- [jmock-junit4 2.12.0](https://clearlydefined.io/definitions/maven/mavencentral/org.jmock/jmock-junit4/2.12.0)