### PR TITLE
org.kohsuke/graphviz-api 1.1

### DIFF
--- a/curations/maven/mavencentral/org.kohsuke/graphviz-api.yaml
+++ b/curations/maven/mavencentral/org.kohsuke/graphviz-api.yaml
@@ -7,3 +7,6 @@ revisions:
   '1.0':
     licensed:
       declared: NONE
+  '1.1':
+    licensed:
+      declared: CPL-1.0


### PR DESCRIPTION

**Type:** Missing

**Summary:**
org.kohsuke/graphviz-api 1.1

**Details:**
There's a file in the package that points to this website where you can see the license is CPL https://www.graphviz.org/license/

**Resolution:**
CPL-1.0

**Affected definitions**:
- [graphviz-api 1.1](https://clearlydefined.io/definitions/maven/mavencentral/org.kohsuke/graphviz-api/1.1/1.1)