### PR TITLE
Add curation for npm applicationinsights-shims

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-shims.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-shims.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-shims
+revisions:
+    2.0.2:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/tools/shims/LICENSE