### PR TITLE
org.junit.jupiter:junit-jupiter-engine:5.10.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -7,6 +7,9 @@ revisions:
   5.10.1:
     licensed:
       declared: EPL-2.0
+  5.10.2:
+    licensed:
+      declared: EPL-2.0
   5.2.0:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.junit.jupiter:junit-jupiter-engine:5.10.2

**Details:**
Add EPL-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.10.2/junit-jupiter-engine-5.10.2.pom

**Affected definitions**:
- [junit-jupiter-engine 5.10.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.10.2)