### PR TITLE
com.google.android.gms/play-services-ads

### DIFF
--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-ads.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-ads.yaml
@@ -64,3 +64,18 @@ revisions:
   21.2.0:
     licensed:
       declared: OTHER
+  21.3.0:
+    licensed:
+      declared: OTHER
+  21.4.0:
+    licensed:
+      declared: OTHER
+  21.5.0:
+    licensed:
+      declared: OTHER
+  22.1.0:
+    licensed:
+      declared: OTHER
+  22.3.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.android.gms/play-services-ads

**Details:**
Fixing Declared field to OTHER

**Resolution:**
Known issue with Google maven packages

**Affected definitions**:
- [play-services-ads 22.3.0](https://clearlydefined.io/definitions/maven/mavengoogle/com.google.android.gms/play-services-ads/22.3.0)