### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-application-base/1.15.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-application-base.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-application-base.yaml
@@ -121,3 +121,6 @@ revisions:
   1.9.1:
     licensed:
       declared: OTHER
+  1.15.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-application-base v1.15.2

**Affected definition**: [sp-application-base v1.15.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-application-base/1.15.2)

---

### File Discovered: package.json

The license specified in the `package.json` file is "SEE LICENSE IN \"EULA\" FOLDER". This suggests the license is included elsewhere in an End User License Agreement (EULA), which is typically commercial.

- Suggested Declared License(s): OTHER
- Confidence: 95%

**Explanation:**
- The term "EULA" commonly refers to a commercial license, which is why it is labeled as "OTHER".
- The package.json does not directly list an open-source license in SPDX format.