### PR TITLE
Add curation for com.apache.commons:commons-pool2

### DIFF
--- a/curations/maven/mavencentral/org.apache.commons/commons-pool-2.yaml
+++ b/curations/maven/mavencentral/org.apache.commons/commons-pool-2.yaml
@@ -1,0 +1,12 @@
+coordinates:
+  name: commons-pool2
+  namespace: org.apache.commons
+  provider: mavencentral
+  type: maven
+revisions:
+  2.12.0:
+    licensed:
+      declared: Apache-2.0
+  2.12.1:
+    licensed:
+      declared: Apache-2.0


### PR DESCRIPTION
The license is incorrectly detected as Apache-2.0 AND CC-PDDC.

License files are here:

- https://github.com/apache/commons-pool/blob/rel/commons-pool-2.12.1/LICENSE.txt
- https://github.com/apache/commons-pool/blob/rel/commons-pool-2.12.0/LICENSE.txt
