### PR TITLE
Microsoft.VisualStudio.Utilities.Internal16.3.73

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal.yaml
@@ -6,3 +6,6 @@ revisions:
   14.0.79-master7f49a4e3:
     licensed:
       declared: OTHER
+  16.3.73:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Utilities.Internal16.3.73

**Details:**
Declared as OTHER for Microsoft EULA

**Resolution:**
Agreed to curate as OTHER for Microsoft EULA because there is no license ref match.

**Affected definitions**:
- [Microsoft.VisualStudio.Utilities.Internal 16.3.73](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal/16.3.73/16.3.73)