### PR TITLE
Add maven packages bound by Xamarin NuGet packages

### DIFF
--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-android-extensions-runtime.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-android-extensions-runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-android-extensions-runtime
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-parcelize-runtime.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-parcelize-runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-parcelize-runtime
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-reflect.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-reflect
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-stdlib-common
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-stdlib-jdk7
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk8.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-stdlib-jdk8
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlin-stdlib
+  namespace: org.jetbrains.kotlin
+  provider: mavencentral
+  type: maven
+revisions:
+  2.0.21:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/atomicfu-jvm.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/atomicfu-jvm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: atomicfu-jvm
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  0.26.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/atomicfu.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/atomicfu.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: atomicfu
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  0.26.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-android.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-android.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-android
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-core-jvm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-core-jvm
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-core.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-core
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-guava.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-guava.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-guava
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-jdk8.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-jdk8
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-play-services.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-play-services.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-play-services
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-reactive.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-reactive.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-reactive
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-rx2.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-rx2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-rx2
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-rx3.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-coroutines-rx3.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-coroutines-rx3
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.9.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-core-jvm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-serialization-core-jvm
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-core.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-serialization-core
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-protobuf-jvm.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-serialization-protobuf-jvm
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-protobuf.yaml
+++ b/curations/maven/mavencentral/org.jetbrains.kotlinx/kotlinx-serialization-protobuf.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: kotlinx-serialization-protobuf
+  namespace: org.jetbrains.kotlinx
+  provider: mavencentral
+  type: maven
+revisions:
+  1.7.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.jetbrains/annotations.yaml
+++ b/curations/maven/mavencentral/org.jetbrains/annotations.yaml
@@ -7,3 +7,6 @@ revisions:
   16.0.2:
     licensed:
       declared: Apache-2.0
+  26.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.ow2.asm/asm.yaml
+++ b/curations/maven/mavencentral/org.ow2.asm/asm.yaml
@@ -42,3 +42,6 @@ revisions:
   '7.1':
     licensed:
       declared: BSD-3-Clause
+  9.7.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-android.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-android.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-android
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  1.13.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-api.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-api.yaml
@@ -13,3 +13,6 @@ revisions:
   2.8.0:
     licensed:
       declared: Apache-2.0
+  2.16.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-gpu-api.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-gpu-api.yaml
@@ -7,3 +7,6 @@ revisions:
   2.10.0:
     licensed:
       declared: Apache-2.0
+  2.16.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-gpu.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-gpu.yaml
@@ -7,3 +7,6 @@ revisions:
   2.10.0:
     licensed:
       declared: Apache-2.0
+  2.16.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-metadata.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-metadata.yaml
@@ -10,3 +10,6 @@ revisions:
   0.1.0-rc2:
     licensed:
       declared: Apache-2.0
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-select-tf-ops.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-select-tf-ops.yaml
@@ -10,3 +10,6 @@ revisions:
   2.11.0:
     licensed:
       declared: Apache-2.0
+  2.16.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-support-api.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-support-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-support-api
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-support.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-support.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-support
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-audio-play-services.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-audio-play-services.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-audio-play-services
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-audio.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-audio.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-audio
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-base.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-base.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-base
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-text-play-services.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-text-play-services.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-text-play-services
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-text.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-text.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-text
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-vision-play-services.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-vision-play-services.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-vision-play-services
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-vision.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite-task-vision.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tensorflow-lite-task-vision
+  namespace: org.tensorflow
+  provider: mavencentral
+  type: maven
+revisions:
+  0.4.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavencentral/org.tensorflow/tensorflow-lite.yaml
+++ b/curations/maven/mavencentral/org.tensorflow/tensorflow-lite.yaml
@@ -13,3 +13,6 @@ revisions:
   2.8.0:
     licensed:
       declared: Apache-2.0
+  2.16.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.android.billingclient/billing-ktx.yaml
+++ b/curations/maven/mavengoogle/com.android.billingclient/billing-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: billing-ktx
+  namespace: com.android.billingclient
+  provider: mavengoogle
+  type: maven
+revisions:
+  7.1.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.android.billingclient/billing.yaml
+++ b/curations/maven/mavengoogle/com.android.billingclient/billing.yaml
@@ -7,3 +7,6 @@ revisions:
   4.0.0:
     licensed:
       declared: OTHER
