### PR TITLE
Microsoft.ServiceHub.Framework4.3.50

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.ServiceHub.Framework.yaml
+++ b/curations/nuget/nuget/-/Microsoft.ServiceHub.Framework.yaml
@@ -30,3 +30,6 @@ revisions:
   2.8.2018:
     licensed:
       declared: OTHER
+  4.3.50:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.ServiceHub.Framework4.3.50

**Details:**
Declared License should be MIT

**Resolution:**
https://www.nuget.org/packages/Microsoft.ServiceHub.Framework/4.3.50

**Affected definitions**:
- [Microsoft.ServiceHub.Framework 4.3.50](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.ServiceHub.Framework/4.3.50/4.3.50)