### PR TITLE
Add BouncyCastle JDK18on license as MIT

### DIFF
--- a/curations/maven/mavencentral/bouncycastle/bcprov-jdk18.yaml
+++ b/curations/maven/mavencentral/bouncycastle/bcprov-jdk18.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: bcprov-jdk18on
+  namespace: bouncycastle
+  provider: mavencentral
+  type: maven
+revisions:
+  '1.70':
+    licensed:
+      declared: MIT


### PR DESCRIPTION
I largely copied the existing `bcprov-jdk15.yaml` file.

**License**
As per https://www.bouncycastle.org/licence.html

![image](https://github.com/user-attachments/assets/6ab7db0a-1e16-4930-a842-f14e20138858)

I think we will save everyone a lot of time and effort by marking this as a license already known to people and tooling.

**Version**
Starts at 1.70 on maven.

![image](https://github.com/user-attachments/assets/39c00ba3-aa4e-40ff-9058-498576332134)
https://mvnrepository.com/artifact/org.bouncycastle/bcprov-jdk18o