### PR TITLE
net.sourceforge.pmd:pmd-java:7.0.0

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.pmd/pmd-java.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.pmd/pmd-java.yaml
@@ -16,3 +16,6 @@ revisions:
   6.55.0:
     licensed:
       declared: OTHER
+  7.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.sourceforge.pmd:pmd-java:7.0.0

**Details:**
Add OTHER

**Resolution:**
https://docs.pmd-code.org/latest/license.html

**Affected definitions**:
- [pmd-java 7.0.0](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.pmd/pmd-java/7.0.0)