### PR TITLE
Add curation for nuget Microsoft.Azure.Management.KeyVault

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.KeyVault.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.KeyVault.yaml
@@ -1,41 +1,45 @@
 coordinates:
-  name: Microsoft.Azure.Management.KeyVault
-  provider: nuget
-  type: nuget
+    type: nuget
+    provider: nuget
+    namespace: ""
+    name: Microsoft.Azure.Management.KeyVault
 revisions:
-  0.9.0-preview:
-    licensed:
-      declared: Apache-2.0
-  1.0.0:
-    licensed:
-      declared: Apache-2.0
-  1.0.1:
-    licensed:
-      declared: MIT
-  2.0.0-preview:
-    licensed:
-      declared: MIT
-  2.0.1-preview:
-    licensed:
-      declared: MIT
-  2.1.0-preview:
-    licensed:
-      declared: MIT
-  2.2.0-preview:
-    licensed:
-      declared: MIT
-  2.3.0-preview:
-    licensed:
-      declared: MIT
-  2.4.1:
-    licensed:
-      declared: MIT
-  2.4.1-alpha:
-    licensed:
-      declared: MIT
-  2.4.2:
-    licensed:
-      declared: MIT
-  2.4.3:
-    licensed:
-      declared: MIT
+    '>= 0':
+        licensed:
+            declared: The MIT License (MIT)
+    0.9.0-preview:
+        licensed:
+            declared: Apache-2.0
+    1.0.0:
+        licensed:
+            declared: Apache-2.0
+    1.0.1:
+        licensed:
+            declared: MIT
+    2.0.0-preview:
+        licensed:
+            declared: MIT
+    2.0.1-preview:
+        licensed:
+            declared: MIT
+    2.1.0-preview:
+        licensed:
+            declared: MIT
+    2.2.0-preview:
+        licensed:
+            declared: MIT
+    2.3.0-preview:
+        licensed:
+            declared: MIT
+    2.4.1:
+        licensed:
+            declared: MIT
+    2.4.1-alpha:
+        licensed:
+            declared: MIT
+    2.4.2:
+        licensed:
+            declared: MIT
+    2.4.3:
+        licensed:
+            declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.Azure.Management.KeyVault.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Management.KeyVault.yaml
@@ -6,7 +6,7 @@ coordinates:
 revisions:
     '>= 0':
         licensed:
-            declared: The MIT License (MIT)
+            declared: MIT
     0.9.0-preview:
         licensed:
             declared: Apache-2.0


### PR DESCRIPTION
The correct license is The MIT License (MIT) which can be found at https://raw.githubusercontent.com/Microsoft/dotnet/master/LICENSE