### PR TITLE
org.apache.poi:poi-ooxml:5.2.2

### DIFF
--- a/curations/maven/mavencentral/org.apache.poi/poi-ooxml.yaml
+++ b/curations/maven/mavencentral/org.apache.poi/poi-ooxml.yaml
@@ -7,3 +7,6 @@ revisions:
   5.2.1:
     licensed:
       declared: Apache-2.0
+  5.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.apache.poi:poi-ooxml:5.2.2

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml/5.2.2/poi-ooxml-5.2.2.pom

**Affected definitions**:
- [poi-ooxml 5.2.2](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.poi/poi-ooxml/5.2.2)