### PR TITLE
feat: add com.google.errorprone/error_prone_annotations/2.28.0

### DIFF
--- a/curations/maven/mavencentral/com.google.errorprone/error_prone_annotations.yaml
+++ b/curations/maven/mavencentral/com.google.errorprone/error_prone_annotations.yaml
@@ -7,6 +7,9 @@ revisions:
   2.0.2:
     licensed:
       declared: Apache-2.0
+  2.28.0:
+    licensed:
+      declared: Apache-2.0
   2.36.0:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION
Hi,

This adds version 2.28.0 of the library.

I'm not sure what's going on since in the Workspace it appears to have the right version, but our tooling is still complaining so I'd like to try adding it here explicitly.

![image](https://github.com/user-attachments/assets/6377d107-fbe2-45fa-9dfc-00bbcdaa67cc)

Any advice or recommendation about this?

Thanks.