### PR TITLE
com.google.code.findbugs/annotations3.0.1

### DIFF
--- a/curations/maven/mavencentral/com.google.code.findbugs/annotations.yaml
+++ b/curations/maven/mavencentral/com.google.code.findbugs/annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: annotations
+  namespace: com.google.code.findbugs
+  provider: mavencentral
+  type: maven
+revisions:
+  3.0.1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.google.code.findbugs/annotations3.0.1

**Details:**
Fixing Declared License field to LGPL-2.1-or-later

**Resolution:**
LGPL-2.1-or-later can be found in header files in sources.jar

**Affected definitions**:
- [annotations 3.0.1](https://clearlydefined.io/definitions/maven/mavencentral/com.google.code.findbugs/annotations/3.0.1/3.0.1)