### PR TITLE
Add typing-extensions 4.11.0-4.14.0 Python-2.0.1

### DIFF
--- a/curations/pypi/pypi/-/typing-extensions.yaml
+++ b/curations/pypi/pypi/-/typing-extensions.yaml
@@ -56,6 +56,45 @@ revisions:
   4.11.0rc1:
     licensed:
       declared: Python-2.0.1
+  4.11.0:
+    licensed:
+      declared: Python-2.0.1
+  4.12.0a1:
+    licensed:
+      declared: Python-2.0.1
+  4.12.0a2:
+    licensed:
+      declared: Python-2.0.1
+  4.12.0rc1:
+    licensed:
+      declared: Python-2.0.1
+  4.12.0:
+    licensed:
+      declared: Python-2.0.1
+  4.12.1:
+    licensed:
+      declared: Python-2.0.1
+  4.12.2:
+    licensed:
+      declared: Python-2.0.1
+  4.13.0rc1:
+    licensed:
+      declared: Python-2.0.1
+  4.13.0:
+    licensed:
+      declared: Python-2.0.1
+  4.13.1:
+    licensed:
+      declared: Python-2.0.1
+  4.13.2:
+    licensed:
+      declared: Python-2.0.1
+  4.14.0rc1:
+    licensed:
+      declared: Python-2.0.1
+  4.14.0:
+    licensed:
+      declared: Python-2.0.1
   4.2.0:
     licensed:
       declared: Python-2.0.1


### PR DESCRIPTION
See https://github.com/python/typing_extensions/commit/bb75d261196aa6f520d1b80b373891c860ebb71b for a list of versions that use the latest version of the LICENSE file with the Python-2.0.1 license.