### PR TITLE
EFCore.BulkExtensions.MySql/8.1.1

### DIFF
--- a/curations/nuget/nuget/-/EFCore.BulkExtensions.MySql.yaml
+++ b/curations/nuget/nuget/-/EFCore.BulkExtensions.MySql.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: EFCore.BulkExtensions.MySql
+  provider: nuget
+  type: nuget
+revisions:
+  8.1.1:
+    licensed:
+      declared: OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
EFCore.BulkExtensions.MySql/8.1.1

**Details:**
Add OTHER

**Resolution:**
https://www.nuget.org/packages/EFCore.BulkExtensions.MySql/8.1.1/License

**Affected definitions**:
- [EFCore.BulkExtensions.MySql 8.1.1](https://clearlydefined.io/definitions/nuget/nuget/-/EFCore.BulkExtensions.MySql/8.1.1)