### PR TITLE
Microsoft.Azure.Cosmos3.46.0

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -21,6 +21,9 @@ revisions:
   3.45.0:
     licensed:
       declared: MIT
+  3.46.0:
+    licensed:
+      declared: MIT
   3.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.Azure.Cosmos3.46.0

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://www.nuget.org/packages/Microsoft.Azure.Cosmos/3.46.0/License

**Affected definitions**:
- [Microsoft.Azure.Cosmos 3.46.0](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos/3.46.0/3.46.0)