### PR TITLE
Google.Apis.Container.v1/1.55.0.2533

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.Container.v1.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.Container.v1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google.Apis.Container.v1
+  provider: nuget
+  type: nuget
+revisions:
+  1.55.0.2533:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.Container.v1/1.55.0.2533

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.Container.v1/1.55.0.2533/License

**Affected definitions**:
- [Google.Apis.Container.v1 1.55.0.2533](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.Container.v1/1.55.0.2533)