### PR TITLE
Add curation for gem oauth2 v2.0.12

### DIFF
--- a/curations/gem/rubygems/-/oauth2.yaml
+++ b/curations/gem/rubygems/-/oauth2.yaml
@@ -1,8 +1,12 @@
 coordinates:
-  name: oauth2
-  provider: rubygems
-  type: gem
+    type: gem
+    provider: rubygems
+    namespace: ""
+    name: oauth2
 revisions:
-  2.0.10:
-    licensed:
-      declared: MIT
+    2.0.10:
+        licensed:
+            declared: MIT
+    2.0.12:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found at https://github.com/oauth-xx/oauth2/blob/main/LICENSE.txt

oauth2 2.0.12 added a new file (a logo) with an explicit CC BY-SA 4.0 license