### PR TITLE
Add curation for gem rubocop

### DIFF
--- a/curations/gem/rubygems/-/rubocop.yaml
+++ b/curations/gem/rubygems/-/rubocop.yaml
@@ -1,11 +1,15 @@
 coordinates:
-  name: rubocop
-  provider: rubygems
-  type: gem
+    type: gem
+    provider: rubygems
+    namespace: ""
+    name: rubocop
 revisions:
-  1.38.0:
-    licensed:
-      declared: MIT
-  1.39.0:
-    licensed:
-      declared: MIT
+    1.38.0:
+        licensed:
+            declared: MIT
+    1.39.0:
+        licensed:
+            declared: MIT
+    1.69.0:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/rubocop/rubocop/blob/master/LICENSE.txt

I think that there is a reference to a Creative Commons license that is specifically [limited to the logo](https://github.com/rubocop/rubocop/tree/master?tab=readme-ov-file#logo):

> The logo is licensed under a [Creative Commons Attribution-NonCommercial 4.0 International License](https://creativecommons.org/licenses/by-nc/4.0/deed.en_GB).
