### PR TITLE
astroid3.2.0

### DIFF
--- a/curations/pypi/pypi/-/astroid.yaml
+++ b/curations/pypi/pypi/-/astroid.yaml
@@ -54,3 +54,6 @@ revisions:
   3.1.0:
     licensed:
       declared: LGPL-2.1-or-later
+  3.2.0:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
astroid3.2.0

**Details:**
Fixing Declared License to LGPL-2.1

**Resolution:**
https://pypi.org/project/astroid/3.2.0/

**Affected definitions**:
- [astroid 3.2.0](https://clearlydefined.io/definitions/pypi/pypi/-/astroid/3.2.0/3.2.0)