+  7.1.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.android.installreferrer/installreferrer.yaml
+++ b/curations/maven/mavengoogle/com.android.installreferrer/installreferrer.yaml
@@ -13,3 +13,6 @@ revisions:
   '2.2':
     licensed:
       declared: OTHER
+  2.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.android.volley/volley-cronet.yaml
+++ b/curations/maven/mavengoogle/com.android.volley/volley-cronet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: volley-cronet
+  namespace: com.android.volley
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.2.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.android.volley/volley.yaml
+++ b/curations/maven/mavengoogle/com.android.volley/volley.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: volley
+  namespace: com.android.volley
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.2.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-appcompat-theme.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-appcompat-theme.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-appcompat-theme
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-drawablepainter.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-drawablepainter.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-drawablepainter
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-flowlayout.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-flowlayout.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-flowlayout
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-pager-indicators.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-pager-indicators.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-pager-indicators
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-pager.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-pager.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-pager
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-permissions.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-permissions.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-permissions
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-placeholder-material.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-placeholder-material.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-placeholder-material
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-placeholder.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-placeholder.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-placeholder
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-swiperefresh.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-swiperefresh.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-swiperefresh
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.accompanist/accompanist-systemuicontroller.yaml
+++ b/curations/maven/mavengoogle/com.google.accompanist/accompanist-systemuicontroller.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: accompanist-systemuicontroller
+  namespace: com.google.accompanist
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.36.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.ads.interactivemedia.v3/interactivemedia.yaml
+++ b/curations/maven/mavengoogle/com.google.ads.interactivemedia.v3/interactivemedia.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: interactivemedia
+  namespace: com.google.ads.interactivemedia.v3
+  provider: mavengoogle
+  type: maven
+revisions:
+  3.35.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.datatransport/transport-api.yaml
+++ b/curations/maven/mavengoogle/com.google.android.datatransport/transport-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: transport-api
+  namespace: com.google.android.datatransport
+  provider: mavengoogle
+  type: maven
+revisions:
+  4.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.android.datatransport/transport-backend-cct.yaml
+++ b/curations/maven/mavengoogle/com.google.android.datatransport/transport-backend-cct.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: transport-backend-cct
+  namespace: com.google.android.datatransport
+  provider: mavengoogle
+  type: maven
+revisions:
+  4.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.android.datatransport/transport-runtime.yaml
+++ b/curations/maven/mavengoogle/com.google.android.datatransport/transport-runtime.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: transport-runtime
+  namespace: com.google.android.datatransport
+  provider: mavengoogle
+  type: maven
+revisions:
+  4.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-ads-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-ads-base.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-ads-base
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  23.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-ads-identifier.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-ads-identifier.yaml
@@ -10,3 +10,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-ads-lite.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-ads-lite.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-ads-lite
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  23.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-ads.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-ads.yaml
@@ -80,3 +80,6 @@ revisions:
     licensed:
       declared: OTHER
 
+  23.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-afs-native.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-afs-native.yaml
@@ -7,3 +7,6 @@ revisions:
   19.0.3:
     licensed:
       declared: OTHER
+  19.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-analytics-impl.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-analytics-impl.yaml
@@ -10,3 +10,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  18.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-analytics.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-analytics.yaml
@@ -34,3 +34,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  18.1.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-appindex.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-appindex.yaml
@@ -7,3 +7,6 @@ revisions:
   16.1.0:
     licensed:
       declared: OTHER
+  16.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-appset.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-appset.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-appset
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-api-phone.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-api-phone.yaml
@@ -13,3 +13,6 @@ revisions:
   18.0.1:
     licensed:
       declared: OTHER
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-base.yaml
@@ -19,3 +19,6 @@ revisions:
   18.0.9:
     licensed:
       declared: OTHER
+  18.0.13:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-blockstore.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-auth-blockstore.yaml
@@ -7,3 +7,6 @@ revisions:
   16.1.0:
     licensed:
       declared: OTHER
+  16.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-auth.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-auth.yaml
@@ -40,3 +40,6 @@ revisions:
   20.7.0:
     licensed:
       declared: OTHER
+  21.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-awareness.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-awareness.yaml
@@ -22,3 +22,6 @@ revisions:
   19.0.1:
     licensed:
       declared: OTHER
+  19.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-base.yaml
@@ -49,3 +49,6 @@ revisions:
   18.1.0:
     licensed:
       declared: OTHER
