### PR TITLE
HotChocolate.Stitching/12.22.4

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Stitching.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Stitching.yaml
@@ -15,6 +15,9 @@ revisions:
   12.22.2:
     licensed:
       declared: MIT
+  12.22.4:
+    licensed:
+      declared: MIT
   12.7.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Stitching/12.22.4

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Stitching/12.22.4/License

**Affected definitions**:
- [HotChocolate.Stitching 12.22.4](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Stitching/12.22.4)