### PR TITLE
Add curation for npm applicationinsights-core-js

### DIFF
--- a/curations/npm/npmjs/@microsoft/applicationinsights-core-js.yaml
+++ b/curations/npm/npmjs/@microsoft/applicationinsights-core-js.yaml
@@ -13,6 +13,9 @@ revisions:
   3.3.5:
     licensed:
       declared: MIT
+  3.3.6:
+    licensed:
+      declared: MIT
   3.3.9:
     licensed:
       declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/microsoft/ApplicationInsights-JS/blob/main/shared/AppInsightsCore/LICENSE