### PR TITLE
Microsoft.VisualStudio.Validation17.0.71

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Validation.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Validation.yaml
@@ -18,6 +18,9 @@ revisions:
   15.3.58:
     licensed:
       declared: MIT
+  17.0.71:
+    licensed:
+      declared: MIT
   17.6.11:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Validation17.0.71

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://github.com/microsoft/vs-validation/blob/v17.0.71/LICENSE

**Affected definitions**:
- [Microsoft.VisualStudio.Validation 17.0.71](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Validation/17.0.71/17.0.71)