### PR TITLE
iTextSharp5.5.13.3

### DIFF
--- a/curations/nuget/nuget/-/iTextSharp.yaml
+++ b/curations/nuget/nuget/-/iTextSharp.yaml
@@ -24,3 +24,6 @@ revisions:
   5.5.13.2:
     licensed:
       declared: AGPL-3.0-only OR OTHER
+  5.5.13.3:
+    licensed:
+      declared: AGPL-3.0-only


### PR DESCRIPTION

**Type:** Missing

**Summary:**
iTextSharp5.5.13.3

**Details:**
Declaring AGPL-3.0 only (but may also need to add OTHER for commercial license option?)

**Resolution:**
https://www.gnu.org/licenses/agpl-3.0.html

**Affected definitions**:
- [iTextSharp 5.5.13.3](https://clearlydefined.io/definitions/nuget/nuget/-/iTextSharp/5.5.13.3/5.5.13.3)