### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wl-msg-reader/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/wl-msg-reader.yaml
+++ b/curations/npm/npmjs/-/wl-msg-reader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wl-msg-reader
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wl-msg-reader v0.2.1

**Affected definition**: [wl-msg-reader v0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/wl-msg-reader/0.2.1)

**Suggested License**: Apache-2.0

---

### File Discovered: package.json

From the `package.json` provided, the license indicated is "APACHE". However, to ensure proper SPDX formatting, we need to check if it's referring to a specific version of the Apache License.

Given common conventions, it's likely referring to Apache License 2.0, which is represented in SPDX format as "Apache-2.0".

Proof:
- The "license" property in the `package.json` states "APACHE".
- "APACHE" typically refers to the Apache License.
- Common interpretation would be Apache License 2.0 in the context of open source projects.

Suggested Declared License: Apache-2.0
Confidence: 90%