### PR TITLE
Add curation for gem factory_bot_rails

### DIFF
--- a/curations/gem/rubygems/-/factory_bot_rails.yaml
+++ b/curations/gem/rubygems/-/factory_bot_rails.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: gem
+    provider: rubygems
+    namespace: '-'
+    name: factory_bot_rails
+revisions:
+    6.5.0:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/thoughtbot/factory_bot_rails/blob/a648ce66e57481d9275bfaa7c434d624225bebbf/LICENSE