### PR TITLE
eslint-plugin-deprecation2.0.0

### DIFF
--- a/curations/npm/npmjs/-/eslint-plugin-deprecation.yaml
+++ b/curations/npm/npmjs/-/eslint-plugin-deprecation.yaml
@@ -6,3 +6,6 @@ revisions:
   1.5.0:
     licensed:
       declared: LGPL-3.0-or-later
+  2.0.0:
+    licensed:
+      declared: LGPL-3.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
eslint-plugin-deprecation2.0.0

**Details:**
Fixing Declared Field to LGPL-3.0-or-later

**Resolution:**
https://www.npmjs.com/package/eslint-plugin-deprecation/v/2.0.0

**Affected definitions**:
- [eslint-plugin-deprecation 2.0.0](https://clearlydefined.io/definitions/npm/npmjs/-/eslint-plugin-deprecation/2.0.0/2.0.0)