### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wl-msg-reader/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/wl-msg-reader.yaml
+++ b/curations/npm/npmjs/-/wl-msg-reader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wl-msg-reader
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wl-msg-reader v0.2.1

**Affected definition**: [wl-msg-reader v0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/wl-msg-reader/0.2.1)

**Suggested License**: Apache-2.0

---

### File Discovered: package.json

APACHE is not a valid SPDX identifier. If you meant the Apache License, the correct SPDX identifier is "Apache-2.0". 

**Suggested Declared License(s): Apache-2.0**

- **Proof**: The "license" field in the `package.json` specifies "APACHE".
- **Confidence**: 90% (assuming "APACHE" refers to "Apache-2.0").