### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/spfx-heft-plugins/1.18.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/spfx-heft-plugins.yaml
+++ b/curations/npm/npmjs/@microsoft/spfx-heft-plugins.yaml
@@ -16,3 +16,6 @@ revisions:
   1.20.1:
     licensed:
       declared: OTHER
+  1.18.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: spfx-heft-plugins v1.18.2

**Affected definition**: [spfx-heft-plugins v1.18.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/spfx-heft-plugins/1.18.2)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): OTHER
- Confidence: 95%

**Explanation:**

The `license` field in the `package.json` points to a URL: `https://aka.ms/spfx/license`. This URL suggests a commercial license related to SPFx (SharePoint Framework), which is typically associated with Microsoft's commercial offerings. Therefore, based on the general rules, this should be labeled as "OTHER" due to the likelihood of it being a commercial license.