### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wl-msg-reader/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/wl-msg-reader.yaml
+++ b/curations/npm/npmjs/-/wl-msg-reader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wl-msg-reader
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wl-msg-reader v0.2.1

**Affected definition**: [wl-msg-reader v0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/wl-msg-reader/0.2.1)

**Suggested License**: Apache-2.0

---

### File Discovered: package.json

Suggested Declared License(s): Apache-2.0  
Confidence: 90%

Proof and Explanation:

- The "license" property in the `package.json` specifies "APACHE". This closely resembles the Apache-2.0 license in SPDX format.
- Since "APACHE" is not a standard SPDX identifier on its own, the closest equivalent in SPDX format is "Apache-2.0".
- No other evidence of a different license is present in the provided data.
- Given the resemblance to a well-known license, we have a high confidence level that the intended license is "Apache-2.0".