### PR TITLE
@napi-rs/canvas0.1.69

### DIFF
--- a/curations/npm/npmjs/@napi-rs/canvas.yaml
+++ b/curations/npm/npmjs/@napi-rs/canvas.yaml
@@ -7,3 +7,6 @@ revisions:
   0.1.65:
     licensed:
       declared: MIT
+  0.1.69:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
@napi-rs/canvas0.1.69

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://www.npmjs.com/package/@napi-rs/canvas/v/0.1.69

**Affected definitions**:
- [canvas 0.1.69](https://clearlydefined.io/definitions/npm/npmjs/@napi-rs/canvas/0.1.69/0.1.69)