### PR TITLE
Add curation for go clock

### DIFF
--- a/curations/go/golang/code.cloudfoundry.org/clock.yaml
+++ b/curations/go/golang/code.cloudfoundry.org/clock.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: go
+    provider: golang
+    namespace: code.cloudfoundry.org
+    name: clock
+revisions:
+    v1.17.0:
+        licensed:
+            declared: It's Apache-2.0


### PR DESCRIPTION
The correct license is It's Apache-2.0 which can be found at https://github.com/cloudfoundry/clock/blob/main/LICENSE