### PR TITLE
Add curation for go mysql

### DIFF
--- a/curations/go/golang/github.com/go-sql-driver/mysql.yaml
+++ b/curations/go/golang/github.com/go-sql-driver/mysql.yaml
@@ -1,9 +1,12 @@
 coordinates:
-  name: mysql
-  namespace: github.com%2fgo-sql-driver
-  provider: golang
-  type: go
+    type: go
+    provider: golang
+    namespace: github.com%2fgo-sql-driver
+    name: mysql
 revisions:
-  v1.9.2:
-    licensed:
-      declared: MPL-2.0
+    v1.9.2:
+        licensed:
+            declared: MPL-2.0
+    v1.9.3:
+        licensed:
+            declared: MPL-2.0


### PR DESCRIPTION
The correct license is MPL-2.0 which can be found
at https://github.com/go-sql-driver/mysql/blob/master/LICENSE