### PR TITLE
org.glassfish.jersey.inject/jersey-hk2/3.1.5

### DIFF
--- a/curations/maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2.yaml
+++ b/curations/maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2.yaml
@@ -7,3 +7,6 @@ revisions:
   '2.26':
     licensed:
       declared: CDDL-1.1 OR GPL-2.0-only WITH Classpath-exception-2.0
+  3.1.5:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.glassfish.jersey.inject/jersey-hk2/3.1.5

**Details:**
Add EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/glassfish/jersey/inject/jersey-hk2/3.1.5/jersey-hk2-3.1.5.pom

**Affected definitions**:
- [jersey-hk2 3.1.5](https://clearlydefined.io/definitions/maven/mavencentral/org.glassfish.jersey.inject/jersey-hk2/3.1.5)