### PR TITLE
antsibull0.58.0

### DIFF
--- a/curations/pypi/pypi/-/antsibull.yaml
+++ b/curations/pypi/pypi/-/antsibull.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: antsibull
+  provider: pypi
+  type: pypi
+revisions:
+  0.58.0:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
antsibull0.58.0

**Details:**
Fixing Declared License field to GPL-3.0-or-later

**Resolution:**
https://github.com/ansible-community/antsibull/blob/0.58.0/requirements.yml

**Affected definitions**:
- [antsibull 0.58.0](https://clearlydefined.io/definitions/pypi/pypi/-/antsibull/0.58.0/0.58.0)