### PR TITLE
com.google.android.play/feature-delivery2.1.0

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.play/feature-delivery.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/feature-delivery.yaml
@@ -10,3 +10,6 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.1.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.play/feature-delivery2.1.0

**Details:**
Declared License is OTHER

**Resolution:**
<license>
      <name>Play Core Software Development Kit Terms of Service</name>
      <url>https://developer.android.com/guide/playcore/license</url>
      <distribution>repo</distribution>


**Affected definitions**:
- [feature-delivery 2.1.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.play/feature-delivery/2.1.0/2.1.0)