### PR TITLE
HotChocolate.Fetching/12.22.4

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Fetching.yaml
@@ -45,6 +45,9 @@ revisions:
   12.22.2:
     licensed:
       declared: MIT
+  12.22.4:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Fetching/12.22.4

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Fetching/12.22.4/License

**Affected definitions**:
- [HotChocolate.Fetching 12.22.4](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Fetching/12.22.4)