### PR TITLE
Add curation for npm applicationinsights-dependencies-js

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-dependencies-js.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-dependencies-js.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-dependencies-js
+revisions:
+    2.8.18:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/master/extensions/applicationinsights-dependencies-js/LICENSE