### PR TITLE
Google.Apis.Storage.v1/1.55.0.2452

### DIFF
--- a/curations/nuget/nuget/-/Google.Apis.Storage.v1.yaml
+++ b/curations/nuget/nuget/-/Google.Apis.Storage.v1.yaml
@@ -18,6 +18,9 @@ revisions:
   1.49.0.2151:
     licensed:
       declared: Apache-2.0
+  1.55.0.2452:
+    licensed:
+      declared: Apache-2.0
   1.55.0.2526:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Google.Apis.Storage.v1/1.55.0.2452

**Details:**
Add Apache-2.0

**Resolution:**
https://www.nuget.org/packages/Google.Apis.Storage.v1/1.55.0.2452/License

**Affected definitions**:
- [Google.Apis.Storage.v1 1.55.0.2452](https://clearlydefined.io/definitions/nuget/nuget/-/Google.Apis.Storage.v1/1.55.0.2452)