### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - httpsys/0.3.2

### DIFF
--- a/curations/npm/npmjs/-/httpsys.yaml
+++ b/curations/npm/npmjs/-/httpsys.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: httpsys
+  provider: npmjs
+  type: npm
+revisions:
+  0.3.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: httpsys v0.3.2

**Affected definition**: [httpsys v0.3.2](https://clearlydefined.io/definitions/npm/npmjs/-/httpsys/0.3.2)

---

### File Discovered: LICENSE.txt

- Suggested Declared License(s): Apache-2.0
- Suggested Discovered License(s): Apache-2.0
- Confidence: 100%

**Proof and Explanation:**

The provided text is a copyright statement and a standard header for the Apache License, Version 2.0. It explicitly mentions that the software is "Licensed under the Apache License, Version 2.0" and provides a link to the official license text at http://www.apache.org/licenses/LICENSE-2.0. The language in the text, such as "AS IS" BASIS and "WITHOUT WARRANTIES OR CONDITIONS," is standard for the Apache License, Version 2.0.

Since the license is explicitly declared in the header and follows the standard form of the Apache License, the confidence level is at 100%.