### PR TITLE
npmjs/cookie-signature: Declare license to be MIT

### DIFF
--- a/curations/npm/npmjs/-/cookie-signature.yaml
+++ b/curations/npm/npmjs/-/cookie-signature.yaml
@@ -6,3 +6,30 @@ revisions:
   1.0.1:
     licensed:
       declared: MIT
+  1.0.2:
+    licensed:
+      declared: MIT
+  1.0.3:
+    licensed:
+      declared: MIT
+  1.0.4:
+    licensed:
+      declared: MIT
+  1.0.5:
+    licensed:
+      declared: MIT
+  1.0.6:
+    licensed:
+      declared: MIT
+  1.1.0:
+    licensed:
+      declared: MIT
+  1.2.0:
+    licensed:
+      declared: MIT
+  1.2.1:
+    licensed:
+      declared: MIT
+  1.2.2:
+    licensed:
+      declared: MIT


### PR DESCRIPTION
For some reason, the `cookie-signature` package is being declared as both MIT and unknown license. It's just MIT. Declare it as such.

https://github.com/tj/node-cookie-signature

https://clearlydefined.io/definitions/npm/npmjs/-/cookie-signature/1.2.2

License: https://github.com/tj/node-cookie-signature/blob/master/LICENSE
Also declared here: https://github.com/tj/node-cookie-signature/blob/b7bd4cb9500bfa5e696143f51d61e5f24f7a625d/package.json#L8