### PR TITLE
[Missing License AI Curation][TESTING - DO NOT MERGE] - highcharts-more/0.1.7

### DIFF
--- a/curations/npm/npmjs/-/highcharts-more.yaml
+++ b/curations/npm/npmjs/-/highcharts-more.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: highcharts-more
+  provider: npmjs
+  type: npm
+revisions:
+  0.1.7:
+    licensed:
+      declared: CC-BY-NC-4.0


### PR DESCRIPTION
## Missing License AI Curation

**Component**: highcharts-more v0.1.7

**Affected definition**: [highcharts-more v0.1.7](https://clearlydefined.io/definitions/npm/npmjs/-/highcharts-more/0.1.7)

**Suggested License**: CC-BY-NC-4.0

---

### File Discovered: package.json

- Suggested Declared License(s): CC-BY-NC-4.0
- Confidence: 90%
- Reasoning: The license field in the package.json specifies "CC", which typically refers to Creative Commons licenses. However, "CC" alone is not a complete license identifier. Given the context and common usage, it is likely referring to a non-commercial variant, such as CC-BY-NC-4.0. This is a common assumption when "CC" is used without further specification, especially in a commercial context like Highcharts.