### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - relative-luminance/0.0.0

### DIFF
--- a/curations/npm/npmjs/-/relative-luminance.yaml
+++ b/curations/npm/npmjs/-/relative-luminance.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: relative-luminance
+  provider: npmjs
+  type: npm
+revisions:
+  0.0.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION
## Missing License AI Curation

**Component**: relative-luminance v0.0.0

**Affected definition**: [relative-luminance v0.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/relative-luminance/0.0.0)

**Suggested License**: BSD-2-Clause

---

### File Discovered: package.json

Suggested Declared License(s): BSD-2-Clause  
Confidence: 90%

**Explanation:**

- The "license" property in the `package.json` is specified as "BSD".
- BSD typically refers to BSD-2-Clause or BSD-3-Clause, but without further details, BSD-2-Clause is often assumed.
- Therefore, the suggested license is BSD-2-Clause in SPDX format.

If you have further content, like from a LICENSE file, it would be beneficial to ascertain the correct rendering of the BSD license.