### PR TITLE
Update github-auth.yaml

### DIFF
--- a/curations/gem/rubygems/-/github-auth.yaml
+++ b/curations/gem/rubygems/-/github-auth.yaml
@@ -10,5 +10,5 @@ revisions:
       - attributions:
            - 'Copyright (c) 2013 Chris Hunt'
         license:  MIT
-        path: https://github.com/chrishunt/github-auth/blob/master/LICENSE.txt
+        path: LICENSE.txt
       

--- a/curations/gem/rubygems/-/github-auth.yaml
+++ b/curations/gem/rubygems/-/github-auth.yaml
@@ -6,3 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: MIT
+    files:
+      - attributions:
+           - 'Copyright (c) 2013 Chris Hunt'
+        license:  MIT
+        path: https://github.com/chrishunt/github-auth/blob/master/LICENSE.txt
+      


### PR DESCRIPTION
Found the github repo for 3.0.0 at https://github.com/chrishunt/github-auth/releases/tag/v3.0.0 and confirmed the license file in the tarball download. Hoping this one goes smoother!