### PR TITLE
Add curation for go mysql

### DIFF
--- a/curations/go/golang/github.com/go-sql-driver/mysql.yaml
+++ b/curations/go/golang/github.com/go-sql-driver/mysql.yaml
@@ -6,4 +6,4 @@ coordinates:
 revisions:
     v1.9.2:
         licensed:
-            declared: MPL 2.0
+            declared: MPL-2.0


### PR DESCRIPTION
The correct license is MPL 2.0 which can be found
at https://github.com/go-sql-driver/mysql/blob/master/LICENSE