### PR TITLE
Add curation for npm elliptic

### DIFF
--- a/curations/npm/npmjs/-/elliptic.yaml
+++ b/curations/npm/npmjs/-/elliptic.yaml
@@ -1,9 +1,12 @@
 coordinates:
-  type: npm
-  provider: npmjs
-  namespace: '-'
-  name: elliptic
+    type: npm
+    provider: npmjs
+    namespace: '-'
+    name: elliptic
 revisions:
-  6.6.0:
-    licensed:
-      declared: MIT
+    6.6.0:
+        licensed:
+            declared: MIT
+    6.6.1:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/indutny/elliptic

I did not see any trace of the OFL license here.