### PR TITLE
net.sourceforge.pmd:pmd-javascript:6.49.0

### DIFF
--- a/curations/maven/mavencentral/net.sourceforge.pmd/pmd-javascript.yaml
+++ b/curations/maven/mavencentral/net.sourceforge.pmd/pmd-javascript.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: pmd-javascript
+  namespace: net.sourceforge.pmd
+  provider: mavencentral
+  type: maven
+revisions:
+  6.49.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.sourceforge.pmd:pmd-javascript:6.49.0

**Details:**
Add OTHER

**Resolution:**
https://docs.pmd-code.org/latest/license.html

**Affected definitions**:
- [pmd-javascript 6.49.0](https://clearlydefined.io/definitions/maven/mavencentral/net.sourceforge.pmd/pmd-javascript/6.49.0)