### PR TITLE
AspNet.ScriptManager.jQuery/2.2.3

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
@@ -12,6 +12,9 @@ revisions:
   1.8.2:
     licensed:
       declared: NONE
+  2.2.3:
+    licensed:
+      declared: NONE
   3.3.1:
     licensed:
       declared: NONE


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
AspNet.ScriptManager.jQuery/2.2.3

**Details:**
Add NONE

**Resolution:**
No license info found.

**Affected definitions**:
- [AspNet.ScriptManager.jQuery 2.2.3](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.jQuery/2.2.3)