### PR TITLE
@esri/calcite-colors/6.0.0

### DIFF
--- a/curations/npm/npmjs/@esri/calcite-colors.yaml
+++ b/curations/npm/npmjs/@esri/calcite-colors.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: calcite-colors
+  namespace: '@esri'
+  provider: npmjs
+  type: npm
+revisions:
+  6.0.0:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@esri/calcite-colors/6.0.0

**Details:**
Add OTHER

**Resolution:**
https://www.npmjs.com/package/@esri/calcite-colors/v/6.0.0?activeTab=readme#licensing

**Affected definitions**:
- [calcite-colors 6.0.0](https://clearlydefined.io/definitions/npm/npmjs/@esri/calcite-colors/6.0.0)