### PR TITLE
HotChocolate.Types.Mutations/12.22.4

### DIFF
--- a/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
+++ b/curations/nuget/nuget/-/HotChocolate.Types.Mutations.yaml
@@ -33,6 +33,9 @@ revisions:
   12.22.2:
     licensed:
       declared: MIT
+  12.22.4:
+    licensed:
+      declared: MIT
   12.5.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
HotChocolate.Types.Mutations/12.22.4

**Details:**
Add MIT

**Resolution:**
https://www.nuget.org/packages/HotChocolate.Types.Mutations/12.22.4/License

**Affected definitions**:
- [HotChocolate.Types.Mutations 12.22.4](https://clearlydefined.io/definitions/nuget/nuget/-/HotChocolate.Types.Mutations/12.22.4)