### PR TITLE
jakarta.annotation/jakarta.annotation-api/3.0.0

### DIFF
--- a/curations/maven/mavencentral/jakarta.annotation/jakarta.annotation-api.yaml
+++ b/curations/maven/mavencentral/jakarta.annotation/jakarta.annotation-api.yaml
@@ -19,3 +19,6 @@ revisions:
   2.1.1:
     licensed:
       declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0
+  3.0.0:
+    licensed:
+      declared: EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
jakarta.annotation/jakarta.annotation-api/3.0.0

**Details:**
Add EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0

**Resolution:**
https://repo1.maven.org/maven2/jakarta/annotation/jakarta.annotation-api/3.0.0/jakarta.annotation-api-3.0.0.pom

**Affected definitions**:
- [jakarta.annotation-api 3.0.0](https://clearlydefined.io/definitions/maven/mavencentral/jakarta.annotation/jakarta.annotation-api/3.0.0)