### PR TITLE
Google.Apis.OSConfig.v1/1.55.0.2501

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.OSConfig.v1.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.OSConfig.v1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google.Apis.OSConfig.v1
+  provider: nuget
+  type: nuget
+revisions:
+  1.55.0.2501:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.OSConfig.v1/1.55.0.2501

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.OSConfig.v1/1.55.0.2501/License

**Affected definitions**:
- [Google.Apis.OSConfig.v1 1.55.0.2501](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.OSConfig.v1/1.55.0.2501)