### PR TITLE
AspNet.ScriptManager.jQuery/3.7.1

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.jQuery.yaml
@@ -30,3 +30,6 @@ revisions:
   3.7.0:
     licensed:
       declared: NONE
+  3.7.1:
+    licensed:
+      declared: NONE


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
AspNet.ScriptManager.jQuery/3.7.1

**Details:**
Add NONE

**Resolution:**
No license info found.

**Affected definitions**:
- [AspNet.ScriptManager.jQuery 3.7.1](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.jQuery/3.7.1)