+  18.5.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-basement.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-basement.yaml
@@ -67,3 +67,6 @@ revisions:
   18.3.0:
     licensed:
       declared: OTHER
+  18.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-cast-framework.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-cast-framework.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-cast-framework
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.5.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-cast-tv.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-cast-tv.yaml
@@ -7,3 +7,6 @@ revisions:
   20.0.0:
     licensed:
       declared: OTHER
+  21.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-cast.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-cast.yaml
@@ -31,3 +31,6 @@ revisions:
   21.1.0:
     licensed:
       declared: OTHER
+  21.5.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-cloud-messaging.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-cloud-messaging.yaml
@@ -13,3 +13,6 @@ revisions:
   17.0.2:
     licensed:
       declared: OTHER
+  17.3.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-code-scanner.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-code-scanner.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-code-scanner
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-cronet.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-cronet.yaml
@@ -16,3 +16,6 @@ revisions:
   18.0.1:
     licensed:
       declared: OTHER
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-deviceperformance.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-deviceperformance.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-deviceperformance
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-fido.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-fido.yaml
@@ -10,3 +10,6 @@ revisions:
   20.1.0:
     licensed:
       declared: OTHER
+  21.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-fitness.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-fitness.yaml
@@ -25,3 +25,6 @@ revisions:
   21.1.0:
     licensed:
       declared: OTHER
+  21.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-flags.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-flags.yaml
@@ -16,3 +16,6 @@ revisions:
   18.0.1:
     licensed:
       declared: OTHER
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-games-v2.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-games-v2.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  20.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-games.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-games.yaml
@@ -28,3 +28,6 @@ revisions:
   23.0.0:
     licensed:
       declared: OTHER
+  23.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-home.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-home.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-home
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-identity.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-identity.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-identity
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-instantapps.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-instantapps.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-instantapps
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-maps.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-maps.yaml
@@ -13,3 +13,6 @@ revisions:
   18.1.0:
     licensed:
       declared: OTHER
+  19.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-api.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-api.yaml
@@ -19,3 +19,6 @@ revisions:
   19.0.2:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-base.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-base.yaml
@@ -19,3 +19,6 @@ revisions:
   19.0.0:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-impl.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-impl.yaml
@@ -16,3 +16,6 @@ revisions:
   21.1.1:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-sdk-api.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-sdk-api.yaml
@@ -16,3 +16,6 @@ revisions:
   19.0.2:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-sdk.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement-sdk.yaml
@@ -16,3 +16,6 @@ revisions:
   19.0.2:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-measurement.yaml
@@ -58,3 +58,6 @@ revisions:
   21.1.1:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-barcode-scanning.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-barcode-scanning.yaml
@@ -13,3 +13,6 @@ revisions:
   18.2.0:
     licensed:
       declared: OTHER
+  18.3.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-chinese.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-chinese.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-mlkit-text-recognition-chinese
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-common.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-common.yaml
@@ -7,3 +7,6 @@ revisions:
   18.0.0:
     licensed:
       declared: OTHER
+  19.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-devanagari.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-devanagari.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-mlkit-text-recognition-devanagari
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-japanese.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-japanese.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-mlkit-text-recognition-japanese
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-korean.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition-korean.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-mlkit-text-recognition-korean
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-mlkit-text-recognition.yaml
@@ -10,3 +10,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  19.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-nearby.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-nearby.yaml
@@ -25,3 +25,6 @@ revisions:
   18.3.0:
     licensed:
       declared: OTHER
+  19.3.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-oss-licenses.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-oss-licenses.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  17.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-pal.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-pal.yaml
@@ -7,3 +7,6 @@ revisions:
   20.0.1:
     licensed:
       declared: OTHER
+  20.3.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-panorama.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-panorama.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  17.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-password-complexity.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-password-complexity.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-password-complexity
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-pay.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-pay.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-pay
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.5.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-places-placereport.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-places-placereport.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  17.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-places.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-places.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  17.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-recaptcha.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-recaptcha.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-recaptcha
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-safetynet.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-safetynet.yaml
@@ -19,3 +19,6 @@ revisions:
   18.0.1:
     licensed:
       declared: OTHER
+  18.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-stats.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-stats.yaml
@@ -19,3 +19,6 @@ revisions:
   17.0.3:
     licensed:
       declared: OTHER
