### PR TITLE
net.java.dev.jna/jna5.12.1

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -15,7 +15,7 @@ revisions:
       declared: Apache-2.0 OR LGPL-2.1-or-later
   5.12.1:
     licensed:
-      declared: LGPL-2.1-or-later OR Apache-2.0
+      declared: Apache-2.0 OR LGPL-2.1-or-later
   5.14.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later

--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -13,6 +13,9 @@ revisions:
   4.1.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later
+  5.12.1:
+    licensed:
+      declared: LGPL-2.1-or-later OR Apache-2.0
   5.14.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.java.dev.jna/jna5.12.1

**Details:**
Fixing Declared License to LGPL-2.1 or later or Apache-2.0 

**Resolution:**
https://repo1.maven.org/maven2/net/java/dev/jna/jna/5.12.1/jna-5.12.1.pom

**Affected definitions**:
- [jna 5.12.1](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/5.12.1/5.12.1)