### PR TITLE
Bogus/28.0.2

### DIFF
--- a/curations/nuget/nuget/-/Bogus.yaml
+++ b/curations/nuget/nuget/-/Bogus.yaml
@@ -18,6 +18,9 @@ revisions:
   25.0.4:
     licensed:
       declared: MIT
+  28.0.2:
+    licensed:
+      declared: MIT
   28.0.3:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Bogus/28.0.2

**Details:**
Add MIT

**Resolution:**
https://github.com/bchavez/Bogus/tree/v28.0.2?tab=readme-ov-file#license

**Affected definitions**:
- [Bogus 28.0.2](https://clearlydefined.io/definitions/nuget/nuget/-/Bogus/28.0.2)