### PR TITLE
net.sourceforge.pmd:pmd-compat6:7.0.0

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.pmd/pmd-compat6.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.pmd/pmd-compat6.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pmd-compat6
+  namespace: net.sourceforge.pmd
+  provider: mavencentral
+  type: maven
+revisions:
+  7.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.sourceforge.pmd:pmd-compat6:7.0.0

**Details:**
Add OTHER

**Resolution:**
https://docs.pmd-code.org/latest/license.html

**Affected definitions**:
- [pmd-compat6 7.0.0](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.pmd/pmd-compat6/7.0.0)