### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wcag-contrast/0.1.0

### DIFF
--- a/curations/npm/npmjs/-/wcag-contrast.yaml
+++ b/curations/npm/npmjs/-/wcag-contrast.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wcag-contrast
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.0:
+    licensed:
+      declared: BSD-2-Clause


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wcag-contrast v0.1.0

**Affected definition**: [wcag-contrast v0.1.0](https://clearlydefined.io/definitions/npm/npmjs/-/wcag-contrast/0.1.0)

**Suggested License**: BSD-2-Clause

---

### File Discovered: package.json

Suggested Declared License: BSD-2-Clause

Proof of Findings:
- The `package.json` file contains a `"license"` property with the value `"BSD"`.
  
Explanation:
- The `"license": "BSD"` in the `package.json` suggests a BSD license. Typically, this is interpreted as BSD-2-Clause in SPDX format when not specified otherwise.

Confidence: 90%
- Since the `package.json` directly declares "BSD" without specifics, there's a slight possibility it could refer to another variant of BSD, but BSD-2-Clause is the most common one used in such cases.