### PR TITLE
com.google.mlkit/vision-common/16.7.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.mlkit/vision-common.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/vision-common.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavengoogle
   type: maven
 revisions:
+  16.7.0:
+    licensed:
+      declared: OTHER
   17.2.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.mlkit/vision-common/16.7.0

**Details:**
Update to OTHER since license is a EULA

**Resolution:**
https://maven.google.com/web/index.html#com.google.mlkit:vision-common:16.7.0

**Affected definitions**:
- [vision-common 16.7.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.mlkit/vision-common/16.7.0/16.7.0)