### PR TITLE
pycdlib1.14.0

### DIFF
--- a/curations/pypi/pypi/-/pycdlib.yaml
+++ b/curations/pypi/pypi/-/pycdlib.yaml
@@ -9,3 +9,6 @@ revisions:
   1.13.0:
     licensed:
       declared: LGPL-2.1-only
+  1.14.0:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pycdlib1.14.0

**Details:**
Declaring LGPL-2.1-only

**Resolution:**
https://github.com/clalancette/pycdlib/blob/master/pycdlib/pycdlib.py

**Affected definitions**:
- [pycdlib 1.14.0](https://clearlydefined.io/definitions/pypi/pypi/-/pycdlib/1.14.0/1.14.0)