+  17.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-streamprotect.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-streamprotect.yaml
@@ -7,3 +7,6 @@ revisions:
   16.0.2:
     licensed:
       declared: OTHER
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-api.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-api.yaml
@@ -7,3 +7,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  18.1.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-v4-impl.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager-v4-impl.yaml
@@ -13,3 +13,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  18.1.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tagmanager.yaml
@@ -22,3 +22,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  18.1.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tasks.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tasks.yaml
@@ -37,3 +37,6 @@ revisions:
   18.0.2:
     licensed:
       declared: OTHER
+  18.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-gpu.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-gpu.yaml
@@ -7,3 +7,6 @@ revisions:
   16.0.0:
     licensed:
       declared: OTHER
+  16.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-impl.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-impl.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-tflite-impl
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-java.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-java.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-tflite-java
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-support.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-tflite-support.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-tflite-support
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-threadnetwork.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-threadnetwork.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: play-services-threadnetwork
+  namespace: com.google.android.gms
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.2.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-wallet.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-wallet.yaml
@@ -19,3 +19,6 @@ revisions:
   19.1.0:
     licensed:
       declared: OTHER
+  19.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.gms/play-services-wearable.yaml
+++ b/curations/maven/mavengoogle/com.google.android.gms/play-services-wearable.yaml
@@ -7,3 +7,6 @@ revisions:
   18.0.0:
     licensed:
       declared: OTHER
+  18.2.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.libraries.places/places-compat.yaml
+++ b/curations/maven/mavengoogle/com.google.android.libraries.places/places-compat.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: places-compat
+  namespace: com.google.android.libraries.places
+  provider: mavengoogle
+  type: maven
+revisions:
+  2.6.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.libraries.places/places.yaml
+++ b/curations/maven/mavengoogle/com.google.android.libraries.places/places.yaml
@@ -7,3 +7,6 @@ revisions:
   2.2.0:
     licensed:
       declared: OTHER
+  4.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.material/compose-theme-adapter-3.yaml
+++ b/curations/maven/mavengoogle/com.google.android.material/compose-theme-adapter-3.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: compose-theme-adapter-3
+  namespace: com.google.android.material
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.0.18:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.android.material/compose-theme-adapter.yaml
+++ b/curations/maven/mavengoogle/com.google.android.material/compose-theme-adapter.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: compose-theme-adapter
+  namespace: com.google.android.material
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.1.18:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.android.material/material.yaml
+++ b/curations/maven/mavengoogle/com.google.android.material/material.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: material
+  namespace: com.google.android.material
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.12.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.android.odml/image.yaml
+++ b/curations/maven/mavengoogle/com.google.android.odml/image.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: image
+  namespace: com.google.android.odml
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.0.0-beta1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/core-common.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/core-common.yaml
@@ -10,3 +10,6 @@ revisions:
   2.0.3:
     licensed:
       declared: OTHER
+  2.0.4:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/feature-delivery-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/feature-delivery-ktx.yaml
@@ -10,3 +10,6 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.1.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/integrity.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/integrity.yaml
@@ -28,3 +28,6 @@ revisions:
       releaseDate: '2023-11-10'
     licensed:
       declared: OTHER
+  1.4.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/review-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/review-ktx.yaml
@@ -10,3 +10,6 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.0.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.play/review.yaml
+++ b/curations/maven/mavengoogle/com.google.android.play/review.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.1:
     licensed:
       declared: OTHER
+  2.0.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.recaptcha/recaptcha.yaml
+++ b/curations/maven/mavengoogle/com.google.android.recaptcha/recaptcha.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: recaptcha
+  namespace: com.google.android.recaptcha
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.6.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.tv/tv-ads.yaml
+++ b/curations/maven/mavengoogle/com.google.android.tv/tv-ads.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tv-ads
+  namespace: com.google.android.tv
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android.ump/user-messaging-platform.yaml
+++ b/curations/maven/mavengoogle/com.google.android.ump/user-messaging-platform.yaml
@@ -7,3 +7,6 @@ revisions:
   2.0.0:
     licensed:
       declared: OTHER
