### PR TITLE
Add curation for pypi sqlalchemy

### DIFF
--- a/curations/pypi/pypi/-/sqlalchemy.yaml
+++ b/curations/pypi/pypi/-/sqlalchemy.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: pypi
+    provider: pypi
+    namespace: '-'
+    name: sqlalchemy
+revisions:
+    "":
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://docs.sqlalchemy.org/en/20/copyright.html