### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-build-web/1.18.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-build-web.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-build-web.yaml
@@ -28,3 +28,6 @@ revisions:
   1.9.1:
     licensed:
       declared: OTHER
+  1.18.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-build-web v1.18.2

**Affected definition**: [sp-build-web v1.18.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-build-web/1.18.2)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): OTHER
- Confidence: 95%

**Explanation:**

The `license` property in the `package.json` file points to a URL: `https://aka.ms/spfx/license`. This URL suggests a commercial license related to SharePoint Framework (SPFX), which is typically not an open-source license. Therefore, based on the general rules, this should be labeled as "OTHER" with high confidence.