### PR TITLE
astroid3.1.0

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -51,3 +51,6 @@ revisions:
   3.0.3:
     licensed:
       declared: LGPL-2.1-or-later
+  3.1.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid3.1.0

**Details:**
Fixing Declared License field to LGPL-2.1-or-later

**Resolution:**
https://pypi.org/project/astroid/3.1.0/

**Affected definitions**:
- [astroid 3.1.0](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/3.1.0/3.1.0)