### PR TITLE
com.mysql/mysql-connector-j8.0.31

### DIFF
--- a/curations/maven/mavencentral/com.mysql/mysql-connector-j.yaml
+++ b/curations/maven/mavencentral/com.mysql/mysql-connector-j.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  8.0.31:
+    licensed:
+      declared: OTHER
   8.3.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.mysql/mysql-connector-j8.0.31

**Details:**
Declaring as OTHER for GPL-2.0 with Universal FOSS exception

**Resolution:**
Per POM file

**Affected definitions**:
- [mysql-connector-j 8.0.31](https://clearlydefined.io/definitions/maven/mavencentral/com.mysql/mysql-connector-j/8.0.31/8.0.31)