### PR TITLE
com.rabbitmq:amqp-client:3.3.5

### DIFF
--- a/curations/maven/mavencentral/com.rabbitmq/amqp-client.yaml
+++ b/curations/maven/mavencentral/com.rabbitmq/amqp-client.yaml
@@ -7,3 +7,6 @@ revisions:
   3.1.4:
     licensed:
       declared: GPL-2.0-only OR MPL-1.1
+  3.3.5:
+    licensed:
+      declared: GPL-2.0-only OR MPL-1.1


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.rabbitmq:amqp-client:3.3.5

**Details:**
Add GPL-2.0-only OR MPL-1.1

**Resolution:**
https://repo1.maven.org/maven2/com/rabbitmq/amqp-client/3.3.5/amqp-client-3.3.5.pom

**Affected definitions**:
- [amqp-client 3.3.5](https://clearlydefined.io/definitions/maven/mavencentral/com.rabbitmq/amqp-client/3.3.5)