+  3.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.android/annotations.yaml
+++ b/curations/maven/mavengoogle/com.google.android/annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: annotations
+  namespace: com.google.android
+  provider: mavengoogle
+  type: maven
+revisions:
+  4.1.1.4:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.assistant.appactions/suggestions.yaml
+++ b/curations/maven/mavengoogle/com.google.assistant.appactions/suggestions.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: suggestions
+  namespace: com.google.assistant.appactions
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.assistant.appactions/widgets.yaml
+++ b/curations/maven/mavengoogle/com.google.assistant.appactions/widgets.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: widgets
+  namespace: com.google.assistant.appactions
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.auto.value/auto-value-annotations.yaml
+++ b/curations/maven/mavengoogle/com.google.auto.value/auto-value-annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: auto-value-annotations
+  namespace: com.google.auto.value
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.11.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.code.findbugs/jsr305.yaml
+++ b/curations/maven/mavengoogle/com.google.code.findbugs/jsr305.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: jsr305
+  namespace: com.google.code.findbugs
+  provider: mavengoogle
+  type: maven
+revisions:
+  3.0.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.code.gson/gson.yaml
+++ b/curations/maven/mavengoogle/com.google.code.gson/gson.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: gson
+  namespace: com.google.code.gson
+  provider: mavengoogle
+  type: maven
+revisions:
+  2.11.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.crypto.tink/tink-android.yaml
+++ b/curations/maven/mavengoogle/com.google.crypto.tink/tink-android.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: tink-android
+  namespace: com.google.crypto.tink
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.15.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.dagger/dagger.yaml
+++ b/curations/maven/mavengoogle/com.google.dagger/dagger.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: dagger
+  namespace: com.google.dagger
+  provider: mavengoogle
+  type: maven
+revisions:
+  2.52:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.errorprone/error_prone_annotations.yaml
+++ b/curations/maven/mavengoogle/com.google.errorprone/error_prone_annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: error_prone_annotations
+  namespace: com.google.errorprone
+  provider: mavengoogle
+  type: maven
+revisions:
+  2.35.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-abt.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-abt.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-abt
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  22.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-ads-lite.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-ads-lite.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-ads-lite
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  23.4.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-ads.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-ads.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-ads
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  23.4.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-analytics-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-analytics-ktx.yaml
@@ -7,3 +7,6 @@ revisions:
   21.1.1:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-analytics.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-analytics.yaml
@@ -10,3 +10,6 @@ revisions:
   20.1.0:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-annotations.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-annotations
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.2.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-debug.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-debug.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-appcheck-debug
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-interop.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-interop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-appcheck-interop
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-appcheck-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-playintegrity.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-playintegrity.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-appcheck-playintegrity
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-safetynet.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck-safetynet.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-appcheck-safetynet
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.1.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-appcheck.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-appcheck
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-auth-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-auth-ktx.yaml
@@ -7,3 +7,6 @@ revisions:
   21.0.8:
     licensed:
       declared: OTHER
+  23.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-auth.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-auth.yaml
@@ -10,3 +10,6 @@ revisions:
   21.0.8:
     licensed:
       declared: OTHER
+  23.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-common-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-common-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-common-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-common.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-common
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-components.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-components.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-components
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-config-interop.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-config-interop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-config-interop
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-config-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-config-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-config-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  22.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-config.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-config.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.0:
     licensed:
       declared: OTHER
+  22.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-crashlytics-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-crashlytics-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-crashlytics-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  19.2.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-crashlytics-ndk.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-crashlytics-ndk.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-crashlytics-ndk
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  19.2.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-crashlytics.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-crashlytics.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-crashlytics
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  19.2.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-database-collection.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-database-collection.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-database-collection
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-database-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-database-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-database-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-database.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-database.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-database
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-datatransport.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-datatransport.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-datatransport
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  19.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-dynamic-links-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-dynamic-links-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-dynamic-links-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  22.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-dynamic-links.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-dynamic-links.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-dynamic-links
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  22.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-encoders-json.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-encoders-json.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-encoders-json
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-encoders-proto.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-encoders-proto.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-encoders-proto
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-encoders.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-encoders.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-encoders
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-firestore-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-firestore-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-firestore-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  25.1.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-firestore.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-firestore.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-firestore
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  25.1.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-functions-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-functions-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-functions-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-functions.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-functions.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-functions
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging-display-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging-display-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-inappmessaging-display-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging-display.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging-display.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-inappmessaging-display
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-inappmessaging-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-inappmessaging.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-inappmessaging
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-installations-interop.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-installations-interop.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-installations-interop
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.2.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-installations-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-installations-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-installations-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-installations.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-installations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-installations
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-invites.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-invites.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-invites
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-measurement-connector.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-measurement-connector.yaml
@@ -16,3 +16,6 @@ revisions:
   20.0.0:
     licensed:
       declared: OTHER
