### PR TITLE
org.kohsuke/graphviz-api 1.0

### DIFF
--- a/curations/maven/mavencentral/org.kohsuke/graphviz-api.yaml
+++ b/curations/maven/mavencentral/org.kohsuke/graphviz-api.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
   '1.0':
     licensed:
-      declared: NONE
+      declared: CPL-1.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.kohsuke/graphviz-api 1.0

**Details:**
This was NONE but found a file that points to this website where you can see the license is CPL - https://www.graphviz.org/license/

**Resolution:**
CPL-1.0

**Affected definitions**:
- [graphviz-api 1.0](https://clearlydefined.io/definitions/maven/mavencentral/org.kohsuke/graphviz-api/1.0/1.0)