### PR TITLE
Add curation for npm applicationinsights-channel-js

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-channel-js.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-channel-js.yaml
@@ -1,12 +1,15 @@
 coordinates:
-  type: npm
-  provider: npmjs
-  namespace: '@microsoft'
-  name: applicationinsights-channel-js
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-channel-js
 revisions:
-  3.3.4:
-    licensed:
-      declared: MIT
-  3.3.5:
-    licensed:
-      declared: MIT
+    2.8.18:
+        licensed:
+            declared: MIT
+    3.3.4:
+        licensed:
+            declared: MIT
+    3.3.5:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/channels/applicationinsights-channel-js/LICENSE