### PR TITLE
Bond 0.2.3.2

### DIFF
--- a/curations/nuget/nuget/-/Bond.yaml
+++ b/curations/nuget/nuget/-/Bond.yaml
@@ -5,4 +5,4 @@ coordinates:
 revisions:
   0.2.3.2:
     licensed:
-      declared: NONE
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Bond 0.2.3.2

**Details:**
Found MIT license in the repo

**Resolution:**
Update to MIT

**Affected definitions**:
- [Bond 0.2.3.2](https://clearlydefined.io/definitions/nuget/nuget/-/Bond/0.2.3.2/0.2.3.2)