### PR TITLE
Add curation for npm applicationinsights-common

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-common.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-common.yaml
@@ -1,9 +1,12 @@
 coordinates:
-  type: npm
-  provider: npmjs
-  namespace: '@microsoft'
-  name: applicationinsights-common
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-common
 revisions:
-  3.3.4:
-    licensed:
-      declared: MIT
+    3.3.4:
+        licensed:
+            declared: MIT
+    3.3.5:
+        licensed:
+            declared: MIT

--- a/curations/npm/npmjs/@microsoft/applicationinsights-common.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-common.yaml
@@ -1,12 +1,12 @@
 coordinates:
-    type: npm
-    provider: npmjs
-    namespace: '@microsoft'
-    name: applicationinsights-common
+  type: npm
+  provider: npmjs
+  namespace: '@microsoft'
+  name: applicationinsights-common
 revisions:
-    3.3.4:
-        licensed:
-            declared: MIT
-    3.3.5:
-        licensed:
-            declared: MIT
+  3.3.4:
+    licensed:
+      declared: MIT
+  3.3.5:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/shared/AppInsightsCommon/LICENSE