### PR TITLE
Add curation for npm unicode-property-aliases-ecmascript

### DIFF
--- a/curations/npm/npmjs/-/unicode-property-aliases-ecmascript.yaml
+++ b/curations/npm/npmjs/-/unicode-property-aliases-ecmascript.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '-'
+    name: unicode-property-aliases-ecmascript
+revisions:
+    2.1.0:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/mathiasbynens/unicode-property-aliases-ecmascript/blob/main/LICENSE-MIT.txt