### PR TITLE
Update mysql-connector-j license

### DIFF
--- a/curations/maven/mavencentral/com.mysql/mysql-connector-j.yaml
+++ b/curations/maven/mavencentral/com.mysql/mysql-connector-j.yaml
@@ -4,6 +4,12 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  9.1.0:
+    licensed:
+      declared: OTHER
+  9.0.0:
+    licensed:
+      declared: OTHER
   8.0.31:
     licensed:
       declared: OTHER


### PR DESCRIPTION
Hi

Similar to https://github.com/clearlydefined/curated-data/pull/28102

Type: Incorrect

Summary:
com.mysql/mysql-connector-j9.1.0 and com.mysql/mysql-connector-j9.0.0

Details:
Declaring as OTHER for GPL-2.0 with Universal FOSS exception

Resolution:
Per POM file

[License for 9.0.0](https://github.com/mysql/mysql-connector-j/blob/e0e8e3461e5257ba4aa19e6b3614a2685b298947/LICENSE)

[License for 9.1.0](https://github.com/mysql/mysql-connector-j/blob/cf2917ea44ae2e43a4514a33771035aa99de73bf/LICENSE)

Is there any way to improve the auto detection for this library? The github license review picks it up as invalid all the time. I don't mind reaching out to mysql team if the hiccup is on their end!

Thanks!