### PR TITLE
ruamel.yaml0.18.6

### DIFF
--- a/curations/pypi/pypi/-/ruamel.yaml.yaml
+++ b/curations/pypi/pypi/-/ruamel.yaml.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: ruamel.yaml
+  provider: pypi
+  type: pypi
+revisions:
+  0.18.6:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
ruamel.yaml0.18.6

**Details:**
Fixing Declared Field to MIT

**Resolution:**
https://pypi.org/project/ruamel.yaml/0.18.6/

**Affected definitions**:
- [ruamel.yaml 0.18.6](https://clearlydefined.io/definitions/pypi/pypi/-/ruamel.yaml/0.18.6/0.18.6)