### PR TITLE
Add curation for npm apexcharts

### DIFF
--- a/curations/npm/npmjs/-/apexcharts.yaml
+++ b/curations/npm/npmjs/-/apexcharts.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '-'
+    name: apexcharts
+revisions:
+    3.54.1:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/apexcharts/apexcharts.js/blob/main/LICENSE

Specific release version: https://github.com/apexcharts/apexcharts.js/blob/v3.54.1/LICENSE