### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - wl-msg-reader/0.2.1

### DIFF
--- a/curations/npm/npmjs/-/wl-msg-reader.yaml
+++ b/curations/npm/npmjs/-/wl-msg-reader.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: wl-msg-reader
+  provider: npmjs
+  type: npm
+revisions:
+  0.2.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: wl-msg-reader v0.2.1

**Affected definition**: [wl-msg-reader v0.2.1](https://clearlydefined.io/definitions/npm/npmjs/-/wl-msg-reader/0.2.1)

**Suggested License**: Apache-2.0

---

### File Discovered: package.json

- Suggested Declared License(s): Apache-2.0
- Confidence: 90%

**Explanation:**

The `license` property in the `package.json` is set to "APACHE". This typically refers to the Apache License, Version 2.0, which is represented in SPDX format as "Apache-2.0". The confidence is 90% because the term "APACHE" is a common shorthand for the Apache License, but without additional context or a specific version number, there is a small chance of ambiguity.