### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - promised-io/0.3.5

### DIFF
--- a/curations/npm/npmjs/-/promised-io.yaml
+++ b/curations/npm/npmjs/-/promised-io.yaml
@@ -6,3 +6,6 @@ revisions:
   0.3.6:
     licensed:
       declared: AFL-2.1 OR BSD-3-Clause
+  0.3.5:
+    licensed:
+      declared: AFL-2.1 OR BSD-3-Clause


### PR DESCRIPTION
## Missing License AI Curation

**Component**: promised-io v0.3.5

**Affected definition**: [promised-io v0.3.5](https://clearlydefined.io/definitions/npm/npmjs/-/promised-io/0.3.5)

**Suggested License**: AFL-2.1 OR BSD-3-Clause

---

### File Discovered: package.json

- Suggested Declared License(s): AFL-2.1, BSD-3-Clause
- Suggested Discovered License(s): AFL-2.1, BSD-3-Clause
- Confidence: 90%

**Explanation:**

1. **Declared Licenses:**
   - The `licenses` property in the `package.json` lists two licenses: AFLv2.1 and BSD. These correspond to the SPDX identifiers AFL-2.1 and BSD-3-Clause, respectively.

2. **Discovered Licenses:**
   - The URLs provided in the `licenses` property point to the Dojo Toolkit's license file, which confirms the presence of both the Academic Free License v2.1 and the BSD license.

3. **Confidence:**
   - The confidence level is set at 90% because the licenses are explicitly stated in the `package.json` with URLs pointing to the license text, which is a strong indicator of the intended licensing. However, the presence of multiple licenses slightly reduces the confidence in determining a sole license.