### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @uifabric/prettier-rules/1.0.2

### DIFF
--- a/curations/npm/npmjs/@uifabric/prettier-rules.yaml
+++ b/curations/npm/npmjs/@uifabric/prettier-rules.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: prettier-rules
+  provider: npmjs
+  type: npm
+  namespace: '@uifabric'
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
## Missing License AI Curation

**Component**: prettier-rules v1.0.2

**Affected definition**: [prettier-rules v1.0.2](https://clearlydefined.io/definitions/npm/npmjs/@uifabric/prettier-rules/1.0.2)

**Suggested License**: MIT

---

### File Discovered: LICENSE

Suggested Declared License(s): MIT

Suggested Discovered License(s): MIT

Confidence: 95%

**Proof and Explanation:**

- The text explicitly states that the component is under the "MIT License."
- The license text provided matches the standard MIT License format.
- The note regarding fonts and icons, while mentioning a different asset license, does not affect the overarching MIT License of the software itself.
- The inclusion of a commercial link related to a specific asset note (https://aka.ms/fabric-assets-license) reinforces that assets have separate terms, but it doesn’t change the main software license.
- Therefore, the overall license for the software part is MIT with 95% confidence since the main content declares the MIT License clearly.