### PR TITLE
antsibull-changelog0.23.0

### DIFF
--- a/curations/pypi/pypi/-/antsibull-changelog.yaml
+++ b/curations/pypi/pypi/-/antsibull-changelog.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: antsibull-changelog
+  provider: pypi
+  type: pypi
+revisions:
+  0.23.0:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
antsibull-changelog0.23.0

**Details:**
Fixing Declared field to GPL-3.0-or-later

**Resolution:**
https://pypi.org/project/antsibull-changelog/0.23.0/

**Affected definitions**:
- [antsibull-changelog 0.23.0](https://clearlydefined.io/definitions/pypi/pypi/-/antsibull-changelog/0.23.0/0.23.0)