### PR TITLE
Add curation for npm applicationinsights-web-basic

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-web-basic.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-web-basic.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-web-basic
+revisions:
+    3.3.5:
+        licensed:
+            declared: MIT

--- a/curations/npm/npmjs/@microsoft/applicationinsights-web-basic.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-web-basic.yaml
@@ -1,9 +1,9 @@
 coordinates:
-    type: npm
-    provider: npmjs
-    namespace: '@microsoft'
-    name: applicationinsights-web-basic
+  type: npm
+  provider: npmjs
+  namespace: '@microsoft'
+  name: applicationinsights-web-basic
 revisions:
-    3.3.5:
-        licensed:
-            declared: MIT
+  3.3.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/AISKULight/LICENSE