### PR TITLE
LicenseRef is a false positive

### DIFF
--- a/curations/git/github/googleapis/common-protos-php.yaml
+++ b/curations/git/github/googleapis/common-protos-php.yaml
@@ -1,0 +1,9 @@
+coordinates:
+  name: common-protos-php
+  namespace: googleapis
+  provider: github
+  type: git
+revisions:
+  96f6873c65fb0289fcdb6ac3d5239f9c9e5750b0:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
LicenseRef is a false positive

**Details:**
LicenseRef-scancode-other-permissive is a false-positive, likely triggered by some text in the project's README:

"These classes are licensed using the Apache 2.0 software license, a
permissive, [copyfree license]. You are free to use them in your applications
provided the license terms are honored.

**Resolution:**
Removed the LicenseRef. Keeping just Apache-2.0 in the expression is acceptable in this case.

**Affected definitions**:
- [common-protos-php 96f6873c65fb0289fcdb6ac3d5239f9c9e5750b0](https://clearlydefined.io/definitions/git/github/googleapis/common-protos-php/96f6873c65fb0289fcdb6ac3d5239f9c9e5750b0/96f6873c65fb0289fcdb6ac3d5239f9c9e5750b0)