### PR TITLE
Google.Apis.SQLAdmin.v1/1.55.0.2505

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.SQLAdmin.v1.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.SQLAdmin.v1.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Google.Apis.SQLAdmin.v1
+  provider: nuget
+  type: nuget
+revisions:
+  1.55.0.2505:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.SQLAdmin.v1/1.55.0.2505

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.SQLAdmin.v1/1.55.0.2505/License

**Affected definitions**:
- [Google.Apis.SQLAdmin.v1 1.55.0.2505](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.SQLAdmin.v1/1.55.0.2505)