### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-dialog/1.19.0

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-dialog.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-dialog.yaml
@@ -25,3 +25,6 @@ revisions:
   1.9.1:
     licensed:
       declared: OTHER
+  1.19.0:
+    licensed:
+      declared: NONE


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-dialog v1.19.0

**Affected definition**: [sp-dialog v1.19.0](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-dialog/1.19.0)

**Suggested License**: NONE

---

### File Discovered: package.json

The `package.json` specifies the license as a URL: `https://aka.ms/spfx/license`. Since it does not provide an explicit license type and is linking externally, it is difficult to determine the SPDX format directly from this information alone.

Therefore, the result is:

NULL