### PR TITLE
patchelf0.18.0.0

### DIFF
--- a/curations/pypi/pypi/-/patchelf.yaml
+++ b/curations/pypi/pypi/-/patchelf.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: patchelf
+  provider: pypi
+  type: pypi
+revisions:
+  0.18.0.0:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
patchelf0.18.0.0

**Details:**
Fixing Declared field to GPL-3.0-or-later

**Resolution:**
https://pypi.org/project/patchelf/0.18.0.0/

**Affected definitions**:
- [patchelf 0.18.0.0](https://clearlydefined.io/definitions/pypi/pypi/-/patchelf/0.18.0.0/0.18.0.0)