### PR TITLE
@10up/babel-preset-default/2.1.1

### DIFF
--- a/curations/npm/npmjs/@10up/babel-preset-default.yaml
+++ b/curations/npm/npmjs/@10up/babel-preset-default.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: babel-preset-default
+  namespace: '@10up'
+  provider: npmjs
+  type: npm
+revisions:
+  2.1.1:
+    licensed:
+      declared: GPL-2.0-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@10up/babel-preset-default/2.1.1

**Details:**
Add GPL-2.0-or-later

**Resolution:**
https://github.com/10up/10up-toolkit/blob/%4010up/babel-preset-default%402.1.1/README.md

**Affected definitions**:
- [babel-preset-default 2.1.1](https://clearlydefined.io/definitions/npm/npmjs/@10up/babel-preset-default/2.1.1)