### PR TITLE
[Missing License Curation][TEST - DO NOT MERGE] - httpsys/0.3.2

### DIFF
--- a/curations/npm/npmjs/-/httpsys.yaml
+++ b/curations/npm/npmjs/-/httpsys.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: httpsys
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
Resolve case of SPDX License missing

**Details:**
There is SPDX mentioned in the declared license, whereas the license information is available in the source repository as Apache-2.0.

**Resolution:**
The license is being curated as Apache-2.0 instead of SPDX as the license information is available in the source repository.

**Affected definitions**:
- [httpsys 0.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/httpsys/0.3.2)