### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @uifabric/prettier-rules/1.0.2

### DIFF
--- a/curations/npm/npmjs/@uifabric/prettier-rules.yaml
+++ b/curations/npm/npmjs/@uifabric/prettier-rules.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: prettier-rules
+  provider: npmjs
+  type: npm
+  namespace: '@uifabric'
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
## Missing License AI Curation

**Component**: prettier-rules v1.0.2

**Affected definition**: [prettier-rules v1.0.2](https://clearlydefined.io/definitions/npm/npmjs/@uifabric/prettier-rules/1.0.2)

**Suggested License**: MIT

---

### File Discovered: LICENSE

- Suggested Declared License(s): MIT
- Suggested Discovered License(s): MIT
- Confidence: 95%

**Proof and Explanation:**

The text provided includes the full text of the MIT License, which is a well-known open-source license allowing extensive freedom to use, copy, modify, merge, publish, distribute, sublicense, and sell copies of the software.

**Reasoning:**

1. **Copyright Notice**: The header includes a copyright notice from Microsoft Corporation.
   
2. **License Text**: The full text of the MIT License is present, providing standard permissions and disclaimers associated with this license.

3. **Confidence**: The mention of an additional note regarding fonts and icons does not alter the main licensing of the software component, which remains under MIT. There's no indication of a commercial license here, thus "OTHER" does not apply.

Given the explicit mention of the MIT License and absence of any conflicting or overriding license in the provided text, the primary license is confidently identified as MIT.