### PR TITLE
pyqt55.15.10

### DIFF
--- a/curations/pypi/pypi/-/pyqt5.yaml
+++ b/curations/pypi/pypi/-/pyqt5.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pyqt5
+  provider: pypi
+  type: pypi
+revisions:
+  5.15.10:
+    licensed:
+      declared: GPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pyqt55.15.10

**Details:**
Fixing curation to only have one license reference to GPL-3.0-only.

**Resolution:**
https://pypi.org/project/PyQt5/5.15.10/

**Affected definitions**:
- [pyqt5 5.15.10](https://clearlydefined.io/definitions/pypi/pypi/-/pyqt5/5.15.10/5.15.10)