### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wl-msg-reader/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/wl-msg-reader.yaml
+++ b/curations/npm/npmjs/-/wl-msg-reader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wl-msg-reader
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wl-msg-reader v0.2.1

**Affected definition**: [wl-msg-reader v0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/wl-msg-reader/0.2.1)

**Suggested License**: Apache-2.0

---

### File Discovered: package.json

- Suggested Declared License(s): Apache-2.0
- Confidence: 90%

**Explanation:**

- The "license" property in the `package.json` indicates "APACHE".
- "APACHE" is not a standard SPDX identifier but it closely resembles "Apache-2.0".
- Apache-2.0 is a commonly used license, so interpreting "APACHE" as "Apache-2.0" is reasonable.
  
**Proof:**

According to SPDX standards, "Apache-2.0" is the correct SPDX identifier for the Apache License, Version 2.0. Considering the commonly accepted abbreviation "APACHE" aligns with "Apache-2.0", it is likely the intended license.