### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @progress/kendo-dateinputs-common/0.3.3

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-dateinputs-common.yaml
+++ b/curations/npm/npmjs/@progress/kendo-dateinputs-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kendo-dateinputs-common
+  provider: npmjs
+  type: npm
+  namespace: '@progress'
+revisions:
+  0.3.3:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: kendo-dateinputs-common v0.3.3

**Affected definition**: [kendo-dateinputs-common v0.3.3](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-dateinputs-common/0.3.3)

**Suggested License**: OTHER

---

### File Discovered: package.json

- Suggested Declared License(s): NULL

- Confidence: 90%

**Explanation:**

The `package.json` file specifies the license as "SEE LICENSE IN LICENSE.md". This indicates that the actual license details are contained within a separate file, `LICENSE.md`. Since the license is not explicitly stated in the `package.json`, I cannot determine the license type from this information alone, resulting in a "NULL" response.