### PR TITLE
@ag-grid-enterprise/status-bar30.2.1

### DIFF
--- a/curations/npm/npmjs/@ag-grid-enterprise/status-bar.yaml
+++ b/curations/npm/npmjs/@ag-grid-enterprise/status-bar.yaml
@@ -34,6 +34,9 @@ revisions:
   30.2.0:
     licensed:
       declared: OTHER
+  30.2.1:
+    licensed:
+      declared: OTHER
   31.0.0:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@ag-grid-enterprise/status-bar30.2.1

**Details:**
Fixing Declared License to OTHER for commercial license

**Resolution:**
https://www.npmjs.com/package/@ag-grid-enterprise/status-bar/v/30.2.1

**Affected definitions**:
- [status-bar 30.2.1](https://clearlydefined.io/definitions/npm/npmjs/@ag-grid-enterprise/status-bar/30.2.1/30.2.1)