### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-css-loader/1.18.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-css-loader.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-css-loader.yaml
@@ -16,3 +16,6 @@ revisions:
   1.20.1:
     licensed:
       declared: OTHER
+  1.18.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-css-loader v1.18.2

**Affected definition**: [sp-css-loader v1.18.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-css-loader/1.18.2)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): OTHER
- Confidence: 95%

**Explanation:**

The `license` property in the `package.json` file points to a URL: `https://aka.ms/spfx/license`. The presence of "spfx" in the URL suggests that it is likely a commercial license, as per the given rules. Therefore, the suggested declared license is "OTHER" with a high confidence level of 95%.