### PR TITLE
Update license for cronexpr v1.1.2

### DIFF
--- a/curations/go/golang/github.com/hashicorp/cronexpr.yaml
+++ b/curations/go/golang/github.com/hashicorp/cronexpr.yaml
@@ -7,3 +7,6 @@ revisions:
   v1.1.1:
     licensed:
       declared: Apache-2.0 OR GPL-3.0-only
+  v1.1.2:
+    licensed:
+      declared: Apache-2.0 OR GPL-3.0-only


### PR DESCRIPTION
The correct license is Apache-2.0 OR GPL-3.0-only which can be found at https://github.com/hashicorp/cronexpr/blob/master/README.md#license