### PR TITLE
Microsoft.VisualStudio.Telemetry17.11.20

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Telemetry.yaml
@@ -9,3 +9,6 @@ revisions:
   17.10.18:
     licensed:
       declared: OTHER
+  17.11.20:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Telemetry17.11.20

**Details:**
Declared License should be OTHER for proprietary EULA.

**Resolution:**
https://visualstudio.microsoft.com/license-terms/mt736442/

**Affected definitions**:
- [Microsoft.VisualStudio.Telemetry 17.11.20](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Telemetry/17.11.20/17.11.20)