### PR TITLE
nokogiri1.16.6

### DIFF
--- a/curations/gem/rubygems/-/nokogiri.yaml
+++ b/curations/gem/rubygems/-/nokogiri.yaml
@@ -51,3 +51,6 @@ revisions:
   1.16.5:
     licensed:
       declared: MIT
+  1.16.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
nokogiri1.16.6

**Details:**
Fixing Declared field to MIT

**Resolution:**
https://github.com/sparklemotion/nokogiri/blob/v1.16.6/LICENSE.md

**Affected definitions**:
- [nokogiri 1.16.6](https://clearlydefined.io/definitions/gem/rubygems/-/nokogiri/1.16.6/1.16.6)