### PR TITLE
[Missing License Curation][TEST - DO NOT MERGE] - httpsys/0.3.2

### DIFF
--- a/curations/npm/npmjs/-/httpsys.yaml
+++ b/curations/npm/npmjs/-/httpsys.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: httpsys
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
### Missing License AI Curation

**Component**:

**Affected definition**: [httpsys 0.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/httpsys/0.3.2)

---

### LICENSE.txt

- Suggested Declared License(s): Apache-2.0
- Suggested Discovered License(s): Apache-2.0
- Confidence: 98%

**Proof and Explanation:**

The content provided is a standard Apache License, Version 2.0 notice. The explicit mention of "Licensed under the Apache License, Version 2.0" and the URL link to the license text strongly indicate that the license is Apache-2.0. The structure and wording are consistent with the typical language used in an Apache-2.0 license header, providing high confidence in the identification.