### PR TITLE
org.springframework:spring-aop:5.3.21

### DIFF
--- a/curations/maven/mavencentral/org.springframework/spring-aop.yaml
+++ b/curations/maven/mavencentral/org.springframework/spring-aop.yaml
@@ -4,6 +4,9 @@ coordinates:
   provider: mavencentral
   type: maven
 revisions:
+  5.3.21:
+    licensed:
+      declared: Apache-2.0
   5.3.23:
     licensed:
       declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
org.springframework:spring-aop:5.3.21

**Details:**
Add Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/org/springframework/spring-aop/5.3.21/spring-aop-5.3.21.pom

**Affected definitions**:
- [spring-aop 5.3.21](https://clearlydefined.io/definitions/maven/mavencentral/org.springframework/spring-aop/5.3.21)