### PR TITLE
Add license declaration for ImageSharp 2.1.8

### DIFF
--- a/curations/nuget/nuget/-/SixLabors.ImageSharp.yaml
+++ b/curations/nuget/nuget/-/SixLabors.ImageSharp.yaml
@@ -9,6 +9,9 @@ revisions:
   2.1.7:
     licensed:
       declared: Apache-2.0
+  2.1.8:
+    licensed:
+      declared: Apache-2.0
   3.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION
Type: Missing

**This is almost identical #26785 but for version `2.1.8`**

Summary:
SixLabors.ImageSharp 2.1.8

Details:
Add Apache-2.0 License

Resolution:
License Url:
https://github.com/SixLabors/ImageSharp/tree/v2.1.8?tab=License-1-ov-file

AND
https://www.nuget.org/packages/SixLabors.ImageSharp/2.1.8#readme-body-tab

Description:

I'm creating this PR in hopes of expediting the harvesting and license definition process for this new version of the library. I have attempted to harvest the new patch (2.1.8) through the ClearlyDefined website, but I was unable to see any updates occur with regards to the tool recognizing this new version.

Please note that as of version 3+ of ImageSharp, they have changed their licensing model into a split license model.
However, all version 2.1.x versions of the library are still licensed under Apache-2.0. You can find more details about this on their repository.

Version 2.1.8 is a backported patch applied on 2.1.7. There was a security vulnerability with the library which they have fixed in newer versions and have backported to 2.1.x.

[SixLabors.ImageSharp 2.1.8](https://clearlydefined.io/definitions/nuget/nuget/-/SixLabors.ImageSharp/2.1.8)