### PR TITLE
Add curation for npm applicationinsights-core-js

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-core-js.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-core-js.yaml
@@ -1,12 +1,12 @@
 coordinates:
-    type: npm
-    provider: npmjs
-    namespace: '@microsoft'
-    name: applicationinsights-core-js
+  type: npm
+  provider: npmjs
+  namespace: '@microsoft'
+  name: applicationinsights-core-js
 revisions:
-    3.3.4:
-        licensed:
-            declared: MIT
-    3.3.5:
-        licensed:
-            declared: MIT
+  3.3.4:
+    licensed:
+      declared: MIT
+  3.3.5:
+    licensed:
+      declared: MIT

--- a/curations/npm/npmjs/@microsoft/applicationinsights-core-js.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-core-js.yaml
@@ -1,9 +1,12 @@
 coordinates:
-  type: npm
-  provider: npmjs
-  namespace: '@microsoft'
-  name: applicationinsights-core-js
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-core-js
 revisions:
-  3.3.4:
-    licensed:
-      declared: MIT
+    3.3.4:
+        licensed:
+            declared: MIT
+    3.3.5:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/shared/AppInsightsCore/LICENSE