### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-build-core-tasks/1.18.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-build-core-tasks.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-build-core-tasks.yaml
@@ -28,3 +28,6 @@ revisions:
   1.9.1:
     licensed:
       declared: OTHER
+  1.18.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-build-core-tasks v1.18.2

**Affected definition**: [sp-build-core-tasks v1.18.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-build-core-tasks/1.18.2)

**Suggested License**: OTHER

---

### File Discovered: package.json

Suggested Declared License(s): OTHER  
Confidence: 95%

**Explanation:**

- The `license` property in the `package.json` file points to a URL: `https://aka.ms/spfx/license`.
- The URL contains "spfx," which is typically associated with commercial licenses.
- Based on the general rules, licenses with "spfx" in the link are labeled as "OTHER."
- Therefore, the suggested declared license is "OTHER" with high confidence.