### PR TITLE
[Missing License Curation] - httpsys/0.3.2

### DIFF
--- a/curations/npm/npmjs/-/httpsys.yaml
+++ b/curations/npm/npmjs/-/httpsys.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: httpsys
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.2:
+    license:
+      declared: TODO


### PR DESCRIPTION
**Type:** Missing

**Summary:**
bootstrap-sortable 2.0.0

**Details:**
Add MIT License

**Resolution:**
License Url:
https://github.com/drvic10k/bootstrap-sortable/blob/master/license.md

Description:
Linked from https://www.nuget.org/packages/bootstrap-sortable

Pull request generated by Microsoft tooling.

**Affected definitions**:
- [bootstrap-sortable 2.0.0](https://clearlydefined.io/definitions/nuget/nuget/-/bootstrap-sortable/2.0.0)