### PR TITLE
Microsoft.VisualStudio.Telemetry17.10.18

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
@@ -6,3 +6,6 @@ revisions:
   15.8.956:
     licensed:
       declared: OTHER
+  17.10.18:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Telemetry17.10.18

**Details:**
Declared License should be OTHER for proprietary EULA.

**Resolution:**
https://visualstudio.microsoft.com/license-terms/mt736442/

**Affected definitions**:
- [Microsoft.VisualStudio.Telemetry 17.10.18](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Telemetry/17.10.18/17.10.18)