### PR TITLE
Microsoft.VisualStudio.Threading.Analyzers17.12.19

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.Analyzers.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Threading.Analyzers.yaml
@@ -12,3 +12,6 @@ revisions:
   15.8.122:
     licensed:
       declared: MIT
+  17.12.19:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Threading.Analyzers17.12.19

**Details:**
Declared License should be MIT

**Resolution:**
https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers/17.12.19

**Affected definitions**:
- [Microsoft.VisualStudio.Threading.Analyzers 17.12.19](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Threading.Analyzers/17.12.19/17.12.19)