### PR TITLE
Microsoft.VisualStudio.Utilities.Internal 16.3.56

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal.yaml
@@ -6,6 +6,9 @@ revisions:
   14.0.79-master7f49a4e3:
     licensed:
       declared: OTHER
+  16.3.56:
+    licensed:
+      declared: OTHER
   16.3.73:
     licensed:
       declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.VisualStudio.Utilities.Internal 16.3.56

**Details:**
This is under a MSFT EULA. Should be OTHER

**Resolution:**
ClearlyDefined including NOTICE file attributions in the declared field, which is a bug

**Affected definitions**:
- [Microsoft.VisualStudio.Utilities.Internal 16.3.56](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.Utilities.Internal/16.3.56/16.3.56)