### PR TITLE
org.xhtmlrenderer/flying-saucer-core9.4.1

### DIFF
--- a/curations/maven/mavencentral/org.xhtmlrenderer/flying-saucer-core.yaml
+++ b/curations/maven/mavencentral/org.xhtmlrenderer/flying-saucer-core.yaml
@@ -7,3 +7,6 @@ revisions:
   9.1.22:
     licensed:
       declared: LGPL-2.1-or-later
+  9.4.1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.xhtmlrenderer/flying-saucer-core9.4.1

**Details:**
Updating Declared License field

**Resolution:**
Per License file it says all the source is under LGPL-2.1-or-later. 

**Affected definitions**:
- [flying-saucer-core 9.4.1](https://clearlydefined.io/definitions/maven/mavencentral/org.xhtmlrenderer/flying-saucer-core/9.4.1/9.4.1)