### PR TITLE
pycountry24.6.1

### DIFF
--- a/curations/pypi/pypi/-/pycountry.yaml
+++ b/curations/pypi/pypi/-/pycountry.yaml
@@ -1,0 +1,8 @@
+coordinates:
+  name: pycountry
+  provider: pypi
+  type: pypi
+revisions:
+  24.6.1:
+    licensed:
+      declared: LGPL-2.1-only


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pycountry24.6.1

**Details:**
Fixing Declared License field to LGPL-2.1-only

**Resolution:**
https://pypi.org/project/pycountry/24.6.1/

**Affected definitions**:
- [pycountry 24.6.1](https://clearlydefined.io/definitions/pypi/pypi/-/pycountry/24.6.1/24.6.1)