### PR TITLE
shapely2.1.1

### DIFF
--- a/curations/pypi/pypi/-/shapely.yaml
+++ b/curations/pypi/pypi/-/shapely.yaml
@@ -6,3 +6,6 @@ revisions:
   2.0.7:
     licensed:
       declared: BSD-3-Clause
+  2.1.1:
+    licensed:
+      declared: BSD-3-Clause


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
shapely2.1.1

**Details:**
Fixing Declared License to BSD-3-Clause

**Resolution:**
https://pypi.org/project/shapely/2.1.1/

**Affected definitions**:
- [shapely 2.1.1](https://clearlydefined.io/definitions/pypi/pypi/-/shapely/2.1.1/2.1.1)