### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @uifabric/prettier-rules/1.0.2

### DIFF
--- a/curations/npm/npmjs/@uifabric/prettier-rules.yaml
+++ b/curations/npm/npmjs/@uifabric/prettier-rules.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: prettier-rules
+  provider: npmjs
+  type: npm
+  namespace: '@uifabric'
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
## Missing License AI Curation

**Component**: prettier-rules v1.0.2

**Affected definition**: [prettier-rules v1.0.2](https://clearlydefined.io/definitions/npm/npmjs/@uifabric/prettier-rules/1.0.2)

**Suggested License**: MIT

---

### File Discovered: LICENSE

**Suggested Declared License(s):** MIT

**Suggested Discovered License(s):** MIT

**Confidence:** 95%

**Proof and Explanation:**

- The text provided is a full MIT License. It explicitly states "MIT License" and follows the standard MIT License template.
- The inclusion of a copyright notice and permission terms aligns with the official MIT License structure.
- Although there is a note about fonts and icons usage being subject to a different license (linked to a URL), it does not affect the overarching license of the software itself, which is MIT.
- Given this information, the MIT License is the sole overarching license for the package.