### PR TITLE
com.github.java-json-tools/json-schema-core1.2.14

### DIFF
--- a/curations/maven/mavencentral/com.github.java-json-tools/json-schema-core.yaml
+++ b/curations/maven/mavencentral/com.github.java-json-tools/json-schema-core.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: json-schema-core
+  namespace: com.github.java-json-tools
+  provider: mavencentral
+  type: maven
+revisions:
+  1.2.14:
+    licensed:
+      declared: LGPL-3.0-or-later OR Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
com.github.java-json-tools/json-schema-core1.2.14

**Details:**
Fixing Declared License to LGPL-3.0-or-later OR Apache-2.0

**Resolution:**
https://repo1.maven.org/maven2/com/github/java-json-tools/json-schema-core/1.2.14/

**Affected definitions**:
- [json-schema-core 1.2.14](https://clearlydefined.io/definitions/maven/mavencentral/com.github.java-json-tools/json-schema-core/1.2.14/1.2.14)