### PR TITLE
Microsoft.VisualStudio.Telemetry17.9.102

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
@@ -9,3 +9,6 @@ revisions:
   17.10.18:
     licensed:
       declared: OTHER
+  17.9.102:
+    licensed:
+      declared: OTHER

--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: OTHER
   17.11.20:
     licensed:
-      declared: OTHER:
+      declared: OTHER
   17.9.102:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Telemetry17.9.102

**Details:**
Declaring OTHER for Microsoft EULA

**Resolution:**
https://visualstudio.microsoft.com/license-terms/mt736442/

**Affected definitions**:
- [Microsoft.VisualStudio.Telemetry 17.9.102](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Telemetry/17.9.102/17.9.102)