### PR TITLE
pillow 8.3.1

### DIFF
--- a/curations/pypi/pypi/-/pillow.yaml
+++ b/curations/pypi/pypi/-/pillow.yaml
@@ -38,7 +38,7 @@ revisions:
       declared: MIT-CMU
   8.3.1:
     licensed:
-      declared: MIT
+      declared: MIT-CMU
   9.0.0:
     licensed:
       declared: MIT-CMU


### PR DESCRIPTION

**Type:** Other

**Summary:**
pillow 8.3.1

**Details:**
Setting back to MIT-CMU since it finally updated from CAL-1.0

**Resolution:**
MIT-CMU

**Affected definitions**:
- [pillow 8.3.1](https://clearlydefined.io/definitions/pypi/pypi/-/pillow/8.3.1/8.3.1)