### PR TITLE
Add curation for go pkg

### DIFF
--- a/curations/go/golang/knative.dev/pkg.yaml
+++ b/curations/go/golang/knative.dev/pkg.yaml
@@ -1,9 +1,12 @@
 coordinates:
-  name: pkg
-  namespace: knative.dev
-  provider: golang
-  type: go
+    type: go
+    provider: golang
+    namespace: knative.dev
+    name: pkg
 revisions:
-  v0.0.0-20221123154742-05b694ec4d3a:
-    licensed:
-      declared: Apache-2.0
+    v0.0.0-20221123154742-05b694ec4d3a:
+        licensed:
+            declared: Apache-2.0
+    v0.0.0-20230612155445-74c4be5e935e:
+        licensed:
+            declared: Apache-2.0


### PR DESCRIPTION
The correct license is Apache-2.0 which can be found at https://github.com/knative/pkg/blob/main/LICENSE