### PR TITLE
com.ibm.icu:icu4j 74.2

### DIFF
--- a/curations/maven/mavencentral/com.ibm.icu/icu4j.yaml
+++ b/curations/maven/mavencentral/com.ibm.icu/icu4j.yaml
@@ -40,6 +40,9 @@ revisions:
   '73.2':
     licensed:
       declared: Unicode-DFS-2016
+  '74.2':
+    licensed:
+      declared: Unicode-3.0
   '75.1':
     licensed:
       declared: Unicode-3.0


### PR DESCRIPTION
Type: Missing

Summary:
[Hic.Mustache.MSBuild 0.0.67](com.ibm.icu:icu4j 74.2)

Details:
Add Unicode-3.0 License

Resolution:
License Url:
https://github.com/unicode-org/icu/blob/release-74-2/LICENSE

Description:
This is the LICENSE file in the component's github repo. Explicitly defining it as having an Unicode-3.0 License.

Pull request manually generated
