### PR TITLE
pillow10.4.0

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -18,6 +18,9 @@ revisions:
   10.3.0:
     licensed:
       declared: HPND
+  10.4.0:
+    licensed:
+      declared: HPND
   6.0.0:
     licensed:
       declared: HPND


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pillow10.4.0

**Details:**
Correcting to HPND

**Resolution:**
The license is not CAL

**Affected definitions**:
- [pillow 10.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/10.4.0/10.4.0)