### PR TITLE
HotChocolate.AspNetCore.Authorization/12.22.4

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.AspNetCore.Authorization.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.AspNetCore.Authorization.yaml
@@ -45,6 +45,9 @@ revisions:
   12.22.2:
     licensed:
       declared: MIT
+  12.22.4:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.AspNetCore.Authorization/12.22.4

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.AspNetCore.Authorization/12.22.4/License

**Affected definitions**:
- [HotChocolate.AspNetCore.Authorization 12.22.4](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.AspNetCore.Authorization/12.22.4)