### PR TITLE
codespell2.2.6

### DIFF
--- a/curations/pypi/pypi/-/codespell.yaml
+++ b/curations/pypi/pypi/-/codespell.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: codespell
+  provider: pypi
+  type: pypi
+revisions:
+  2.2.6:
+    licensed:
+      declared: GPL-2.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
codespell2.2.6

**Details:**
Fixing Declared Field to GPL-2.0-only

**Resolution:**
https://github.com/codespell-project/codespell/blob/master/codespell_lib/_codespell.py

**Affected definitions**:
- [codespell 2.2.6](https://clearlydefined.io/definitions/pypi/pypi/-/codespell/2.2.6/2.2.6)