### PR TITLE
Add curation for npm katex

### DIFF
--- a/curations/npm/npmjs/-/katex.yaml
+++ b/curations/npm/npmjs/-/katex.yaml
@@ -1,8 +1,9 @@
 coordinates:
-  name: katex
-  provider: npmjs
-  type: npm
+    type: npm
+    provider: npmjs
+    namespace: ""
+    name: katex
 revisions:
-  0.16.21:
-    licensed:
-      declared: MIT
+    0.16.21:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/KaTeX/KaTeX/blob/main/LICENSE