### PR TITLE
Add curation for gem diff-lcs

### DIFF
--- a/curations/gem/rubygems/-/diff-lcs.yaml
+++ b/curations/gem/rubygems/-/diff-lcs.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: gem
+    provider: rubygems
+    namespace: '-'
+    name: diff-lcs
+revisions:
+    1.6.1:
+        licensed:
+            declared: (GPL-2.0-or-later OR Artistic-2.0 OR MIT)

--- a/curations/gem/rubygems/-/diff-lcs.yaml
+++ b/curations/gem/rubygems/-/diff-lcs.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
     1.6.1:
         licensed:
-            declared: (GPL-2.0-or-later OR Artistic-2.0 OR MIT)
+            declared: GPL-2.0-or-later OR Artistic-2.0 OR MIT


### PR DESCRIPTION
The correct license is (GPL-2.0-or-later OR Artistic-2.0 OR MIT) which can be found at https://github.com/halostatue/diff-lcs/blob/bb28cd9c8e395cabb3a905cb651249133169b2e6/LICENCE.md