### PR TITLE
ansible-core2.15.10

### DIFF
--- a/curations/pypi/pypi/-/ansible-core.yaml
+++ b/curations/pypi/pypi/-/ansible-core.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ansible-core
+  provider: pypi
+  type: pypi
+revisions:
+  2.15.10:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ansible-core2.15.10

**Details:**
Fixing Declared Field to GPL-3.0-or-later

**Resolution:**
https://pypi.org/project/ansible-core/2.15.10/

**Affected definitions**:
- [ansible-core 2.15.10](https://clearlydefined.io/definitions/pypi/pypi/-/ansible-core/2.15.10/2.15.10)