### PR TITLE
ci: fix build script to ignore directories with yaml in the name

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -17,7 +17,7 @@ const colors = {
 
 // @todo only load new/changed yaml - use git diff
 function getYamlFilePaths() {
-  return glob.sync('{**/*.yaml,**/*.yml}');
+  return glob.sync('{**/*.yaml,**/*.yml}').filter(path => fs.statSync(path).isFile());
 }
 
 function failure(error = 'Error') {


### PR DESCRIPTION
Currently in the repo, there are two directories that end with .yaml which then erroneously appear to the build script as if they were yaml files.

* curations/maven/mavencentral/org.yaml
* curations/sourcearchive/mavencentral/org.yaml

This change adjusts the build script to only process paths which match the glob and which are actual files, not directories.