### PR TITLE
sushy5.5.0

### DIFF
--- a/curations/pypi/pypi/-/sushy.yaml
+++ b/curations/pypi/pypi/-/sushy.yaml
@@ -6,3 +6,6 @@ revisions:
   5.4.0:
     licensed:
       declared: Apache-2.0
+  5.5.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
sushy5.5.0

**Details:**
Fixing Declared field to Apache-2.0

**Resolution:**
https://pypi.org/project/sushy/5.5.0/

**Affected definitions**:
- [sushy 5.5.0](https://clearlydefined.io/definitions/pypi/pypi/-/sushy/5.5.0/5.5.0)