### PR TITLE
Adds the licence for v 0.0.68

### DIFF
--- a/curations/nuget/nuget/-/Hic.Mustache.MSBuild.yaml
+++ b/curations/nuget/nuget/-/Hic.Mustache.MSBuild.yaml
@@ -12,3 +12,6 @@ revisions:
   0.0.67:
     licensed:
       declared: NONE
+  0.0.68:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
Type: Missing

Summary:
Hic.Mustache.MSBuild 0.0.68

Details:
Add MIT License

Resolution:
License Url:
https://github.com/oyvindh/Mustache.MSBuild/blob/main/LICENSE

Description:
This is the LICENSE file in the component's github repo. Explicitly defining it as having an MIT license.
The repo is also tagged as having an MIT License in github. The license is included in the package and is visible on the nuget package page here https://www.nuget.org/packages/Hic.Mustache.MSBuild/0.0.68#readme-body-tab

Pull request generated by Microsoft tooling.

Affected definitions:

Hic.Mustache.MSBuild 0.0.68