### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wl-msg-reader/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/wl-msg-reader.yaml
+++ b/curations/npm/npmjs/-/wl-msg-reader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wl-msg-reader
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wl-msg-reader v0.2.1

**Affected definition**: [wl-msg-reader v0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/wl-msg-reader/0.2.1)

**Suggested License**: Apache-2.0

---

### File Discovered: package.json

- Declared License: Apache-2.0
- Confidence: 90%

### Explanation:

1. **Declared License:**
   - The `license` field in the `package.json` specifies "APACHE". In SPDX format, the correct identifier for the Apache License is "Apache-2.0".

2. **Confidence:**
   - The confidence level is set to 90% because the license field provides a clear indication of the intended license. However, it's slightly reduced due to the use of "APACHE" instead of the full SPDX identifier.