### PR TITLE
Add curation for gem crowdin-api

### DIFF
--- a/curations/gem/rubygems/-/crowdin-api.yaml
+++ b/curations/gem/rubygems/-/crowdin-api.yaml
@@ -1,0 +1,9 @@
+coordinates:
+    type: gem
+    provider: rubygems
+    namespace: '-'
+    name: crowdin-api
+revisions:
+    1.12.0:
+        licensed:
+            declared: MIT


### PR DESCRIPTION
The correct license is MIT which can be found
at https://github.com/crowdin/crowdin-api-client-ruby/blob/main/LICENSE

Cannot find any references to the Sunsoft license reported as LicenseRef-scancode-sunsoft. 