### PR TITLE
BananaCakePop.Middleware 16.0.1

### DIFF
--- a/curations/nuget/nuget/-/BananaCakePop.Middleware.yaml
+++ b/curations/nuget/nuget/-/BananaCakePop.Middleware.yaml
@@ -9,6 +9,9 @@ revisions:
   16.0.1:
     licensed:
       declared: OTHER
+  16.0.3:
+    licensed:
+      declared: OTHER
   7.0.4:
     licensed:
       declared: OTHER

--- a/curations/nuget/nuget/-/BananaCakePop.Middleware.yaml
+++ b/curations/nuget/nuget/-/BananaCakePop.Middleware.yaml
@@ -6,6 +6,9 @@ revisions:
   13.0.0:
     licensed:
       declared: OTHER
+  16.0.1:
+    licensed:
+      declared: OTHER
   7.0.4:
     licensed:
       declared: OTHER


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
BananaCakePop.Middleware 16.0.1

**Details:**
Add OTHER License

**Resolution:**
License Url:
https://www.nuget.org/packages/BananaCakePop.Middleware/16.0.1/License

Description:
License is similar to Elastic 2.0 but removes the 1st paragraph in the "Limitations" section

**Affected definitions**:
- [BananaCakePop.Middleware 16.0.1](https://clearlydefined.io/definitions/nuget/nuget/-/BananaCakePop.Middleware/16.0.1)