### PR TITLE
AspNet.ScriptManager.bootstrap/3.3.5

### DIFF
--- a/curations/nuget/nuget/-/AspNet.ScriptManager.bootstrap.yaml
+++ b/curations/nuget/nuget/-/AspNet.ScriptManager.bootstrap.yaml
@@ -6,6 +6,9 @@ revisions:
   3.0.0:
     licensed:
       declared: LicenseRef-scancode-ms-net-library-2019-06
+  3.3.5:
+    licensed:
+      declared: LicenseRef-scancode-ms-net-library-2019-06
   3.3.6:
     licensed:
       declared: LicenseRef-scancode-ms-net-library-2019-06


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
AspNet.ScriptManager.bootstrap/3.3.5

**Details:**
Add LicenseRef-scancode-ms-net-library-2019-06

**Resolution:**
Later versions have this license.

**Affected definitions**:
- [AspNet.ScriptManager.bootstrap 3.3.5](https://clearlydefined.io/definitions/nuget/nuget/-/AspNet.ScriptManager.bootstrap/3.3.5)