### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-tslint-rules/1.18.2

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-tslint-rules.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-tslint-rules.yaml
@@ -94,3 +94,6 @@ revisions:
   1.9.1:
     licensed:
       declared: OTHER
+  1.18.2:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-tslint-rules v1.18.2

**Affected definition**: [sp-tslint-rules v1.18.2](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-tslint-rules/1.18.2)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): OTHER
- Confidence: 95%

**Explanation:**

The `license` property in the `package.json` file points to a URL: `https://aka.ms/spfx/license`. The presence of "spfx" in the URL suggests that it is likely a commercial license, as per the given rules. Therefore, the declared license is labeled as "OTHER" with high confidence.