### PR TITLE
Add curation for pypi jedi

### DIFF
--- a/curations/pypi/pypi/-/jedi.yaml
+++ b/curations/pypi/pypi/-/jedi.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: pypi
+    provider: pypi
+    namespace: '-'
+    name: jedi
+revisions:
+    0.19.2:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/davidhalter/jedi/blob/master/LICENSE.txt