### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @uifabric/prettier-rules/1.0.2

### DIFF
--- a/curations/npm/npmjs/@uifabric/prettier-rules.yaml
+++ b/curations/npm/npmjs/@uifabric/prettier-rules.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: prettier-rules
+  provider: npmjs
+  type: npm
+  namespace: '@uifabric'
+revisions:
+  1.0.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
## Missing License AI Curation

**Component**: prettier-rules v1.0.2

**Affected definition**: [prettier-rules v1.0.2](https://clearlydefined.io/definitions/npm/npmjs/@uifabric/prettier-rules/1.0.2)

**Suggested License**: MIT

---

### File Discovered: LICENSE

- Suggested Declared License(s): MIT
- Suggested Discovered License(s): MIT
- Confidence: 95%

**Explanation:**

The text provided is a standard MIT License, which is a permissive open-source license. The key elements of the MIT License are present, such as permission to use, copy, modify, merge, publish, distribute, sublicense, and sell copies of the software. The disclaimer of warranty is also included.

The note about fonts and icons being subject to a different license does not affect the overall license of the software itself, which remains MIT. The link provided does not explicitly indicate a commercial license for the software, so it does not change the declared license.

The confidence level is set at 95% due to the clear presence of the MIT License text.