### PR TITLE
katex0.16.22

### DIFF
--- a/curations/npm/npmjs/-/katex.yaml
+++ b/curations/npm/npmjs/-/katex.yaml
@@ -9,3 +9,6 @@ revisions:
   0.16.21:
     licensed:
       declared: MIT
+  0.16.22:
+    licensed:
+      declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
katex0.16.22

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://github.com/KaTeX/KaTeX/blob/main/LICENSE

**Affected definitions**:
- [katex 0.16.22](https://clearlydefined.io/definitions/npm/npmjs/-/katex/0.16.22/0.16.22)