### PR TITLE
Adding versions to SqlServer.Types and Graph

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Graph.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Graph.yaml
@@ -144,3 +144,6 @@ revisions:
   4.49.0:
     licensed:
       declared: MIT
+  4.51.0:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.SqlServer.Types.yaml
+++ b/curations/nuget/nuget/-/Microsoft.SqlServer.Types.yaml
@@ -6,3 +6,6 @@ revisions:
   11.0.2:
     licensed:
       declared: OTHER
+  160.1000.6:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
Add additional versions to Microsoft SqlServer.Types and Microsoft.Graph components for the D365BC 2024W2 release.