### PR TITLE
@grafana/ui 8.3.7

### DIFF
--- a/curations/npm/npmjs/@grafana/ui.yaml
+++ b/curations/npm/npmjs/@grafana/ui.yaml
@@ -4,9 +4,12 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
-  9.1.0:
+  8.3.7:
     licensed:
       declared: Apache-2.0
   8.5.4:
+    licensed:
+      declared: Apache-2.0
+  9.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@grafana/ui8.3.7

**Details:**
Per https://github.com/grafana/grafana/blob/HEAD/LICENSING.md, the ui package is Apache

**Resolution:**
Apache-2.0

**Affected definitions**:
- [ui 8.3.7](https://clearlydefined.io/definitions/npm/npmjs/@grafana/ui/8.3.7/8.3.7)