### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - @progress/kendo-react-dropdowns/6.1.1

### DIFF
--- a/curations/npm/npmjs/@progress/kendo-react-dropdowns.yaml
+++ b/curations/npm/npmjs/@progress/kendo-react-dropdowns.yaml
@@ -85,3 +85,6 @@ revisions:
   8.0.0:
     licensed:
       declared: OTHER
+  6.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: kendo-react-dropdowns v6.1.1

**Affected definition**: [kendo-react-dropdowns v6.1.1](https://clearlydefined.io/definitions/npm/npmjs/@progress/kendo-react-dropdowns/6.1.1)

**Suggested License**: OTHER

---

### File Discovered: LICENSE.md

- Suggested Declared License(s): OTHER
- Suggested Discovered License(s): OTHER
- Confidence: 100%

**Explanation:**

The text explicitly states that the software is commercial and requires agreement to an End User License Agreement (EULA) for Progress KendoReact. The presence of a commercial license and EULA indicates that the appropriate classification is "OTHER." The links provided also suggest commercial licensing terms. Therefore, the confidence in labeling this as "OTHER" is 100%.