### PR TITLE
net.java.dev.jna/jna 5.13.0

### DIFF
--- a/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
+++ b/curations/maven/mavencentral/net.java.dev.jna/jna.yaml
@@ -16,6 +16,9 @@ revisions:
   5.12.1:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later
+  5.13.0:
+    licensed:
+      declared: Apache-2.0 OR LGPL-2.1-or-later
   5.14.0:
     licensed:
       declared: Apache-2.0 OR LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
net.java.dev.jna/jna 5.13.0

**Details:**
Updating to Apache 2.0 or LGPL 2.1 or later per pom.

**Resolution:**
https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/5.13.0

**Affected definitions**:
- [jna 5.13.0](https://clearlydefined.io/definitions/maven/mavencentral/net.java.dev.jna/jna/5.13.0/5.13.0)