### PR TITLE
org.junit.platform:junit-platform-commons:1.10.2

### DIFF
--- a/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
+++ b/curations/maven/mavencentral/org.junit.platform/junit-platform-commons.yaml
@@ -7,6 +7,9 @@ revisions:
   1.10.1:
     licensed:
       declared: EPL-2.0
+  1.10.2:
+    licensed:
+      declared: EPL-2.0
   1.2.0:
     licensed:
       declared: EPL-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.junit.platform:junit-platform-commons:1.10.2

**Details:**
Add EPL-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/junit/platform/junit-platform-commons/1.10.2/junit-platform-commons-1.10.2.pom

**Affected definitions**:
- [junit-platform-commons 1.10.2](https://clearlydefined.io/definitions/maven/mavencentral/org.junit.platform/junit-platform-commons/1.10.2)