### PR TITLE
Google.Apis.Compute.v1/1.55.0.2511

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.Compute.v1.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.Compute.v1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google.Apis.Compute.v1
+  provider: nuget
+  type: nuget
+revisions:
+  1.55.0.2511:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.Compute.v1/1.55.0.2511

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.Compute.v1/1.55.0.2511/License

**Affected definitions**:
- [Google.Apis.Compute.v1 1.55.0.2511](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.Compute.v1/1.55.0.2511)