### PR TITLE
pylint3.2.3

### DIFF
--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -78,4 +78,4 @@ revisions:
       declared: GPL-2.0-or-later
   3.2.3:
     licensed:
-      declared: GPL-2.0-only
+      declared: GPL-2.0-or-later

--- a/curations/pypi/pypi/-/pylint.yaml
+++ b/curations/pypi/pypi/-/pylint.yaml
@@ -76,3 +76,6 @@ revisions:
   3.2.2:
     licensed:
       declared: GPL-2.0-or-later
+  3.2.3:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pylint3.2.3

**Details:**
Fixing Declared License to GPL-2.0-only

**Resolution:**
https://pypi.org/project/pylint/3.2.3/

**Affected definitions**:
- [pylint 3.2.3](https://clearlydefined.io/definitions/pypi/pypi/-/pylint/3.2.3/3.2.3)