### PR TITLE
mathjs14.4.0

### DIFF
--- a/curations/npm/npmjs/-/mathjs.yaml
+++ b/curations/npm/npmjs/-/mathjs.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: mathjs
+  provider: npmjs
+  type: npm
+revisions:
+  14.4.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
mathjs14.4.0

**Details:**
Fixing Declared License to Apache-2.0

**Resolution:**
https://www.npmjs.com/package/mathjs/v/14.4.0

**Affected definitions**:
- [mathjs 14.4.0](https://clearlydefined.io/definitions/npm/npmjs/-/mathjs/14.4.0/14.4.0)