### PR TITLE
Add curation for pypi mako

### DIFF
--- a/curations/pypi/pypi/-/mako.yaml
+++ b/curations/pypi/pypi/-/mako.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: pypi
+    provider: pypi
+    namespace: '-'
+    name: mako
+revisions:
+    1.3.6:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/sqlalchemy/mako/blob/main/LICENSE

Very mysterious that scancode decided to add `LicenseRef-scancode-proprietary-license` for this one.