### PR TITLE
Microsoft.VisualStudio.Sdk.TestFramework.Xunit17.11.8

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Sdk.TestFramework.Xunit.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: Microsoft.VisualStudio.Sdk.TestFramework.Xunit
+  provider: nuget
+  type: nuget
+revisions:
+  17.11.8:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Sdk.TestFramework.Xunit17.11.8

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://www.nuget.org/packages/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/17.11.8

**Affected definitions**:
- [Microsoft.VisualStudio.Sdk.TestFramework.Xunit 17.11.8](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Sdk.TestFramework.Xunit/17.11.8/17.11.8)