### PR TITLE
org.apache.poi:poi-ooxml-lite:5.2.2

### DIFF
--- a/curations/maven/mavencentral/org.apache.poi/poi-ooxml-lite.yaml
+++ b/curations/maven/mavencentral/org.apache.poi/poi-ooxml-lite.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: poi-ooxml-lite
+  namespace: org.apache.poi
+  provider: mavencentral
+  type: maven
+revisions:
+  5.2.2:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.apache.poi:poi-ooxml-lite:5.2.2

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/apache/poi/poi-ooxml-lite/5.2.2/poi-ooxml-lite-5.2.2.pom

**Affected definitions**:
- [poi-ooxml-lite 5.2.2](https://clearlydefined.io/definitions/maven/mavencentral/org.apache.poi/poi-ooxml-lite/5.2.2)