### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - highcharts-more/0.1.7

### DIFF
--- a/curations/npm/npmjs/-/highcharts-more.yaml
+++ b/curations/npm/npmjs/-/highcharts-more.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: highcharts-more
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.7:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: highcharts-more v0.1.7

**Affected definition**: [highcharts-more v0.1.7](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-more/0.1.7)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): CC
- Confidence: 90%

**Explanation:**

The `package.json` file specifies the license as "CC". This likely refers to a Creative Commons license, but without further specification (e.g., CC-BY, CC-BY-SA), it's unclear which exact license it is. Therefore, the confidence is not 100%.