### PR TITLE
Add curation for pypi tqdm

### DIFF
--- a/curations/pypi/pypi/-/tqdm.yaml
+++ b/curations/pypi/pypi/-/tqdm.yaml
@@ -1,8 +1,12 @@
 coordinates:
-  name: tqdm
-  provider: pypi
   type: pypi
+  provider: pypi
+  namespace: ""
+  name: tqdm
 revisions:
+  "":
+    licensed:
+      declared: MIT AND MPL-2.0
   4.66.4:
     licensed:
       declared: MPL-2.0


### PR DESCRIPTION
The correct license is MIT AND MPL-2.0 which can be found at https://github.com/tqdm/tqdm/blob/master/LICENCE