### PR TITLE
Create logassert.yaml for logassert package

### DIFF
--- a/curations/pypi/pypi/-/logassert.yaml
+++ b/curations/pypi/pypi/-/logassert.yaml
@@ -5,25 +5,25 @@ coordinates:
 revisions:
   '7':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8.1':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8.2':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8.3':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8.4':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8.5':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only
   '8.6':
     licensed:
-      declared: LGPL-3.0
+      declared: LGPL-3.0-only

--- a/curations/pypi/pypi/-/logassert.yaml
+++ b/curations/pypi/pypi/-/logassert.yaml
@@ -1,0 +1,29 @@
+coordinates:
+  name: logassert
+  provider: pypi
+  type: pypi
+revisions:
+  '7':
+    licensed:
+      declared: LGPL-3.0
+  '8':
+    licensed:
+      declared: LGPL-3.0
+  '8.1':
+    licensed:
+      declared: LGPL-3.0
+  '8.2':
+    licensed:
+      declared: LGPL-3.0
+  '8.3':
+    licensed:
+      declared: LGPL-3.0
+  '8.4':
+    licensed:
+      declared: LGPL-3.0
+  '8.5':
+    licensed:
+      declared: LGPL-3.0
+  '8.6':
+    licensed:
+      declared: LGPL-3.0


### PR DESCRIPTION
Type: Incorrect

Summary:
logassert

Details:
License file is GPL-3.0

Resolution:
Curated to remove CAL-1.0 and GLP-3.0-only

Affected definitions:
[logassert 8.6](https://clearlydefined.io/definitions/pypi/pypi/-/logassert/8.6)
[logassert 8.5](https://clearlydefined.io/definitions/pypi/pypi/-/logassert/8.5)
[logassert 8.4](https://clearlydefined.io/definitions/pypi/pypi/-/logassert/8.4)
[logassert 8.3](https://clearlydefined.io/definitions/pypi/pypi/-/logassert/8.3)
[logassert 8.2](https://clearlydefined.io/definitions/pypi/pypi/-/logassert/8.2)