### PR TITLE
net.java.dev.jna/jna5.15.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -13,6 +13,9 @@ revisions:
   4.1.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later
+  5.15.0:
+    licensed:
+      declared: Apache-2.0 OR LGPL-2.1-or-later
   5.9.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.java.dev.jna/jna5.15.0

**Details:**
Fixing Declared Field to Apache-2.0 OR LGPL-2.1-or-later

**Resolution:**
https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.15.0/jna-5.15.0.pom

**Affected definitions**:
- [jna 5.15.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/5.15.0/5.15.0)