### PR TITLE
paramiko3.5.1

### DIFF
--- a/curations/pypi/pypi/-/paramiko.yaml
+++ b/curations/pypi/pypi/-/paramiko.yaml
@@ -66,3 +66,6 @@ revisions:
   3.5.0:
     licensed:
       declared: LGPL-2.1-or-later
+  3.5.1:
+    licensed:
+      declared: LGPL-2.1-or-later


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
paramiko3.5.1

**Details:**
Fixing Declared License to LGPL-2.1-or-later

**Resolution:**
https://github.com/paramiko/paramiko/blob/main/paramiko/__init__.py

**Affected definitions**:
- [paramiko 3.5.1](https://clearlydefined.io/definitions/pypi/pypi/-/paramiko/3.5.1/3.5.1)