### PR TITLE
com.mysql/mysql-connector-j8.3.0

### DIFF
--- a/curations/maven/mavencentral/com.mysql/mysql-connector-j.yaml
+++ b/curations/maven/mavencentral/com.mysql/mysql-connector-j.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: mysql-connector-j
+  namespace: com.mysql
+  provider: mavencentral
+  type: maven
+revisions:
+  8.3.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.mysql/mysql-connector-j8.3.0

**Details:**
Declaring as OTHER for exceptions

**Resolution:**
https://repo1.maven.org/maven2/com/mysql/mysql-connector-j/8.3.0/mysql-connector-j-8.3.0.pom

**Affected definitions**:
- [mysql-connector-j 8.3.0](https://clearlydefined.io/definitions/maven/mavencentral/com.mysql/mysql-connector-j/8.3.0/8.3.0)