### PR TITLE
Add curation for npm applicationinsights-web

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-web.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-web.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: npm
+    provider: npmjs
+    namespace: '@microsoft'
+    name: applicationinsights-web
+revisions:
+    2.8.18:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/LICENSE