### PR TITLE
ultralytics8.0.100

### DIFF
--- a/curations/pypi/pypi/-/ultralytics.yaml
+++ b/curations/pypi/pypi/-/ultralytics.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ultralytics
+  provider: pypi
+  type: pypi
+revisions:
+  8.0.100:
+    licensed:
+      declared: AGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ultralytics8.0.100

**Details:**
Fixing Declared License to AGPL-3.0-or-later

**Resolution:**
https://pypi.org/project/ultralytics/8.0.100/

**Affected definitions**:
- [ultralytics 8.0.100](https://clearlydefined.io/definitions/pypi/pypi/-/ultralytics/8.0.100/8.0.100)