### PR TITLE
org.glassfish.jersey.media/jersey-media-multipart/3.1.5

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart.yaml
@@ -22,3 +22,6 @@ revisions:
   2.25.1:
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  3.1.5:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.glassfish.jersey.media/jersey-media-multipart/3.1.5

**Details:**
Add EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/glassfish/jersey/media/jersey-media-multipart/3.1.5/jersey-media-multipart-3.1.5.pom

**Affected definitions**:
- [jersey-media-multipart 3.1.5](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.media/jersey-media-multipart/3.1.5)