+  20.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-messaging-directboot.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-messaging-directboot.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-messaging-directboot
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  24.0.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-messaging-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-messaging-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-messaging-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  24.0.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-messaging.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-messaging.yaml
@@ -22,3 +22,6 @@ revisions:
   22.0.0:
     licensed:
       declared: OTHER
+  24.0.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-ml-common.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-ml-common.yaml
@@ -7,3 +7,6 @@ revisions:
   22.0.0:
     licensed:
       declared: OTHER
+  22.1.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-ml-vision.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-ml-vision.yaml
@@ -7,3 +7,6 @@ revisions:
   24.0.0:
     licensed:
       declared: OTHER
+  24.1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-perf-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-perf-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-perf-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-perf.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-perf.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-perf
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-sessions.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-sessions.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-sessions
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  2.0.6:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-storage-ktx.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-storage-ktx.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-storage-ktx
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/firebase-storage.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/firebase-storage.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: firebase-storage
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  21.0.1:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.firebase/protolite-well-known-types.yaml
+++ b/curations/maven/mavengoogle/com.google.firebase/protolite-well-known-types.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: protolite-well-known-types
+  namespace: com.google.firebase
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.flatbuffers/flatbuffers-java.yaml
+++ b/curations/maven/mavengoogle/com.google.flatbuffers/flatbuffers-java.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: flatbuffers-java
+  namespace: com.google.flatbuffers
+  provider: mavengoogle
+  type: maven
+revisions:
+  24.3.25:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.flogger/flogger-system-backend.yaml
+++ b/curations/maven/mavengoogle/com.google.flogger/flogger-system-backend.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: flogger-system-backend
+  namespace: com.google.flogger
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.8:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.flogger/flogger.yaml
+++ b/curations/maven/mavengoogle/com.google.flogger/flogger.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: flogger
+  namespace: com.google.flogger
+  provider: mavengoogle
+  type: maven
+revisions:
+  0.8:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.guava/failureaccess.yaml
+++ b/curations/maven/mavengoogle/com.google.guava/failureaccess.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: failureaccess
+  namespace: com.google.guava
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.0.2:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.guava/guava.yaml
+++ b/curations/maven/mavengoogle/com.google.guava/guava.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: guava
+  namespace: com.google.guava
+  provider: mavengoogle
+  type: maven
+revisions:
+  33.3.1-android:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.guava/listenablefuture.yaml
+++ b/curations/maven/mavengoogle/com.google.guava/listenablefuture.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: listenablefuture
+  namespace: com.google.guava
+  provider: mavengoogle
+  type: maven
+revisions:
+  1.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.inject/guice.yaml
+++ b/curations/maven/mavengoogle/com.google.inject/guice.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: guice
+  namespace: com.google.inject
+  provider: mavengoogle
+  type: maven
+revisions:
+  7.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.j2objc/j2objc-annotations.yaml
+++ b/curations/maven/mavengoogle/com.google.j2objc/j2objc-annotations.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: j2objc-annotations
+  namespace: com.google.j2objc
+  provider: mavengoogle
+  type: maven
+revisions:
+  3.0.0:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/com.google.mlkit/barcode-scanning.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/barcode-scanning.yaml
@@ -10,3 +10,6 @@ revisions:
   17.1.0:
     licensed:
       declared: OTHER
+  17.3.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/common.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/common.yaml
@@ -10,3 +10,6 @@ revisions:
   18.5.0:
     licensed:
       declared: OTHER
+  18.11.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/face-detection.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/face-detection.yaml
@@ -7,3 +7,6 @@ revisions:
   16.1.5:
     licensed:
       declared: OTHER
+  16.1.7:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/image-labeling-custom.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/image-labeling-custom.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.1:
     licensed:
       declared: OTHER
+  17.0.3:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/image-labeling-default-common.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/image-labeling-default-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: image-labeling-default-common
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/image-labeling.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/image-labeling.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: image-labeling
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.9:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/language-id.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/language-id.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.4:
     licensed:
       declared: OTHER
+  17.0.6:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/linkfirebase.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/linkfirebase.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: linkfirebase
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/object-detection-common.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/object-detection-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: object-detection-common
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/object-detection-custom.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/object-detection-custom.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: object-detection-custom
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/object-detection.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/object-detection.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: object-detection
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.2:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/smart-reply.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/smart-reply.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.2:
     licensed:
       declared: OTHER
