### PR TITLE
Microsoft.Azure.Cosmos3.53.1

### DIFF
--- a/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
+++ b/curations/nuget/nuget/-/Microsoft.Azure.Cosmos.yaml
@@ -45,6 +45,9 @@ revisions:
   3.51.0:
     licensed:
       declared: MIT
+  3.53.1:
+    licensed:
+      declared: MIT
   3.8.0:
     licensed:
       declared: MIT


### PR DESCRIPTION

**Type:** Incorrect

**Summary:**
Microsoft.Azure.Cosmos3.53.1

**Details:**
Fixing Declared License to MIT

**Resolution:**
https://licenses.nuget.org/MIT

**Affected definitions**:
- [Microsoft.Azure.Cosmos 3.53.1](https://clearlydefined.io/definitions/nuget/nuget/-/Microsoft.Azure.Cosmos/3.53.1/3.53.1)