### PR TITLE
Architect.AmbientContexts/1.1.1

### DIFF
--- a/curations/nuget/nuget/-/Architect.AmbientContexts.yaml
+++ b/curations/nuget/nuget/-/Architect.AmbientContexts.yaml
@@ -6,3 +6,6 @@ revisions:
   1.0.0:
     licensed:
       declared: LGPL-3.0-only
+  1.1.1:
+    licensed:
+      declared: LGPL-3.0-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Architect.AmbientContexts/1.1.1

**Details:**
Add LGPL-3.0-only

**Resolution:**
https://github.com/TheArchitectDev/Architect.AmbientContexts/blob/f7baba1032043494cb11691b14b73bb6f9836dca/LICENSE

**Affected definitions**:
- [Architect.AmbientContexts 1.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/Architect.AmbientContexts/1.1.1)