### PR TITLE
dracutdevs/dracut4980bad34775da715a2639b736cba5e65a8a2604

### DIFF
--- a/curations/git/github/dracutdevs/dracut.yaml
+++ b/curations/git/github/dracutdevs/dracut.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dracut
+  namespace: dracutdevs
+  provider: github
+  type: git
+revisions:
+  4980bad34775da715a2639b736cba5e65a8a2604:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
dracutdevs/dracut4980bad34775da715a2639b736cba5e65a8a2604

**Details:**
Fixing Declared License field to GPL-2.0-or-later

**Resolution:**
https://github.com/dracutdevs/dracut/blob/4980bad34775da715a2639b736cba5e65a8a2604/dracut-functions.sh

**Affected definitions**:
- [dracut 4980bad34775da715a2639b736cba5e65a8a2604](https://clearlydefined.io/definitions/git/github/dracutdevs/dracut/4980bad34775da715a2639b736cba5e65a8a2604/4980bad34775da715a2639b736cba5e65a8a2604)