### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - topo/2.1.1

### DIFF
--- a/curations/npm/npmjs/-/topo.yaml
+++ b/curations/npm/npmjs/-/topo.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: topo
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION
## Missing License AI Curation

**Component**: topo v2.1.1

**Affected definition**: [topo v2.1.1](https://clearlydefined.io/definitions/npm/npmjs/-/topo/2.1.1)

**Suggested License**: OTHER

---

### File Discovered: LICENSE.md

- Suggested Declared License(s): OTHER
- Suggested Discovered License(s): OTHER
- Confidence: 100%

**Explanation:**

The text explicitly states that the package requires a commercial license from Sideway Inc. and cannot be used, copied, or distributed without acquiring such a license. This is a clear indication of a commercial license, which falls under "OTHER" according to the guidelines provided. The mention of previous open-source materials does not change the current commercial nature of the package.