### PR TITLE
sushy5.4.0

### DIFF
--- a/curations/pypi/pypi/-/sushy.yaml
+++ b/curations/pypi/pypi/-/sushy.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: sushy
+  provider: pypi
+  type: pypi
+revisions:
+  5.4.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
sushy5.4.0

**Details:**
Declared License should be Apache-2.0

**Resolution:**
https://pypi.org/project/sushy/5.4.0/

**Affected definitions**:
- [sushy 5.4.0](https://clearlydefined.io/definitions/pypi/pypi/-/sushy/5.4.0/5.4.0)