### PR TITLE
mypy 1.11.2

### DIFF
--- a/curations/pypi/pypi/-/mypy.yaml
+++ b/curations/pypi/pypi/-/mypy.yaml
@@ -83,6 +83,9 @@ revisions:
   1.11.1:
     licensed:
       declared: MIT
+  1.11.2:
+    licensed:
+      declared: MIT
   1.2.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incomplete

**Summary:**
mypy 1.11.2

**Details:**
"Discovered" license info erroneously included in "declared" field

**Resolution:**
MIT

**Affected definitions**:
- [mypy 1.11.2](https://clearlydefined.io/definitions/pypi/pypi/-/mypy/1.11.2/1.11.2)