### PR TITLE
Add curation for npm canvas

### DIFF
--- a/curations/npm/npmjs/@napi-rs/canvas.yaml
+++ b/curations/npm/npmjs/@napi-rs/canvas.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '@napi-rs'
+    name: canvas
+revisions:
+    0.1.65:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/Brooooooklyn/canvas?tab=MIT-1-ov-file#readme