### PR TITLE
@grafana/schema 9.0.2

### DIFF
--- a/curations/npm/npmjs/@grafana/schema.yaml
+++ b/curations/npm/npmjs/@grafana/schema.yaml
@@ -4,9 +4,12 @@ coordinates:
   provider: npmjs
   type: npm
 revisions:
-  9.1.0:
+  8.5.4:
     licensed:
       declared: Apache-2.0
-  8.5.4:
+  9.0.2:
+    licensed:
+      declared: Apache-2.0
+  9.1.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@grafana/schema 9.0.2

**Details:**
Per https://github.com/grafana/grafana/blob/HEAD/LICENSING.md, schema package is Apache-2.0

**Resolution:**
Apache-2.0

**Affected definitions**:
- [schema 9.0.2](https://clearlydefined.io/definitions/npm/npmjs/@grafana/schema/9.0.2/9.0.2)