### PR TITLE
pillow 8.3.1

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -36,6 +36,9 @@ revisions:
   6.2.1:
     licensed:
       declared: MIT-CMU
+  8.3.1:
+    licensed:
+      declared: MIT
   9.0.0:
     licensed:
       declared: MIT-CMU


### PR DESCRIPTION

**Type:** Other

**Summary:**
pillow 8.3.1

**Details:**
Still showing CAL-1.0. Cannot get it reflect MIT-CMU so I'm making the changes manually

**Resolution:**
Will update back to MIT-CMU

**Affected definitions**:
- [pillow 8.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/8.3.1/8.3.1)