### PR TITLE
Update abundance.yaml

### DIFF
--- a/curations/gem/rubygems/-/abundance.yaml
+++ b/curations/gem/rubygems/-/abundance.yaml
@@ -8,6 +8,6 @@ revisions:
       releaseDate: '2008-12-05'
     licensed:
       declared: MIT
-    attributions:  
+    - attributions:  
       - Copyright:: 2008 Louis-Philippe Perron
-    path: data.tar/data/lib/abundance.rb  
+    - path: data.tar/data/lib/abundance.rb  

--- a/curations/gem/rubygems/-/abundance.yaml
+++ b/curations/gem/rubygems/-/abundance.yaml
@@ -8,3 +8,6 @@ revisions:
       releaseDate: '2008-12-05'
     licensed:
       declared: MIT
+    attributions:  
+      - Copyright:: 2008 Louis-Philippe Perron
+    path: data.tar/data/lib/abundance.rb  

--- a/curations/gem/rubygems/-/abundance.yaml
+++ b/curations/gem/rubygems/-/abundance.yaml
@@ -10,4 +10,4 @@ revisions:
       declared: MIT
     - attributions:  
       - Copyright:: 2008 Louis-Philippe Perron
-    - path: data.tar/data/lib/abundance.rb  
+    - path: data/lib/abundance.rb  


### PR DESCRIPTION
Adding a copyright attribution and source path for the abundance ruby gem.  Kind of like the pull request better because I can upload the doc to show my work.  
[abundance-1.0.5.zip](https://github.com/user-attachments/files/21301762/abundance-1.0.5.zip)
