### PR TITLE
parallel-ssh 2.12.0

### DIFF
--- a/curations/pypi/pypi/-/parallel-ssh.yaml
+++ b/curations/pypi/pypi/-/parallel-ssh.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: parallel-ssh
+  provider: pypi
+  type: pypi
+revisions:
+  2.12.0:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
parallel-ssh 2.12.0

**Details:**
The license information on the setup.py is LGPL-2.1-only

**Resolution:**
 LGPL-2.1-only

**Affected definitions**:
- [parallel-ssh 2.12.0](https://clearlydefined.io/definitions/pypi/pypi/-/parallel-ssh/2.12.0/2.12.0)