### PR TITLE
shapely2.0.7

### DIFF
--- a/curations/pypi/pypi/-/shapely.yaml
+++ b/curations/pypi/pypi/-/shapely.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: shapely
+  provider: pypi
+  type: pypi
+revisions:
+  2.0.7:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
shapely2.0.7

**Details:**
Fixing Declared License to BSD-3-Clause

**Resolution:**
https://pypi.org/project/shapely/2.0.7/

**Affected definitions**:
- [shapely 2.0.7](https://clearlydefined.io/definitions/pypi/pypi/-/shapely/2.0.7/2.0.7)