### PR TITLE
@ag-grid-enterprise/range-selection29.3.5

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/range-selection.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/range-selection.yaml
@@ -49,6 +49,9 @@ revisions:
   29.0.0:
     licensed:
       declared: OTHER
+  29.3.5:
+    licensed:
+      declared: OTHER
   30.0.6:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Missing

**Summary:**
@ag-grid-enterprise/range-selection29.3.5

**Details:**
Declaring OTHER for commercial license

**Resolution:**
https://www.npmjs.com/package/@ag-grid-enterprise/range-selection/v/29.3.5

**Affected definitions**:
- [range-selection 29.3.5](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/range-selection/29.3.5/29.3.5)