### PR TITLE
archetype/0.0.1.pre.6

### DIFF
--- a/curations/gem/rubygems/-/archetype.yaml
+++ b/curations/gem/rubygems/-/archetype.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: archetype
+  provider: rubygems
+  type: gem
+revisions:
+  0.0.1.pre.6:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
archetype/0.0.1.pre.6

**Details:**
Add Apache 2.0

**Resolution:**
https://github.com/LinkedInAttic/archetype/blob/424049b59e34f619b341eea6deea43d60db83e75/LICENSE

**Affected definitions**:
- [archetype 0.0.1.pre.6](https://clearlydefined.io/definitions/gem/rubygems/-/archetype/0.0.1.pre.6/0.0.1.pre.6)