### PR TITLE
Add curation for gem shoulda-matchers

### DIFF
--- a/curations/gem/rubygems/-/shoulda-matchers.yaml
+++ b/curations/gem/rubygems/-/shoulda-matchers.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: gem
+    provider: rubygems
+    namespace: '-'
+    name: shoulda-matchers
+revisions:
+    6.5.0:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/thoughtbot/shoulda-matchers/blob/d8140e8eb340f1b4e70d9cca7c5e87ca86b37f73/LICENSE