### PR TITLE
com.google.android.gms/play-services-location/21.1.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-location.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-location.yaml
@@ -34,3 +34,6 @@ revisions:
   21.0.1:
     licensed:
       declared: OTHER
+  21.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.gms/play-services-location/21.1.0

**Details:**
Add OTHER

**Resolution:**
https://maven.google.com/web/index.html#com.google.android.gms:play-services-location:21.1.0

**Affected definitions**:
- [play-services-location 21.1.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-location/21.1.0)