### PR TITLE
Add curation for gem oauth2

### DIFF
--- a/curations/gem/rubygems/-/oauth2.yaml
+++ b/curations/gem/rubygems/-/oauth2.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: gem
+    provider: rubygems
+    namespace: '-'
+    name: oauth2
+revisions:
+    2.0.10:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/oauth-xx/oauth2/blob/main/LICENSE.txt