### PR TITLE
grpcio1.73.0

### DIFF
--- a/curations/pypi/pypi/-/grpcio.yaml
+++ b/curations/pypi/pypi/-/grpcio.yaml
@@ -15,3 +15,6 @@ revisions:
   1.70.0:
     licensed:
       declared: Apache-2.0
+  1.73.0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
grpcio1.73.0

**Details:**
Fixing Declared License to Apache-2.0

**Resolution:**
https://pypi.org/project/grpcio/1.73.0/

**Affected definitions**:
- [grpcio 1.73.0](https://clearlydefined.io/definitions/pypi/pypi/-/grpcio/1.73.0/1.73.0)