### PR TITLE
grpcio1.68.1

### DIFF
--- a/curations/pypi/pypi/-/grpcio.yaml
+++ b/curations/pypi/pypi/-/grpcio.yaml
@@ -6,3 +6,6 @@ revisions:
   1.68.0:
     licensed:
       declared: Apache-2.0
+  1.68.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
grpcio1.68.1

**Details:**
Fixing Declared Field to Apache-2.0

**Resolution:**
https://pypi.org/project/grpcio/1.68.1/

**Affected definitions**:
- [grpcio 1.68.1](https://clearlydefined.io/definitions/pypi/pypi/-/grpcio/1.68.1/1.68.1)