### PR TITLE
Hangfire.AspNetCore1.8.14

### DIFF
--- a/curations/nuget/nuget/-/Hangfire.AspNetCore.yaml
+++ b/curations/nuget/nuget/-/Hangfire.AspNetCore.yaml
@@ -24,3 +24,6 @@ revisions:
   1.7.9:
     licensed:
       declared: LGPL-3.0-or-later OR OTHER
+  1.8.14:
+    licensed:
+      declared: LGPL-3.0-or-later OR OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Hangfire.AspNetCore1.8.14

**Details:**
Fixing curation to LPGL-3.0-or-later OR OTHER

**Resolution:**
https://www.nuget.org/packages/Hangfire.AspNetCore/1.8.14/License

**Affected definitions**:
- [Hangfire.AspNetCore 1.8.14](https://clearlydefined.io/definitions/nuget/nuget/-/Hangfire.AspNetCore/1.8.14/1.8.14)