### PR TITLE
nokogiri1.16.3

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -45,3 +45,6 @@ revisions:
   1.16.2:
     licensed:
       declared: MIT
+  1.16.3:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri1.16.3

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.16.3

**Affected definitions**:
- [nokogiri 1.16.3](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.16.3/1.16.3)