### PR TITLE
ios-deploy1.12.2

### DIFF
--- a/curations/npm/npmjs/-/ios-deploy.yaml
+++ b/curations/npm/npmjs/-/ios-deploy.yaml
@@ -3,6 +3,9 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  1.12.2:
+    licensed:
+      declared: GPL-3.0-or-later
   1.8.7:
     licensed:
       declared: GPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ios-deploy1.12.2

**Details:**
Fixing Declared License to GPL-3.0-or-later

**Resolution:**
https://github.com/ios-control/ios-deploy/blob/1.12.2/README.md#license

**Affected definitions**:
- [ios-deploy 1.12.2](https://clearlydefined.io/definitions/npm/npmjs/-/ios-deploy/1.12.2/1.12.2)