### PR TITLE
NetSpell 2.1.7

### DIFF
--- a/curations/nuget/nuget/-/NetSpell.yaml
+++ b/curations/nuget/nuget/-/NetSpell.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: NetSpell
+  provider: nuget
+  type: nuget
+revisions:
+  2.1.7:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Missing

**Summary:**
NetSpell 2.1.7

**Details:**
NuGet package page does not link to a GitHub repo or include license info. It does point to an project page that leads you to this repo: https://github.com/loresoft/NetSpell. However, the MIT license was added years after the package was published.

**Resolution:**
Therefore, curating the package as NONE. 

**Affected definitions**:
- [NetSpell 2.1.7](https://clearlydefined.io/definitions/nuget/nuget/-/NetSpell/2.1.7/2.1.7)