### PR TITLE
Google.Apis.Bigquery.v2/1.54.0.2397

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.Bigquery.v2.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.Bigquery.v2.yaml
@@ -6,6 +6,9 @@ revisions:
   1.45.0.1909:
     licensed:
       declared: Apache-2.0
+  1.54.0.2397:
+    licensed:
+      declared: Apache-2.0
   1.57.0.2718:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.Bigquery.v2/1.54.0.2397

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.Bigquery.v2/1.54.0.2397/License

**Affected definitions**:
- [Google.Apis.Bigquery.v2 1.54.0.2397](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.Bigquery.v2/1.54.0.2397)