### PR TITLE
pymupdf 1.24.12

### DIFF
--- a/curations/pypi/pypi/-/pymupdf.yaml
+++ b/curations/pypi/pypi/-/pymupdf.yaml
@@ -11,7 +11,7 @@ revisions:
       declared: AGPL-3.0-only OR OTHER
   1.24.10:
     licensed:
-      declared: AGPL-3.0-only AND OTHER
+      declared: AGPL-3.0-only OR OTHER
   1.24.12:
     licensed:
       declared: AGPL-3.0-only OR OTHER

--- a/curations/pypi/pypi/-/pymupdf.yaml
+++ b/curations/pypi/pypi/-/pymupdf.yaml
@@ -12,6 +12,9 @@ revisions:
   1.24.10:
     licensed:
       declared: AGPL-3.0-only AND OTHER
+  1.24.12:
+    licensed:
+      declared: AGPL-3.0-only OR OTHER
   1.24.9:
     licensed:
       declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pymupdf 1.24.12

**Details:**
For commercial license option see https://github.com/pymupdf/PyMuPDF/blob/main/setup.py#L1248

**Resolution:**
AGPL-3.0-only OR OTHER

**Affected definitions**:
- [pymupdf 1.24.12](https://clearlydefined.io/definitions/pypi/pypi/-/pymupdf/1.24.12/1.24.12)