### PR TITLE
HotChocolate.Language.SyntaxTree/12.22.4

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Language.SyntaxTree.yaml
@@ -45,6 +45,9 @@ revisions:
   12.22.2:
     licensed:
       declared: MIT
+  12.22.4:
+    licensed:
+      declared: MIT
   12.3.2:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Language.SyntaxTree/12.22.4

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Language.SyntaxTree/12.22.4/License

**Affected definitions**:
- [HotChocolate.Language.SyntaxTree 12.22.4](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Language.SyntaxTree/12.22.4)