### PR TITLE
org.apache.avro/avro-mapred 1.8.2

### DIFF
--- a/curations/maven/mavencentral/org.apache.avro/avro-mapred.yaml
+++ b/curations/maven/mavencentral/org.apache.avro/avro-mapred.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: avro-mapred
+  namespace: org.apache.avro
+  provider: mavencentral
+  type: maven
+revisions:
+  1.8.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.apache.avro/avro-mapred 1.8.2

**Details:**
Not sure why NOASSERTION is included in the declared field - because there's a NOTICE file?

**Resolution:**
Should just be "Apache-2.0" for the declared license

**Affected definitions**:
- [avro-mapred 1.8.2](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.avro/avro-mapred/1.8.2/1.8.2)