### PR TITLE
Google.Apis.Dns.v1/1.55.0.2498

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.Dns.v1.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.Dns.v1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google.Apis.Dns.v1
+  provider: nuget
+  type: nuget
+revisions:
+  1.55.0.2498:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.Dns.v1/1.55.0.2498

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.Container.v1/1.55.0.2533/License

**Affected definitions**:
- [Google.Apis.Dns.v1 1.55.0.2498](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.Dns.v1/1.55.0.2498)