### PR TITLE
HotChocolate.Stitching.Redis/12.22.4

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Stitching.Redis.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Stitching.Redis.yaml
@@ -6,3 +6,6 @@ revisions:
   12.22.2:
     licensed:
       declared: MIT
+  12.22.4:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Stitching.Redis/12.22.4

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Stitching.Redis/12.22.4/License

**Affected definitions**:
- [HotChocolate.Stitching.Redis 12.22.4](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Stitching.Redis/12.22.4)