### PR TITLE
pymupdf 1.25.2

### DIFF
--- a/curations/pypi/pypi/-/pymupdf.yaml
+++ b/curations/pypi/pypi/-/pymupdf.yaml
@@ -18,3 +18,6 @@ revisions:
   1.24.9:
     licensed:
       declared: AGPL-3.0-only OR OTHER
+  1.25.2:
+    licensed:
+      declared: AGPL-3.0-only OR OTHER


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
pymupdf 1.25.2

**Details:**
Updating to AGPL-3.0-only OR OTHER per license.

**Resolution:**
https://github.com/pymupdf/PyMuPDF/tree/1.25.2?tab=readme-ov-file#license-and-copyright

**Affected definitions**:
- [pymupdf 1.25.2](https://clearlydefined.io/definitions/pypi/pypi/-/pymupdf/1.25.2/1.25.2)