### PR TITLE
Microsoft.Web.WebView21.0.2903.40

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Web.WebView2.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Web.WebView2.yaml
@@ -9,6 +9,9 @@ revisions:
   1.0.2849.39:
     licensed:
       declared: BSD-3-Clause
+  1.0.2903.40:
+    licensed:
+      declared: BSD-3-Clause
   1.0.864.35:
     licensed:
       declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.Web.WebView21.0.2903.40

**Details:**
Declaring BSD-3-Clause

**Resolution:**
Per license file in the ClearlyDefined Files folder

**Affected definitions**:
- [Microsoft.Web.WebView2 1.0.2903.40](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Web.WebView2/1.0.2903.40/1.0.2903.40)