### PR TITLE
net.sourceforge.pmd:pmd-java:6.49.0

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.pmd/pmd-java.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.pmd/pmd-java.yaml
@@ -10,6 +10,9 @@ revisions:
   6.21.0:
     licensed:
       declared: OTHER
+  6.49.0:
+    licensed:
+      declared: OTHER
   6.51.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.sourceforge.pmd:pmd-java:6.49.0

**Details:**
Add OTHER

**Resolution:**
https://docs.pmd-code.org/latest/license.html

**Affected definitions**:
- [pmd-java 6.49.0](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.pmd/pmd-java/6.49.0)