+  17.0.4:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/text-recognition-bundled-common.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/text-recognition-bundled-common.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: text-recognition-bundled-common
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  17.0.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/text-recognition-chinese.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/text-recognition-chinese.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: text-recognition-chinese
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/text-recognition-devanagari.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/text-recognition-devanagari.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: text-recognition-devanagari
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/text-recognition-japanese.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/text-recognition-japanese.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: text-recognition-japanese
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/text-recognition-korean.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/text-recognition-korean.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: text-recognition-korean
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/text-recognition.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/text-recognition.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: text-recognition
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  16.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/translate.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/translate.yaml
@@ -7,3 +7,6 @@ revisions:
   17.0.1:
     licensed:
       declared: OTHER
+  17.0.3:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/vision-interfaces.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/vision-interfaces.yaml
@@ -10,3 +10,6 @@ revisions:
   16.2.0:
     licensed:
       declared: OTHER
+  16.3.0:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.mlkit/vision-internal-vkp.yaml
+++ b/curations/maven/mavengoogle/com.google.mlkit/vision-internal-vkp.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: vision-internal-vkp
+  namespace: com.google.mlkit
+  provider: mavengoogle
+  type: maven
+revisions:
+  18.2.3:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.protobuf/protobuf-javalite.yaml
+++ b/curations/maven/mavengoogle/com.google.protobuf/protobuf-javalite.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: protobuf-javalite
+  namespace: com.google.protobuf
+  provider: mavengoogle
+  type: maven
+revisions:
+  4.28.3:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.protobuf/protobuf-lite.yaml
+++ b/curations/maven/mavengoogle/com.google.protobuf/protobuf-lite.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: protobuf-lite
+  namespace: com.google.protobuf
+  provider: mavengoogle
+  type: maven
+revisions:
+  3.0.1:
+    licensed:
+      declared: OTHER

--- a/curations/maven/mavengoogle/com.google.zxing/core.yaml
+++ b/curations/maven/mavengoogle/com.google.zxing/core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: core
+  namespace: com.google.zxing
+  provider: mavengoogle
+  type: maven
+revisions:
+  3.5.3:
+    licensed:
+      declared: Apache-2.0

--- a/curations/maven/mavengoogle/org.chromium.net/cronet-api.yaml
+++ b/curations/maven/mavengoogle/org.chromium.net/cronet-api.yaml
@@ -10,3 +10,6 @@ revisions:
   92.4515.131:
     licensed:
       declared: BSD-3-Clause
+  119.6045.31:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavengoogle/org.chromium.net/cronet-common.yaml
+++ b/curations/maven/mavengoogle/org.chromium.net/cronet-common.yaml
@@ -7,3 +7,6 @@ revisions:
   92.4515.131:
     licensed:
       declared: BSD-3-Clause
+  119.6045.31:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavengoogle/org.chromium.net/cronet-embedded.yaml
+++ b/curations/maven/mavengoogle/org.chromium.net/cronet-embedded.yaml
@@ -7,3 +7,6 @@ revisions:
   92.4515.131:
     licensed:
       declared: BSD-3-Clause
+  119.6045.31:
+    licensed:
+      declared: BSD-3-Clause

--- a/curations/maven/mavengoogle/org.chromium.net/cronet-fallback.yaml
+++ b/curations/maven/mavengoogle/org.chromium.net/cronet-fallback.yaml
@@ -7,3 +7,6 @@ revisions:
   92.4515.131:
     licensed:
       declared: BSD-3-Clause
+  119.6045.31:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION
[Component Governance][cgdocs] is a Microsoft internal DevOps tool which scans code to find all dependencies, and issues reports if dependencies have legal or security issues.  Component Governance has created multiple alerts concerning packages used by [xamarin/AndroidX][xamarin-bindings], some due to missing license information, and some due to *incorrect* license information. For example, `com.google.mlkit:barcode-scanning` 17.3.0 is detected as having an APSL-1.0 license, and
`com.android.billingclient:billing` 7.1.1 is detected as GPL-2.0. Neither of these is correct.

Component Governance uses clearlydefined/curated-data as it's backend "source of truth" regarding license information.

Fix my issues by updating curated-data to have the correct license information for these packages.

[cgdocs]: https://aka.ms/cgdocs
[xamarin-bindings]: https://github.com/xamarin/AndroidX/