### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-application-base/1.15.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-application-base.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-application-base.yaml
@@ -121,3 +121,6 @@ revisions:
   1.9.1:
     licensed:
       declared: OTHER
+  1.15.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-application-base v1.15.2

**Affected definition**: [sp-application-base v1.15.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-application-base/1.15.2)

**Suggested License**: OTHER

---

### File Discovered: package.json

Based on the provided `package.json`, the declared license is "SEE LICENSE IN \"EULA\" FOLDER". This indicates a reference to a specific EULA folder for licensing information, which typically points to a commercial license.

**Suggested Declared License(s):** OTHER

**Confidence:** 95%

**Proof & Explanation:**

- The `"license"` field suggests that the specific terms can be found in the "EULA" folder. EULAs (End User License Agreements) often imply a commercial nature, hence the label "OTHER".
- There is no direct mapping to an SPDX identifier in the information provided, reinforcing the classification as "OTHER".

Given this setup, without further content from the EULA folder, the classification aligns with typical commercial licensing practices.