### PR TITLE
psycopg2/2.4.0, psycopg2/2.9.5, psycopg2/2.9.6, psycopg2/2.9.8

### DIFF
--- a/curations/pypi/pypi/-/psycopg2.yaml
+++ b/curations/pypi/pypi/-/psycopg2.yaml
@@ -60,6 +60,9 @@ revisions:
   '2.4':
     licensed:
       declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
+  2.4.0:
+    licensed:
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.4.1:
     licensed:
       declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
@@ -324,6 +327,15 @@ revisions:
   2.9.3:
     licensed:
       declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
+  2.9.5:
+    licensed:
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
+  2.9.6:
+    licensed:
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
   2.9.7:
+    licensed:
+      declared: LGPL-3.0-or-later WITH openvpn-openssl-exception
+  2.9.8:
     licensed:
       declared: LGPL-3.0-or-later WITH openvpn-openssl-exception


### PR DESCRIPTION
**Type:** Incorrect

**Summary:**
psycopg2/2.4.0, psycopg2/2.9.5, psycopg2/2.9.6, psycopg2/2.9.8

**Details:**
Add LGPL-3.0-or-later WITH openvpn-openssl-exception

**Resolution:**
- https://github.com/psycopg/psycopg2/blob/2_4_0/LICENSE
- https://github.com/psycopg/psycopg2/blob/2_9_5/LICENSE
- https://github.com/psycopg/psycopg2/blob/2.9.6/LICENSE
- https://github.com/psycopg/psycopg2/blob/2.9.8/LICENSE


**Affected definitions**:
- [psycopg2 2.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2/2.4.0)
- [psycopg2 2.9.5](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2/2.9.5)
- [psycopg2 2.9.6](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2/2.9.6)
- [psycopg2 2.9.8](https://clearlydefined.io/definitions/pypi/pypi/-/psycopg2/2.9.8)