### PR TITLE
org.junit.jupiter:junit-jupiter-engine:5.5.1

### DIFF
--- a/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
+++ b/curations/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine.yaml
@@ -25,6 +25,9 @@ revisions:
   5.5.0-M1:
     licensed:
       declared: EPL-2.0
+  5.5.1:
+    licensed:
+      declared: EPL-2.0
   5.5.2:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.junit.jupiter:junit-jupiter-engine:5.5.1

**Details:**
Add EPL-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/junit/jupiter/junit-jupiter-engine/5.5.1/junit-jupiter-engine-5.5.1.pom

**Affected definitions**:
- [junit-jupiter-engine 5.5.1](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.jupiter/junit-jupiter-engine/5.5.1)