### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @microsoft/sp-listview-extensibility/1.16.1

### DIFF
--- a/curations/npm/npmjs/@microsoft/sp-listview-extensibility.yaml
+++ b/curations/npm/npmjs/@microsoft/sp-listview-extensibility.yaml
@@ -25,3 +25,6 @@ revisions:
   1.19.0:
     licensed:
       declared: OTHER
+  1.16.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: sp-listview-extensibility v1.16.1

**Affected definition**: [sp-listview-extensibility v1.16.1](https://clearlydefined.io/definitions/npm/npmjs/@microsoft/sp-listview-extensibility/1.16.1)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): OTHER
- Confidence: 95%

**Explanation:**

The `license` property in the `package.json` file points to a URL: `https://aka.ms/spfx/license`. The presence of "spfx" in the URL suggests that it is likely a commercial license, as per the general rules provided. Therefore, the suggested declared license is "OTHER" with a high confidence level of 95%.