### PR TITLE
pylint3.2.2

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -73,3 +73,6 @@ revisions:
   3.1.0:
     licensed:
       declared: GPL-2.0-or-later
+  3.2.2:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint3.2.2

**Details:**
Fixing Declared License to GPL-2.0-or-later

**Resolution:**
https://pypi.org/project/pylint/3.2.2/

**Affected definitions**:
- [pylint 3.2.2](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/3.2.2/3.2.2)