### PR TITLE
gmpy22.1.5

### DIFF
--- a/curations/pypi/pypi/-/gmpy2.yaml
+++ b/curations/pypi/pypi/-/gmpy2.yaml
@@ -6,3 +6,6 @@ revisions:
   2.1.2:
     licensed:
       declared: LGPL-3.0-or-later
+  2.1.5:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
gmpy22.1.5

**Details:**
Fixing Declared License to LGPL-3.0-or-later

**Resolution:**
https://pypi.org/project/gmpy2/2.1.5/

**Affected definitions**:
- [gmpy2 2.1.5](https://clearlydefined.io/definitions/pypi/pypi/-/gmpy2/2.1.5/2.1.5)