### PR TITLE
org.apache.tomcat.embed/tomcat-embed-core9.0.91

### DIFF
--- a/curations/maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core.yaml
+++ b/curations/maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tomcat-embed-core
+  namespace: org.apache.tomcat.embed
+  provider: mavencentral
+  type: maven
+revisions:
+  9.0.91:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.apache.tomcat.embed/tomcat-embed-core9.0.91

**Details:**
Fixing Declared License to Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/apache/tomcat/embed/tomcat-embed-core/9.0.91/tomcat-embed-core-9.0.91.pom

**Affected definitions**:
- [tomcat-embed-core 9.0.91](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-core/9.0.91/9.0.91)