### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - azure-maps-control/3.0.3

### DIFF
--- a/curations/npm/npmjs/-/azure-maps-control.yaml
+++ b/curations/npm/npmjs/-/azure-maps-control.yaml
@@ -63,3 +63,6 @@ revisions:
   3.3.0:
     licensed:
       declared: OTHER
+  3.0.3:
+    licensed:
+      declared: NONE


### PR DESCRIPTION
## Missing License AI Curation

**Component**: azure-maps-control v3.0.3

**Affected definition**: [azure-maps-control v3.0.3](https://clearlydefined.io/definitions/npm/npmjs/-/azure-maps-control/3.0.3)

**Suggested License**: NONE

---

### File Discovered: package.json

The `package.json` file specifies that the license information can be found in a file named `LICENSE.TXT`. The presence of "SEE LICENSE IN LICENSE.TXT" indicates that the license details are not explicitly stated in the `package.json` itself, so it's necessary to consult the referenced `LICENSE.TXT` file to determine the actual license.

Since the exact license isn't directly declared in the `package.json`, and the file `LICENSE.TXT` content wasn't provided here, my response based only on `package.json` is:

NULL