### PR TITLE
ansible-core2.15.9

### DIFF
--- a/curations/pypi/pypi/-/ansible-core.yaml
+++ b/curations/pypi/pypi/-/ansible-core.yaml
@@ -6,3 +6,6 @@ revisions:
   2.15.10:
     licensed:
       declared: GPL-3.0-or-later
+  2.15.9:
+    licensed:
+      declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ansible-core2.15.9

**Details:**
Fixing Declared License to GPL-3.0-or-later

**Resolution:**
https://pypi.org/project/ansible-core/2.15.9/

**Affected definitions**:
- [ansible-core 2.15.9](https://clearlydefined.io/definitions/pypi/pypi/-/ansible-core/2.15.9/2.15.9)