### PR TITLE
@grafana/e2e-selectors 9.1.0

### DIFF
--- a/curations/npm/npmjs/@grafana/e2e-selectors.yaml
+++ b/curations/npm/npmjs/@grafana/e2e-selectors.yaml
@@ -4,9 +4,12 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
+  8.4.11:
+    licensed:
+      declared: Apache-2.0
   8.5.4:
     licensed:
       declared: Apache-2.0
-  8.4.11:
+  9.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@grafana/e2e-selectors 9.1.0

**Details:**
This package is Apache per https://github.com/grafana/grafana/blob/HEAD/LICENSING.md

**Resolution:**
Apache-2.0

**Affected definitions**:
- [e2e-selectors 9.1.0](https://clearlydefined.io/definitions/npm/npmjs/@grafana/e2e-selectors/9.1.0/9.1.0)