### PR TITLE
Add curations for JavaFX 18.0.1 and 21.0.5

### DIFF
--- a/curations/maven/mavencentral/org.openjfx/javafx-base.yaml
+++ b/curations/maven/mavencentral/org.openjfx/javafx-base.yaml
@@ -22,3 +22,9 @@ revisions:
   18-ea+8:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  18.0.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0
+  21.0.5:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.openjfx/javafx-controls.yaml
+++ b/curations/maven/mavencentral/org.openjfx/javafx-controls.yaml
@@ -13,3 +13,9 @@ revisions:
   '16':
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  18.0.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0
+  21.0.5:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.openjfx/javafx-fxml.yaml
+++ b/curations/maven/mavencentral/org.openjfx/javafx-fxml.yaml
@@ -7,3 +7,9 @@ revisions:
   11.0.2:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  18.0.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0
+  21.0.5:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.openjfx/javafx-graphics.yaml
+++ b/curations/maven/mavencentral/org.openjfx/javafx-graphics.yaml
@@ -22,3 +22,9 @@ revisions:
   18-ea+8:
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  18.0.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0
+  21.0.5:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0

--- a/curations/maven/mavencentral/org.openjfx/javafx-media.yaml
+++ b/curations/maven/mavencentral/org.openjfx/javafx-media.yaml
@@ -7,3 +7,9 @@ revisions:
   '15':
     licensed:
       declared: GPL-2.0-only WITH Classpath-exception-2.0
+  18.0.1:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0
+  21.0.5:
+    licensed:
+      declared: GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION
**Type:** Missing
 
**Summary:** JavaFX 18.0.1 and 21.0.5

**Details:** Add licence information for these versions

**Resolution:** The licence information isn't different that that of earlier versions.

**Affected definitions**:

* [maven/mavencentral/org.openjfx/javafx-base/18.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-base/18.0.1)
* [maven/mavencentral/org.openjfx/javafx-controls/18.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-controls/18.0.1)
* [maven/mavencentral/org.openjfx/javafx-fxml/18.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-fxml/18.0.1)
* [maven/mavencentral/org.openjfx/javafx-graphics/18.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-graphics/18.0.1)
* [maven/mavencentral/org.openjfx/javafx-media/18.0.1](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-media/18.0.1)
* [maven/mavencentral/org.openjfx/javafx-base/21.0.5](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-base/21.0.5)
* [maven/mavencentral/org.openjfx/javafx-controls/21.0.5](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-controls/21.0.5)
* [maven/mavencentral/org.openjfx/javafx-fxml/21.0.5](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-fxml/21.0.5)
* [maven/mavencentral/org.openjfx/javafx-graphics/21.0.5](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-graphics/21.0.5)
* [maven/mavencentral/org.openjfx/javafx-media/21.0.5](https://clearlydefined.io/definitions/maven/mavencentral/org.openjfx/javafx-media/21.0.5)
