### PR TITLE
Add curation NuGet: Microsoft.VisualStudio.SolutionPersistence

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.SolutionPersistence.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.SolutionPersistence.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.9:
     licensed:
       declared: MIT
+  1.0.38:
+    licensed:
+      declared: MIT

--- a/curations/nuget/nuget/-/Microsoft.VisualStudio.SolutionPersistence.yaml
+++ b/curations/nuget/nuget/-/Microsoft.VisualStudio.SolutionPersistence.yaml
@@ -6,6 +6,6 @@ revisions:
   1.0.9:
     licensed:
       declared: MIT
-  1.0.38:
+  1.0.28:
     licensed:
       declared: MIT


### PR DESCRIPTION
**Type**: Incorrect

**Summary**:
Microsoft.VisualStudio.SolutionPersistence 1.0.28

**Details**:
The package declares the MIT license, found here https://github.com/microsoft/vs-solutionpersistence/blob/v1.0.28/LICENSE

The automation seems to mistakenly pick up LGPL from the notice (no component is licensed with LGPL but there is confusing wording there)

**Resolution**:
MIT

Affected definitions:
[Microsoft.VisualStudio.SolutionPersistence 1.0.28](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.VisualStudio.SolutionPersistence/1.0.28)


