### PR TITLE
Add curation for npm elliptic

### DIFF
--- a/curations/npm/npmjs/-/elliptic.yaml
+++ b/curations/npm/npmjs/-/elliptic.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '-'
+    name: elliptic
+revisions:
+    6.6.0:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found at https://github.com/indutny/elliptic?tab=readme-ov-file#license

I'm not sure how OFL was spotted in this code.